### PR TITLE
docs: remove outdated cloud storage migration documentation

### DIFF
--- a/en/getting-started/install-self-hosted/install-faq.mdx
+++ b/en/getting-started/install-self-hosted/install-faq.mdx
@@ -246,36 +246,6 @@ These IP addresses are _**examples**_, you must execute the command to get your 
 
 The API service port is consistent with the one used by the Dify platform. You can reassign the running port by modifying the `nginx` configuration in the `docker-compose.yaml` file.
 
-### 22. How to Migrate from Local to Cloud Storage?
-
-To migrate files from local storage to cloud storage (e.g., Alibaba Cloud OSS), you'll need to transfer data from the 'upload_files' and 'privkeys' folders. Follow these steps:
-
-1. Configure Storage Settings
-
-   For local source code deployment:
-   - Update storage settings in `.env` file
-   - Set `STORAGE_TYPE=aliyun-oss`
-   - Configure Alibaba Cloud OSS credentials
-
-   For Docker Compose deployment:
-   - Update storage settings in `docker-compose.yaml`
-   - Set `STORAGE_TYPE: aliyun-oss`
-   - Configure Alibaba Cloud OSS credentials
-
-2. Execute Migration Commands
-
-   For local source code:
-   ```bash
-   flask upload-private-key-file-to-cloud-storage
-   flask upload-local-files-to-cloud-storage
-   ```
-
-   For Docker Compose:
-   ```bash
-   docker exec -it docker-api-1 flask upload-private-key-file-to-cloud-storage
-   docker exec -it docker-api-1 flask upload-local-files-to-cloud-storage
-   ```
-
 {/*
 Contributing Section
 DO NOT edit this section!

--- a/en/learn-more/faq/install-faq.mdx
+++ b/en/learn-more/faq/install-faq.mdx
@@ -252,37 +252,7 @@ This behavior helps reduce potential XSS attacks. For more information on CSP re
 
 The API service port is consistent with the one used by the Dify platform. You can reassign the running port by modifying the `nginx` configuration in the `docker-compose.yaml` file.
 
-### 23. How to Migrate from Local to Cloud Storage?
-
-To migrate files from local storage to cloud storage (e.g., Alibaba Cloud OSS), you'll need to transfer data from the 'upload_files' and 'privkeys' folders. Follow these steps:
-
-1. Configure Storage Settings
-
-   For local source code deployment:
-   - Update storage settings in `.env` file
-   - Set `STORAGE_TYPE=aliyun-oss`
-   - Configure Alibaba Cloud OSS credentials
-
-   For Docker Compose deployment:
-   - Update storage settings in `docker-compose.yaml`
-   - Set `STORAGE_TYPE: aliyun-oss`
-   - Configure Alibaba Cloud OSS credentials
-
-2. Execute Migration Commands
-
-   For local source code:
-   ```bash
-   flask upload-private-key-file-to-cloud-storage
-   flask upload-local-files-to-cloud-storage
-   ```
-
-   For Docker Compose:
-   ```bash
-   docker exec -it docker-api-1 flask upload-private-key-file-to-cloud-storage
-   docker exec -it docker-api-1 flask upload-local-files-to-cloud-storage
-   ```
-
-### 24. How to delete old logs and unused files to reduce storage usage?
+### 23. How to delete old logs and unused files to reduce storage usage?
 
 Dify does **not** automatically delete old logs in database or unused files on storage. Instead, several commands are provided for instance administrators to **manually** delete old logs and unused files.
 

--- a/ja-jp/learn-more/faq/install-faq.mdx
+++ b/ja-jp/learn-more/faq/install-faq.mdx
@@ -247,37 +247,7 @@ docker ps -q | xargs -n 1 docker inspect --format '{{ .Name }}: {{range .Network
 
 API サービスのポートは、Dify プラットフォームで使用されるポートと一致します。`docker-compose.yaml` ファイルの `nginx` 設定を変更することで、実行中のポートを再指定することができます。
 
-### 23. ファイルをローカルストレージからクラウドストレージに移行する方法
-
-ファイルをローカルストレージからクラウドストレージ（例：Alibaba Cloud OSS）に移行するには、'upload_files'と'privkeys'ディレクトリからデータを移行する必要があります。以下の手順に従って操作してください：
-
-1. ストレージ設定を構成する
-
-   ローカルソースコードデプロイメントの方法：
-   - `.env`ファイルでストレージ設定を更新します
-   - `STORAGE_TYPE=aliyun-oss`を設定します
-   - Alibaba Cloud OSSの認証情報を設定します
-
-   Docker Composeデプロイメントの方法：
-   - `docker-compose.yaml`ファイルでストレージ設定を更新します
-   - `STORAGE_TYPE: aliyun-oss`を設定します
-   - Alibaba Cloud OSSの認証情報を設定します
-
-2. 移行コマンドを実行する
-
-   ローカルソースコードの場合：
-   ```bash
-   flask upload-private-key-file-to-cloud-storage
-   flask upload-local-files-to-cloud-storage
-   ```
-
-   Docker Composeの場合：
-   ```bash
-   docker exec -it docker-api-1 flask upload-private-key-file-to-cloud-storage
-   docker exec -it docker-api-1 flask upload-local-files-to-cloud-storage
-   ```
-
-### 24. 古いログや未使用のファイルを削除し、ストレージの使用量を削減する方法
+### 23. 古いログや未使用のファイルを削除し、ストレージの使用量を削減する方法
 
 Dify はデータベース上の古いログやストレージ上の未使用のファイルの自動的な削除は **行いません**。代わりに、インスタンスの管理者が古いログや未使用のファイルを **手動で** 削除できるように、いくつかのコマンドが用意されています。
 

--- a/zh-hans/learn-more/faq/install-faq.mdx
+++ b/zh-hans/learn-more/faq/install-faq.mdx
@@ -252,37 +252,7 @@ docker ps -q | xargs -n 1 docker inspect --format '{{ .Name }}: {{range .Network
 
 API 服务与 Dify 平台使用的端口号相一致。你可以通过修改 `docker-compose.yaml` 文件内的 `nginx` 配置项，重新指定运行端口。
 
-### 23. 如何将文件从本地存储迁移到云存储？
-
-要将文件从本地存储迁移到云存储（如阿里云 OSS），你需要从本地存储目录中的 'upload_files' 和 'privkeys' 文件夹迁移数据。请按照以下步骤操作：
-
-1. 配置存储设置
-
-   对于本地源码部署方式：
-   - 在 `.env` 文件中更新存储设置
-   - 设置 `STORAGE_TYPE=aliyun-oss`
-   - 配置阿里云 OSS 凭证
-
-   对于 Docker Compose 部署方式：
-   - 在 `docker-compose.yaml` 文件中更新存储设置
-   - 设置 `STORAGE_TYPE: aliyun-oss`
-   - 配置阿里云 OSS 凭证
-
-2. 执行迁移命令
-
-   对于本地源码：
-   ```bash
-   flask upload-private-key-file-to-cloud-storage
-   flask upload-local-files-to-cloud-storage
-   ```
-
-   对于 Docker Compose：
-   ```bash
-   docker exec -it docker-api-1 flask upload-private-key-file-to-cloud-storage
-   docker exec -it docker-api-1 flask upload-local-files-to-cloud-storage
-   ```
-
-### 24. 如何删除旧日志和未使用的文件以减少存储使用量？
+### 23. 如何删除旧日志和未使用的文件以减少存储使用量？
 
 Dify**不会**自动删除数据库中的旧日志或存储中的未使用文件。请参考以下命令**手动**删除旧日志和未使用的文件。
 


### PR DESCRIPTION
Remove documentation for cloud storage migration feature since the corresponding implementation in PR langgenius/dify#9532 was not merged into the main Dify codebase, making this documentation obsolete.