### PR TITLE
Docs: add WFGY 16-problem checklist as RAG troubleshooting reference (langgenius/dify#32439)

### DIFF
--- a/en/use-dify/knowledge/readme.mdx
+++ b/en/use-dify/knowledge/readme.mdx
@@ -16,7 +16,6 @@ This is made possible through Retrieval-Augmented Generation (RAG). It means tha
 
 3. (Generation) The LLM uses this context to generate a **more precise** answer.
 
-
 Knowledge is stored and managed in knowledge bases. You can create multiple knowledge bases, each tailored to different domains, use cases, or data sources, and selectively integrate them into your application as needed.
 
 ## Build with Knowledge
@@ -53,6 +52,28 @@ With Dify knowledge, you can build AI apps that are grounded in your own data an
 
 **[Integrate into applications](/en/use-dify/knowledge/integrate-knowledge-within-application)**: Ground your AI app in your own knowledge.
 
+## Troubleshoot RAG quality
+
+When you start shipping RAG applications, most “it feels wrong” bugs are not model bugs, but
+pipeline bugs. Typical examples:
+
+- Retrieval returns the wrong or irrelevant chunks.
+- The chunks are correct, but the reasoning jumps to the wrong conclusion.
+- Session state or memory is lost between turns.
+- A deployment or infra change silently breaks an otherwise good flow.
+
+To make these failures easier to talk about, you can optionally use a public 16-pattern checklist,
+such as the open-source **WFGY ProblemMap**:
+
+- **Input & Retrieval** – e.g. hallucination, chunk drift, retrieval mis-routing.
+- **Reasoning & Planning** – long-chain drift, logic collapse, bluffing / overconfidence.
+- **State & Context** – memory breaks across sessions, entropy collapse.
+- **Infra & Deployment** – bootstrap ordering issues, deployment deadlocks, pre-deploy collapse.
+
+Each failure mode is given a stable label (No.1–16). You can log this label alongside your Dify
+workflow runs to see *where* the RAG stack is breaking (retrieval vs reasoning vs state vs infra),
+then decide which part of the pipeline to fix first.
+
 ---
 
 **Read More**:
@@ -70,3 +91,5 @@ With Dify knowledge, you can build AI apps that are grounded in your own data an
 - [Enhance Dify RAG with InfraNodus: Expand Your LLM's Context](https://dify.ai/blog/enhance-dify-rag-with-infranodus-expand-your-llm-s-context)
 
 - [Dify.AI x Jina AI: Dify now Integrates Jina Embedding Model](https://dify.ai/blog/integrating-jina-embeddings-v2-dify-enhancing-rag-applications)
+
+- [WFGY ProblemMap: 16 real-world RAG failure modes](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md)


### PR DESCRIPTION
This PR implements the documentation part of langgenius/dify#32439.

Changes:

- Adds a short “Troubleshoot RAG quality” section to the Knowledge overview page.
- Briefly introduces the 4 regions and 16 common failure patterns (input/retrieval, reasoning/planning, state/context, infra/deployment).
- Adds an external “Read More” link to the open-source WFGY ProblemMap (16 real-world RAG failure modes and suggested fixes).

No product or API changes are included in this PR.
The checklist is optional and can be used as a shared vocabulary when debugging RAG pipelines in Dify.