### PR TITLE
Add file-preview API to OpenAPI specifications

### DIFF
--- a/en/openapi_chat.json
+++ b/en/openapi_chat.json
@@ -204,6 +204,139 @@
         }
       }
     },
+    "/files/{file_id}/preview": {
+      "get": {
+        "summary": "File Preview",
+        "description": "Preview or download uploaded files. This endpoint allows you to access files that have been previously uploaded via the File Upload API. Files can only be accessed if they belong to messages within the requesting application.",
+        "operationId": "previewChatFile",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the file to preview, obtained from the File Upload API response.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "as_attachment",
+            "in": "query",
+            "required": false,
+            "description": "Whether to force download the file as an attachment. Default is `false` (preview in browser).",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File content returned successfully. Headers set based on file type and request parameters.",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "MIME type of the file",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "description": "File size in bytes (if available)",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Content-Disposition": {
+                "description": "Set to 'attachment' if as_attachment=true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Cache-Control": {
+                "description": "Caching headers for performance",
+                "schema": {
+                  "type": "string",
+                  "example": "public, max-age=3600"
+                }
+              },
+              "Accept-Ranges": {
+                "description": "Set to 'bytes' for audio/video files",
+                "schema": {
+                  "type": "string",
+                  "example": "bytes"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Possible error codes:\n- `invalid_param`: Abnormal parameter input.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. Possible error codes:\n- `file_access_denied`: File access denied or file does not belong to current application.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found. Possible error codes:\n- `file_not_found`: File not found or has been deleted.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/chat-messages/{task_id}/stop": {
       "post": {
         "summary": "Stop Chat Message Generation",
@@ -1774,7 +1907,7 @@
   },
   "tags": [
     { "name": "Chat", "description": "Operations related to chat messages and interactions." },
-    { "name": "Files", "description": "File upload operations." },
+    { "name": "Files", "description": "File upload and preview operations." },
     { "name": "Feedback", "description": "User feedback operations." },
     { "name": "Conversations", "description": "Operations related to managing conversations." },
     { "name": "TTS", "description": "Text-to-Speech and Speech-to-Text operations." },

--- a/en/openapi_chatflow.json
+++ b/en/openapi_chatflow.json
@@ -137,6 +137,139 @@
         }
       }
     },
+    "/files/{file_id}/preview": {
+      "get": {
+        "summary": "File Preview",
+        "description": "Preview or download uploaded files. This endpoint allows you to access files that have been previously uploaded via the File Upload API. Files can only be accessed if they belong to messages within the requesting application.",
+        "operationId": "previewChatFlowFile",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the file to preview, obtained from the File Upload API response.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "as_attachment",
+            "in": "query",
+            "required": false,
+            "description": "Whether to force download the file as an attachment. Default is `false` (preview in browser).",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File content returned successfully. Headers set based on file type and request parameters.",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "MIME type of the file",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "description": "File size in bytes (if available)",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Content-Disposition": {
+                "description": "Set to 'attachment' if as_attachment=true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Cache-Control": {
+                "description": "Caching headers for performance",
+                "schema": {
+                  "type": "string",
+                  "example": "public, max-age=3600"
+                }
+              },
+              "Accept-Ranges": {
+                "description": "Set to 'bytes' for audio/video files",
+                "schema": {
+                  "type": "string",
+                  "example": "bytes"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Possible error codes:\n- `invalid_param`: Abnormal parameter input.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. Possible error codes:\n- `file_access_denied`: File access denied or file does not belong to current application.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found. Possible error codes:\n- `file_not_found`: File not found or has been deleted.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/chat-messages/{task_id}/stop": {
       "post": {
         "summary": "Stop Advanced Chat Message Generation",
@@ -997,7 +1130,7 @@
   },
   "tags": [
     { "name": "Chatflow", "description": "Advanced chat operations with workflow events." },
-    { "name": "Files", "description": "File upload operations for advanced chat." },
+    { "name": "Files", "description": "File upload and preview operations for advanced chat." },
     { "name": "Feedback", "description": "User feedback operations for advanced chat." },
     { "name": "Conversations", "description": "Conversation management for advanced chat." },
     { "name": "TTS", "description": "Speech and Text conversion for advanced chat." },

--- a/en/openapi_workflow.json
+++ b/en/openapi_workflow.json
@@ -194,6 +194,139 @@
         }
       }
     },
+    "/files/{file_id}/preview": {
+      "get": {
+        "summary": "File Preview",
+        "description": "Preview or download uploaded files. This endpoint allows you to access files that have been previously uploaded via the File Upload API. Files can only be accessed if they belong to messages within the requesting application.",
+        "operationId": "previewWorkflowFile",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the file to preview, obtained from the File Upload API response.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "as_attachment",
+            "in": "query",
+            "required": false,
+            "description": "Whether to force download the file as an attachment. Default is `false` (preview in browser).",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File content returned successfully. Headers set based on file type and request parameters.",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "MIME type of the file",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "description": "File size in bytes (if available)",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Content-Disposition": {
+                "description": "Set to 'attachment' if as_attachment=true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Cache-Control": {
+                "description": "Caching headers for performance",
+                "schema": {
+                  "type": "string",
+                  "example": "public, max-age=3600"
+                }
+              },
+              "Accept-Ranges": {
+                "description": "Set to 'bytes' for audio/video files",
+                "schema": {
+                  "type": "string",
+                  "example": "bytes"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Possible error codes:\n- `invalid_param`: Abnormal parameter input.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. Possible error codes:\n- `file_access_denied`: File access denied or file does not belong to current application.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found. Possible error codes:\n- `file_not_found`: File not found or has been deleted.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/workflows/logs": {
         "get": {
             "summary": "Get Workflow Logs",
@@ -483,7 +616,7 @@
   },
   "tags": [
     { "name": "Workflow Execution", "description": "Operations related to executing and managing workflows." },
-    { "name": "Files", "description": "File upload operations specific to workflows." },
+    { "name": "Files", "description": "File upload and preview operations specific to workflows." },
     { "name": "Application", "description": "Application settings and info for workflow apps." }
   ]
 }

--- a/ja-jp/openapi_chat.json
+++ b/ja-jp/openapi_chat.json
@@ -117,6 +117,139 @@
         }
       }
     },
+    "/files/{file_id}/preview": {
+      "get": {
+        "summary": "ファイルプレビュー",
+        "description": "アップロードされたファイルのプレビューまたはダウンロード。このエンドポイントは、ファイルアップロードAPIを通じて事前にアップロードされたファイルにアクセスすることができます。ファイルは、リクエストしているアプリケーション内のメッセージに属している場合のみアクセス可能です。",
+        "operationId": "previewBasicChatFileJa",
+        "tags": ["ファイル操作"],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "description": "プレビューするファイルの一意識別子、ファイルアップロードAPIのレスポンスから取得されます。",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "as_attachment",
+            "in": "query",
+            "required": false,
+            "description": "ファイルを添付ファイルとして強制ダウンロードするかどうか。デフォルトは`false`（ブラウザでプレビュー）です。",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ファイルコンテンツが正常に返されました。ヘッダーはファイルタイプとリクエストパラメータに基づいて設定されます。",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "ファイルのMIMEタイプ",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "description": "ファイルサイズ（バイト単位、利用可能な場合）",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Content-Disposition": {
+                "description": "as_attachment=trueの場合、'attachment'に設定されます",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Cache-Control": {
+                "description": "パフォーマンス用キャッシュヘッダー",
+                "schema": {
+                  "type": "string",
+                  "example": "public, max-age=3600"
+                }
+              },
+              "Accept-Ranges": {
+                "description": "オーディオ/ビデオファイルの場合は'bytes'に設定されます",
+                "schema": {
+                  "type": "string",
+                  "example": "bytes"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト。可能なエラーコード:\n- `invalid_param`: 異常なパラメータ入力。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJa" }
+              }
+            }
+          },
+          "403": {
+            "description": "禁止。可能なエラーコード:\n- `file_access_denied`: ファイルアクセス拒否またはファイルが現在のアプリケーションに属していません。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJa" }
+              }
+            }
+          },
+          "404": {
+            "description": "見つかりません。可能なエラーコード:\n- `file_not_found`: ファイルが見つからないか削除されています。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJa" }
+              }
+            }
+          },
+          "500": {
+            "description": "内部サーバーエラー。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJa" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/chat-messages/{task_id}/stop": {
       "post": {
         "summary": "生成停止",
@@ -448,7 +581,7 @@
   },
   "tags": [
     { "name": "チャットメッセージ", "description": "チャットメッセージと対話に関連する操作。" },
-    { "name": "ファイル操作", "description": "ファイルアップロードに関連する操作。" },
+    { "name": "ファイル操作", "description": "ファイルアップロードとプレビューに関連する操作。" },
     { "name": "メッセージフィードバック", "description": "ユーザーからのメッセージフィードバック操作。" },
     { "name": "会話管理", "description": "会話セッションの管理に関連する操作。" },
     { "name": "音声とテキスト変換", "description": "テキストから音声、音声からテキストへの変換操作。" },

--- a/ja-jp/openapi_chatflow.json
+++ b/ja-jp/openapi_chatflow.json
@@ -136,6 +136,139 @@
         }
       }
     },
+    "/files/{file_id}/preview": {
+      "get": {
+        "summary": "ファイルプレビュー",
+        "description": "アップロードされたファイルのプレビューまたはダウンロード。このエンドポイントは、ファイルアップロードAPIを通じて事前にアップロードされたファイルにアクセスすることができます。ファイルは、リクエストしているアプリケーション内のメッセージに属している場合のみアクセス可能です。",
+        "operationId": "previewChatflowFileJp",
+        "tags": ["ファイル操作"],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "description": "プレビューするファイルの一意識別子、ファイルアップロードAPIのレスポンスから取得されます。",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "as_attachment",
+            "in": "query",
+            "required": false,
+            "description": "ファイルを添付ファイルとして強制ダウンロードするかどうか。デフォルトは`false`（ブラウザでプレビュー）です。",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ファイルコンテンツが正常に返されました。ヘッダーはファイルタイプとリクエストパラメータに基づいて設定されます。",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "ファイルのMIMEタイプ",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "description": "ファイルサイズ（バイト単位、利用可能な場合）",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Content-Disposition": {
+                "description": "as_attachment=trueの場合、'attachment'に設定されます",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Cache-Control": {
+                "description": "パフォーマンス用キャッシュヘッダー",
+                "schema": {
+                  "type": "string",
+                  "example": "public, max-age=3600"
+                }
+              },
+              "Accept-Ranges": {
+                "description": "オーディオ/ビデオファイルの場合は'bytes'に設定されます",
+                "schema": {
+                  "type": "string",
+                  "example": "bytes"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト。可能なエラーコード:\n- `invalid_param`: 異常なパラメータ入力。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJp" }
+              }
+            }
+          },
+          "403": {
+            "description": "禁止。可能なエラーコード:\n- `file_access_denied`: ファイルアクセス拒否またはファイルが現在のアプリケーションに属していません。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJp" }
+              }
+            }
+          },
+          "404": {
+            "description": "見つかりません。可能なエラーコード:\n- `file_not_found`: ファイルが見つからないか削除されています。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJp" }
+              }
+            }
+          },
+          "500": {
+            "description": "内部サーバーエラー。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJp" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/chat-messages/{task_id}/stop": {
       "post": {
         "summary": "生成を停止",
@@ -596,7 +729,7 @@
   },
   "tags": [
     { "name": "チャットメッセージ", "description": "チャットメッセージとインタラクションに関連する操作。" },
-    { "name": "ファイル操作", "description": "ファイルアップロードに関連する操作。" },
+    { "name": "ファイル操作", "description": "ファイルアップロードとプレビューに関連する操作。" },
     { "name": "メッセージフィードバック", "description": "ユーザーメッセージへのフィードバック操作。" },
     { "name": "会話管理", "description": "会話セッションの管理に関連する操作。" },
     { "name": "音声・テキスト変換", "description": "テキストから音声へ、音声からテキストへの変換操作。" },

--- a/ja-jp/openapi_workflow.json
+++ b/ja-jp/openapi_workflow.json
@@ -188,6 +188,139 @@
         }
       }
     },
