### PR TITLE
Fix type errors in example code

### DIFF
--- a/en/guides/workflow/node/code.mdx
+++ b/en/guides/workflow/node/code.mdx
@@ -31,7 +31,7 @@ Using the code node, you can perform the following common operations:
 In workflows, you often have to deal with unstructured data processing, such as parsing, extracting, and transforming JSON strings. A typical example is data processing from an HTTP node. In common API return structures, data may be nested within multiple layers of JSON objects, and you need to extract certain fields. The code node can help you perform these operations. Here is a simple example that extracts the `data.name` field from a JSON string returned by an HTTP node:
 
 ```python
-def main(http_response: str) -> str:
+def main(http_response: str) -> dict:
     import json
     data = json.loads(http_response)
     return {
@@ -45,7 +45,7 @@ def main(http_response: str) -> str:
 When you need to perform complex mathematical calculations in a workflow, you can also use the code node. For example, calculating a complex mathematical formula or performing some statistical analysis on data. Here is a simple example that calculates the variance of an array:
 
 ```python
-def main(x: list) -> float:
+def main(x: list) -> dict:
     return {
         # Note to declare 'result' in the output variables
         'result': sum([(i - sum(x) / len(x)) ** 2 for i in x]) / len(x)
@@ -57,7 +57,7 @@ def main(x: list) -> float:
 Sometimes, you may need to concatenate multiple data sources, such as multiple knowledge retrievals, data searches, API calls, etc. The code node can help you integrate these data sources together. Here is a simple example that merges data from two knowledge bases:
 
 ```python
-def main(knowledge1: list, knowledge2: list) -> list:
+def main(knowledge1: list, knowledge2: list) -> dict:
     return {
         # Note to declare 'result' in the output variables
         'result': knowledge1 + knowledge2

--- a/ja-jp/guides/workflow/node/code.mdx
+++ b/ja-jp/guides/workflow/node/code.mdx
@@ -24,7 +24,7 @@ version: '日本語'
 ワークフローでは、しばしば非構造化データの処理が必要です。例えば、JSON文字列の解析、抽出、変換などです。典型的な例として、HTTPノードのデータ処理があります。一般的なAPI応答構造では、データが多層のJSONオブジェクトにネストされていることがあり、特定のフィールドを抽出する必要があります。コードノードはこれらの操作を支援します。以下は、HTTPノードから返されたJSON文字列から`data.name`フィールドを抽出する簡単な例です：
 
 ```python
-def main(http_response: str) -> str:
+def main(http_response: str) -> dict:
     import json
     data = json.loads(http_response)
     return {
@@ -38,7 +38,7 @@ def main(http_response: str) -> str:
 ワークフロー内で複雑な数学計算を行う必要がある場合、コードノードを使用できます。例えば、複雑な数学公式の計算やデータの統計分析です。以下は、配列の平方差を計算する簡単な例です：
 
 ```python
-def main(x: list) -> float:
+def main(x: list) -> dict:
     return {
         # 出力変数にresultを宣言することに注意
         'result' : sum([(i - sum(x) / len(x)) ** 2 for i in x]) / len(x)
@@ -50,7 +50,7 @@ def main(x: list) -> float:
 時には、複数のデータソースを結合する必要がある場合があります。例えば、複数の知識検索、データサーチ、API呼び出しなどです。コードノードはこれらのデータソースを統合するのに役立ちます。以下は、2つのナレッジベースのデータを結合する簡単な例です：
 
 ```python
-def main(knowledge1: list, knowledge2: list) -> list:
+def main(knowledge1: list, knowledge2: list) -> dict:
     return {
         # 出力変数にresultを宣言することに注意
         'result': knowledge1 + knowledge2

--- a/zh-hans/guides/workflow/node/code.mdx
+++ b/zh-hans/guides/workflow/node/code.mdx
@@ -30,7 +30,7 @@ title: 代码执行
 在工作流中，经常要面对非结构化的数据处理，如JSON字符串的解析、提取、转换等。最典型的例子就是HTTP节点的数据处理，在常见的API返回结构中，数据可能会被嵌套在多层JSON对象中，而我们需要提取其中的某些字段。代码节点可以帮助你完成这些操作，下面是一个简单的例子，它从HTTP节点返回的JSON字符串中提取了`data.name`字段：
 
 ```python
-def main(http_response: str) -> str:
+def main(http_response: str) -> dict:
     import json
     data = json.loads(http_response)
     return {
@@ -44,7 +44,7 @@ def main(http_response: str) -> str:
 当工作流中需要进行一些复杂的数学计算时，也可以使用代码节点。例如，计算一个复杂的数学公式，或者对数据进行一些统计分析。下面是一个简单的例子，它计算了一个数组的平方差：
 
 ```python
-def main(x: list) -> float:
+def main(x: list) -> dict:
     return {
         # 注意在输出变量中声明result
         'result' : sum([(i - sum(x) / len(x)) ** 2 for i in x]) / len(x)
@@ -56,7 +56,7 @@ def main(x: list) -> float:
 有时，也许你需要拼接多个数据源，如多个知识检索、数据搜索、API调用等，代码节点可以帮助你将这些数据源整合在一起。下面是一个简单的例子，它将两个知识库的数据合并在一起：
 
 ```python
-def main(knowledge1: list, knowledge2: list) -> list:
+def main(knowledge1: list, knowledge2: list) -> dict:
     return {
         # 注意在输出变量中声明result
         'result': knowledge1 + knowledge2


### PR DESCRIPTION
In the code node, the return type of the function is always `dict`