### PR TITLE
feat: Add Arize & Phoenix Integration Docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -207,6 +207,8 @@
                                                 "group": "Integrate External Ops Tools",
                                                 "pages": [
                                                     "en/guides/monitoring/integrate-external-ops-tools/README",
+                                                    "en/guides/monitoring/integrate-external-ops-tools/integrate-arize",
+                                                    "en/guides/monitoring/integrate-external-ops-tools/integrate-phoenix",
                                                     "en/guides/monitoring/integrate-external-ops-tools/integrate-langsmith",
                                                     "en/guides/monitoring/integrate-external-ops-tools/integrate-langfuse",
                                                     "en/guides/monitoring/integrate-external-ops-tools/integrate-opik",
@@ -857,6 +859,8 @@
                                                 "group": "集成外部与 Ops 工具",
                                                 "pages": [
                                                     "zh-hans/guides/monitoring/integrate-external-ops-tools/readme",
+                                                    "zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-arize",
+                                                    "zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-phoenix",
                                                     "zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-langfuse",
                                                     "zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-langsmith",
                                                     "zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-opik",
@@ -1490,6 +1494,8 @@
                                             {
                                                 "group": "外部Opsツール統合",
                                                 "pages": [
+                                                    "ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-arize",
+                                                    "ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-phoenix",
                                                     "ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-langfuse",
                                                     "ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-langsmith",
                                                     "ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-opik",
@@ -2587,6 +2593,14 @@
         {
             "source": "/guides/monitoring/integrate-external-ops-tools",
             "destination": "/en/guides/monitoring/integrate-external-ops-tools/readme"
+        },
+        {
+            "source": "/guides/monitoring/integrate-external-ops-tools/integrate-arize",
+            "destination": "/en/guides/monitoring/integrate-external-ops-tools/integrate-arize"
+        },
+        {
+            "source": "/guides/monitoring/integrate-external-ops-tools/integrate-phoenix",
+            "destination": "/en/guides/monitoring/integrate-external-ops-tools/integrate-phoenix"
         },
         {
             "source": "/guides/monitoring/integrate-external-ops-tools/integrate-langsmith",

--- a/en/guides/monitoring/integrate-external-ops-tools/integrate-arize.mdx
+++ b/en/guides/monitoring/integrate-external-ops-tools/integrate-arize.mdx
@@ -1,0 +1,572 @@
+---
+title: Integrate Arize
+---
+
+
+### What is Arize
+
+Enterprise-grade LLM observability, online & offline evaluation, monitoring, and experimentation—powered by OpenTelemetry. Purpose-built for LLM & agent-driven applications.
+
+<Info>
+For more details, please refer to [Arize](https://arize.com).
+</Info>
+
+***
+
+### How to Configure Arize
+
+#### 1. Register/Login to [Arize](https://app.arize.com/auth/join)
+
+#### 2. Get your Arize API Key
+
+Retrieve your Arize API Key from the user menu at the top-right. Click on **API Key**, then on the API Key to copy it:
+
+![Arize API Key](https://i.ibb.co/JwBmQxnf/dify-docs-arize-api-key.png)
+
+#### 3. Integrating Arize with Dify
+
+Configure Arize in the Dify application. Open the application you need to monitor, open **Monitoring** in the side menu, and select **Tracing app performance** on the page.
+
+![Tracing app performance](https://i.ibb.co/v6cL6rPs/dify-docs-arize-in-use.png)
+
+After clicking configure, paste the **API Key**, **Space ID** and **project name** created in Arize into the configuration and save.
+
+![Configure Arize](https://i.ibb.co/m5Xww8gL/dify-docs-arize-config.png)
+
+Once successfully saved, you can view the monitoring status on the current page.
+
+![Configure Arize](https://i.ibb.co/xtggVmb7/dify-docs-arize-in-service.png)
+
+### Monitoring Data List
+
+#### **Workflow/Chatflow Trace Information**
+
+**Used to track workflows and chatflows**
+
+<table>
+  <thead>
+    <tr>
+      <th>Workflow</th>
+      <th>Arize Trace</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>workflow_app_log_id/workflow_run_id</td>
+      <td>id</td>
+    </tr>
+    <tr>
+      <td>user_session_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>workflow\_{id}</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>Model token consumption</td>
+      <td>usage_metadata</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>error</td>
+      <td>error</td>
+    </tr>
+    <tr>
+      <td>\[workflow]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>"conversation_id/none for workflow"</td>
+      <td>conversation_id in metadata</td>
+    </tr>
+  </tbody>
+</table>
+**Workflow Trace Info**
+
+- workflow_id - Unique identifier of the workflow
+- conversation_id - Conversation ID
+- workflow_run_id - ID of the current run
+- tenant_id - Tenant ID
+- elapsed_time - Time taken for the current run
+- status - Run status
+- version - Workflow version
+- total_tokens - Total tokens used in the current run
+- file_list - List of processed files
+- triggered_from - Source that triggered the current run
+- workflow_run_inputs - Input data for the current run
+- workflow_run_outputs - Output data for the current run
+- error - Errors encountered during the current run
+- query - Query used during the run
+- workflow_app_log_id - Workflow application log ID
+- message_id - Associated message ID
+- start_time - Start time of the run
+- end_time - End time of the run
+- workflow node executions - Information about workflow node executions
+- Metadata
+  - workflow_id - Unique identifier of the workflow
+  - conversation_id - Conversation ID
+  - workflow_run_id - ID of the current run
+  - tenant_id - Tenant ID
+  - elapsed_time - Time taken for the current run
+  - status - Run status
+  - version - Workflow version
+  - total_tokens - Total tokens used in the current run
+  - file_list - List of processed files
+  - triggered_from - Source that triggered the current run
+
+#### **Message Trace Information**
+
+**Used to track LLM-related conversations**
+
+<table>
+  <thead>
+    <tr>
+      <th>Chat</th>
+      <th>Arize LLM</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>message_id</td>
+      <td>id</td>
+    </tr>
+    <tr>
+      <td>user_session_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>"llm"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>Model token consumption</td>
+      <td>usage_metadata</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["message", conversation_mode]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>conversation_id</td>
+      <td>conversation_id in metadata</td>
+    </tr>
+  </tbody>
+</table>
+**Message Trace Info**
+
+- message_id - Message ID
+- message_data - Message data
+- user_session_id - User session ID
+- conversation_model - Conversation mode
+- message_tokens - Number of tokens in the message
+- answer_tokens - Number of tokens in the answer
+- total_tokens - Total number of tokens in the message and answer
+- error - Error information
+- inputs - Input data
+- outputs - Output data
+- file_list - List of processed files
+- start_time - Start time
+- end_time - End time
+- message_file_data - File data associated with the message
+- conversation_mode - Conversation mode
+- Metadata
+  - conversation_id - Conversation ID
+  - ls_provider - Model provider
+  - ls_model_name - Model ID
+  - status - Message status
+  - from_end_user_id - ID of the sending user
+  - from_account_id - ID of the sending account
+  - agent_based - Whether the message is agent-based
+  - workflow_run_id - Workflow run ID
+  - from_source - Message source
+
+#### **Moderation Trace Information**
+
+**Used to track conversation moderation**
+
+<table>
+  <thead>
+    <tr>
+      <th>Moderation</th>
+      <th>Arize Tool</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>“moderation"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["moderation"]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**Moderation Trace Info**
+
+- message_id - Message ID
+- user_id: User ID
+- workflow_app_log_id - Workflow application log ID
+- inputs - Moderation input data
+- message_data - Message data
+- flagged - Whether the content is flagged for attention
+- action - Specific actions taken
+- preset_response - Preset response
+- start_time - Moderation start time
+- end_time - Moderation end time
+- Metadata
+  - message_id - Message ID
+  - action - Specific actions taken
+  - preset_response - Preset response
+
+#### **Suggested Question Trace Information**
+
+**Used to track suggested questions**
+
+<table>
+  <thead>
+    <tr>
+      <th>Suggested Question</th>
+      <th>Arize LLM</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>"suggested_question"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["suggested_question"]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**Message Trace Info**
+
+- message_id - Message ID
+- message_data - Message data
+- inputs - Input content
+- outputs - Output content
+- start_time - Start time
+- end_time - End time
+- total_tokens - Number of tokens
+- status - Message status
+- error - Error information
+- from_account_id - ID of the sending account
+- agent_based - Whether the message is agent-based
+- from_source - Message source
+- model_provider - Model provider
+- model_id - Model ID
+- suggested_question - Suggested question
+- level - Status level
+- status_message - Status message
+- Metadata
+  - message_id - Message ID
+  - ls_provider - Model provider
+  - ls_model_name - Model ID
+  - status - Message status
+  - from_end_user_id - ID of the sending user
+  - from_account_id - ID of the sending account
+  - workflow_run_id - Workflow run ID
+  - from_source - Message source
+
+#### **Dataset Retrieval Trace Information**
+
+**Used to track knowledge base retrieval**
+
+<table>
+  <thead>
+    <tr>
+      <th>Dataset Retrieval</th>
+      <th>Arize Retriever</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>"dataset_retrieval"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["dataset_retrieval"]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>message_id</td>
+      <td>parent_run_id</td>
+    </tr>
+  </tbody>
+</table>
+**Dataset Retrieval Trace Info**
+
+- message_id - Message ID
+- inputs - Input content
+- documents - Document data
+- start_time - Start time
+- end_time - End time
+- message_data - Message data
+- Metadata
+  - message_id - Message ID
+  - ls_provider - Model provider
+  - ls_model_name - Model ID
+  - status - Message status
+  - from_end_user_id - ID of the sending user
+  - from_account_id - ID of the sending account
+  - agent_based - Whether the message is agent-based
+  - workflow_run_id - Workflow run ID
+  - from_source - Message source
+
+#### **Tool Trace Information**
+
+**Used to track tool invocation**
+
+<table>
+  <thead>
+    <tr>
+      <th>Tool</th>
+      <th>Arize Tool</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>tool_name</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["tool", tool_name]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+#### **Tool Trace Info**
+
+- message_id - Message ID
+- tool_name - Tool name
+- start_time - Start time
+- end_time - End time
+- tool_inputs - Tool inputs
+- tool_outputs - Tool outputs
+- message_data - Message data
+- error - Error information, if any
+- inputs - Inputs for the message
+- outputs - Outputs of the message
+- tool_config - Tool configuration
+- time_cost - Time cost
+- tool_parameters - Tool parameters
+- file_url - URL of the associated file
+- Metadata
+  - message_id - Message ID
+  - tool_name - Tool name
+  - tool_inputs - Tool inputs
+  - tool_outputs - Tool outputs
+  - tool_config - Tool configuration
+  - time_cost - Time cost
+  - error - Error information, if any
+  - tool_parameters - Tool parameters
+  - message_file_id - Message file ID
+  - created_by_role - Role of the creator
+  - created_user_id - User ID of the creator
+
+**Generate Name Trace Information**
+
+**Used to track conversation title generation**
+
+<table>
+  <thead>
+    <tr>
+      <th>Generate Name</th>
+      <th>Arize Tool</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>"generate_conversation_name"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["generate_name"]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**Generate Name Trace Info**
+
+- conversation_id - Conversation ID
+- inputs - Input data
+- outputs - Generated conversation name
+- start_time - Start time
+- end_time - End time
+- tenant_id - Tenant ID
+- Metadata
+  - conversation_id - Conversation ID
+  - tenant_id - Tenant ID
+
+{/*
+Contributing Section
+DO NOT edit this section!
+It will be automatically generated by the script.
+*/}
+
+---
+
+[Edit this page](https://github.com/langgenius/dify-docs/edit/main/en/guides/monitoring/integrate-external-ops-tools/integrate-arize.mdx) | [Report an issue](https://github.com/langgenius/dify-docs/issues/new?title=Documentation%20Issue%3A%20rate-o&body=%23%23%20Issue%20Description%0A%3C%21--%20Please%20briefly%20describe%20the%20issue%20you%20found%20--%3E%0A%0A%23%23%20Page%20Link%0Ahttps%3A%2F%2Fgithub.com%2Flanggenius%2Fdify-docs%2Fblob%2Fmain%2Fen/guides/monitoring/integrate-external-ops-tools%2Fintegrate-arize.mdx%0A%0A%23%23%20Suggested%20Changes%0A%3C%21--%20If%20you%20have%20specific%20suggestions%20for%20changes%2C%20please%20describe%20them%20here%20--%3E%0A%0A%3C%21--%20Thank%20you%20for%20helping%20improve%20our%20documentation%21%20--%3E)
+

--- a/en/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
+++ b/en/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
@@ -1,0 +1,572 @@
+---
+title: Integrate Phoenix
+---
+
+
+### What is Phoenix
+
+Open-source & OpenTelemetry-based observability, evaluation, prompt engineering and experimentation platform for your LLM workflows and agents.
+
+<Info>
+For more details, please refer to [Phoenix](https://phoenix.arize.com).
+</Info>
+
+***
+
+### How to Configure Phoenix
+
+#### 1. Register/Login to [Phoenix](https://app.arize.com/auth/phoenix/signup)
+
+#### 2. Get your Phoenix API Key
+
+Retrieve your Phoenix API Key from the user menu at the top-right. Click on **API Key**, then on the API Key to copy it:
+
+![Phoenix API Key](https://i.ibb.co/pB1W0pk8/dify-docs-phoenix-api-key.png)
+
+#### 3. Integrating Phoenix with Dify
+
+Configure Phoenix in the Dify application. Open the application you need to monitor, open **Monitoring** in the side menu, and select **Tracing app performance** on the page.
+
+![Tracing app performance](https://i.ibb.co/gMmXxfhQ/dify-docs-phoenix-in-use.png)
+
+After clicking configure, paste the **API Key** and **project name** created in Phoenix into the configuration and save.
+
+![Configure Phoenix](https://i.ibb.co/jv6QFbp7/dify-docs-phoenix-config.png)
+
+Once successfully saved, you can view the monitoring status on the current page.
+
+![Configure Phoenix](https://i.ibb.co/HTJsj9x2/dify-docs-phoenix-in-service.png)
+
+### Monitoring Data List
+
+#### **Workflow/Chatflow Trace Information**
+
+**Used to track workflows and chatflows**
+
+<table>
+  <thead>
+    <tr>
+      <th>Workflow</th>
+      <th>Phoenix Trace</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>workflow_app_log_id/workflow_run_id</td>
+      <td>id</td>
+    </tr>
+    <tr>
+      <td>user_session_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>workflow\_{id}</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>Model token consumption</td>
+      <td>usage_metadata</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>error</td>
+      <td>error</td>
+    </tr>
+    <tr>
+      <td>\[workflow]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>"conversation_id/none for workflow"</td>
+      <td>conversation_id in metadata</td>
+    </tr>
+  </tbody>
+</table>
+**Workflow Trace Info**
+
+- workflow_id - Unique identifier of the workflow
+- conversation_id - Conversation ID
+- workflow_run_id - ID of the current run
+- tenant_id - Tenant ID
+- elapsed_time - Time taken for the current run
+- status - Run status
+- version - Workflow version
+- total_tokens - Total tokens used in the current run
+- file_list - List of processed files
+- triggered_from - Source that triggered the current run
+- workflow_run_inputs - Input data for the current run
+- workflow_run_outputs - Output data for the current run
+- error - Errors encountered during the current run
+- query - Query used during the run
+- workflow_app_log_id - Workflow application log ID
+- message_id - Associated message ID
+- start_time - Start time of the run
+- end_time - End time of the run
+- workflow node executions - Information about workflow node executions
+- Metadata
+  - workflow_id - Unique identifier of the workflow
+  - conversation_id - Conversation ID
+  - workflow_run_id - ID of the current run
+  - tenant_id - Tenant ID
+  - elapsed_time - Time taken for the current run
+  - status - Run status
+  - version - Workflow version
+  - total_tokens - Total tokens used in the current run
+  - file_list - List of processed files
+  - triggered_from - Source that triggered the current run
+
+#### **Message Trace Information**
+
+**Used to track LLM-related conversations**
+
+<table>
+  <thead>
+    <tr>
+      <th>Chat</th>
+      <th>Phoenix LLM</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>message_id</td>
+      <td>id</td>
+    </tr>
+    <tr>
+      <td>user_session_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>"llm"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>Model token consumption</td>
+      <td>usage_metadata</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["message", conversation_mode]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>conversation_id</td>
+      <td>conversation_id in metadata</td>
+    </tr>
+  </tbody>
+</table>
+**Message Trace Info**
+
+- message_id - Message ID
+- message_data - Message data
+- user_session_id - User session ID
+- conversation_model - Conversation mode
+- message_tokens - Number of tokens in the message
+- answer_tokens - Number of tokens in the answer
+- total_tokens - Total number of tokens in the message and answer
+- error - Error information
+- inputs - Input data
+- outputs - Output data
+- file_list - List of processed files
+- start_time - Start time
+- end_time - End time
+- message_file_data - File data associated with the message
+- conversation_mode - Conversation mode
+- Metadata
+  - conversation_id - Conversation ID
+  - ls_provider - Model provider
+  - ls_model_name - Model ID
+  - status - Message status
+  - from_end_user_id - ID of the sending user
+  - from_account_id - ID of the sending account
+  - agent_based - Whether the message is agent-based
+  - workflow_run_id - Workflow run ID
+  - from_source - Message source
+
+#### **Moderation Trace Information**
+
+**Used to track conversation moderation**
+
+<table>
+  <thead>
+    <tr>
+      <th>Moderation</th>
+      <th>Phoenix Tool</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>“moderation"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["moderation"]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**Moderation Trace Info**
+
+- message_id - Message ID
+- user_id: User ID
+- workflow_app_log_id - Workflow application log ID
+- inputs - Moderation input data
+- message_data - Message data
+- flagged - Whether the content is flagged for attention
+- action - Specific actions taken
+- preset_response - Preset response
+- start_time - Moderation start time
+- end_time - Moderation end time
+- Metadata
+  - message_id - Message ID
+  - action - Specific actions taken
+  - preset_response - Preset response
+
+#### **Suggested Question Trace Information**
+
+**Used to track suggested questions**
+
+<table>
+  <thead>
+    <tr>
+      <th>Suggested Question</th>
+      <th>Phoenix LLM</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>"suggested_question"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["suggested_question"]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**Message Trace Info**
+
+- message_id - Message ID
+- message_data - Message data
+- inputs - Input content
+- outputs - Output content
+- start_time - Start time
+- end_time - End time
+- total_tokens - Number of tokens
+- status - Message status
+- error - Error information
+- from_account_id - ID of the sending account
+- agent_based - Whether the message is agent-based
+- from_source - Message source
+- model_provider - Model provider
+- model_id - Model ID
+- suggested_question - Suggested question
+- level - Status level
+- status_message - Status message
+- Metadata
+  - message_id - Message ID
+  - ls_provider - Model provider
+  - ls_model_name - Model ID
+  - status - Message status
+  - from_end_user_id - ID of the sending user
+  - from_account_id - ID of the sending account
+  - workflow_run_id - Workflow run ID
+  - from_source - Message source
+
+#### **Dataset Retrieval Trace Information**
+
+**Used to track knowledge base retrieval**
+
+<table>
+  <thead>
+    <tr>
+      <th>Dataset Retrieval</th>
+      <th>Phoenix Retriever</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>"dataset_retrieval"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["dataset_retrieval"]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>message_id</td>
+      <td>parent_run_id</td>
+    </tr>
+  </tbody>
+</table>
+**Dataset Retrieval Trace Info**
+
+- message_id - Message ID
+- inputs - Input content
+- documents - Document data
+- start_time - Start time
+- end_time - End time
+- message_data - Message data
+- Metadata
+  - message_id - Message ID
+  - ls_provider - Model provider
+  - ls_model_name - Model ID
+  - status - Message status
+  - from_end_user_id - ID of the sending user
+  - from_account_id - ID of the sending account
+  - agent_based - Whether the message is agent-based
+  - workflow_run_id - Workflow run ID
+  - from_source - Message source
+
+#### **Tool Trace Information**
+
+**Used to track tool invocation**
+
+<table>
+  <thead>
+    <tr>
+      <th>Tool</th>
+      <th>Phoenix Tool</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>tool_name</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["tool", tool_name]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+#### **Tool Trace Info**
+
+- message_id - Message ID
+- tool_name - Tool name
+- start_time - Start time
+- end_time - End time
+- tool_inputs - Tool inputs
+- tool_outputs - Tool outputs
+- message_data - Message data
+- error - Error information, if any
+- inputs - Inputs for the message
+- outputs - Outputs of the message
+- tool_config - Tool configuration
+- time_cost - Time cost
+- tool_parameters - Tool parameters
+- file_url - URL of the associated file
+- Metadata
+  - message_id - Message ID
+  - tool_name - Tool name
+  - tool_inputs - Tool inputs
+  - tool_outputs - Tool outputs
+  - tool_config - Tool configuration
+  - time_cost - Time cost
+  - error - Error information, if any
+  - tool_parameters - Tool parameters
+  - message_file_id - Message file ID
+  - created_by_role - Role of the creator
+  - created_user_id - User ID of the creator
+
+**Generate Name Trace Information**
+
+**Used to track conversation title generation**
+
+<table>
+  <thead>
+    <tr>
+      <th>Generate Name</th>
+      <th>Phoenix Tool</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- placed in metadata</td>
+    </tr>
+    <tr>
+      <td>"generate_conversation_name"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["generate_name"]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**Generate Name Trace Info**
+
+- conversation_id - Conversation ID
+- inputs - Input data
+- outputs - Generated conversation name
+- start_time - Start time
+- end_time - End time
+- tenant_id - Tenant ID
+- Metadata
+  - conversation_id - Conversation ID
+  - tenant_id - Tenant ID
+
+{/*
+Contributing Section
+DO NOT edit this section!
+It will be automatically generated by the script.
+*/}
+
+---
+
+[Edit this page](https://github.com/langgenius/dify-docs/edit/main/en/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx) | [Report an issue](https://github.com/langgenius/dify-docs/issues/new?title=Documentation%20Issue%3A%20rate-o&body=%23%23%20Issue%20Description%0A%3C%21--%20Please%20briefly%20describe%20the%20issue%20you%20found%20--%3E%0A%0A%23%23%20Page%20Link%0Ahttps%3A%2F%2Fgithub.com%2Flanggenius%2Fdify-docs%2Fblob%2Fmain%2Fen/guides/monitoring/integrate-external-ops-tools%2Fintegrate-phoenix.mdx%0A%0A%23%23%20Suggested%20Changes%0A%3C%21--%20If%20you%20have%20specific%20suggestions%20for%20changes%2C%20please%20describe%20them%20here%20--%3E%0A%0A%3C%21--%20Thank%20you%20for%20helping%20improve%20our%20documentation%21%20--%3E)
+

--- a/ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-arize.mdx
+++ b/ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-arize.mdx
@@ -1,0 +1,522 @@
+---
+title: Arizeの統合
+---
+
+
+### 1 Arizeとは
+
+エンタープライズグレードのLLM可観測性、オンラインおよびオフライン評価、モニタリング、実験—OpenTelemetryによって支えられています。LLMおよびエージェント駆動型アプリケーション向けに特別に設計されています。
+
+<Info>
+Arizeの公式サイト：[https://arize.com](https://arize.com)
+</Info>
+
+***
+
+### 2 Arizeの使い方
+
+#### 1. Arizeの[公式サイト](https://app.arize.com/auth/join)から登録し、ログインする。
+
+### 2. Arize APIキーの取得
+
+右上のユーザーメニューから**API Key**を選択し、APIキーを取得・コピーしてください。
+
+![Arize APIキー](https://i.ibb.co/JwBmQxnf/dify-docs-arize-api-key.png)
+
+### 3. ArizeとDifyを統合
+
+DifyアプリケーションでArizeを設定します。監視するアプリケーションを開き、サイドメニューで**監視**を選択し、ページ上の**アプリケーションパフォーマンスを追跡**をクリックします。
+
+![アプリケーションパフォーマンスを追跡](https://i.ibb.co/v6cL6rPs/dify-docs-arize-in-use.png)
+
+設定後、Arizeで作成した**API Key**, **Space ID**と**プロジェクト名**を設定ページに貼り付けて保存します。
+
+![Arizeの設定](https://i.ibb.co/m5Xww8gL/dify-docs-arize-config.png)
+
+保存に成功すると、現在のページで監視ステータスを確認できます。
+
+![Arizeの設定](https://i.ibb.co/xtggVmb7/dify-docs-arize-in-service.png)
+
+## モニタリングデータリスト
+
+### **ワークフロー/会話フロートラッキング情報**
+
+**ワークフローと会話フローの追跡に使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>ワークフロー</th>
+      <th>Arizeトラッキング</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>workflow_app_log_id/workflow_run_id</td>
+      <td>id</td>
+    </tr>
+    <tr>
+      <td>user_session_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>workflow\_{id}</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>モデルトークン消費</td>
+      <td>usage_metadata</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>error</td>
+      <td>error</td>
+    </tr>
+    <tr>
+      <td>\[workflow]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>"conversation_id/none for workflow"</td>
+      <td>conversation_id in metadata</td>
+    </tr>
+  </tbody>
+</table>
+**ワークフロートラッキング情報**
+
+- workflow_id - ワークフローの一意識別子
+- conversation_id - 会話ID
+- workflow_run_id - 現在の実行ID
+- tenant_id - テナントID
+- elapsed_time - 現在の実行にかかった時間
+- status - 実行ステータス
+- version - ワークフローバージョン
+- total_tokens - 現在の実行で使用されたトークン総数
+- file_list - 処理されたファイルのリスト
+- triggered_from - 実行をトリガーしたソース
+- workflow_run_inputs - 現在の実行の入力データ
+- workflow_run_outputs - 現在の実行の出力データ
+- error - 実行中に発生したエラー
+- query - 実行中に使用されたクエリ
+- workflow_app_log_id - ワークフローアプリケーションログID
+- message_id - 関連するメッセージID
+- start_time - 実行開始時間
+- end_time - 実行終了時間
+- workflow node executions - ワークフローノードの実行情報
+- メタデータ
+  - workflow_id - ワークフローの一意識別子
+  - conversation_id - 会話ID
+  - workflow_run_id - 現在の実行ID
+  - tenant_id - テナントID
+  - elapsed_time - 現在の実行にかかった時間
+  - status - 実行ステータス
+  - version - ワークフローバージョン
+  - total_tokens - 現在の実行で使用されたトークン総数
+  - file_list - 処理されたファイルのリスト
+  - triggered_from - 実行をトリガーしたソース
+
+---
+
+### **メッセージトラッキング情報**
+
+**LLM関連の会話を追跡するために使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>チャット</th>
+      <th>Arize LLM</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>message_id</td>
+      <td>id</td>
+    </tr>
+    <tr>
+      <td>user_session_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>"llm"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>モデルトークン消費</td>
+      <td>usage_metadata</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["message", conversation_mode]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>conversation_id</td>
+      <td>conversation_id in metadata</td>
+    </tr>
+  </tbody>
+</table>
+**メッセージトラッキング情報**
+
+- message_id - メッセージID
+- message_data - メッセージデータ
+- user_session_id - ユーザーセッションID
+- conversation_model - 会話モード
+- message_tokens - メッセージ内のトークン数
+- answer_tokens - 回答内のトークン数
+- total_tokens - メッセージと回答のトークン総数
+- error - エラー情報
+- inputs - 入力データ
+- outputs - 出力データ
+- file_list - 処理されたファイルリスト
+- start_time - 開始時間
+- end_time - 終了時間
+- message_file_data - メッセージ関連のファイルデータ
+- conversation_mode - 会話モード
+- メタデータ
+  - conversation_id - 会話ID
+  - ls_provider - モデルプロバイダー
+  - ls_model_name - モデルID
+  - status - メッセージステータス
+  - from_end_user_id - 送信ユーザーID
+  - from_account_id - 送信アカウントID
+  - agent_based - エージェントベースかどうか
+  - workflow_run_id - ワークフロー実行ID
+  - from_source - メッセージソース
+
+### **レビュー追跡情報**
+
+**会話のレビューを追跡するために使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>レビュー</th>
+      <th>Arize Tool</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>"moderation"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["moderation"]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**レビュー追跡情報**
+
+- message_id - メッセージID
+- user_id - ユーザーID
+- workflow_app_log_id - ワークフローアプリケーションログID
+- inputs - レビュー入力データ
+- message_data - メッセージデータ
+- flagged - 注意が必要とマークされたかどうか
+- action - 実施された具体的なアクション
+- preset_response - プリセットレスポンス
+- start_time - レビュー開始時間
+- end_time - レビュー終了時間
+- メタデータ
+  - message_id - メッセージID
+  - action - 実施されたアクション
+  - preset_response - プリセットレスポンス
+
+---
+
+### **提案質問追跡情報**
+
+**提案質問を追跡するために使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>提案質問</th>
+      <th>Arize LLM</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>"suggested_question"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["suggested_question"]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**提案質問追跡情報**
+
+- message_id - メッセージID
+- message_data - メッセージデータ
+- inputs - 入力データ
+- outputs - 出力データ
+- start_time - 開始時間
+- end_time - 終了時間
+- total_tokens - トークン総数
+- status - メッセージステータス
+- error - エラー情報
+- from_account_id - 送信アカウントID
+- agent_based - エージェントベースかどうか
+- from_source - メッセージの送信元
+- model_provider - モデルプロバイダー
+- model_id - モデルID
+- suggested_question - 提案された質問
+- level - ステータスレベル
+- status_message - ステータスメッセージ
+- メタデータ
+  - message_id - メッセージID
+  - ls_provider - モデルプロバイダー
+  - ls_model_name - モデルID
+  - status - メッセージステータス
+  - from_end_user_id - 送信ユーザーID
+  - from_account_id - 送信アカウントID
+  - workflow_run_id - ワークフロー実行ID
+  - from_source - メッセージの送信元
+
+---
+
+### **データセット検索追跡情報**
+
+**ナレッジベース検索を追跡するために使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>データセット検索</th>
+      <th>Arize Retriever</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>"dataset_retrieval"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["dataset_retrieval"]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>message_id</td>
+      <td>parent_run_id</td>
+    </tr>
+  </tbody>
+</table>
+**データセット検索追跡情報**
+
+- message_id - メッセージID
+- inputs - 入力データ
+- documents - ドキュメントデータ
+- start_time - 開始時間
+- end_time - 終了時間
+- message_data - メッセージデータ
+- メタデータ
+  - message_id - メッセージID
+  - ls_provider - モデルプロバイダー
+  - ls_model_name - モデルID
+  - status - メッセージステータス
+  - from_end_user_id - 送信ユーザーID
+  - from_account_id - 送信アカウントID
+  - agent_based - エージェントベースかどうか
+  - workflow_run_id - ワークフロー実行ID
+  - from_source - メッセージの送信元
+
+---
+
+### **ツール追跡情報**
+
+**ツールの呼び出しを追跡するために使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>ツール</th>
+      <th>Arize Tool</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>tool_name</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["tool", tool_name]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**ツール追跡情報**
+
+- message_id - メッセージID
+- tool_name - ツール名
+- start_time - 開始時間
+- end_time - 終了時間
+- tool_inputs - ツール入力
+- tool_outputs - ツール出力
+- message_data - メッセージデータ
+- error - エラー情報（該当する場合）
+- inputs - メッセージの入力
+- outputs - メッセージの出力
+- tool_config - ツール設定
+- time_cost - 時間コスト
+- tool_parameters - ツールパラメーター
+- file_url - 関連するファイルのURL
+- メタデータ
+  - message_id - メッセージID
+  - tool_name - ツール名
+  - tool_inputs - ツール入力
+  - tool_outputs - ツール出力
+  - tool_config - ツール設定
+  - time_cost - 時間コスト
+  - error - エラー情報（該当する場合）
+  - tool_parameters - ツールパラメーター
+  - message_file_id - メッセージファイルID
+  - created_by_role - 作成者の役割
+  - created_user_id - 作成者ユーザーID
+
+{/*
+Contributing Section
+DO NOT edit this section!
+It will be automatically generated by the script.
+*/}
+
+---
+
+[このページを編集する](https://github.com/langgenius/dify-docs/edit/main/ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-arize.mdx) | [問題を報告する](https://github.com/langgenius/dify-docs/issues/new?title=ドキュメントの問題%3A%20rate-o&body=%23%23%20問題の説明%0A%3C%21--%20発見した問題について簡単に説明してください%20--%3E%0A%0A%23%23%20ページリンク%0Ahttps%3A%2F%2Fgithub.com%2Flanggenius%2Fdify-docs%2Fblob%2Fmain%2Fja-jp/guides/monitoring/integrate-external-ops-tools%2Fintegrate-arize.mdx%0A%0A%23%23%20提案される変更%0A%3C%21--%20特定の変更案がある場合は、ここで説明してください%20--%3E%0A%0A%3C%21--%20ドキュメントの品質向上にご協力いただきありがとうございます！%20--%3E)
+

--- a/ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
+++ b/ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
@@ -1,0 +1,522 @@
+---
+title: Phoenixの統合
+---
+
+
+### 1 Phoenixとは
+
+オープンソースおよびOpenTelemetryベースの可観測性、評価、プロンプトエンジニアリング、実験プラットフォームで、LLMワークフローおよびエージェントに対応します。
+
+<Info>
+Phoenixの公式サイト：[https://phoenix.arize.com](https://phoenix.arize.com)
+</Info>
+
+***
+
+### 2 Phoenixの使い方
+
+#### 1. Phoenixの[公式サイト](https://app.arize.com/auth/phoenix/signup)から登録し、ログインする。
+
+### 2. Phoenix APIキーの取得
+
+右上のユーザーメニューから**API Key**を選択し、APIキーを取得・コピーしてください。
+
+![Phoenix APIキー](https://i.ibb.co/pB1W0pk8/dify-docs-phoenix-api-key.png)
+
+### 3. PhoenixとDifyを統合
+
+DifyアプリケーションでPhoenixを設定します。監視するアプリケーションを開き、サイドメニューで**監視**を選択し、ページ上の**アプリケーションパフォーマンスを追跡**をクリックします。
+
+![アプリケーションパフォーマンスを追跡](https://i.ibb.co/gMmXxfhQ/dify-docs-phoenix-in-use.png)
+
+設定後、Phoenixで作成した**API Key**と**プロジェクト名**を設定ページに貼り付けて保存します。
+
+![Phoenixの設定](https://i.ibb.co/jv6QFbp7/dify-docs-phoenix-config.png)
+
+保存に成功すると、現在のページで監視ステータスを確認できます。
+
+![Phoenixの設定](https://i.ibb.co/HTJsj9x2/dify-docs-phoenix-in-service.png)
+
+## モニタリングデータリスト
+
+### **ワークフロー/会話フロートラッキング情報**
+
+**ワークフローと会話フローの追跡に使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>ワークフロー</th>
+      <th>Phoenixトラッキング</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>workflow_app_log_id/workflow_run_id</td>
+      <td>id</td>
+    </tr>
+    <tr>
+      <td>user_session_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>workflow\_{id}</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>モデルトークン消費</td>
+      <td>usage_metadata</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>error</td>
+      <td>error</td>
+    </tr>
+    <tr>
+      <td>\[workflow]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>"conversation_id/none for workflow"</td>
+      <td>conversation_id in metadata</td>
+    </tr>
+  </tbody>
+</table>
+**ワークフロートラッキング情報**
+
+- workflow_id - ワークフローの一意識別子
+- conversation_id - 会話ID
+- workflow_run_id - 現在の実行ID
+- tenant_id - テナントID
+- elapsed_time - 現在の実行にかかった時間
+- status - 実行ステータス
+- version - ワークフローバージョン
+- total_tokens - 現在の実行で使用されたトークン総数
+- file_list - 処理されたファイルのリスト
+- triggered_from - 実行をトリガーしたソース
+- workflow_run_inputs - 現在の実行の入力データ
+- workflow_run_outputs - 現在の実行の出力データ
+- error - 実行中に発生したエラー
+- query - 実行中に使用されたクエリ
+- workflow_app_log_id - ワークフローアプリケーションログID
+- message_id - 関連するメッセージID
+- start_time - 実行開始時間
+- end_time - 実行終了時間
+- workflow node executions - ワークフローノードの実行情報
+- メタデータ
+  - workflow_id - ワークフローの一意識別子
+  - conversation_id - 会話ID
+  - workflow_run_id - 現在の実行ID
+  - tenant_id - テナントID
+  - elapsed_time - 現在の実行にかかった時間
+  - status - 実行ステータス
+  - version - ワークフローバージョン
+  - total_tokens - 現在の実行で使用されたトークン総数
+  - file_list - 処理されたファイルのリスト
+  - triggered_from - 実行をトリガーしたソース
+
+---
+
+### **メッセージトラッキング情報**
+
+**LLM関連の会話を追跡するために使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>チャット</th>
+      <th>Phoenix LLM</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>message_id</td>
+      <td>id</td>
+    </tr>
+    <tr>
+      <td>user_session_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>"llm"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>モデルトークン消費</td>
+      <td>usage_metadata</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["message", conversation_mode]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>conversation_id</td>
+      <td>conversation_id in metadata</td>
+    </tr>
+  </tbody>
+</table>
+**メッセージトラッキング情報**
+
+- message_id - メッセージID
+- message_data - メッセージデータ
+- user_session_id - ユーザーセッションID
+- conversation_model - 会話モード
+- message_tokens - メッセージ内のトークン数
+- answer_tokens - 回答内のトークン数
+- total_tokens - メッセージと回答のトークン総数
+- error - エラー情報
+- inputs - 入力データ
+- outputs - 出力データ
+- file_list - 処理されたファイルリスト
+- start_time - 開始時間
+- end_time - 終了時間
+- message_file_data - メッセージ関連のファイルデータ
+- conversation_mode - 会話モード
+- メタデータ
+  - conversation_id - 会話ID
+  - ls_provider - モデルプロバイダー
+  - ls_model_name - モデルID
+  - status - メッセージステータス
+  - from_end_user_id - 送信ユーザーID
+  - from_account_id - 送信アカウントID
+  - agent_based - エージェントベースかどうか
+  - workflow_run_id - ワークフロー実行ID
+  - from_source - メッセージソース
+
+### **レビュー追跡情報**
+
+**会話のレビューを追跡するために使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>レビュー</th>
+      <th>Phoenix Tool</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>"moderation"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["moderation"]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**レビュー追跡情報**
+
+- message_id - メッセージID
+- user_id - ユーザーID
+- workflow_app_log_id - ワークフローアプリケーションログID
+- inputs - レビュー入力データ
+- message_data - メッセージデータ
+- flagged - 注意が必要とマークされたかどうか
+- action - 実施された具体的なアクション
+- preset_response - プリセットレスポンス
+- start_time - レビュー開始時間
+- end_time - レビュー終了時間
+- メタデータ
+  - message_id - メッセージID
+  - action - 実施されたアクション
+  - preset_response - プリセットレスポンス
+
+---
+
+### **提案質問追跡情報**
+
+**提案質問を追跡するために使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>提案質問</th>
+      <th>Phoenix LLM</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>"suggested_question"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["suggested_question"]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**提案質問追跡情報**
+
+- message_id - メッセージID
+- message_data - メッセージデータ
+- inputs - 入力データ
+- outputs - 出力データ
+- start_time - 開始時間
+- end_time - 終了時間
+- total_tokens - トークン総数
+- status - メッセージステータス
+- error - エラー情報
+- from_account_id - 送信アカウントID
+- agent_based - エージェントベースかどうか
+- from_source - メッセージの送信元
+- model_provider - モデルプロバイダー
+- model_id - モデルID
+- suggested_question - 提案された質問
+- level - ステータスレベル
+- status_message - ステータスメッセージ
+- メタデータ
+  - message_id - メッセージID
+  - ls_provider - モデルプロバイダー
+  - ls_model_name - モデルID
+  - status - メッセージステータス
+  - from_end_user_id - 送信ユーザーID
+  - from_account_id - 送信アカウントID
+  - workflow_run_id - ワークフロー実行ID
+  - from_source - メッセージの送信元
+
+---
+
+### **データセット検索追跡情報**
+
+**ナレッジベース検索を追跡するために使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>データセット検索</th>
+      <th>Phoenix Retriever</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>"dataset_retrieval"</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["dataset_retrieval"]</td>
+      <td>tags</td>
+    </tr>
+    <tr>
+      <td>message_id</td>
+      <td>parent_run_id</td>
+    </tr>
+  </tbody>
+</table>
+**データセット検索追跡情報**
+
+- message_id - メッセージID
+- inputs - 入力データ
+- documents - ドキュメントデータ
+- start_time - 開始時間
+- end_time - 終了時間
+- message_data - メッセージデータ
+- メタデータ
+  - message_id - メッセージID
+  - ls_provider - モデルプロバイダー
+  - ls_model_name - モデルID
+  - status - メッセージステータス
+  - from_end_user_id - 送信ユーザーID
+  - from_account_id - 送信アカウントID
+  - agent_based - エージェントベースかどうか
+  - workflow_run_id - ワークフロー実行ID
+  - from_source - メッセージの送信元
+
+---
+
+### **ツール追跡情報**
+
+**ツールの呼び出しを追跡するために使用**
+
+<table>
+  <thead>
+    <tr>
+      <th>ツール</th>
+      <th>Phoenix Tool</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user_id</td>
+      <td>- メタデータに配置</td>
+    </tr>
+    <tr>
+      <td>tool_name</td>
+      <td>name</td>
+    </tr>
+    <tr>
+      <td>start_time</td>
+      <td>start_time</td>
+    </tr>
+    <tr>
+      <td>end_time</td>
+      <td>end_time</td>
+    </tr>
+    <tr>
+      <td>inputs</td>
+      <td>inputs</td>
+    </tr>
+    <tr>
+      <td>outputs</td>
+      <td>outputs</td>
+    </tr>
+    <tr>
+      <td>metadata</td>
+      <td>metadata</td>
+    </tr>
+    <tr>
+      <td>\["tool", tool_name]</td>
+      <td>tags</td>
+    </tr>
+  </tbody>
+</table>
+**ツール追跡情報**
+
+- message_id - メッセージID
+- tool_name - ツール名
+- start_time - 開始時間
+- end_time - 終了時間
+- tool_inputs - ツール入力
+- tool_outputs - ツール出力
+- message_data - メッセージデータ
+- error - エラー情報（該当する場合）
+- inputs - メッセージの入力
+- outputs - メッセージの出力
+- tool_config - ツール設定
+- time_cost - 時間コスト
+- tool_parameters - ツールパラメーター
+- file_url - 関連するファイルのURL
+- メタデータ
+  - message_id - メッセージID
+  - tool_name - ツール名
+  - tool_inputs - ツール入力
+  - tool_outputs - ツール出力
+  - tool_config - ツール設定
+  - time_cost - 時間コスト
+  - error - エラー情報（該当する場合）
+  - tool_parameters - ツールパラメーター
+  - message_file_id - メッセージファイルID
+  - created_by_role - 作成者の役割
+  - created_user_id - 作成者ユーザーID
+
+{/*
+Contributing Section
+DO NOT edit this section!
+It will be automatically generated by the script.
+*/}
+
+---
+
+[このページを編集する](https://github.com/langgenius/dify-docs/edit/main/ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx) | [問題を報告する](https://github.com/langgenius/dify-docs/issues/new?title=ドキュメントの問題%3A%20rate-o&body=%23%23%20問題の説明%0A%3C%21--%20発見した問題について簡単に説明してください%20--%3E%0A%0A%23%23%20ページリンク%0Ahttps%3A%2F%2Fgithub.com%2Flanggenius%2Fdify-docs%2Fblob%2Fmain%2Fja-jp/guides/monitoring/integrate-external-ops-tools%2Fintegrate-phoenix.mdx%0A%0A%23%23%20提案される変更%0A%3C%21--%20特定の変更案がある場合は、ここで説明してください%20--%3E%0A%0A%3C%21--%20ドキュメントの品質向上にご協力いただきありがとうございます！%20--%3E)
+

--- a/zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-arize.mdx
+++ b/zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-arize.mdx
@@ -1,0 +1,348 @@
+---
+title: 集成 Arize
+---
+
+### Arize 简介
+
+企业级LLM可观测性、在线和离线评估、监控和实验平台，基于OpenTelemetry构建，专为LLM和代理驱动的应用程序设计。
+
+<Callout>
+Arize [官网介绍](https://arize.com)
+</Callout>
+
+***
+
+### 配置 Arize
+
+本章节将指引你注册 Arize 并将其集成至 Dify 平台内。
+
+#### 1. 注册/登录 [Arize](https://app.arize.com/auth/join)
+
+### 2. 获取 Arize API 密钥
+
+从右上角的用户菜单中获取 Arize API 密钥。点击 **API Key**，然后点击 API Key 进行复制：
+
+<img
+src="https://i.ibb.co/JwBmQxnf/dify-docs-arize-api-key.png"
+className="mx-auto"
+alt=""
+/>
+
+### 3. 集成 Arize 与 Dify
+
+在 Dify 应用程序中配置 Arize。打开需要监控的应用程序，在侧边菜单中打开**监控**，并在页面上选择**追踪应用性能**。
+
+<img
+src="https://i.ibb.co/v6cL6rPs/dify-docs-arize-in-use.png"
+className="mx-auto"
+alt=""
+/>
+
+点击配置后，将在 Arize 中创建的 **API Key**, **Space ID** 和**项目名称**粘贴到配置中并保存。
+
+<img
+src="https://i.ibb.co/m5Xww8gL/dify-docs-arize-config.png"
+className="mx-auto"
+alt=""
+/>
+
+成功保存后，你可以在当前页面查看监控状态。
+
+<img
+src="https://i.ibb.co/xtggVmb7/dify-docs-arize-in-service.png"
+className="mx-auto"
+alt=""
+/>
+
+## 监控数据列表
+
+### **工作流/对话流追踪信息**
+
+**用于追踪工作流和对话流**
+
+| 工作流                              | Arize 追踪                   |
+| ---------------------------------- | -------------------------- |
+| workflow_app_log_id/workflow_run_id | id                         |
+| user_session_id                     | - 放置在元数据中            |
+| `workflow_{id}`                      | name                       |
+| start_time                          | start_time                 |
+| end_time                            | end_time                   |
+| inputs                              | inputs                     |
+| outputs                             | outputs                    |
+| Model token consumption             | usage_metadata             |
+| metadata                            | metadata                   |
+| error                               | error                      |
+| \[workflow]                         | tags                       |
+| conversation_id/none for workflow | conversation_id in metadata |
+
+**工作流追踪信息**
+
+- workflow_id - 工作流唯一标识符
+- conversation_id - 对话 ID
+- workflow_run_id - 当前运行的 ID
+- tenant_id - 租户 ID
+- elapsed_time - 当前运行所用时间
+- status - 运行状态
+- version - 工作流版本
+- total_tokens - 当前运行使用的总令牌数
+- file_list - 处理的文件列表
+- triggered_from - 触发当前运行的来源
+- workflow_run_inputs - 当前运行的输入数据
+- workflow_run_outputs - 当前运行的输出数据
+- error - 当前运行期间遇到的错误
+- query - 运行期间使用的查询
+- workflow_app_log_id - 工作流应用程序日志 ID
+- message_id - 关联的消息 ID
+- start_time - 运行开始时间
+- end_time - 运行结束时间
+- workflow node executions - 工作流节点执行信息
+- 元数据
+  - workflow_id - 工作流唯一标识符
+  - conversation_id - 对话 ID
+  - workflow_run_id - 当前运行的 ID
+  - tenant_id - 租户 ID
+  - elapsed_time - 当前运行所用时间
+  - status - 运行状态
+  - version - 工作流版本
+  - total_tokens - 当前运行使用的总令牌数
+  - file_list - 处理的文件列表
+  - triggered_from - 触发当前运行的来源
+
+#### **消息追踪信息**
+
+**用于追踪 LLM 相关对话**
+
+| 聊天                            | Arize LLM                    |
+| ------------------------------- | --------------------------- |
+| message_id                      | id                          |
+| user_session_id                 | - 放置在元数据中             |
+| "llm"                           | name                        |
+| start_time                      | start_time                  |
+| end_time                        | end_time                    |
+| inputs                          | inputs                      |
+| outputs                         | outputs                     |
+| Model token consumption         | usage_metadata              |
+| metadata                        | metadata                    |
+| \["message", conversation_mode] | tags                        |
+| conversation_id                 | conversation_id in metadata |
+
+**消息追踪信息**
+
+- message_id - 消息 ID
+- message_data - 消息数据
+- user_session_id - 用户会话 ID
+- conversation_model - 对话模式
+- message_tokens - 消息中的令牌数
+- answer_tokens - 答案中的令牌数
+- total_tokens - 消息和答案中的总令牌数
+- error - 错误信息
+- inputs - 输入数据
+- outputs - 输出数据
+- file_list - 处理的文件列表
+- start_time - 开始时间
+- end_time - 结束时间
+- message_file_data - 与消息关联的文件数据
+- conversation_mode - 对话模式
+- 元数据
+  - conversation_id - 对话 ID
+  - ls_provider - 模型提供商
+  - ls_model_name - 模型 ID
+  - status - 消息状态
+  - from_end_user_id - 发送用户的 ID
+  - from_account_id - 发送账户的 ID
+  - agent_based - 消息是否基于代理
+  - workflow_run_id - 工作流运行 ID
+  - from_source - 消息来源
+
+#### **审核追踪信息**
+
+**用于追踪对话审核**
+
+| 审核           | Arize Tool         |
+| -------------- | ----------------- |
+| user_id        | - 放置在元数据中   |
+| "moderation"   | name              |
+| start_time     | start_time        |
+| end_time       | end_time          |
+| inputs         | inputs            |
+| outputs        | outputs           |
+| metadata       | metadata          |
+| \["moderation"]| tags              |
+
+**审核追踪信息**
+
+- message_id - 消息 ID
+- user_id - 用户 ID
+- workflow_app_log_id - 工作流应用程序日志 ID
+- inputs - 审核输入数据
+- message_data - 消息数据
+- flagged - 内容是否被标记需要注意
+- action - 采取的具体行动
+- preset_response - 预设响应
+- start_time - 审核开始时间
+- end_time - 审核结束时间
+- 元数据
+  - message_id - 消息 ID
+  - action - 采取的具体行动
+  - preset_response - 预设响应
+
+#### **建议问题追踪信息**
+
+**用于追踪建议问题**
+
+| 建议问题              | Arize LLM          |
+| --------------------- | ----------------- |
+| user_id               | - 放置在元数据中   |
+| "suggested_question"  | name              |
+| start_time            | start_time        |
+| end_time              | end_time          |
+| inputs                | inputs            |
+| outputs               | outputs           |
+| metadata              | metadata          |
+| \["suggested_question"]| tags             |
+
+**消息追踪信息**
+
+- message_id - 消息 ID
+- message_data - 消息数据
+- inputs - 输入内容
+- outputs - 输出内容
+- start_time - 开始时间
+- end_time - 结束时间
+- total_tokens - 令牌数量
+- status - 消息状态
+- error - 错误信息
+- from_account_id - 发送账户的 ID
+- agent_based - 是否基于代理
+- from_source - 消息来源
+- model_provider - 模型提供商
+- model_id - 模型 ID
+- suggested_question - 建议问题
+- level - 状态级别
+- status_message - 状态消息
+- 元数据
+  - message_id - 消息 ID
+  - ls_provider - 模型提供商
+  - ls_model_name - 模型 ID
+  - status - 消息状态
+  - from_end_user_id - 发送用户的 ID
+  - from_account_id - 发送账户的 ID
+  - workflow_run_id - 工作流运行 ID
+  - from_source - 消息来源
+
+#### **数据集检索追踪信息**
+
+**用于追踪知识库检索**
+
+| 数据集检索           | Arize Retriever    |
+| ------------------- | ----------------- |
+| user_id             | - 放置在元数据中   |
+| "dataset_retrieval" | name              |
+| start_time          | start_time        |
+| end_time            | end_time          |
+| inputs              | inputs            |
+| outputs             | outputs           |
+| metadata            | metadata          |
+| \["dataset_retrieval"]| tags            |
+| message_id          | parent_run_id     |
+
+**数据集检索追踪信息**
+
+- message_id - 消息 ID
+- inputs - 输入内容
+- documents - 文档数据
+- start_time - 开始时间
+- end_time - 结束时间
+- message_data - 消息数据
+- 元数据
+  - message_id - 消息 ID
+  - ls_provider - 模型提供商
+  - ls_model_name - 模型 ID
+  - status - 消息状态
+  - from_end_user_id - 发送用户的 ID
+  - from_account_id - 发送账户的 ID
+  - agent_based - 是否基于代理
+  - workflow_run_id - 工作流运行 ID
+  - from_source - 消息来源
+
+#### **工具追踪信息**
+
+**用于追踪工具调用**
+
+| 工具                  | Arize Tool         |
+| -------------------- | ----------------- |
+| user_id              | - 放置在元数据中   |
+| tool_name            | name              |
+| start_time           | start_time        |
+| end_time             | end_time          |
+| inputs               | inputs            |
+| outputs              | outputs           |
+| metadata             | metadata          |
+| \["tool", tool_name] | tags              |
+
+#### **工具追踪信息**
+
+- message_id - 消息 ID
+- tool_name - 工具名称
+- start_time - 开始时间
+- end_time - 结束时间
+- tool_inputs - 工具输入
+- tool_outputs - 工具输出
+- message_data - 消息数据
+- error - 错误信息（如果有）
+- inputs - 消息的输入
+- outputs - 消息的输出
+- tool_config - 工具配置
+- time_cost - 时间消耗
+- tool_parameters - 工具参数
+- file_url - 关联文件的 URL
+- 元数据
+  - message_id - 消息 ID
+  - tool_name - 工具名称
+  - tool_inputs - 工具输入
+  - tool_outputs - 工具输出
+  - tool_config - 工具配置
+  - time_cost - 时间消耗
+  - error - 错误信息（如果有）
+  - tool_parameters - 工具参数
+  - message_file_id - 消息文件 ID
+  - created_by_role - 创建者角色
+  - created_user_id - 创建者用户 ID
+
+#### **生成名称追踪信息**
+
+**用于追踪对话标题生成**
+
+| 生成名称                      | Arize Tool         |
+| ---------------------------- | ----------------- |
+| user_id                      | - 放置在元数据中   |
+| "generate_conversation_name" | name              |
+| start_time                   | start_time        |
+| end_time                     | end_time          |
+| inputs                       | inputs            |
+| outputs                      | outputs           |
+| metadata                     | metadata          |
+| \["generate_name"]           | tags              |
+
+**生成名称追踪信息**
+
+- conversation_id - 对话 ID
+- inputs - 输入数据
+- outputs - 生成的对话名称
+- start_time - 开始时间
+- end_time - 结束时间
+- tenant_id - 租户 ID
+- 元数据
+  - conversation_id - 对话 ID
+  - tenant_id - 租户 ID
+
+{/*
+Contributing Section
+DO NOT edit this section!
+It will be automatically generated by the script.
+*/}
+
+---
+
+[编辑此页面](https://github.com/langgenius/dify-docs/edit/main/zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-arize.mdx) | [提交问题](https://github.com/langgenius/dify-docs/issues/new?title=文档问题%3A%20rate-o&body=%23%23%20问题描述%0A%3C%21--%20请简要描述您发现的问题%20--%3E%0A%0A%23%23%20页面链接%0Ahttps%3A%2F%2Fgithub.com%2Flanggenius%2Fdify-docs%2Fblob%2Fmain%2Fzh-hans/guides/monitoring/integrate-external-ops-tools%2Fintegrate-arize.mdx%0A%0A%23%23%20建议修改%0A%3C%21--%20如果有具体的修改建议，请在此说明%20--%3E%0A%0A%3C%21--%20感谢您对文档质量的关注！%20--%3E)
+

--- a/zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
+++ b/zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
@@ -1,0 +1,348 @@
+---
+title: 集成 Phoenix
+---
+
+### Phoenix 简介
+
+开源且基于OpenTelemetry的可观测性、评估、提示工程和实验平台，适用于您的LLM工作流程和代理。
+
+<Callout>
+Phoenix [官网介绍](https://phoenix.arize.com)
+</Callout>
+
+***
+
+### 配置 Phoenix
+
+本章节将指引你注册 Phoenix 并将其集成至 Dify 平台内。
+
+#### 1. 注册/登录 [Phoenix](https://app.arize.com/auth/phoenix/signup)
+
+### 2. 获取 Phoenix API 密钥
+
+从右上角的用户菜单中获取 Phoenix API 密钥。点击 **API Key**，然后点击 API Key 进行复制：
+
+<img
+src="https://i.ibb.co/pB1W0pk8/dify-docs-phoenix-api-key.png"
+className="mx-auto"
+alt=""
+/>
+
+### 3. 集成 Phoenix 与 Dify
+
+在 Dify 应用程序中配置 Phoenix。打开需要监控的应用程序，在侧边菜单中打开**监控**，并在页面上选择**追踪应用性能**。
+
+<img
+src="https://i.ibb.co/gMmXxfhQ/dify-docs-phoenix-in-use.png"
+className="mx-auto"
+alt=""
+/>
+
+点击配置后，将在 Phoenix 中创建的 **API Key** 和**项目名称**粘贴到配置中并保存。
+
+<img
+src="https://i.ibb.co/jv6QFbp7/dify-docs-phoenix-config.png"
+className="mx-auto"
+alt=""
+/>
+
+成功保存后，你可以在当前页面查看监控状态。
+
+<img
+src="https://i.ibb.co/HTJsj9x2/dify-docs-phoenix-in-service.png"
+className="mx-auto"
+alt=""
+/>
+
+## 监控数据列表
+
+### **工作流/对话流追踪信息**
+
+**用于追踪工作流和对话流**
+
+| 工作流                              | Phoenix 追踪                   |
+| ---------------------------------- | -------------------------- |
+| workflow_app_log_id/workflow_run_id | id                         |
+| user_session_id                     | - 放置在元数据中            |
+| `workflow_{id}`                      | name                       |
+| start_time                          | start_time                 |
+| end_time                            | end_time                   |
+| inputs                              | inputs                     |
+| outputs                             | outputs                    |
+| Model token consumption             | usage_metadata             |
+| metadata                            | metadata                   |
+| error                               | error                      |
+| \[workflow]                         | tags                       |
+| conversation_id/none for workflow | conversation_id in metadata |
+
+**工作流追踪信息**
+
+- workflow_id - 工作流唯一标识符
+- conversation_id - 对话 ID
+- workflow_run_id - 当前运行的 ID
+- tenant_id - 租户 ID
+- elapsed_time - 当前运行所用时间
+- status - 运行状态
+- version - 工作流版本
+- total_tokens - 当前运行使用的总令牌数
+- file_list - 处理的文件列表
+- triggered_from - 触发当前运行的来源
+- workflow_run_inputs - 当前运行的输入数据
+- workflow_run_outputs - 当前运行的输出数据
+- error - 当前运行期间遇到的错误
+- query - 运行期间使用的查询
+- workflow_app_log_id - 工作流应用程序日志 ID
+- message_id - 关联的消息 ID
+- start_time - 运行开始时间
+- end_time - 运行结束时间
+- workflow node executions - 工作流节点执行信息
+- 元数据
+  - workflow_id - 工作流唯一标识符
+  - conversation_id - 对话 ID
+  - workflow_run_id - 当前运行的 ID
+  - tenant_id - 租户 ID
+  - elapsed_time - 当前运行所用时间
+  - status - 运行状态
+  - version - 工作流版本
+  - total_tokens - 当前运行使用的总令牌数
+  - file_list - 处理的文件列表
+  - triggered_from - 触发当前运行的来源
+
+#### **消息追踪信息**
+
+**用于追踪 LLM 相关对话**
+
+| 聊天                            | Phoenix LLM                    |
+| ------------------------------- | --------------------------- |
+| message_id                      | id                          |
+| user_session_id                 | - 放置在元数据中             |
+| "llm"                           | name                        |
+| start_time                      | start_time                  |
+| end_time                        | end_time                    |
+| inputs                          | inputs                      |
+| outputs                         | outputs                     |
+| Model token consumption         | usage_metadata              |
+| metadata                        | metadata                    |
+| \["message", conversation_mode] | tags                        |
+| conversation_id                 | conversation_id in metadata |
+
+**消息追踪信息**
+
+- message_id - 消息 ID
+- message_data - 消息数据
+- user_session_id - 用户会话 ID
+- conversation_model - 对话模式
+- message_tokens - 消息中的令牌数
+- answer_tokens - 答案中的令牌数
+- total_tokens - 消息和答案中的总令牌数
+- error - 错误信息
+- inputs - 输入数据
+- outputs - 输出数据
+- file_list - 处理的文件列表
+- start_time - 开始时间
+- end_time - 结束时间
+- message_file_data - 与消息关联的文件数据
+- conversation_mode - 对话模式
+- 元数据
+  - conversation_id - 对话 ID
+  - ls_provider - 模型提供商
+  - ls_model_name - 模型 ID
+  - status - 消息状态
+  - from_end_user_id - 发送用户的 ID
+  - from_account_id - 发送账户的 ID
+  - agent_based - 消息是否基于代理
+  - workflow_run_id - 工作流运行 ID
+  - from_source - 消息来源
+
+#### **审核追踪信息**
+
+**用于追踪对话审核**
+
+| 审核           | Phoenix Tool         |
+| -------------- | ----------------- |
+| user_id        | - 放置在元数据中   |
+| "moderation"   | name              |
+| start_time     | start_time        |
+| end_time       | end_time          |
+| inputs         | inputs            |
+| outputs        | outputs           |
+| metadata       | metadata          |
+| \["moderation"]| tags              |
+
+**审核追踪信息**
+
+- message_id - 消息 ID
+- user_id - 用户 ID
+- workflow_app_log_id - 工作流应用程序日志 ID
+- inputs - 审核输入数据
+- message_data - 消息数据
+- flagged - 内容是否被标记需要注意
+- action - 采取的具体行动
+- preset_response - 预设响应
+- start_time - 审核开始时间
+- end_time - 审核结束时间
+- 元数据
+  - message_id - 消息 ID
+  - action - 采取的具体行动
+  - preset_response - 预设响应
+
+#### **建议问题追踪信息**
+
+**用于追踪建议问题**
+
+| 建议问题              | Phoenix LLM          |
+| --------------------- | ----------------- |
+| user_id               | - 放置在元数据中   |
+| "suggested_question"  | name              |
+| start_time            | start_time        |
+| end_time              | end_time          |
+| inputs                | inputs            |
+| outputs               | outputs           |
+| metadata              | metadata          |
+| \["suggested_question"]| tags             |
+
+**消息追踪信息**
+
+- message_id - 消息 ID
+- message_data - 消息数据
+- inputs - 输入内容
+- outputs - 输出内容
+- start_time - 开始时间
+- end_time - 结束时间
+- total_tokens - 令牌数量
+- status - 消息状态
+- error - 错误信息
+- from_account_id - 发送账户的 ID
+- agent_based - 是否基于代理
+- from_source - 消息来源
+- model_provider - 模型提供商
+- model_id - 模型 ID
+- suggested_question - 建议问题
+- level - 状态级别
+- status_message - 状态消息
+- 元数据
+  - message_id - 消息 ID
+  - ls_provider - 模型提供商
+  - ls_model_name - 模型 ID
+  - status - 消息状态
+  - from_end_user_id - 发送用户的 ID
+  - from_account_id - 发送账户的 ID
+  - workflow_run_id - 工作流运行 ID
+  - from_source - 消息来源
+
+#### **数据集检索追踪信息**
+
+**用于追踪知识库检索**
+
+| 数据集检索           | Phoenix Retriever    |
+| ------------------- | ----------------- |
+| user_id             | - 放置在元数据中   |
+| "dataset_retrieval" | name              |
+| start_time          | start_time        |
+| end_time            | end_time          |
+| inputs              | inputs            |
+| outputs             | outputs           |
+| metadata            | metadata          |
+| \["dataset_retrieval"]| tags            |
+| message_id          | parent_run_id     |
+
+**数据集检索追踪信息**
+
+- message_id - 消息 ID
+- inputs - 输入内容
+- documents - 文档数据
+- start_time - 开始时间
+- end_time - 结束时间
+- message_data - 消息数据
+- 元数据
+  - message_id - 消息 ID
+  - ls_provider - 模型提供商
+  - ls_model_name - 模型 ID
+  - status - 消息状态
+  - from_end_user_id - 发送用户的 ID
+  - from_account_id - 发送账户的 ID
+  - agent_based - 是否基于代理
+  - workflow_run_id - 工作流运行 ID
+  - from_source - 消息来源
+
+#### **工具追踪信息**
+
+**用于追踪工具调用**
+
+| 工具                  | Phoenix Tool         |
+| -------------------- | ----------------- |
+| user_id              | - 放置在元数据中   |
+| tool_name            | name              |
+| start_time           | start_time        |
+| end_time             | end_time          |
+| inputs               | inputs            |
+| outputs              | outputs           |
+| metadata             | metadata          |
+| \["tool", tool_name] | tags              |
+
+#### **工具追踪信息**
+
+- message_id - 消息 ID
+- tool_name - 工具名称
+- start_time - 开始时间
+- end_time - 结束时间
+- tool_inputs - 工具输入
+- tool_outputs - 工具输出
+- message_data - 消息数据
+- error - 错误信息（如果有）
+- inputs - 消息的输入
+- outputs - 消息的输出
+- tool_config - 工具配置
+- time_cost - 时间消耗
+- tool_parameters - 工具参数
+- file_url - 关联文件的 URL
+- 元数据
+  - message_id - 消息 ID
+  - tool_name - 工具名称
+  - tool_inputs - 工具输入
+  - tool_outputs - 工具输出
+  - tool_config - 工具配置
+  - time_cost - 时间消耗
+  - error - 错误信息（如果有）
+  - tool_parameters - 工具参数
+  - message_file_id - 消息文件 ID
+  - created_by_role - 创建者角色
+  - created_user_id - 创建者用户 ID
+
+#### **生成名称追踪信息**
+
+**用于追踪对话标题生成**
+
+| 生成名称                      | Phoenix Tool         |
+| ---------------------------- | ----------------- |
+| user_id                      | - 放置在元数据中   |
+| "generate_conversation_name" | name              |
+| start_time                   | start_time        |
+| end_time                     | end_time          |
+| inputs                       | inputs            |
+| outputs                      | outputs           |
+| metadata                     | metadata          |
+| \["generate_name"]           | tags              |
+
+**生成名称追踪信息**
+
+- conversation_id - 对话 ID
+- inputs - 输入数据
+- outputs - 生成的对话名称
+- start_time - 开始时间
+- end_time - 结束时间
+- tenant_id - 租户 ID
+- 元数据
+  - conversation_id - 对话 ID
+  - tenant_id - 租户 ID
+
+{/*
+Contributing Section
+DO NOT edit this section!
+It will be automatically generated by the script.
+*/}
+
+---
+
+[编辑此页面](https://github.com/langgenius/dify-docs/edit/main/zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx) | [提交问题](https://github.com/langgenius/dify-docs/issues/new?title=文档问题%3A%20rate-o&body=%23%23%20问题描述%0A%3C%21--%20请简要描述您发现的问题%20--%3E%0A%0A%23%23%20页面链接%0Ahttps%3A%2F%2Fgithub.com%2Flanggenius%2Fdify-docs%2Fblob%2Fmain%2Fzh-hans/guides/monitoring/integrate-external-ops-tools%2Fintegrate-phoenix.mdx%0A%0A%23%23%20建议修改%0A%3C%21--%20如果有具体的修改建议，请在此说明%20--%3E%0A%0A%3C%21--%20感谢您对文档质量的关注！%20--%3E)
+


### PR DESCRIPTION
This PR adds dedicated documentation pages for integrating Arize and Phoenix with Dify. It includes English, Simplified Chinese, and Japanese versions of the content under the **Integrate External Ops Tools** section. The updates are reflected in `docs.json` for proper navigation. These pages outline the setup instructions, span attribute mappings, and general onboarding guidance for both tools, helping users get started easily.

**Arize Page**
![dify-docs-arize-page](https://github.com/user-attachments/assets/a4f52872-1c66-457f-bd5b-3a02a3a2b5e9)

**Phoenix Page**
![dify-docs-phoenix-page](https://github.com/user-attachments/assets/b615d2e3-be93-4010-93e5-a7f157f91108)