+    "/files/{file_id}/preview": {
+      "get": {
+        "summary": "ファイルプレビュー",
+        "description": "アップロードされたファイルのプレビューまたはダウンロード。このエンドポイントは、ファイルアップロードAPIを通じて事前にアップロードされたファイルにアクセスすることができます。ファイルは、リクエストしているアプリケーション内のメッセージに属している場合のみアクセス可能です。",
+        "operationId": "previewWorkflowFileJp",
+        "tags": ["ファイル操作 (ワークフロー)"],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "description": "プレビューするファイルの一意識別子、ファイルアップロードAPIのレスポンスから取得されます。",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "as_attachment",
+            "in": "query",
+            "required": false,
+            "description": "ファイルを添付ファイルとして強制ダウンロードするかどうか。デフォルトは`false`（ブラウザでプレビュー）です。",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ファイルコンテンツが正常に返されました。ヘッダーはファイルタイプとリクエストパラメータに基づいて設定されます。",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "ファイルのMIMEタイプ",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "description": "ファイルサイズ（バイト単位、利用可能な場合）",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Content-Disposition": {
+                "description": "as_attachment=trueの場合、'attachment'に設定されます",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Cache-Control": {
+                "description": "パフォーマンス用キャッシュヘッダー",
+                "schema": {
+                  "type": "string",
+                  "example": "public, max-age=3600"
+                }
+              },
+              "Accept-Ranges": {
+                "description": "オーディオ/ビデオファイルの場合は'bytes'に設定されます",
+                "schema": {
+                  "type": "string",
+                  "example": "bytes"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト。可能なエラーコード:\n- `invalid_param`: 異常なパラメータ入力。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJp" }
+              }
+            }
+          },
+          "403": {
+            "description": "禁止。可能なエラーコード:\n- `file_access_denied`: ファイルアクセス拒否またはファイルが現在のアプリケーションに属していません。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJp" }
+              }
+            }
+          },
+          "404": {
+            "description": "見つかりません。可能なエラーコード:\n- `file_not_found`: ファイルが見つからないか削除されています。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJp" }
+              }
+            }
+          },
+          "500": {
+            "description": "内部サーバーエラー。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseJp" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/workflows/logs": {
         "get": {
             "summary": "ワークフローログを取得",
@@ -396,7 +529,7 @@
   },
   "tags": [
     { "name": "ワークフロー実行", "description": "ワークフローの実行と管理に関連する操作。" },
-    { "name": "ファイル操作 (ワークフロー)", "description": "ワークフロー固有のファイルアップロード操作。" },
+    { "name": "ファイル操作 (ワークフロー)", "description": "ワークフロー固有のファイルアップロードとプレビュー操作。" },
     { "name": "アプリケーション設定 (ワークフロー)", "description": "ワークフローアプリのアプリケーション設定と情報。" }
   ]
 }

