### PR TITLE
Update 9231-extension-plugin.mdx

### DIFF
--- a/plugin-dev-zh/9231-extension-plugin.mdx
+++ b/plugin-dev-zh/9231-extension-plugin.mdx
@@ -242,6 +242,8 @@ REMOTE_INSTALL_KEY=****-****-****-****-****
 
 ![](https://assets-docs.dify.ai/2024/11/0fe19a8386b1234755395018bc2e0e35.png)
 
+> 如果启动的时候遇到 An error occurred while parsing the data: b'handshake failed, invalid key'，那就是 调试key 过期了，需要 前往“插件管理”页面重新获取调试 Key。
+
 在插件内新增 Endpoint，随意填写名称和 `api_key` 等信息。访问自动生成的 URL，即可看到由插件提供的网页服务。
 
 ![](https://assets-docs.dify.ai/2024/11/c76375b8df2449d0d8c31a7c2a337579.png)


### PR DESCRIPTION
增加 启动 报错 An error occurred while parsing the data: b'handshake failed, invalid key' 的提示文本。