### PR TITLE
docs: Fix link to use-cases/how-to-connect-aws-bedrock

### DIFF
--- a/en/guides/knowledge-base/connect-external-knowledge-base.mdx
+++ b/en/guides/knowledge-base/connect-external-knowledge-base.mdx
@@ -25,7 +25,7 @@ The **Connect to External Knowledge Base** feature enables integration between t
 
 #### AWS Bedrock
 
-[How to connect with AWS Bedrock Knowledge Base](../../learn-more/use-cases/how-to-connect-aws-bedrock.md "mention")
+[How to connect with AWS Bedrock Knowledge Base](../../learn-more/use-cases/how-to-connect-aws-bedrock)
 
 #### LlamaCloud
 

--- a/ja-jp/guides/knowledge-base/connect-external-knowledge-base.mdx
+++ b/ja-jp/guides/knowledge-base/connect-external-knowledge-base.mdx
@@ -114,7 +114,7 @@ title: 外部ナレッジベースとの接続
 
 #### AWS Bedrock
 
-[AWS Bedrockナレッジベースへの接続方法](../../learn-more/use-cases/how-to-connect-aws-bedrock.md "mention")
+[AWS Bedrockナレッジベースへの接続方法](../../learn-more/use-cases/how-to-connect-aws-bedrock)
 
 #### LlamaCloud
 


### PR DESCRIPTION
Hi😀 Thanks for the useful service and documentation!

I found that the link to `use-cases/how-to-connect-aws-bedrock` in the **Connect External Knowledge** was pointing to a Markdown file by mistake.  

- https://docs.dify.ai/en/guides/knowledge-base/connect-external-knowledge-base
- https://docs.dify.ai/ja-jp/guides/knowledge-base/connect-external-knowledge-base

<img width="1920" height="947" alt="image" src="https://github.com/user-attachments/assets/62d05ca3-ec7e-419c-9411-8c63cf75f5a3" />

I fixed the link so that it navigates to the correct page.

Thank you!