### PR TITLE
Other page also not including Author in so large manner, so suggest remove in those page

### DIFF
--- a/zh-hans/guides/workflow/bulletin.mdx
+++ b/zh-hans/guides/workflow/bulletin.mdx
@@ -1,6 +1,5 @@
 ---
 title: 变更公告：图片上传被替换为文件上传
-description: 作者：Evanchen，Allen。
 ---
 
 

--- a/zh-hans/guides/workflow/variables.mdx
+++ b/zh-hans/guides/workflow/variables.mdx
@@ -1,6 +1,5 @@
 ---
 title: 变量
-description: 最近编辑：Allen, Dify Technical Writer
 ---
 
 Workflow 和 Chatflow 类型应用由独立节点相构成。大部分节点设有输入和输出项，但每个节点的输入信息不一致，各个节点所输出的答复也不尽相同。

--- a/zh-hans/plugins/faq.mdx
+++ b/zh-hans/plugins/faq.mdx
@@ -1,6 +1,5 @@
 ---
 title: 常见问题
-description: 'Author: Allen'
 ---
 
 

--- a/zh-hans/plugins/quick-start/develop-plugins/README.mdx
+++ b/zh-hans/plugins/quick-start/develop-plugins/README.mdx
@@ -1,6 +1,5 @@
 ---
 title: 插件开发
-description: 'Author: Yeuoly, Allen'
 ---
 
 

--- a/zh-hans/plugins/quick-start/install-plugins.mdx
+++ b/zh-hans/plugins/quick-start/install-plugins.mdx
@@ -1,6 +1,5 @@
 ---
 title: 安装与使用插件
-description: 'Author: Allen'
 ---
 
 

--- a/zh-hans/plugins/schema-definition/endpoint.mdx
+++ b/zh-hans/plugins/schema-definition/endpoint.mdx
@@ -1,6 +1,5 @@
 ---
 title: Endpoint
-description: 'Author: Yeuoly，Allen'
 ---
 
 

--- a/zh-hans/plugins/schema-definition/manifest.mdx
+++ b/zh-hans/plugins/schema-definition/manifest.mdx
@@ -1,6 +1,5 @@
 ---
 title: Manifest
-description: 'Author: Yeuoly，Allen'
 ---
 
 

--- a/zh-hans/policies/agreement/get-compliance-report.mdx
+++ b/zh-hans/policies/agreement/get-compliance-report.mdx
@@ -1,6 +1,5 @@
 ---
 title: 获取合规报告
-description: 'Author: Yongle, Allen'
 ---
 
 


### PR DESCRIPTION
For example:

https://docs.dify.ai/zh-hans/guides/workflow/key-concept

NO description, then turn to next page:

https://docs.dify.ai/zh-hans/guides/workflow/variables


<img width="824" alt="image" src="https://github.com/user-attachments/assets/4233fed6-bf58-47d6-a12d-ba49c8a8b39b" />


Really don't think those information is need to keep, although I'm highly respecting those author. 💗