### PR TITLE
docs: fix typo in aliyun documentation

### DIFF
--- a/zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-aliyun.mdx
+++ b/zh-hans/guides/monitoring/integrate-external-ops-tools/integrate-aliyun.mdx
@@ -62,10 +62,10 @@ title: 集成 阿里云 云监控
 | Dify 组件      | 探针               | 详情 |
 |---------------|--------------------|----------------|
 | Nginx         | OpenTelemetry 探针 | [使用OpenTelemetry对Nginx进行链路追踪](https://help.aliyun.com/zh/opentelemetry/user-guide/use-opentelemetry-to-perform-tracing-analysis-on-nginx)  |
-| Api           | LoongSuit-Python 探针 | [loongsuite-python-agent](https://github.com/alibaba/loongsuite-python-agent/blob/main/README.md)  |
-| Sandbox       | LoongSuit-Go 探针  | [loongsuite-go-agent](https://github.com/alibaba/loongsuite-go-agent/blob/main/README.md)  |
+| Api           | LoongSuite-Python 探针 | [loongsuite-python-agent](https://github.com/alibaba/loongsuite-python-agent/blob/main/README.md)  |
+| Sandbox       | LoongSuite-Go 探针  | [loongsuite-go-agent](https://github.com/alibaba/loongsuite-go-agent/blob/main/README.md)  |
 | Worker        | OpenTelemetry 探针 | [通过OpenTelemetry上报Python应用数据](https://help.aliyun.com/zh/opentelemetry/user-guide/use-managed-service-for-opentelemetry-to-submit-the-trace-data-of-python-applications)  |
-| Plugin-Daemon | LoongSuit-Go 探针  | [loongsuite-go-agent](https://github.com/alibaba/loongsuite-go-agent/blob/main/README.md)  |
+| Plugin-Daemon | LoongSuite-Go 探针  | [loongsuite-go-agent](https://github.com/alibaba/loongsuite-go-agent/blob/main/README.md)  |
 
 ## 监测数据清单
 


### PR DESCRIPTION
correct typo "LoongSuit" → "LoongSuite"