### PR TITLE
feat: Update Docs For Phoenix Cloud Instance Setup Guide

### DIFF
--- a/en/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
+++ b/en/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
@@ -37,6 +37,40 @@ Once successfully saved, you can view the monitoring status on the current page.
 
 ![Configure Phoenix](https://i.ibb.co/HTJsj9x2/dify-docs-phoenix-in-service.png)
 
+### How to Configure Phoenix Cloud
+
+#### 1. Register/Login to [Phoenix Cloud](https://app.arize.com/auth/phoenix/signup)
+
+#### 2. Create your Phoenix Space
+
+You can create your Phoenix Space from the user menu at the top-right. Click on **Create Space**, then provide a unique URL identifier for your space:
+
+![Phoenix Cloud Create Space](https://i.ibb.co/7JYPzZBf/dify-docs-phoenix-cloud-create-space.png)
+
+Once successfully saved, you can view the space status on the overview page.
+
+![Phoenix Cloud Space Overview](https://i.ibb.co/Z6RqMhhq/dify-docs-phoenix-cloud-space-overview.png)
+
+#### 3. Create your Phoenix API Key
+
+After launching your space, you can create your Phoenix API Key from the **Settings** option in the user menu at the bottom-left. Click on **System Key**, then provide a name for your Phoenix API Key:
+
+![Phoenix Cloud API Key](https://i.ibb.co/SXMyX9K3/dify-docs-phoenix-cloud-api-key.png)
+
+#### 4. Integrating Phoenix Cloud with Dify
+
+Configure Phoenix in the Dify application. Open the application you need to monitor, open **Monitoring** in the side menu, and select **Tracing app performance** on the page.
+
+![Tracing app performance](https://i.ibb.co/gMmXxfhQ/dify-docs-phoenix-in-use.png)
+
+After clicking configure, paste the **API Key** and **project name** along with **Space Hostname** created in Phoenix Cloud into the configuration and save.
+
+![Configure Phoenix](https://i.ibb.co/jv6QFbp7/dify-docs-phoenix-config.png)
+
+Once successfully saved, you can view the monitoring status on the current page.
+
+![Configure Phoenix](https://i.ibb.co/HTJsj9x2/dify-docs-phoenix-in-service.png)
+
 ### Monitoring Data List
 
 #### **Workflow/Chatflow Trace Information**

--- a/ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
+++ b/ja-jp/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
@@ -37,6 +37,40 @@ DifyアプリケーションでPhoenixを設定します。監視するアプリ
 
 ![Phoenixの設定](https://i.ibb.co/HTJsj9x2/dify-docs-phoenix-in-service.png)
 
+### 3 Phoenix Cloudの使い方
+
+#### 1. Phoenix Cloudの[公式サイト](https://app.arize.com/auth/phoenix/signup)から登録し、ログインする。
+
+### 2. Phoenix スペースの作成
+
+右上のユーザーメニューから Phoenix スペースを作成できます。スペースを作成 をクリックし、スペース用の一意の URL 識別子を入力してください。
+
+![Phoenix Cloud Create Space](https://i.ibb.co/7JYPzZBf/dify-docs-phoenix-cloud-create-space.png)
+
+保存に成功すると、概要ページでスペースのステータスを確認できます。
+
+![Phoenix Cloud Space Overview](https://i.ibb.co/Z6RqMhhq/dify-docs-phoenix-cloud-space-overview.png)
+
+### 3. Phoenix API キーの作成
+
+スペースを起動した後、左下のユーザーメニューから 設定 を開き、Phoenix API キーを作成できます。システムキー をクリックし、API キーの名前を入力してください。
+
+![Phoenix Cloud API Key](https://i.ibb.co/SXMyX9K3/dify-docs-phoenix-cloud-api-key.png)
+
+### 4. Phoenix CloudとDifyを統合
+
+DifyアプリケーションでPhoenixを設定します。監視するアプリケーションを開き、サイドメニューで**監視**を選択し、ページ上の**アプリケーションパフォーマンスを追跡**をクリックします。
+
+![アプリケーションパフォーマンスを追跡](https://i.ibb.co/gMmXxfhQ/dify-docs-phoenix-in-use.png)
+
+設定画面で、Phoenix Cloud で作成した API キー、プロジェクト名、および スペースのホスト名 を入力して保存してください。
+
+![Phoenixの設定](https://i.ibb.co/jv6QFbp7/dify-docs-phoenix-config.png)
+
+保存に成功すると、現在のページで監視ステータスを確認できます。
+
+![Phoenixの設定](https://i.ibb.co/HTJsj9x2/dify-docs-phoenix-in-service.png)
+
 ## モニタリングデータリスト
 
 ### **ワークフロー/会話フロートラッキング情報**

--- a/zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
+++ b/zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-phoenix.mdx
@@ -54,6 +54,66 @@ className="mx-auto"
 alt=""
 />
 
+### 配置 Phoenix Cloud
+
+本章节将指引你注册 Phoenix Cloud 并将其集成至 Dify 平台内。
+
+#### 1. 注册/登录 [Phoenix Cloud](https://app.arize.com/auth/phoenix/signup)
+
+### 2. 创建你的 Phoenix 空间
+
+你可以在右上角的用户菜单中创建 Phoenix 空间。点击 创建空间，然后为你的空间提供一个唯一的 URL 标识符：
+
+<img
+src="https://i.ibb.co/7JYPzZBf/dify-docs-phoenix-cloud-create-space.png"
+className="mx-auto"
+alt=""
+/>
+
+保存成功后，你可以在概览页面查看空间的状态。
+
+<img
+src="https://i.ibb.co/Z6RqMhhq/dify-docs-phoenix-cloud-space-overview.png"
+className="mx-auto"
+alt=""
+/>
+
+### 3. 创建你的 Phoenix API 密钥
+
+启动空间后，你可以在左下角的用户菜单中点击 设置 来创建 Phoenix API 密钥。点击 系统密钥，然后为你的 API 密钥命名：
+
+<img
+src="https://i.ibb.co/SXMyX9K3/dify-docs-phoenix-cloud-api-key.png"
+className="mx-auto"
+alt=""
+/>
+
+### 4. 集成 Phoenix Cloud 与 Dify
+
+在 Dify 应用程序中配置 Phoenix。打开需要监控的应用程序，在侧边菜单中打开**监控**，并在页面上选择**追踪应用性能**。
+
+<img
+src="https://i.ibb.co/gMmXxfhQ/dify-docs-phoenix-in-use.png"
+className="mx-auto"
+alt=""
+/>
+
+点击配置后，粘贴从 Phoenix Cloud 中获取的 API 密钥、项目名称 和 空间主机名 到配置项中并保存。
+
+<img
+src="https://i.ibb.co/jv6QFbp7/dify-docs-phoenix-config.png"
+className="mx-auto"
+alt=""
+/>
+
+成功保存后，你可以在当前页面查看监控状态。
+
+<img
+src="https://i.ibb.co/HTJsj9x2/dify-docs-phoenix-in-service.png"
+className="mx-auto"
+alt=""
+/>
+
 ## 监控数据列表
 
 ### **工作流/对话流追踪信息**


### PR DESCRIPTION
This PR updates the documentation to include setup instructions for Phoenix Cloud tracing. It outlines the required configuration steps, including how to set endpoint URLs for cloud-hosted instances. The goal is to make it easier for users to integrate Phoenix Cloud into their observability workflows with minimal friction.