### PR TITLE
 Add Celery Beat environment variable description

### DIFF
--- a/en/getting-started/install-self-hosted/environments.mdx
+++ b/en/getting-started/install-self-hosted/environments.mdx
@@ -628,6 +628,66 @@ For a list of available [tools](https://github.com/langgenius/dify/blob/main/api
 
   Example: `POSITION_PROVIDER_EXCLUDES=openrouter,ollama`
 
+### Scheduled Tasks Configuration
+
+Dify uses Celery Beat to execute various background scheduled tasks for system maintenance and data cleanup. The following environment variables configure scheduled task settings:
+
+- CELERY_BEAT_SCHEDULER_TIME
+
+  Celery Beat scheduling time interval (in days) that controls the execution frequency of certain scheduled tasks. Default is 1 day.
+
+- ENABLE_CLEAN_EMBEDDING_CACHE_TASK
+
+  Whether to enable the embedding cache cleanup task. Default is false. When enabled, it cleans expired embedding caches at 2:00 AM daily to reduce storage usage.
+
+- ENABLE_CLEAN_UNUSED_DATASETS_TASK
+
+  Whether to enable the unused datasets cleanup task. Default is false. When enabled, it cleans long-unused datasets at 3:00 AM daily to free up storage space.
+
+- ENABLE_CLEAN_MESSAGES
+
+  Whether to enable the message cleanup task. Default is false. When enabled, it cleans expired conversation message records at 4:00 AM daily.
+
+- ENABLE_MAIL_CLEAN_DOCUMENT_NOTIFY_TASK
+
+  Whether to enable the mail document cleanup notification task. Default is false. When enabled, it sends document cleanup notification emails at 10:00 AM every Monday.
+
+- ENABLE_DATASETS_QUEUE_MONITOR
+
+  Whether to enable the datasets queue monitoring task. Default is false. When enabled, it monitors the dataset processing queue status and sends alerts when the queue backlog exceeds the threshold.
+
+- QUEUE_MONITOR_INTERVAL
+
+  Dataset queue monitoring interval (in minutes). Default is 30 minutes. Only effective when the queue monitoring task is enabled.
+
+- ENABLE_CHECK_UPGRADABLE_PLUGIN_TASK
+
+  Whether to enable the check upgradable plugin task. Default is true. When enabled, it checks for upgradable plugin versions every 15 minutes. Requires MARKETPLACE_ENABLED to be enabled.
+
+- MARKETPLACE_ENABLED
+
+  Whether to enable the marketplace functionality. Default is true. When disabled, plugin-related features including plugin upgrade checks will be unavailable.
+
+- ENABLE_CREATE_TIDB_SERVERLESS_TASK
+
+  Whether to enable the create TiDB Serverless task. Default is false. Used for TiDB cloud service integration, executes every hour.
+
+- ENABLE_UPDATE_TIDB_SERVERLESS_STATUS_TASK
+
+  Whether to enable the update TiDB Serverless status task. Default is false. Used to update TiDB cloud service status, executes every 10 minutes.
+
+- WORKFLOW_LOG_CLEANUP_ENABLED
+
+  Whether to enable automatic workflow log cleanup task. Default is false. When enabled, it cleans workflow execution logs that exceed the retention period at 2:00 AM daily.
+
+- WORKFLOW_LOG_RETENTION_DAYS
+
+  Workflow log retention days. Default is 30 days. Only effective when the workflow log cleanup task is enabled.
+
+- WORKFLOW_LOG_CLEANUP_BATCH_SIZE
+
+  Workflow log cleanup batch size. Default is 100. Number of log entries processed per cleanup operation, can be adjusted based on system performance.
+
 ### Others
 
 - INVITE_EXPIRY_HOURS: Member invitation link valid time (hours), Default: 72.

--- a/ja-jp/getting-started/install-self-hosted/environments.mdx
+++ b/ja-jp/getting-started/install-self-hosted/environments.mdx
@@ -604,6 +604,66 @@ Notion統合設定。変数はNotion integrationを申請することで取得�
 
   例: `POSITION_PROVIDER_EXCLUDES=openrouter,ollama`
 
+### スケジュール済みタスク設定
+
+DifyはCelery Beatを使用してシステムメンテナンスとデータクリーンアップのためのさまざまなバックグラウンドスケジュール済みタスクを実行します。以下は、スケジュール済みタスク関連の環境変数設定です：
+
+- CELERY_BEAT_SCHEDULER_TIME
+
+  特定のスケジュール済みタスクの実行頻度を制御するCelery Beatスケジュール時間間隔（日）。デフォルトは1日です。
+
+- ENABLE_CLEAN_EMBEDDING_CACHE_TASK
+
+  埋め込みキャッシュクリーンアップタスクを有効にするかどうか。デフォルトはfalse。有効にすると、毎日午前2:00に期限切れの埋め込みキャッシュをクリーンアップしてストレージ使用量を減らします。
+
+- ENABLE_CLEAN_UNUSED_DATASETS_TASK
+
+  未使用データセットクリーンアップタスクを有効にするかどうか。デフォルトはfalse。有効にすると、毎日午前3:00に長期間未使用のデータセットをクリーンアップしてストレージスペースを解放します。
+
+- ENABLE_CLEAN_MESSAGES
+
+  メッセージクリーンアップタスクを有効にするかどうか。デフォルトはfalse。有効にすると、毎日午前4:00に期限切れの会話メッセージレコードをクリーンアップします。
+
+- ENABLE_MAIL_CLEAN_DOCUMENT_NOTIFY_TASK
+
+  メール文書クリーンアップ通知タスクを有効にするかどうか。デフォルトはfalse。有効にすると、毎週月曜日の午前10:00に文書クリーンアップ通知メールを送信します。
+
+- ENABLE_DATASETS_QUEUE_MONITOR
+
+  データセットキュー監視タスクを有効にするかどうか。デフォルトはfalse。有効にすると、データセット処理キューの状態を監視し、キューのバックログが閾値を超えたときにアラートを送信します。
+
+- QUEUE_MONITOR_INTERVAL
+
+  データセットキュー監視間隔（分）。デフォルトは30分。キュー監視タスクが有効な場合にのみ有効です。
+
+- ENABLE_CHECK_UPGRADABLE_PLUGIN_TASK
+
+  アップグレード可能プラグインチェックタスクを有効にするかどうか。デフォルトはtrue。有効にすると、15分ごとにアップグレード可能なプラグインバージョンをチェックします。MARKETPLACE_ENABLEDが有効になっている必要があります。
+
+- MARKETPLACE_ENABLED
+
+  マーケットプレイス機能を有効にするかどうか。デフォルトはtrue。無効にすると、プラグインアップグレードチェックを含むプラグイン関連機能が利用できなくなります。
+
+- ENABLE_CREATE_TIDB_SERVERLESS_TASK
+
+  TiDB Serverless作成タスクを有効にするかどうか。デフォルトはfalse。TiDBクラウドサービス統合に使用され、1時間ごとに実行されます。
+
+- ENABLE_UPDATE_TIDB_SERVERLESS_STATUS_TASK
+
+  TiDB Serverlessステータス更新タスクを有効にするかどうか。デフォルトはfalse。TiDBクラウドサービスのステータス更新に使用され、10分ごとに実行されます。
+
+- WORKFLOW_LOG_CLEANUP_ENABLED
+
+  ワークフローログ自動クリーンアップタスクを有効にするかどうか。デフォルトはfalse。有効にすると、毎日午前2:00に保持期間を超えたワークフロー実行ログをクリーンアップします。
+
+- WORKFLOW_LOG_RETENTION_DAYS
+
+  ワークフローログ保持日数。デフォルトは30日。ワークフローログクリーンアップタスクが有効な場合にのみ有効です。
+
+- WORKFLOW_LOG_CLEANUP_BATCH_SIZE
+
+  ワークフローログクリーンアップバッチサイズ。デフォルトは100。クリーンアップ操作ごとに処理されるログエントリ数。システムパフォーマンスに基づいて調整できます。
+
 ### 其他
 
 - INVITE_EXPIRY_HOURS：メンバーを招待するのリンクの有効期間（時），デフォルト：72。

--- a/zh-hans/getting-started/install-self-hosted/environments.mdx
+++ b/zh-hans/getting-started/install-self-hosted/environments.mdx
@@ -624,6 +624,66 @@ Notion 集成配置，变量可通过申请 Notion integration 获取：[https:/
 
   示例: `POSITION_PROVIDER_EXCLUDES=openrouter,ollama`
 
+### 定时任务配置
+
+Dify 使用 Celery Beat 执行各种后台定时任务，用于系统维护和数据清理。以下是定时任务相关的环境变量配置：
+
+* CELERY_BEAT_SCHEDULER_TIME
+
+  Celery Beat 调度时间间隔（天），用于控制某些定时任务的执行频率，默认为 1 天。
+
+* ENABLE_CLEAN_EMBEDDING_CACHE_TASK
+
+  是否启用清理嵌入向量缓存任务，默认为 false。启用后会在每天凌晨 2:00 定时清理过期的嵌入向量缓存，减少存储占用。
+
+* ENABLE_CLEAN_UNUSED_DATASETS_TASK
+
+  是否启用清理未使用数据集任务，默认为 false。启用后会在每天凌晨 3:00 定时清理长期未使用的数据集，释放存储空间。
+
+* ENABLE_CLEAN_MESSAGES
+
+  是否启用清理对话消息任务，默认为 false。启用后会在每天凌晨 4:00 定时清理过期的对话消息记录。
+
+* ENABLE_MAIL_CLEAN_DOCUMENT_NOTIFY_TASK
+
+  是否启用邮件清理文档通知任务，默认为 false。启用后会在每周一上午 10:00 发送文档清理通知邮件。
+
+* ENABLE_DATASETS_QUEUE_MONITOR
+
+  是否启用数据集队列监控任务，默认为 false。启用后会定时监控数据集处理队列状态，当队列积压超过阈值时发送告警。
+
+* QUEUE_MONITOR_INTERVAL
+
+  数据集队列监控时间间隔（分钟），默认为 30 分钟。仅在启用队列监控任务时有效。
+
+* ENABLE_CHECK_UPGRADABLE_PLUGIN_TASK
+
+  是否启用检查可升级插件任务，默认为 true。启用后会每 15 分钟检查一次可升级的插件版本。需要同时启用 MARKETPLACE_ENABLED。
+
+* MARKETPLACE_ENABLED
+
+  是否启用插件市场功能，默认为 true。关闭后将无法使用插件相关功能，包括插件升级检查任务。
+
+* ENABLE_CREATE_TIDB_SERVERLESS_TASK
+
+  是否启用创建 TiDB Serverless 任务，默认为 false。用于 TiDB 云服务集成，每小时执行一次。
+
+* ENABLE_UPDATE_TIDB_SERVERLESS_STATUS_TASK
+
+  是否启用更新 TiDB Serverless 状态任务，默认为 false。用于更新 TiDB 云服务状态，每 10 分钟执行一次。
+
+* WORKFLOW_LOG_CLEANUP_ENABLED
+
+  是否启用工作流日志自动清理任务，默认为 false。启用后会在每天凌晨 2:00 清理超过保留期限的工作流执行日志。
+
+* WORKFLOW_LOG_RETENTION_DAYS
+
+  工作流日志保留天数，默认为 30 天。仅在启用工作流日志清理任务时有效。
+
+* WORKFLOW_LOG_CLEANUP_BATCH_SIZE
+
+  工作流日志清理批次大小，默认为 100。每次清理操作处理的日志条目数，可根据系统性能调整。
+
 ### 其他
 
 * INVITE_EXPIRY_HOURS：成员邀请链接有效时间（小时），默认：72。


### PR DESCRIPTION
Description:
  This commit adds comprehensive documentation for Celery Beat scheduled task configuration environment variables to the Dify self-hosted installation documentation.

  Key Updates

  - Added "Scheduled Tasks Configuration" section explaining how Dify uses Celery Beat for background task scheduling
  - Documented 13 scheduled task-related environment variables with complete descriptions:
    - Cache cleanup tasks (embedding cache, unused datasets, conversation messages)
    - System monitoring tasks (queue monitoring, plugin upgrade checks)
    - Cloud service integration tasks (TiDB Serverless)
    - Workflow log management tasks
    - Email notification tasks

  Languages Covered

  - English documentation (en/getting-started/install-self-hosted/environments.mdx)
  - Chinese documentation (zh-hans/getting-started/install-self-hosted/environments.mdx)
  - Japanese documentation (ja-jp/getting-started/install-self-hosted/environments.mdx)

 This update provides users with a complete guide for configuring scheduled tasks, helping administrators better configure and optimize Dify's background maintenance operations.

<img width="1427" height="882" alt="screenshot_2025-08-20_09-37-30" src="https://github.com/user-attachments/assets/3f3f4bcd-d305-497a-a826-d3bdb63bf725" />

