### PR TITLE
fix: use latest version of plugin cli in plugin auto publish workflow

### DIFF
--- a/plugin-dev-en/0321-plugin-auto-publish-pr.mdx
+++ b/plugin-dev-en/0321-plugin-auto-publish-pr.mdx
@@ -136,7 +136,7 @@ Once set up, the workflow automatically handles these parameters:
               cd $RUNNER_TEMP/bin
 
               # Download CLI tool
-              wget https://github.com/langgenius/dify-plugin-daemon/releases/latest/download/dify-plugin-darwin-arm64
+              wget https://github.com/langgenius/dify-plugin-daemon/releases/latest/download/dify-plugin-linux-amd64
               chmod +x dify-plugin-linux-amd64
 
               # Show download location and file

--- a/plugin-dev-en/0321-plugin-auto-publish-pr.mdx
+++ b/plugin-dev-en/0321-plugin-auto-publish-pr.mdx
@@ -136,7 +136,7 @@ Once set up, the workflow automatically handles these parameters:
               cd $RUNNER_TEMP/bin
 
               # Download CLI tool
-              wget https://github.com/langgenius/dify-plugin-daemon/releases/download/0.0.6/dify-plugin-linux-amd64
+              wget https://github.com/langgenius/dify-plugin-daemon/releases/latest/download/dify-plugin-darwin-arm64
               chmod +x dify-plugin-linux-amd64
 
               # Show download location and file

--- a/plugin-dev-ja/0321-plugin-auto-publish-pr.mdx
+++ b/plugin-dev-ja/0321-plugin-auto-publish-pr.mdx
@@ -135,7 +135,7 @@ dify-plugins/
               cd $RUNNER_TEMP/bin
 
               # Download CLI tool
-              wget https://github.com/langgenius/dify-plugin-daemon/releases/download/0.0.6/dify-plugin-linux-amd64
+              wget https://github.com/langgenius/dify-plugin-daemon/releases/latest/download/dify-plugin-darwin-arm64
               chmod +x dify-plugin-linux-amd64
 
               # Show download location and file

--- a/plugin-dev-ja/0321-plugin-auto-publish-pr.mdx
+++ b/plugin-dev-ja/0321-plugin-auto-publish-pr.mdx
@@ -135,7 +135,7 @@ dify-plugins/
               cd $RUNNER_TEMP/bin
 
               # Download CLI tool
-              wget https://github.com/langgenius/dify-plugin-daemon/releases/latest/download/dify-plugin-darwin-arm64
+              wget https://github.com/langgenius/dify-plugin-daemon/releases/latest/download/dify-plugin-linux-amd64
               chmod +x dify-plugin-linux-amd64
 
               # Show download location and file

--- a/plugin-dev-zh/0321-plugin-auto-publish-pr.mdx
+++ b/plugin-dev-zh/0321-plugin-auto-publish-pr.mdx
@@ -136,7 +136,7 @@ dify-plugins/
               cd $RUNNER_TEMP/bin
 
               # Download CLI tool
-              wget https://github.com/langgenius/dify-plugin-daemon/releases/latest/download/dify-plugin-darwin-arm64
+              wget https://github.com/langgenius/dify-plugin-daemon/releases/latest/download/dify-plugin-linux-amd64
               chmod +x dify-plugin-linux-amd64
 
               # Show download location and file

--- a/plugin-dev-zh/0321-plugin-auto-publish-pr.mdx
+++ b/plugin-dev-zh/0321-plugin-auto-publish-pr.mdx
@@ -136,7 +136,7 @@ dify-plugins/
               cd $RUNNER_TEMP/bin
 
               # Download CLI tool
-              wget https://github.com/langgenius/dify-plugin-daemon/releases/download/0.0.6/dify-plugin-linux-amd64
+              wget https://github.com/langgenius/dify-plugin-daemon/releases/latest/download/dify-plugin-darwin-arm64
               chmod +x dify-plugin-linux-amd64
 
               # Show download location and file


### PR DESCRIPTION
- currently hardcoded version 0.0.6 of dify plugin cli is not supporting for packaging the trigger plugin
- use latest version of dify plugin cli instead