--- a/zh-hans/openapi_chat.json
+++ b/zh-hans/openapi_chat.json
@@ -136,6 +136,139 @@
         }
       }
     },
+    "/files/{file_id}/preview": {
+      "get": {
+        "summary": "文件预览",
+        "description": "预览或下载已上传的文件。此端点允许您访问之前通过文件上传API上传的文件。文件只能在所属的应用程序消息内访问。",
+        "operationId": "previewBasicChatFileCn",
+        "tags": ["文件操作"],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "description": "要预览的文件的唯一标识符，从文件上传API响应中获取。",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "as_attachment",
+            "in": "query",
+            "required": false,
+            "description": "是否强制作为附件下载文件。默认为`false`（在浏览器中预览）。",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "文件内容成功返回。根据文件类型和请求参数设置响应头。",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "文件的MIME类型",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "description": "文件大小（字节）（如果可用）",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Content-Disposition": {
+                "description": "如果as_attachment=true，则设置为'attachment'",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Cache-Control": {
+                "description": "用于性能的缓存头",
+                "schema": {
+                  "type": "string",
+                  "example": "public, max-age=3600"
+                }
+              },
+              "Accept-Ranges": {
+                "description": "对于音频/视频文件设置为'bytes'",
+                "schema": {
+                  "type": "string",
+                  "example": "bytes"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "错误请求。可能的错误代码:\n- `invalid_param`: 异常参数输入。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          },
+          "403": {
+            "description": "禁止访问。可能的错误代码:\n- `file_access_denied`: 文件访问被拒绝或文件不属于当前应用程序。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          },
+          "404": {
+            "description": "未找到。可能的错误代码:\n- `file_not_found`: 文件未找到或已被删除。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          },
+          "500": {
+            "description": "内部服务器错误。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/chat-messages/{task_id}/stop": {
       "post": {
         "summary": "停止响应",
@@ -622,7 +755,7 @@
   },
   "tags": [
     { "name": "对话消息", "description": "与对话消息和交互相关的操作。" },
-    { "name": "文件操作", "description": "文件上传相关的操作。" },
+    { "name": "文件操作", "description": "文件上传和预览相关的操作。" },
     { "name": "消息反馈", "description": "用户对消息的反馈操作。" },
     { "name": "会话管理", "description": "管理对话会话相关的操作。" },
     { "name": "语音与文字转换", "description": "文本转语音和语音转文本操作。" },

--- a/zh-hans/openapi_chatflow.json
+++ b/zh-hans/openapi_chatflow.json
@@ -136,6 +136,139 @@
         }
       }
     },
+    "/files/{file_id}/preview": {
+      "get": {
+        "summary": "文件预览",
+        "description": "预览或下载已上传的文件。此端点允许您访问之前通过文件上传API上传的文件。文件只能在所属的应用程序消息内访问。",
+        "operationId": "previewChatFlowFileCn",
+        "tags": ["文件操作"],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "description": "要预览的文件的唯一标识符，从文件上传API响应中获取。",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "as_attachment",
+            "in": "query",
+            "required": false,
+            "description": "是否强制作为附件下载文件。默认为`false`（在浏览器中预览）。",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "文件内容成功返回。根据文件类型和请求参数设置响应头。",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "文件的MIME类型",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "description": "文件大小（字节）（如果可用）",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Content-Disposition": {
+                "description": "如果as_attachment=true，则设置为'attachment'",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Cache-Control": {
+                "description": "用于性能的缓存头",
+                "schema": {
+                  "type": "string",
+                  "example": "public, max-age=3600"
+                }
+              },
+              "Accept-Ranges": {
+                "description": "对于音频/视频文件设置为'bytes'",
+                "schema": {
+                  "type": "string",
+                  "example": "bytes"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "错误请求。可能的错误代码:\n- `invalid_param`: 异常参数输入。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          },
+          "403": {
+            "description": "禁止访问。可能的错误代码:\n- `file_access_denied`: 文件访问被拒绝或文件不属于当前应用程序。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          },
+          "404": {
+            "description": "未找到。可能的错误代码:\n- `file_not_found`: 文件未找到或已被删除。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          },
+          "500": {
+            "description": "内部服务器错误。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/chat-messages/{task_id}/stop": {
       "post": {
         "summary": "停止响应",
@@ -665,7 +798,7 @@
   },
   "tags": [
     { "name": "对话消息", "description": "与对话消息和交互相关的操作。" },
-    { "name": "文件操作", "description": "文件上传相关的操作。" },
+    { "name": "文件操作", "description": "文件上传和预览相关的操作。" },
     { "name": "消息反馈", "description": "用户对消息的反馈操作。" },
     { "name": "会话管理", "description": "管理对话会话相关的操作。" },
     { "name": "语音与文字转换", "description": "文本转语音和语音转文本操作。" },

--- a/zh-hans/openapi_workflow.json
+++ b/zh-hans/openapi_workflow.json
@@ -188,6 +188,139 @@
         }
       }
     },
+    "/files/{file_id}/preview": {
+      "get": {
+        "summary": "文件预览",
+        "description": "预览或下载已上传的文件。此端点允许您访问之前通过文件上传API上传的文件。文件只能在所属的应用程序消息内访问。",
+        "operationId": "previewWorkflowFileCn",
+        "tags": ["文件操作 (工作流)"],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "description": "要预览的文件的唯一标识符，从文件上传API响应中获取。",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "as_attachment",
+            "in": "query",
+            "required": false,
+            "description": "是否强制作为附件下载文件。默认为`false`（在浏览器中预览）。",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "文件内容成功返回。根据文件类型和请求参数设置响应头。",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "文件的MIME类型",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "description": "文件大小（字节）（如果可用）",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Content-Disposition": {
+                "description": "如果as_attachment=true，则设置为'attachment'",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Cache-Control": {
+                "description": "用于性能的缓存头",
+                "schema": {
+                  "type": "string",
+                  "example": "public, max-age=3600"
+                }
+              },
+              "Accept-Ranges": {
+                "description": "对于音频/视频文件设置为'bytes'",
+                "schema": {
+                  "type": "string",
+                  "example": "bytes"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "错误请求。可能的错误代码:\n- `invalid_param`: 异常参数输入。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          },
+          "403": {
+            "description": "禁止访问。可能的错误代码:\n- `file_access_denied`: 文件访问被拒绝或文件不属于当前应用程序。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          },
+          "404": {
+            "description": "未找到。可能的错误代码:\n- `file_not_found`: 文件未找到或已被删除。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          },
+          "500": {
+            "description": "内部服务器错误。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseCn" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/workflows/logs": {
         "get": {
             "summary": "获取 workflow 日志",
@@ -395,7 +528,7 @@
   },
   "tags": [
     { "name": "工作流执行", "description": "与执行和管理工作流相关的操作。" },
-    { "name": "文件操作 (Workflow)", "description": "特定于工作流的文件上传操作。" },
+    { "name": "文件操作 (工作流)", "description": "特定于工作流的文件上传和预览操作。" },
     { "name": "应用配置 (Workflow)", "description": "工作流应用的应用设置和信息。" }
   ]
 }


### PR DESCRIPTION
## Summary
Add the missing `GET /files/{file_id}/preview` endpoint to OpenAPI specifications for chat, chatflow, and workflow APIs across all language versions (English, Japanese, Chinese).

## Changes
- Added file preview endpoint with `as_attachment` query parameter
- Included proper error handling (400, 403, 404, 500) 
- Updated Files tag descriptions to include preview operations
- Maintained language-specific naming conventions and translations

## Test Plan
- [x] JSON syntax validation passed for all files
- [x] Verified unique operationIds across all APIs
- [x] Confirmed alignment with existing API patterns

Fixes #389