### PR TITLE
docs: update Node.js and package manager requirements in contribution guides

### DIFF
--- a/en/community/contribution.mdx
+++ b/en/community/contribution.mdx
@@ -73,8 +73,8 @@ Dify requires the following dependencies to build, make sure they're installed o
 
 - [Docker](https://www.docker.com/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
-- [Node.js v18.x (LTS)](http://nodejs.org)
-- [npm](https://www.npmjs.com/) version 8.x.x or [Yarn](https://yarnpkg.com/)
+- [Node.js v22.x or higher](http://nodejs.org)
+- [pnpm](https://pnpm.io/) version 10.x
 - [Python](https://www.python.org/) version 3.11.x
 
 #### 4. Installations

--- a/ja-jp/community/contribution.mdx
+++ b/ja-jp/community/contribution.mdx
@@ -94,9 +94,9 @@ Difyは以下のツールとライブラリに依存しています：
 
 - [Docker](https://www.docker.com/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
-- [Node.js v18.x (LTS)](http://nodejs.org)
-- [npm](https://www.npmjs.com/) バージョン 8.x.x もしくは [Yarn](https://yarnpkg.com/)
-- [Python](https://www.python.org/) バージョン 3.10.x
+- [Node.js v22.x or higher](http://nodejs.org)
+- [pnpm](https://pnpm.io/) バージョン 10.x
+- [Python](https://www.python.org/) バージョン 3.11.x
 
 ### 4. インストール
 

--- a/zh-hans/community/contribution.mdx
+++ b/zh-hans/community/contribution.mdx
@@ -95,8 +95,8 @@ Dify 依赖以下工具和库：
 
 - [Docker](https://www.docker.com/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
-- [Node.js v18.x (LTS)](http://nodejs.org)
-- [npm](https://www.npmjs.com/) version 8.x.x or [Yarn](https://yarnpkg.com/)
+- [Node.js v22.x or higher](http://nodejs.org)
+- [pnpm](https://pnpm.io/) version 10.x
 - [Python](https://www.python.org/) version 3.11.x
 
 ### 4. 安装


### PR DESCRIPTION
## Summary
- Updated Node.js version requirement from v18.x to v22.x or higher across all language versions (English, Chinese, Japanese)
- Changed package manager requirement from npm/yarn to pnpm v10.x to match actual frontend requirements
- Standardized Python version to 3.11.x across all language versions

## Problem
The contribution documentation was outdated and inconsistent with the actual project requirements:
- Documentation specified Node.js v18.x, but frontend README requires >= v22.11.x
- Documentation mentioned npm/yarn, but project actually uses pnpm v10.x
- Japanese version had inconsistent Python version (3.10.x vs 3.11.x)

## Solution
Updated all three language versions of the contribution guide to match the actual project requirements, preventing setup issues for new contributors.

## Test plan
- [x] Verified changes match actual frontend README requirements
- [x] Ensured consistency across all language versions
- [x] Confirmed no other references need updating