### PR TITLE
Docs: Update chinese to japanese for tools.mdx

### DIFF
--- a/ja-jp/guides/workflow/node/tools.mdx
+++ b/ja-jp/guides/workflow/node/tools.mdx
@@ -27,7 +27,7 @@ version: '日本語'
   <img src="https://assets-docs.dify.ai/2024/12/39dc3b5881d9a5fe35b877971f70d3a6.png" alt="" />
 </Frame>
 
-### 将工作流应用发布为工具
+### ワークフローをツールとして公開する
 
 カスタムツールの作成とツールの設定方法については[ツール設定説明](/ja-jp/introduction)を参照してください。
 


### PR DESCRIPTION

This pull request includes a localization update to the Japanese guide for workflows in the `ja-jp/guides/workflow/node/tools.mdx` file. The most important change involves updating a section title for better clarity and alignment with the Japanese language.

Localization update:

* Updated the section title from "将工作流应用发布为工具" to "ワークフローをツールとして公開する" to improve the Japanese translation and ensure consistency with the rest of the document.