### PR TITLE
docs(faq): remove exported directory after clearing expired logs

### DIFF
--- a/en/learn-more/faq/install-faq.mdx
+++ b/en/learn-more/faq/install-faq.mdx
@@ -316,6 +316,19 @@ You can delete old logs by specifying the number of days using the `clear-free-p
    - Use the `--tenant_ids` option to specify the tenant ID.
    - Logs older than the number of days specified by the `--days` option will be deleted.
 
+3. (Optional) Remove exported `free_plan_tenant_expired_logs` directory
+
+   ```bash
+   $ docker exec -it docker-api-1 bash -c 'ls -l ${OPENDAL_FS_ROOT}/free_plan_tenant_expired_logs'
+   ```
+
+   - The `flask clear-free-plan-tenant-expired-logs` command first exports any logs marked for deletion to the `free_plan_tenant_expired_logs` directory before actually deleting them. If you want to free up storage space, it's a good idea to delete this directory afterward.
+   - The method for deleting the `free_plan_tenant_expired_logs` directory may vary depending on your storage type. The above command is an example for environments with the default settings.
+
+<Info>
+  If you'd like to reduce storage usage even further, you might consider reclaiming storage for the database (e.g. [`VACUUM` for PostgreSQL](https://www.postgresql.org/docs/current/sql-vacuum.html)) as well.
+</Info>
+
 **Deleting unused files**
 
 You can delete unused files using the `clear-orphaned-file-records` command and the `remove-orphaned-files-on-storage` command.

--- a/ja-jp/learn-more/faq/install-faq.mdx
+++ b/ja-jp/learn-more/faq/install-faq.mdx
@@ -311,6 +311,19 @@ Dify はデータベース上の古いログやストレージ上の未使用の
   - `--tenant_ids` オプションでテナント ID を指定します。
   - `--days` オプションで指定した日数より古いログが削除されます。
 
+3. （オプション）エクスポートされた `free_plan_tenant_expired_logs` ディレクトリを削除する
+
+   ```bash
+   $ docker exec -it docker-api-1 bash -c 'ls -l ${OPENDAL_FS_ROOT}/free_plan_tenant_expired_logs'
+   ```
+
+   - `flask clear-free-plan-tenant-expired-logs` コマンドは、実際に削除する前に削除対象のログを `free_plan_tenant_expired_logs` ディレクトリにエクスポートします。ストレージ容量を解放したい場合は、このディレクトリも削除することをおすすめします。
+   - `free_plan_tenant_expired_logs` ディレクトリの削除方法はストレージタイプによって異なります。上記コマンドはデフォルト設定環境での例です。
+
+<Info>
+  さらにストレージ使用量を削減したい場合は、データベースのストレージの再利用（例: [PostgreSQL の `VACUUM`](https://www.postgresql.org/docs/current/sql-vacuum.html) など）も検討できます。
+</Info>
+
 **未使用のファイルを削除する**
 
 `clear-orphaned-file-records` コマンドと `remove-orphaned-files-on-storage` コマンドを使用して、未使用のファイルを削除できます。

--- a/zh-hans/learn-more/faq/install-faq.mdx
+++ b/zh-hans/learn-more/faq/install-faq.mdx
@@ -316,6 +316,19 @@ Dify**不会**自动删除数据库中的旧日志或存储中的未使用文件
    - 使用 `--tenant_ids` 选项指定租户 ID。
    - 将删除比 `--days` 选项指定的天数更旧的日志。
 
+3. （可选）删除已导出的 `free_plan_tenant_expired_logs` 目录
+
+   ```bash
+   $ docker exec -it docker-api-1 bash -c 'ls -l ${OPENDAL_FS_ROOT}/free_plan_tenant_expired_logs'
+   ```
+
+   - `flask clear-free-plan-tenant-expired-logs` 命令会在实际删除前，将标记为删除的日志先导出到 `free_plan_tenant_expired_logs` 目录。如果你想释放存储空间，建议随后删除该目录。
+   - 删除 `free_plan_tenant_expired_logs` 目录的方法可能因存储类型不同而有所差异。上述命令适用于默认设置环境。
+
+<Info>
+  如果你希望进一步减少存储占用，也可以考虑回收存储空间（例如 [PostgreSQL 的 `VACUUM`](https://www.postgresql.org/docs/current/sql-vacuum.html)）。
+</Info>
+
 #### 删除未使用的文件
 
 你可以使用 `clear-orphaned-file-records` 命令和 `remove-orphaned-files-on-storage` 命令删除未使用的文件。


### PR DESCRIPTION
This PR adds an optional step to remove exported `free_plan_tenant_expired_logs` directory after `flask clear-free-plan-tenant-expired-logs` commands.

![image](https://github.com/user-attachments/assets/bdae90af-d4ea-402a-a483-4b65b277c158)

![image](https://github.com/user-attachments/assets/789a5894-2e02-4afd-82b3-58bc514580dd)

![image](https://github.com/user-attachments/assets/cbc825b0-eebd-4111-bef4-4c483e7eea6d)
