### PR TITLE
docs(plugin): add guide to log strings for debugging

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -352,7 +352,8 @@
                                         "pages": [
                                             "en/plugins/best-practice/README",
                                             "en/plugins/best-practice/develop-a-slack-bot-plugin",
-                                            "en/plugins/best-practice/how-to-use-mcp-zapier"
+                                            "en/plugins/best-practice/how-to-use-mcp-zapier",
+                                            "en/plugins/best-practice/how-to-print-strings-to-logs-for-debugging"
                                         ]
                                     },
                                     {
@@ -963,7 +964,8 @@
                                         "group": "最佳实践",
                                         "pages": [
                                             "zh-hans/plugins/best-practice/develop-a-slack-bot-plugin",
-                                            "zh-hans/plugins/best-practice/how-to-use-mcp-zapier"
+                                            "zh-hans/plugins/best-practice/how-to-use-mcp-zapier",
+                                            "zh-hans/plugins/best-practice/how-to-print-strings-to-logs-for-debugging"
                                         ]
                                     },
                                     {
@@ -1555,7 +1557,8 @@
                                         "pages": [
                                             "ja-jp/plugins/best-practice/README",
                                             "ja-jp/plugins/best-practice/develop-a-slack-bot-plugin",
-                                            "ja-jp/plugins/best-practice/how-to-use-mcp-zapier"
+                                            "ja-jp/plugins/best-practice/how-to-use-mcp-zapier",
+                                            "ja-jp/plugins/best-practice/how-to-print-strings-to-logs-for-debugging"
                                         ]
                                     },
                                     {

--- a/en/plugins/best-practice/how-to-print-strings-to-logs-for-debugging.mdx
+++ b/en/plugins/best-practice/how-to-print-strings-to-logs-for-debugging.mdx
@@ -1,0 +1,39 @@
+---
+title: Outputting Logs for Development and Debugging
+---
+
+As a plugin developer, you may want to print arbitrary strings to logs during plugin processing for development or debugging purposes.
+
+For this purpose, the plugin SDK implements a handler for Python's standard `logging` library. By using this, you can output any string to both the **standard output during remote debugging** and the **plugin daemon container logs** (community edition only).
+
+## Sample
+
+Import `plugin_logger_handler` and add it to your logger as a handler. Below is a sample code for a tool plugin.
+
+```python
+from collections.abc import Generator
+from typing import Any
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+
+# Import logging and custom handler
+import logging
+from dify_plugin.config.logger_format import plugin_logger_handler
+
+# Set up logging with the custom handler
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(plugin_logger_handler)
+
+
+class LoggerDemoTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
+
+        # Log messages with different severity levels
+        logger.info("This is a INFO log message.")
+        logger.warning("This is a WARNING log message.")
+        logger.error("This is a ERROR log message.")
+
+        yield self.create_text_message("Hello, Dify!")
+```

--- a/ja-jp/plugins/best-practice/how-to-print-strings-to-logs-for-debugging.mdx
+++ b/ja-jp/plugins/best-practice/how-to-print-strings-to-logs-for-debugging.mdx
@@ -1,0 +1,39 @@
+---
+title: 開発やデバッグのためのログの出力
+---
+
+プラグインの開発者は、開発やデバッグの目的で、プラグインの処理の過程で任意の文字列をログに出力したいと考えることがあるでしょう。
+
+この目的で、プラグインの SDK には、Python の標準ライブラリである `logging` 用のハンドラが実装されています。これを利用すれば、**リモートデバッグ中の標準出力** にも **プラグインデーモンのコンテナログ**（コミュニティ版のみ）にも、任意の文字列を出力できます。
+
+## サンプル
+
+`plugin_logger_handler` をインポートして、ロガーにハンドラとして追加します。以下は、ツールプラグインのサンプルコードです。
+
+```python
+from collections.abc import Generator
+from typing import Any
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+
+# Import logging and custom handler
+import logging
+from dify_plugin.config.logger_format import plugin_logger_handler
+
+# Set up logging with the custom handler
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(plugin_logger_handler)
+
+
+class LoggerDemoTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
+
+        # Log messages with different severity levels
+        logger.info("This is a INFO log message.")
+        logger.warning("This is a WARNING log message.")
+        logger.error("This is a ERROR log message.")
+
+        yield self.create_text_message("Hello, Dify!")
+```

--- a/zh-hans/plugins/best-practice/how-to-print-strings-to-logs-for-debugging.mdx
+++ b/zh-hans/plugins/best-practice/how-to-print-strings-to-logs-for-debugging.mdx
@@ -1,0 +1,39 @@
+---
+title: 为开发和调试输出日志
+---
+
+作为插件开发者，你可能希望在插件处理过程中，为了开发或调试目的，将任意字符串输出到日志中。
+
+为此，插件 SDK 实现了一个适用于 Python 标准库 `logging` 的处理器。通过使用它，你可以将任意字符串输出到**远程调试时的标准输出**以及**插件守护进程的容器日志**（仅社区版）。
+
+## 示例
+
+导入 `plugin_logger_handler` 并将其添加到你的 logger 处理器中。以下是工具插件的示例代码。
+
+```python
+from collections.abc import Generator
+from typing import Any
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+
+# 导入 logging 和自定义处理器
+import logging
+from dify_plugin.config.logger_format import plugin_logger_handler
+
+# 使用自定义处理器设置日志
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(plugin_logger_handler)
+
+
+class LoggerDemoTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
+
+        # 以不同级别输出日志信息
+        logger.info("This is a INFO log message.")
+        logger.warning("This is a WARNING log message.")
+        logger.error("This is a ERROR log message.")
+
+        yield self.create_text_message("Hello, Dify!")
+```


### PR DESCRIPTION
This PR adds a new page to guide users on how to log strings from a plugin to stdout for remote debugging, or to container logs for the plugin daemon.

![image](https://github.com/user-attachments/assets/a6957302-eecf-4996-b301-a1e03dd56d10)

![image](https://github.com/user-attachments/assets/3a01006b-0e8c-4dea-912f-fb84712942e1)

![image](https://github.com/user-attachments/assets/1286ad6b-d024-40d6-a645-b3b319b9c712)