### PR TITLE
Remove `pyenv` from documentation

### DIFF
--- a/en/getting-started/install-self-hosted/local-source-code.mdx
+++ b/en/getting-started/install-self-hosted/local-source-code.mdx
@@ -43,22 +43,6 @@ The backend services include
 1. API Service: serving API requests for Frontend service and API accessing
 2. Worker Service: serving the aync tasks for datasets processing, workspaces, cleaning-ups etc.
 
-### Environment Preparation
-
-Python 3.12 is required. It is recommended to use [pyenv](https://github.com/pyenv/pyenv) for quick installation of the Python environment.
-
-To install additional Python versions, use pyenv install.
-
-```Bash
-pyenv install 3.12
-```
-
-To switch to the "3.12" Python environment, use the following command:
-
-```Bash
-pyenv global 3.12
-```
-
 ### Start API service
 
 1. Navigate to the `api` directory:

--- a/ja-jp/getting-started/install-self-hosted/local-source-code.mdx
+++ b/ja-jp/getting-started/install-self-hosted/local-source-code.mdx
@@ -43,22 +43,6 @@ docker compose -f docker-compose.middleware.yaml up -d
 1. API サービス：フロントエンドサービスと API アクセス用の API リクエストを提供
 2. Worker サービス：データセット処理、ワークスペース、クリーンアップなどの非同期タスクを提供
 
-### 環境の準備
-
-Python 3.12 が必要です。Python 環境をすばやくインストールするには [pyenv](https://github.com/pyenv/pyenv) の使用をお勧めします。
-
-追加の Python バージョンをインストールするには、pyenv install を使用します。
-
-```Bash
-pyenv install 3.12
-```
-
-「3.12」Python 環境に切り替えるには、次のコマンドを使用します：
-
-```Bash
-pyenv global 3.12
-```
-
 ### API サービスの起動
 
 1. `api` ディレクトリに移動します：

--- a/zh-hans/getting-started/install-self-hosted/local-source-code.mdx
+++ b/zh-hans/getting-started/install-self-hosted/local-source-code.mdx
@@ -45,22 +45,6 @@ docker compose -f docker-compose.middleware.yaml up -d
 1. API 服务：为前端服务和 API 访问提供 API 请求服务
 2. Worker 服务：为数据集处理、工作区、清理等异步任务提供服务
 
-### 环境准备
-
-需要 Python 3.12。推荐使用 [pyenv](https://github.com/pyenv/pyenv) 快速安装 Python 环境。
-
-要安装额外的 Python 版本，请使用 pyenv install。
-
-```Bash
-pyenv install 3.12
-```
-
-要切换到 "3.12" Python 环境，请使用以下命令：
-
-```Bash
-pyenv global 3.12
-```
-
 ### 启动 API 服务
 
 1. 导航到 `api` 目录：


### PR DESCRIPTION
`uv` will automatically install the required python, `pyenv` is not needed.