### PR TITLE
docs: add Plivo SMS & Verify environment variables

### DIFF
--- a/en/self-host/configuration/environments.mdx
+++ b/en/self-host/configuration/environments.mdx
@@ -630,6 +630,20 @@ Notion integration configuration variables can be obtained by applying for Notio
 
 For more details about the SendGrid email provider, please refer to the [SendGrid documentation](https://sendgrid.com/docs/for-developers/sending-email/).
 
+### Plivo SMS & Verify Configuration
+
+Used to configure [Plivo](https://www.plivo.com/) as a communications provider for SMS messaging and phone-based OTP verification. Obtain your Auth ID and Auth Token from the [Plivo console dashboard](https://console.plivo.com/dashboard/).
+
+- PLIVO_AUTH_ID: Your Plivo Auth ID for API authentication.
+- PLIVO_AUTH_TOKEN: Your Plivo Auth Token for API authentication.
+- PLIVO_VERIFY_ENABLED: Set to `true` to enable phone verification via Plivo Verify API. Default is `false`.
+- PLIVO_DEFAULT_FROM_NUMBER: Default Plivo phone number in E.164 format (e.g. `+14155550100`) used as the sender for outbound SMS. Must be a number rented from Plivo.
+- PHONE_CODE_LOGIN_TOKEN_EXPIRY_MINUTES: Duration in minutes for phone verification login tokens. Default is `5`.
+- PHONE_VERIFY_LOCKOUT_DURATION: Duration in minutes of lockout after too many failed verification attempts. Default is `5`.
+- PHONE_VERIFY_MAX_ATTEMPTS: Maximum number of incorrect OTP attempts before lockout. Default is `5`.
+
+For more details about Plivo, please refer to the [Plivo SMS documentation](https://www.plivo.com/docs/sms/) and [Plivo Verify documentation](https://www.plivo.com/docs/verify/).
+
 ### ModelProvider & Tool Position Configuration
 
 Used to specify the model providers and tools that can be used in the app. These settings allow you to customize which tools and model providers are available, as well as their order and inclusion/exclusion in the app's interface.


### PR DESCRIPTION
## Summary

- Add Plivo SMS & Verify configuration section to `environments.mdx`, documenting all environment variables for the Plivo integration introduced in [langgenius/dify#31585](https://github.com/langgenius/dify/pull/31585)

## Details

Adds a new **Plivo SMS & Verify Configuration** section alongside the existing mail provider documentation, covering:

- `PLIVO_AUTH_ID` — Auth ID for API authentication
- `PLIVO_AUTH_TOKEN` — Auth Token for API authentication
- `PLIVO_VERIFY_ENABLED` — Feature flag for phone verification
- `PLIVO_DEFAULT_FROM_NUMBER` — Default sender number for outbound SMS
- `PHONE_CODE_LOGIN_TOKEN_EXPIRY_MINUTES` — Token expiry duration
- `PHONE_VERIFY_LOCKOUT_DURATION` — Lockout duration after failed attempts
- `PHONE_VERIFY_MAX_ATTEMPTS` — Max incorrect OTP attempts before lockout

## Test plan

- [ ] Verify the new section renders correctly in Mintlify preview
- [ ] Confirm environment variable names match the Dify API codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)