### PR TITLE
docs: fix typo in Key Concepts

### DIFF
--- a/en/use-dify/getting-started/key-concepts.mdx
+++ b/en/use-dify/getting-started/key-concepts.mdx
@@ -116,7 +116,7 @@ Like inputs, node outputs cannot be updated either.
 
 **Environment Variables**: Use environment variable to store sensitive information like API keys specific to your app. This allows a clean separation between secrets and the Dify app itself, so you don't have to risk exposing passwords and keys when sharing your app's DSL. Environment variables are also constants and cannot be updated.
 
-**Conversation Variables (Chatflow only)**: These variables are conversation-specific -- meaning they persist over multi-turn chatflow runs in a single conversatio so you can store and access dynamic information like to-do list and token cost. You can update the value of a conversation variable via the Variable Assigner node:
+**Conversation Variables (Chatflow only)**: These variables are conversation-specific -- meaning they persist over multi-turn chatflow runs in a single conversation so you can store and access dynamic information like to-do list and token cost. You can update the value of a conversation variable via the Variable Assigner node:
 
 <img
   src="/images/2935cb58851e5c5407a08dde49f7d9738bb13aa0e64df24278e2104b316f6af6.png"


### PR DESCRIPTION
This PR fixes a minor typo in the Key Concepts page.

fixes #687 