### PR TITLE
Fix incorrect link in two pages

### DIFF
--- a/zh-hans/guides/tools/extensions/api-based/external-data-tool.mdx
+++ b/zh-hans/guides/tools/extensions/api-based/external-data-tool.mdx
@@ -3,11 +3,11 @@ title: 外部数据工具
 version: '简体中文'
 ---
 
-在创建 AI 应用时，开发者可以通过 API 扩展的方式实现使用外部工具获取额外数据组装至 Prompt 中作为 LLM 额外信息。具体的实操过程可以参考 [API 扩展](/zh-hans/user-guide/tools/extensions/api-based/api-based-extension)。
+在创建 AI 应用时，开发者可以通过 API 扩展的方式实现使用外部工具获取额外数据组装至 Prompt 中作为 LLM 额外信息。具体的实操过程可以参考 [API 扩展](/zh-hans/guides/tools/extensions/api-based/api-based-extension)。
 
 ### 前置条件
 
-请先阅读 [API 扩展](/zh-hans/user-guide/tools/extensions/api-based/api-based-extension) 完成 API 服务基础能力的开发和接入。
+请先阅读 [API 扩展](/zh-hans/guides/tools/extensions/api-based/api-based-extension) 完成 API 服务基础能力的开发和接入。
 
 ### 扩展点
 

--- a/zh-hans/guides/workflow/additional-feature.mdx
+++ b/zh-hans/guides/workflow/additional-feature.mdx
@@ -126,7 +126,7 @@ LLM 并不具备直接读取文档文件的能力，因此需要使用 [文档�
 
 * **音视频文件**
 
-LLM 尚未支持直接读取音视频文件，Dify 平台也尚未内置相关文件处理工具。应用开发者可以参考 [外部数据工具](../extension/api-based-extension/external-data-tool) 接入工具自行处理文件信息。
+LLM 尚未支持直接读取音视频文件，Dify 平台也尚未内置相关文件处理工具。应用开发者可以参考 [外部数据工具](/zh-hans/guides/tools/extensions/api-based/external-data-tool) 接入工具自行处理文件信息。
 
 {/*
 Contributing Section


### PR DESCRIPTION
Fix incorrect link in '手册-扩展-API扩展-外部数据工具' and '手册-工作流-附加功能'