### PR TITLE
fix: update command to gather tenant ids

### DIFF
--- a/en/learn-more/faq/install-faq.mdx
+++ b/en/learn-more/faq/install-faq.mdx
@@ -293,9 +293,9 @@ You can delete old logs by specifying the number of days using the `clear-free-p
 1. Gather the tenant ID
 
    ```bash
-   $ docker exec -it docker-api-1 bash -c "echo 'db.session.query(Tenant).all(); quit()' | flask shell"
+   $ docker exec -it docker-api-1 bash -c "echo 'from models import Tenant; db.session.query(Tenant.id, Tenant.name).all(); quit()' | flask shell"
    ...
-   >>> [<Tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2>]
+   >>> [('618b5d66-a1f5-4b6b-8d12-f171182a1cb2', "Dify's Workspace")]
    ```
 
    - In this example, the tenant ID is `618b5d66-a1f5-4b6b-8d12-f171182a1cb2`.

--- a/ja-jp/learn-more/faq/install-faq.mdx
+++ b/ja-jp/learn-more/faq/install-faq.mdx
@@ -288,9 +288,9 @@ Dify はデータベース上の古いログやストレージ上の未使用の
 1. テナント ID を確認する
 
    ```bash
-   $ docker exec -it docker-api-1 bash -c "echo 'db.session.query(Tenant).all(); quit()' | flask shell"
+   $ docker exec -it docker-api-1 bash -c "echo 'from models import Tenant; db.session.query(Tenant.id, Tenant.name).all(); quit()' | flask shell"
    ...
-   >>> [<Tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2>]
+   >>> [('618b5d66-a1f5-4b6b-8d12-f171182a1cb2', "Dify's Workspace")]
    ```
 
    - この例では、テナント ID が `618b5d66-a1f5-4b6b-8d12-f171182a1cb2` であることがわかります。

--- a/ja-jp/learn-more/faq/install-faq.mdx
+++ b/ja-jp/learn-more/faq/install-faq.mdx
@@ -287,29 +287,29 @@ Dify はデータベース上の古いログやストレージ上の未使用の
 
 1. テナント ID を確認する
 
-  ```bash
-  $ docker exec -it docker-api-1 bash -c "echo 'db.session.query(Tenant).all(); quit()' | flask shell"
-  ...
-  >>> [<Tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2>]
-  ```
+   ```bash
+   $ docker exec -it docker-api-1 bash -c "echo 'db.session.query(Tenant).all(); quit()' | flask shell"
+   ...
+   >>> [<Tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2>]
+   ```
 
-  - この例では、テナント ID が `618b5d66-a1f5-4b6b-8d12-f171182a1cb2` であることがわかります。
+   - この例では、テナント ID が `618b5d66-a1f5-4b6b-8d12-f171182a1cb2` であることがわかります。
 
 2. テナント ID と日数を指定して、古いログを削除する
 
-  ```bash
-  $ docker exec -it docker-api-1 flask clear-free-plan-tenant-expired-logs --days 30 --batch 100 --tenant_ids 618b5d66-a1f5-4b6b-8d12-f171182a1cb2
-  ...
-  Starting clear free plan tenant expired logs.
-  Clearing free plan tenant expired logs
-  Total tenant count: 1
-  [2025-04-27 05:28:22.027032] Processed 2555 messages for tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2
-  [2025-04-27 05:28:22.085901] Processed 2190 conversations for tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2
-  [2025-04-27 05:28:22.112561] Processed 5110 workflow node executions for tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2
-  ```
+   ```bash
+   $ docker exec -it docker-api-1 flask clear-free-plan-tenant-expired-logs --days 30 --batch 100 --tenant_ids 618b5d66-a1f5-4b6b-8d12-f171182a1cb2
+   ...
+   Starting clear free plan tenant expired logs.
+   Clearing free plan tenant expired logs
+   Total tenant count: 1
+   [2025-04-27 05:28:22.027032] Processed 2555 messages for tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2
+   [2025-04-27 05:28:22.085901] Processed 2190 conversations for tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2
+   [2025-04-27 05:28:22.112561] Processed 5110 workflow node executions for tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2
+   ```
 
-  - `--tenant_ids` オプションでテナント ID を指定します。
-  - `--days` オプションで指定した日数より古いログが削除されます。
+   - `--tenant_ids` オプションでテナント ID を指定します。
+   - `--days` オプションで指定した日数より古いログが削除されます。
 
 3. （オプション）エクスポートされた `free_plan_tenant_expired_logs` ディレクトリを削除する
 

--- a/zh-hans/learn-more/faq/install-faq.mdx
+++ b/zh-hans/learn-more/faq/install-faq.mdx
@@ -293,9 +293,9 @@ Dify**不会**自动删除数据库中的旧日志或存储中的未使用文件
 1. 获取租户 ID
 
    ```bash
-   $ docker exec -it docker-api-1 bash -c "echo 'db.session.query(Tenant).all(); quit()' | flask shell"
+   $ docker exec -it docker-api-1 bash -c "echo 'from models import Tenant; db.session.query(Tenant.id, Tenant.name).all(); quit()' | flask shell"
    ...
-   >>> [<Tenant 618b5d66-a1f5-4b6b-8d12-f171182a1cb2>]
+   >>> [('618b5d66-a1f5-4b6b-8d12-f171182a1cb2', "Dify's Workspace")]
    ```
 
    - 在此示例中，租户 ID 为 `618b5d66-a1f5-4b6b-8d12-f171182a1cb2`。


### PR DESCRIPTION
## Changed sections

- `Learn More` > `FAQ` > `Self Host / Local Deployment`

## Changes

- Correct indentation for some code blocks and lists; added one space for each lines (ja-jp)
- Update command to gather tenant ids (all languages)
  - Due to recent changes in Dify, the older commands no longer work