### PR TITLE
Modify quick-start instructions for Docker setup

### DIFF
--- a/en/self-host/quick-start/docker-compose.mdx
+++ b/en/self-host/quick-start/docker-compose.mdx
@@ -60,7 +60,12 @@ git clone --branch "$(curl -s https://api.github.com/repos/langgenius/dify/relea
     ```bash
     cp .env.example .env
     ```
-3.  Start the Docker containers
+3.  Update directory ownership on the host
+
+    ```bash
+    sudo chown -R 1001:1001 ./volumes/app/storage
+    ```
+4.  Start the Docker containers
 
     Choose the appropriate command to start the containers based on the Docker Compose version on your system. You can use the `$ docker compose version` command to check the version, and refer to the [Docker documentation](https://docs.docker.com/compose/install/) for more information:
 


### PR DESCRIPTION
Updated the steps for starting Docker containers to include directory ownership adjustment.

From [1.10.1](https://github.com/langgenius/dify/releases/tag/1.10.1), the Docker container no longer runs as root but as a non-root user (UID/GID 1001). Because of this, any mounted host directories must be writable by that user; otherwise, the service will not function correctly. To avoid permission-related failures, make sure to update the ownership of the required host directories (such as `./volumes/app/storage`) before launching the Docker services.