### PR TITLE
Fix: Generalize tool customization language in agent.mdx

### DIFF
--- a/en/guides/workflow/node/agent.mdx
+++ b/en/guides/workflow/node/agent.mdx
@@ -84,9 +84,9 @@ For example, when users employ pronouns (such as “it”, “this”, or “the
 
 <video controls src="https://assets-docs.dify.ai/2025/04/1801b96763eb8f22f1e2158645897885.mp4" width="100%"></video>
 
-## Customizing MCP Tools for Your Use Case
+## Customizing Tools for Your Use Case
 
-When you add an MCP tool to an agent node or agent, you can customize how it behaves:
+When you add a tool to an agent node or agent, you can customize how it behaves:
 
 <img
   src="/images/CleanShot2025-07-07at07.41.33@2x.png"

--- a/ja-jp/guides/workflow/node/agent.mdx
+++ b/ja-jp/guides/workflow/node/agent.mdx
@@ -84,9 +84,9 @@ title: エージェント
 
 <video controls src="https://assets-docs.dify.ai/2025/04/1801b96763eb8f22f1e2158645897885.mp4" width="100%"></video>
 
-### MCP ツールをユースケースにカスタマイズする
+### ツールをユースケースにカスタマイズする
 
-Agent ノードや Agent に MCP ツールを追加すると、カスタマイズ方法はこちらです：
+Agent ノードや Agent にツールを追加すると、カスタマイズ方法はこちらです：
 
 <img
   src="/images/CleanShot2025-07-07at07.41.33@2x.png"

--- a/zh-hans/guides/workflow/node/agent.mdx
+++ b/zh-hans/guides/workflow/node/agent.mdx
@@ -80,9 +80,9 @@ Agent 节点执行过程中将生成详细日志。显示节点执行的总体�
 
 <video controls src="https://assets-docs.dify.ai/2025/04/1801b96763eb8f22f1e2158645897885.mp4" width="100%"></video>
 
-## 按需定制 MCP 工具
+## 按需定制工具
 
-将 MCP 工具添加到Agent节点或 Agent 应用中后，你可以根据实际需求灵活定制：
+将工具添加到Agent节点或 Agent 应用中后，你可以根据实际需求灵活定制：
 
 <img
   src="/images/CleanShot2025-07-07at07.41.33@2x.png"


### PR DESCRIPTION
- Change 'MCP Tools' to 'Tools' in section headers
- Update description text to be tool-agnostic
- Applied to all three language versions: en, zh-hans, ja-jp
- Only 6 lines changed across 3 files