### PR TITLE
docs(api): add end-user lookup

### DIFF
--- a/en/api-reference/openapi_chat.json
+++ b/en/api-reference/openapi_chat.json
@@ -204,6 +204,35 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "Get End User",
+        "description": "Retrieve an end user by ID.\n\nThis is useful when other APIs return an end-user ID (e.g. `created_by` from File Upload).",
+        "operationId": "getEndUser",
+        "tags": ["End Users"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "End user ID.",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "End user retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetail" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/EndUserNotFound" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
     "/files/{file_id}/preview": {
       "get": {
         "summary": "File Preview",
@@ -1111,6 +1140,10 @@
         "ConversationNotFound": {
             "description": "Conversation not found. Error code: `conversation_not_exists`",
              "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+        },
+        "EndUserNotFound": {
+            "description": "End user not found. Error code: `end_user_not_found`",
+             "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
         }
     },
     "schemas": {
@@ -1489,6 +1522,21 @@
           "mime_type": { "type": "string" },
           "created_by": { "type": "string", "format": "uuid" },
           "created_at": { "type": "integer", "format": "int64" }
+        }
+      },
+      "EndUserDetail": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
         }
       },
       "MessageFeedbackRequest": {
@@ -1908,6 +1956,7 @@
   "tags": [
     { "name": "Chat", "description": "Operations related to chat messages and interactions." },
     { "name": "Files", "description": "File upload and preview operations." },
+    { "name": "End Users", "description": "Operations related to end user information." },
     { "name": "Feedback", "description": "User feedback operations." },
     { "name": "Conversations", "description": "Operations related to managing conversations." },
     { "name": "TTS", "description": "Text-to-Speech and Speech-to-Text operations." },

--- a/en/api-reference/openapi_chatflow.json
+++ b/en/api-reference/openapi_chatflow.json
@@ -137,6 +137,35 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "Get End User",
+        "description": "Retrieve an end user by ID.\n\nThis is useful when other APIs return an end-user ID (e.g. `created_by` from File Upload).",
+        "operationId": "getEndUser",
+        "tags": ["End Users"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "End user ID.",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "End user retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetail" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/EndUserNotFound" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
     "/files/{file_id}/preview": {
       "get": {
         "summary": "File Preview",
@@ -768,7 +797,8 @@
         "S3ErrorFile": { "description": "S3 storage error.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
         "InternalServerError": { "description": "Internal server error.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
         "SuccessResult": { "description": "Operation successful.", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } },
-        "ConversationNotFound": { "description": "Conversation not found.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+        "ConversationNotFound": { "description": "Conversation not found.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
+        "EndUserNotFound": { "description": "End user not found. Error code: `end_user_not_found`", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
     },
     "schemas": {
       "AdvancedChatRequest": {
@@ -1049,6 +1079,21 @@
       "FileUploadResponse": {
         "type": "object", "properties": { "id": { "type": "string", "format": "uuid" }, "name": { "type": "string" }, "size": { "type": "integer" }, "extension": { "type": "string" }, "mime_type": { "type": "string" }, "created_by": { "type": "string", "format": "uuid" }, "created_at": { "type": "integer", "format": "int64" } }
       },
+      "EndUserDetail": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "MessageFeedbackRequest": {
         "type": "object", "required": ["user"], "properties": { "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true }, "user": { "type": "string" }, "content": { "type": "string", "nullable": true } }
       },
@@ -1129,6 +1174,7 @@
   "tags": [
     { "name": "Chatflow", "description": "Advanced chat operations with workflow events." },
     { "name": "Files", "description": "File upload and preview operations for advanced chat." },
+    { "name": "End Users", "description": "Operations related to end user information." },
     { "name": "Feedback", "description": "User feedback operations for advanced chat." },
     { "name": "Conversations", "description": "Conversation management for advanced chat." },
     { "name": "TTS", "description": "Speech and Text conversion for advanced chat." },

--- a/en/api-reference/openapi_completion.json
+++ b/en/api-reference/openapi_completion.json
@@ -232,6 +232,49 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "Get End User",
+        "description": "Retrieve an end user by ID.\n\nThis is useful when other APIs return an end-user ID (e.g. `created_by` from File Upload).",
+        "operationId": "getEndUser",
+        "tags": ["End Users"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "End user ID.",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "End user retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetail" }
+              }
+            }
+          },
+          "404": {
+            "description": "End user not found. Error code: `end_user_not_found`",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/completion-messages/{task_id}/stop": {
       "post": {
         "summary": "Stop Generate",
@@ -961,6 +1004,21 @@
           "created_at": { "type": "integer", "format": "int64", "description": "Creation timestamp (Unix epoch).", "example": 1577836800 }
         }
       },
+      "EndUserDetail": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "MessageFeedbackRequest": {
         "type": "object",
         "properties": {
@@ -1211,6 +1269,7 @@
   "tags": [
     { "name": "Completion", "description": "Operations related to text generation and completion." },
     { "name": "Files", "description": "Operations related to file management." },
+    { "name": "End Users", "description": "Operations related to end user information." },
     { "name": "Feedback", "description": "Operations related to user feedback." },
     { "name": "TTS", "description": "Operations related to Text-to-Speech." },
     { "name": "Application", "description": "Operations to retrieve application settings and information." }

--- a/en/api-reference/openapi_workflow.json
+++ b/en/api-reference/openapi_workflow.json
@@ -194,6 +194,35 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "Get End User",
+        "description": "Retrieve an end user by ID.\n\nThis is useful when other APIs return an end-user ID (e.g. `created_by` from File Upload).",
+        "operationId": "getEndUser",
+        "tags": ["End Users"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "End user ID.",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "End user retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetail" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/EndUserNotFound" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
     "/workflows/logs": {
         "get": {
             "summary": "Get Workflow Logs",
@@ -256,7 +285,8 @@
         "UnsupportedFileTypeFile": { "description": "Unsupported file type for upload.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
         "S3ErrorFile": { "description": "S3 storage error.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
         "InternalServerError": { "description": "Internal server error.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-        "SuccessResult": { "description": "Operation successful.", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } }
+        "SuccessResult": { "description": "Operation successful.", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } },
+        "EndUserNotFound": { "description": "End user not found. Error code: `end_user_not_found`", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
     },
     "schemas": {
       "WorkflowExecutionRequest": {
@@ -417,6 +447,21 @@
       "FileUploadResponse": {
         "type": "object", "properties": { "id": { "type": "string", "format": "uuid" }, "name": { "type": "string" }, "size": { "type": "integer" }, "extension": { "type": "string" }, "mime_type": { "type": "string" }, "created_by": { "type": "string", "format": "uuid" }, "created_at": { "type": "integer", "format": "int64" } }
       },
+      "EndUserDetail": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "WorkflowLogsResponse": {
         "type": "object",
         "properties": {
@@ -484,6 +529,7 @@
   "tags": [
     { "name": "Workflow Execution", "description": "Operations related to executing and managing workflows." },
     { "name": "Files", "description": "File upload and preview operations specific to workflows." },
+    { "name": "End Users", "description": "Operations related to end user information." },
     { "name": "Application", "description": "Application settings and info for workflow apps." }
   ]
 }

--- a/ja/api-reference/openapi_chat.json
+++ b/ja/api-reference/openapi_chat.json
@@ -117,6 +117,35 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "エンドユーザー取得",
+        "description": "IDでエンドユーザーを取得します。\n\n他のAPIがエンドユーザーID（例：ファイルアップロードの `created_by`）を返す場合に利用できます。",
+        "operationId": "getEndUserChatJa",
+        "tags": ["エンドユーザー"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "エンドユーザーID。",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "エンドユーザーの取得に成功しました。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetailJa" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/EndUserNotFoundJa" },
+          "500": { "$ref": "#/components/responses/InternalServerErrorJa" }
+        }
+      }
+    },
     "/files/{file_id}/preview": {
       "get": {
         "summary": "ファイルプレビュー",
@@ -424,7 +453,8 @@
         "S3ErrorFileJa": { "description": "S3ストレージサービスエラー。考えられる原因：s3_connection_failed, s3_permission_denied, s3_file_too_large。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJa" } } } },
         "InternalServerErrorJa": { "description": "内部サーバーエラー。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJa" } } } },
         "SuccessResultJa": { "description": "操作成功。", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } },
-        "ConversationNotFoundJa": { "description": "会話が存在しません。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJa" } } } }
+        "ConversationNotFoundJa": { "description": "会話が存在しません。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJa" } } } },
+        "EndUserNotFoundJa": { "description": "エンドユーザーが見つかりません。エラーコード：`end_user_not_found`", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJa" } } } }
     },
     "schemas": {
       "BasicChatRequestJa": {
@@ -534,6 +564,21 @@
       "UsageJa": { "type": "object", "description": "モデル使用情報。", "properties": { "prompt_tokens": { "type": "integer" }, "prompt_unit_price": { "type": "string" }, "prompt_price_unit": { "type": "string" }, "prompt_price": { "type": "string" }, "completion_tokens": { "type": "integer" }, "completion_unit_price": { "type": "string" }, "completion_price_unit": { "type": "string" }, "completion_price": { "type": "string" }, "total_tokens": { "type": "integer" }, "total_price": { "type": "string" }, "currency": { "type": "string" }, "latency": { "type": "number", "format": "double" } } },
       "RetrieverResourceJa": { "type": "object", "description": "引用と帰属情報。", "properties": { "position": { "type": "integer" }, "dataset_id": { "type": "string", "format": "uuid" }, "dataset_name": { "type": "string" }, "document_id": { "type": "string", "format": "uuid" }, "document_name": { "type": "string" }, "segment_id": { "type": "string", "format": "uuid" }, "score": { "type": "number", "format": "float" }, "content": { "type": "string" } } },
       "FileUploadResponseJa": { "type": "object", "description": "ファイルアップロード成功後の応答。", "properties": { "id": { "type": "string", "format": "uuid", "description": "ID。" }, "name": { "type": "string", "description": "ファイル名。" }, "size": { "type": "integer", "description": "ファイルサイズ（バイト）。" }, "extension": { "type": "string", "description": "ファイル拡張子。" }, "mime_type": { "type": "string", "description": "ファイルのMIMEタイプ。" }, "created_by": { "type": "string", "format": "uuid", "description": "エンドユーザーID。" }, "created_at": { "type": "integer", "format": "int64", "description": "作成タイムスタンプ。" } } },
+      "EndUserDetailJa": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "MessageFeedbackRequestJa": { "type": "object", "required": ["user"], "properties": { "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true, "description": "アップボートは`like`、ダウンボートは`dislike`、アップボートの取り消しは`null`。" }, "user": { "type": "string", "description": "ユーザー識別子。" }, "content": { "type": "string", "nullable": true, "description": "メッセージのフィードバックです。" } } },
       "AppFeedbacksResponseJa": { "type": "object", "properties": { "data": { "type": "array", "items": { "$ref": "#/components/schemas/FeedbackItemJa" }, "description": "このアプリの「いいね」とフィードバックの一覧を返します。" } } },
       "FeedbackItemJa": { "type": "object", "properties": { "id": { "type": "string", "format": "uuid" }, "app_id": { "type": "string", "format": "uuid" }, "conversation_id": { "type": "string", "format": "uuid" }, "message_id": { "type": "string", "format": "uuid" }, "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true }, "content": { "type": "string" }, "from_source": { "type": "string" }, "from_end_user_id": { "type": "string", "format": "uuid" }, "from_account_id": { "type": "string", "format": "uuid", "nullable": true }, "created_at": { "type": "string", "format": "date-time" }, "updated_at": { "type": "string", "format": "date-time" } } },
@@ -582,6 +627,7 @@
   "tags": [
     { "name": "チャットメッセージ", "description": "チャットメッセージと対話に関連する操作。" },
     { "name": "ファイル操作", "description": "ファイルアップロードとプレビューに関連する操作。" },
+    { "name": "エンドユーザー", "description": "エンドユーザー情報に関連する操作。" },
     { "name": "メッセージフィードバック", "description": "ユーザーからのメッセージフィードバック操作。" },
     { "name": "会話管理", "description": "会話セッションの管理に関連する操作。" },
     { "name": "音声とテキスト変換", "description": "テキストから音声、音声からテキストへの変換操作。" },

--- a/ja/api-reference/openapi_chatflow.json
+++ b/ja/api-reference/openapi_chatflow.json
@@ -136,6 +136,35 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "エンドユーザー取得",
+        "description": "IDでエンドユーザーを取得します。\n\n他のAPIがエンドユーザーID（例：ファイルアップロードの `created_by`）を返す場合に利用できます。",
+        "operationId": "getEndUserChatflowJp",
+        "tags": ["エンドユーザー"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "エンドユーザーID。",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "エンドユーザーの取得に成功しました。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetailJp" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/EndUserNotFoundJp" },
+          "500": { "$ref": "#/components/responses/InternalServerErrorJp" }
+        }
+      }
+    },
     "/files/{file_id}/preview": {
       "get": {
         "summary": "ファイルプレビュー",
@@ -585,7 +614,8 @@
         "S3ErrorFileJp": { "description": "S3ストレージサービスエラー。考えられる原因：s3_connection_failed, s3_permission_denied, s3_file_too_large。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } },
         "InternalServerErrorJp": { "description": "内部サーバーエラー。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } },
         "SuccessResultJp": { "description": "操作成功。", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } },
-        "ConversationNotFoundJp": { "description": "会話が存在しません。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } }
+        "ConversationNotFoundJp": { "description": "会話が存在しません。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } },
+        "EndUserNotFoundJp": { "description": "エンドユーザーが見つかりません。エラーコード：`end_user_not_found`", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } }
     },
     "schemas": {
       "ChatflowRequestJp": {
@@ -694,6 +724,21 @@
       "UsageJp": { "type": "object", "description": "モデル使用情報。", "properties": { "prompt_tokens": { "type": "integer" }, "prompt_unit_price": { "type": "string" }, "prompt_price_unit": { "type": "string" }, "prompt_price": { "type": "string" }, "completion_tokens": { "type": "integer" }, "completion_unit_price": { "type": "string" }, "completion_price_unit": { "type": "string" }, "completion_price": { "type": "string" }, "total_tokens": { "type": "integer" }, "total_price": { "type": "string" }, "currency": { "type": "string" }, "latency": { "type": "number", "format": "double" } } },
       "RetrieverResourceJp": { "type": "object", "description": "引用と帰属リスト。", "properties": { "position": { "type": "integer" }, "dataset_id": { "type": "string", "format": "uuid" }, "dataset_name": { "type": "string" }, "document_id": { "type": "string", "format": "uuid" }, "document_name": { "type": "string" }, "segment_id": { "type": "string", "format": "uuid" }, "score": { "type": "number", "format": "float" }, "content": { "type": "string" } } },
       "FileUploadResponseJp": { "type": "object", "description": "ファイルアップロード成功時の応答。", "properties": { "id": { "type": "string", "format": "uuid", "description": "ID。" }, "name": { "type": "string", "description": "ファイル名。" }, "size": { "type": "integer", "description": "ファイルサイズ（バイト）。" }, "extension": { "type": "string", "description": "ファイル拡張子。" }, "mime_type": { "type": "string", "description": "ファイルのMIMEタイプ。" }, "created_by": { "type": "string", "format": "uuid", "description": "エンドユーザーID。" }, "created_at": { "type": "integer", "format": "int64", "description": "作成タイムスタンプ。" } } },
+      "EndUserDetailJp": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "MessageFeedbackRequestJp": { "type": "object", "required": ["user"], "properties": { "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true, "description": "アップボートは`like`、ダウンボートは`dislike`、取り消しは`null`。" }, "user": { "type": "string", "description": "ユーザー識別子。" }, "content": { "type": "string", "nullable": true, "description": "メッセージフィードバックの具体的な内容。" } } },
       "AppFeedbacksResponseJp": { "type": "object", "properties": { "data": { "type": "array", "items": { "$ref": "#/components/schemas/FeedbackItemJp" }, "description": "このアプリの「いいね」とフィードバックの一覧。" } } },
       "FeedbackItemJp": { "type": "object", "properties": { "id": { "type": "string", "format": "uuid" }, "app_id": { "type": "string", "format": "uuid" }, "conversation_id": { "type": "string", "format": "uuid" }, "message_id": { "type": "string", "format": "uuid" }, "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true }, "content": { "type": "string" }, "from_source": { "type": "string" }, "from_end_user_id": { "type": "string", "format": "uuid" }, "from_account_id": { "type": "string", "format": "uuid", "nullable": true }, "created_at": { "type": "string", "format": "date-time" }, "updated_at": { "type": "string", "format": "date-time" } } },
@@ -728,6 +773,7 @@
   "tags": [
     { "name": "チャットメッセージ", "description": "チャットメッセージとインタラクションに関連する操作。" },
     { "name": "ファイル操作", "description": "ファイルアップロードとプレビューに関連する操作。" },
+    { "name": "エンドユーザー", "description": "エンドユーザー情報に関連する操作。" },
     { "name": "メッセージフィードバック", "description": "ユーザーメッセージへのフィードバック操作。" },
     { "name": "会話管理", "description": "会話セッションの管理に関連する操作。" },
     { "name": "音声・テキスト変換", "description": "テキストから音声へ、音声からテキストへの変換操作。" },

--- a/ja/api-reference/openapi_completion.json
+++ b/ja/api-reference/openapi_completion.json
@@ -106,6 +106,35 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "エンドユーザー取得",
+        "description": "IDでエンドユーザーを取得します。\n\n他のAPIがエンドユーザーID（例：ファイルアップロードの `created_by`）を返す場合に利用できます。",
+        "operationId": "getEndUserCompletionJp",
+        "tags": ["エンドユーザー"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "エンドユーザーID。",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "エンドユーザーの取得に成功しました。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetailJp" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/EndUserNotFoundJp" },
+          "500": { "$ref": "#/components/responses/InternalServerErrorJp" }
+        }
+      }
+    },
     "/completion-messages/{task_id}/stop": {
       "post": {
         "summary": "生成の停止",
@@ -198,7 +227,8 @@
         "FileTooLargeJp": { "description": "ファイルが大きすぎます (file_too_large)。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } },
         "UnsupportedFileTypeFileJp": { "description": "サポートされていないファイルタイプです (unsupported_file_type)。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } },
         "S3ErrorFileJp": { "description": "S3ストレージサービスエラー。エラーコード例: s3_connection_failed, s3_permission_denied, s3_file_too_large。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } },
-        "SuccessResultJp": { "description": "操作成功。", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } }
+        "SuccessResultJp": { "description": "操作成功。", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } },
+        "EndUserNotFoundJp": { "description": "エンドユーザーが見つかりません。エラーコード：`end_user_not_found`", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } }
     },
     "schemas": {
       "CompletionRequestJp": {
@@ -265,6 +295,21 @@
       "UsageJp": { "type": "object", "description": "モデル使用情報。", "properties": { "prompt_tokens": { "type": "integer" }, "prompt_unit_price": { "type": "string" }, "prompt_price_unit": { "type": "string" }, "prompt_price": { "type": "string" }, "completion_tokens": { "type": "integer" }, "completion_unit_price": { "type": "string" }, "completion_price_unit": { "type": "string" }, "completion_price": { "type": "string" }, "total_tokens": { "type": "integer" }, "total_price": { "type": "string" }, "currency": { "type": "string" }, "latency": { "type": "number", "format": "double" } } },
       "RetrieverResourceJp": { "type": "object", "description": "引用と帰属の情報。", "properties": { "document_id": { "type": "string" }, "segment_id": { "type": "string" }, "score": { "type": "number" }, "content": { "type": "string" } } },
       "FileUploadResponseJp": { "type": "object", "description": "ファイルアップロード成功時のレスポンス。", "properties": { "id": { "type": "string", "format": "uuid", "description": "ID。" }, "name": { "type": "string", "description": "ファイル名。" }, "size": { "type": "integer", "description": "ファイルサイズ（バイト）。" }, "extension": { "type": "string", "description": "ファイル拡張子。" }, "mime_type": { "type": "string", "description": "ファイルのMIMEタイプ。" }, "created_by": { "type": "string", "format": "uuid", "description": "エンドユーザーID。" }, "created_at": { "type": "integer", "format": "int64", "description": "作成タイムスタンプ。" } } },
+      "EndUserDetailJp": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "MessageFeedbackRequestJp": { "type": "object", "required": ["user"], "properties": { "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true, "description": "高評価 `like`, 低評価 `dislike`, 取り消し `null`。" }, "user": { "type": "string", "description": "ユーザー識別子。" }, "content": { "type": "string", "nullable": true, "description": "メッセージフィードバックの具体的な内容。" } } },
       "AppFeedbacksResponseJp": { "type": "object", "properties": { "data": { "type": "array", "items": { "$ref": "#/components/schemas/FeedbackItemJp" }, "description": "このアプリの「いいね」とフィードバックの一覧。" } } },
       "FeedbackItemJp": { "type": "object", "properties": { "id": { "type": "string", "format": "uuid" }, "app_id": { "type": "string", "format": "uuid" }, "conversation_id": { "type": "string", "format": "uuid" }, "message_id": { "type": "string", "format": "uuid" }, "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true }, "content": { "type": "string" }, "from_source": { "type": "string" }, "from_end_user_id": { "type": "string", "format": "uuid" }, "from_account_id": { "type": "string", "format": "uuid", "nullable": true }, "created_at": { "type": "string", "format": "date-time" }, "updated_at": { "type": "string", "format": "date-time" } } },
@@ -285,6 +330,7 @@
   "tags": [
     { "name": "完了メッセージ", "description": "テキスト生成と完了に関連する操作。" },
     { "name": "ファイル操作", "description": "ファイル管理に関連する操作。" },
+    { "name": "エンドユーザー", "description": "エンドユーザー情報に関連する操作。" },
     { "name": "メッセージフィードバック", "description": "ユーザーフィードバックに関連する操作。" },
     { "name": "音声変換", "description": "テキストから音声への変換に関連する操作。" },
     { "name": "アプリケーション情報", "description": "アプリケーションの設定と情報を取得する操作。" }

--- a/ja/api-reference/openapi_workflow.json
+++ b/ja/api-reference/openapi_workflow.json
@@ -188,6 +188,35 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "エンドユーザー取得",
+        "description": "IDでエンドユーザーを取得します。\n\n他のAPIがエンドユーザーID（例：ファイルアップロードの `created_by`）を返す場合に利用できます。",
+        "operationId": "getEndUserWorkflowJp",
+        "tags": ["エンドユーザー"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "エンドユーザーID。",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "エンドユーザーの取得に成功しました。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetailJp" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/EndUserNotFoundJp" },
+          "500": { "$ref": "#/components/responses/InternalServerErrorJp" }
+        }
+      }
+    },
     "/workflows/logs": {
         "get": {
             "summary": "ワークフローログを取得",
@@ -241,7 +270,8 @@
         "UnsupportedFileTypeFileJp": { "description": "サポートされていないファイルタイプです (unsupported_file_type)。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } },
         "S3ErrorFileJp": { "description": "S3ストレージサービスエラー。考えられるエラーコード：s3_connection_failed, s3_permission_denied, s3_file_too_large。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } },
         "InternalServerErrorJp": { "description": "内部サーバーエラー。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } },
-        "SuccessResultJp": { "description": "操作に成功しました。", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } }
+        "SuccessResultJp": { "description": "操作に成功しました。", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } },
+        "EndUserNotFoundJp": { "description": "エンドユーザーが見つかりません。エラーコード：`end_user_not_found`", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseJp" } } } }
     },
     "schemas": {
       "WorkflowExecutionRequestJp": {
@@ -341,6 +371,21 @@
         }
       },
       "FileUploadResponseJp": { "type": "object", "description": "ファイルアップロード成功時の応答。", "properties": { "id": { "type": "string", "format": "uuid", "description": "ID。" }, "name": { "type": "string", "description": "ファイル名。" }, "size": { "type": "integer", "description": "ファイルサイズ（バイト）。" }, "extension": { "type": "string", "description": "ファイル拡張子。" }, "mime_type": { "type": "string", "description": "ファイルのMIMEタイプ。" }, "created_by": { "type": "string", "format": "uuid", "description": "エンドユーザーID。" }, "created_at": { "type": "integer", "format": "int64", "description": "作成タイムスタンプ。" } } },
+      "EndUserDetailJp": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "WorkflowLogsResponseJp": {
         "type": "object", "description": "ワークフローログリストの応答。",
         "properties": {
@@ -397,6 +442,7 @@
   "tags": [
     { "name": "ワークフロー実行", "description": "ワークフローの実行と管理に関連する操作。" },
     { "name": "ファイル操作 (ワークフロー)", "description": "ワークフロー固有のファイルアップロードとプレビュー操作。" },
+    { "name": "エンドユーザー", "description": "エンドユーザー情報に関連する操作。" },
     { "name": "アプリケーション設定 (ワークフロー)", "description": "ワークフローアプリのアプリケーション設定と情報。" }
   ]
 }

--- a/zh/api-reference/openapi_chat.json
+++ b/zh/api-reference/openapi_chat.json
@@ -136,6 +136,35 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "获取终端用户",
+        "description": "通过 ID 获取终端用户信息。\n\n当其他 API 返回终端用户 ID（例如文件上传接口返回的 `created_by`）时，可使用该接口查询对应的终端用户信息。",
+        "operationId": "getEndUserChatCn",
+        "tags": ["终端用户"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "终端用户 ID。",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功获取终端用户信息。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetailCn" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/EndUserNotFoundCn" },
+          "500": { "$ref": "#/components/responses/InternalServerErrorCn" }
+        }
+      }
+    },
     "/files/{file_id}/preview": {
       "get": {
         "summary": "文件预览",
@@ -589,7 +618,8 @@
         "S3ErrorFileCn": { "description": "S3 存储服务错误。可能原因：s3_connection_failed, s3_permission_denied, s3_file_too_large。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } },
         "InternalServerErrorCn": { "description": "服务内部异常。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } },
         "SuccessResultCn": { "description": "操作成功。", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } },
-        "ConversationNotFoundCn": { "description": "对话不存在。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } }
+        "ConversationNotFoundCn": { "description": "对话不存在。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } },
+        "EndUserNotFoundCn": { "description": "终端用户不存在。错误码：`end_user_not_found`", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } }
     },
     "schemas": {
       "BasicChatRequestCn": {
@@ -707,6 +737,21 @@
       "UsageCn": { "type": "object", "description": "模型用量信息。", "properties": { "prompt_tokens": { "type": "integer" }, "prompt_unit_price": { "type": "string" }, "prompt_price_unit": { "type": "string" }, "prompt_price": { "type": "string" }, "completion_tokens": { "type": "integer" }, "completion_unit_price": { "type": "string" }, "completion_price_unit": { "type": "string" }, "completion_price": { "type": "string" }, "total_tokens": { "type": "integer" }, "total_price": { "type": "string" }, "currency": { "type": "string" }, "latency": { "type": "number", "format": "double" } } },
       "RetrieverResourceCn": { "type": "object", "description": "引用和归属分段信息。", "properties": { "position": { "type": "integer" }, "dataset_id": { "type": "string", "format": "uuid" }, "dataset_name": { "type": "string" }, "document_id": { "type": "string", "format": "uuid" }, "document_name": { "type": "string" }, "segment_id": { "type": "string", "format": "uuid" }, "score": { "type": "number", "format": "float" }, "content": { "type": "string" } } },
       "FileUploadResponseCn": { "type": "object", "description": "文件上传成功后的响应。", "properties": { "id": { "type": "string", "format": "uuid", "description": "ID。" }, "name": { "type": "string", "description": "文件名。" }, "size": { "type": "integer", "description": "文件大小 (byte)。" }, "extension": { "type": "string", "description": "文件后缀。" }, "mime_type": { "type": "string", "description": "文件 mime-type。" }, "created_by": { "type": "string", "format": "uuid", "description": "上传人 ID。" }, "created_at": { "type": "integer", "format": "int64", "description": "上传时间。" } } },
+      "EndUserDetailCn": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "MessageFeedbackRequestCn": { "type": "object", "required": ["user"], "properties": { "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true, "description": "点赞 'like', 点踩 'dislike', 撤销点赞 null。" }, "user": { "type": "string", "description": "用户标识。" }, "content": { "type": "string", "nullable": true, "description": "消息反馈的具体信息。" } } },
       "AppFeedbacksResponseCn": { "type": "object", "properties": { "data": { "type": "array", "items": { "$ref": "#/components/schemas/FeedbackItemCn" }, "description": "返回该APP的点赞、反馈列表。" } } },
       "FeedbackItemCn": { "type": "object", "properties": { "id": { "type": "string", "format": "uuid" }, "app_id": { "type": "string", "format": "uuid" }, "conversation_id": { "type": "string", "format": "uuid" }, "message_id": { "type": "string", "format": "uuid" }, "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true }, "content": { "type": "string" }, "from_source": { "type": "string" }, "from_end_user_id": { "type": "string", "format": "uuid" }, "from_account_id": { "type": "string", "format": "uuid", "nullable": true }, "created_at": { "type": "string", "format": "date-time" }, "updated_at": { "type": "string", "format": "date-time" } } },
@@ -756,6 +801,7 @@
   "tags": [
     { "name": "对话消息", "description": "与对话消息和交互相关的操作。" },
     { "name": "文件操作", "description": "文件上传和预览相关的操作。" },
+    { "name": "终端用户", "description": "终端用户信息相关的操作。" },
     { "name": "消息反馈", "description": "用户对消息的反馈操作。" },
     { "name": "会话管理", "description": "管理对话会话相关的操作。" },
     { "name": "语音与文字转换", "description": "文本转语音和语音转文本操作。" },

--- a/zh/api-reference/openapi_chatflow.json
+++ b/zh/api-reference/openapi_chatflow.json
@@ -136,6 +136,35 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "获取终端用户",
+        "description": "通过 ID 获取终端用户信息。\n\n当其他 API 返回终端用户 ID（例如文件上传接口返回的 `created_by`）时，可使用该接口查询对应的终端用户信息。",
+        "operationId": "getEndUserChatflowCn",
+        "tags": ["终端用户"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "终端用户 ID。",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功获取终端用户信息。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetailCn" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/EndUserNotFoundCn" },
+          "500": { "$ref": "#/components/responses/InternalServerErrorCn" }
+        }
+      }
+    },
     "/files/{file_id}/preview": {
       "get": {
         "summary": "文件预览",
@@ -647,7 +676,8 @@
         "S3ErrorFileCn": { "description": "S3 存储服务错误。可能原因：s3_connection_failed, s3_permission_denied, s3_file_too_large。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } },
         "InternalServerErrorCn": { "description": "服务内部异常。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } },
         "SuccessResultCn": { "description": "操作成功。", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } },
-        "ConversationNotFoundCn": { "description": "对话不存在。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } }
+        "ConversationNotFoundCn": { "description": "对话不存在。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } },
+        "EndUserNotFoundCn": { "description": "终端用户不存在。错误码：`end_user_not_found`", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } }
     },
     "schemas": {
       "ChatRequestCn": {
@@ -756,6 +786,21 @@
       "UsageCn": { "type": "object", "description": "模型用量信息。", "properties": { "prompt_tokens": { "type": "integer" }, "prompt_unit_price": { "type": "string" }, "prompt_price_unit": { "type": "string" }, "prompt_price": { "type": "string" }, "completion_tokens": { "type": "integer" }, "completion_unit_price": { "type": "string" }, "completion_price_unit": { "type": "string" }, "completion_price": { "type": "string" }, "total_tokens": { "type": "integer" }, "total_price": { "type": "string" }, "currency": { "type": "string" }, "latency": { "type": "number", "format": "double" } } },
       "RetrieverResourceCn": { "type": "object", "description": "引用和归属分段信息。", "properties": { "position": { "type": "integer" }, "dataset_id": { "type": "string", "format": "uuid" }, "dataset_name": { "type": "string" }, "document_id": { "type": "string", "format": "uuid" }, "document_name": { "type": "string" }, "segment_id": { "type": "string", "format": "uuid" }, "score": { "type": "number", "format": "float" }, "content": { "type": "string" } } },
       "FileUploadResponseCn": { "type": "object", "description": "文件上传成功后的响应。", "properties": { "id": { "type": "string", "format": "uuid", "description": "ID。" }, "name": { "type": "string", "description": "文件名。" }, "size": { "type": "integer", "description": "文件大小 (byte)。" }, "extension": { "type": "string", "description": "文件后缀。" }, "mime_type": { "type": "string", "description": "文件 mime-type。" }, "created_by": { "type": "string", "format": "uuid", "description": "上传人 ID (应为 uuid，示例中为 int，已修正)。" }, "created_at": { "type": "integer", "format": "int64", "description": "上传时间。" } } },
+      "EndUserDetailCn": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "MessageFeedbackRequestCn": { "type": "object", "required": ["user"], "properties": { "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true, "description": "点赞 'like', 点踩 'dislike', 撤销点赞 null。" }, "user": { "type": "string", "description": "用户标识。" }, "content": { "type": "string", "nullable": true, "description": "消息反馈的具体信息。" } } },
       "AppFeedbacksResponseCn": { "type": "object", "properties": { "data": { "type": "array", "items": { "$ref": "#/components/schemas/FeedbackItemCn" }, "description": "返回该APP的点赞、反馈列表。" } } },
       "FeedbackItemCn": { "type": "object", "properties": { "id": { "type": "string", "format": "uuid" }, "app_id": { "type": "string", "format": "uuid" }, "conversation_id": { "type": "string", "format": "uuid" }, "message_id": { "type": "string", "format": "uuid" }, "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true }, "content": { "type": "string" }, "from_source": { "type": "string" }, "from_end_user_id": { "type": "string", "format": "uuid" }, "from_account_id": { "type": "string", "format": "uuid", "nullable": true }, "created_at": { "type": "string", "format": "date-time" }, "updated_at": { "type": "string", "format": "date-time" } } },
@@ -797,6 +842,7 @@
   "tags": [
     { "name": "对话消息", "description": "与对话消息和交互相关的操作。" },
     { "name": "文件操作", "description": "文件上传和预览相关的操作。" },
+    { "name": "终端用户", "description": "终端用户信息相关的操作。" },
     { "name": "消息反馈", "description": "用户对消息的反馈操作。" },
     { "name": "会话管理", "description": "管理对话会话相关的操作。" },
     { "name": "语音与文字转换", "description": "文本转语音和语音转文本操作。" },

--- a/zh/api-reference/openapi_completion.json
+++ b/zh/api-reference/openapi_completion.json
@@ -149,6 +149,49 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "获取终端用户",
+        "description": "通过 ID 获取终端用户信息。\n\n当其他 API 返回终端用户 ID（例如文件上传接口返回的 `created_by`）时，可使用该接口查询对应的终端用户信息。",
+        "operationId": "getEndUserCompletionCn",
+        "tags": ["终端用户"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "终端用户 ID。",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功获取终端用户信息。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetail" }
+              }
+            }
+          },
+          "404": {
+            "description": "终端用户不存在。错误码：`end_user_not_found`",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "服务内部异常。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/completion-messages/{task_id}/stop": {
       "post": {
         "summary": "停止响应",
@@ -563,6 +606,21 @@
         "type": "object", "description": "文件上传成功后的响应。",
         "properties": { "id": { "type": "string", "format": "uuid", "description": "ID。" }, "name": { "type": "string", "description": "文件名。" }, "size": { "type": "integer", "description": "文件大小（byte）。" }, "extension": { "type": "string", "description": "文件后缀。" }, "mime_type": { "type": "string", "description": "文件 mime-type。" }, "created_by": { "type": "string", "format": "uuid", "description": "上传人 ID (示例中为integer，规范为uuid)。" }, "created_at": { "type": "integer", "format": "int64", "description": "上传时间。" } }
       },
+      "EndUserDetail": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "MessageFeedbackRequest": {
         "type": "object", "required": ["user"], "description": "消息反馈请求体。",
         "properties": { "rating": { "type": "string", "enum": ["like", "dislike", null], "nullable": true, "description": "点赞 `like`, 点踩 `dislike`, 撤销 `null`。" }, "user": { "type": "string", "description": "用户标识，应用内唯一。" }, "content": { "type": "string", "nullable": true, "description": "消息反馈的具体信息。" } }
@@ -652,6 +710,7 @@
   "tags": [
     { "name": "文本生成", "description": "与文本生成和完成相关的操作。" },
     { "name": "文件管理", "description": "与文件上传和管理相关的操作。" },
+    { "name": "终端用户", "description": "终端用户信息相关的操作。" },
     { "name": "反馈", "description": "与用户反馈相关的操作。" },
     { "name": "语音服务", "description": "与文本转语音相关的操作。" },
     { "name": "应用设置", "description": "获取应用基本信息和参数配置的操作。" },

--- a/zh/api-reference/openapi_workflow.json
+++ b/zh/api-reference/openapi_workflow.json
@@ -188,6 +188,35 @@
         }
       }
     },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "summary": "获取终端用户",
+        "description": "通过 ID 获取终端用户信息。\n\n当其他 API 返回终端用户 ID（例如文件上传接口返回的 `created_by`）时，可使用该接口查询对应的终端用户信息。",
+        "operationId": "getEndUserWorkflowCn",
+        "tags": ["终端用户"],
+        "parameters": [
+          {
+            "name": "end_user_id",
+            "in": "path",
+            "required": true,
+            "description": "终端用户 ID。",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功获取终端用户信息。",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EndUserDetailCn" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/EndUserNotFoundCn" },
+          "500": { "$ref": "#/components/responses/InternalServerErrorCn" }
+        }
+      }
+    },
     "/workflows/logs": {
         "get": {
             "summary": "获取 workflow 日志",
@@ -241,7 +270,8 @@
         "UnsupportedFileTypeFileCn": { "description": "不支持的文件类型 (unsupported_file_type)。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } },
         "S3ErrorFileCn": { "description": "S3 存储服务错误。可能错误码：s3_connection_failed, s3_permission_denied, s3_file_too_large。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } },
         "InternalServerErrorCn": { "description": "服务内部异常。", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } },
-        "SuccessResultCn": { "description": "操作成功。", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } }
+        "SuccessResultCn": { "description": "操作成功。", "content": { "application/json": { "schema": { "type": "object", "properties": { "result": { "type": "string", "example": "success" } } } } } },
+        "EndUserNotFoundCn": { "description": "终端用户不存在。错误码：`end_user_not_found`", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponseCn" } } } }
     },
     "schemas": {
       "WorkflowExecutionRequestCn": {
@@ -340,6 +370,21 @@
         }
       },
       "FileUploadResponseCn": { "type": "object", "description": "文件上传成功响应。", "properties": { "id": { "type": "string", "format": "uuid", "description": "ID。" }, "name": { "type": "string", "description": "文件名。" }, "size": { "type": "integer", "description": "文件大小 (byte)。" }, "extension": { "type": "string", "description": "文件后缀。" }, "mime_type": { "type": "string", "description": "文件 mime-type。" }, "created_by": { "type": "string", "format": "uuid", "description": "上传人 ID (应为 uuid，示例中为 int，已修正)。" }, "created_at": { "type": "integer", "format": "int64", "description": "上传时间。" } } },
+      "EndUserDetailCn": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "tenant_id": { "type": "string", "format": "uuid" },
+          "app_id": { "type": "string", "format": "uuid", "nullable": true },
+          "type": { "type": "string", "example": "service_api" },
+          "external_user_id": { "type": "string", "nullable": true },
+          "name": { "type": "string", "nullable": true },
+          "is_anonymous": { "type": "boolean" },
+          "session_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" }
+        }
+      },
       "WorkflowLogsResponseCn": {
         "type": "object", "description": "Workflow 日志列表响应。",
         "properties": {
@@ -396,6 +441,7 @@
   "tags": [
     { "name": "工作流执行", "description": "与执行和管理工作流相关的操作。" },
     { "name": "文件操作 (工作流)", "description": "特定于工作流的文件上传和预览操作。" },
+    { "name": "终端用户", "description": "终端用户信息相关的操作。" },
     { "name": "应用配置 (Workflow)", "description": "工作流应用的应用设置和信息。" }
   ]
 }


### PR DESCRIPTION
Adds Service API end-user lookup endpoint to the OpenAPI specs: `GET /end-users/{end_user_id}`.

- Updates: Chat / Chatflow / Workflow / Completion OpenAPI JSON
- Related: langgenius/dify#32015 (merged), langgenius/dify#32018
