### PR TITLE
fix(ja): fix broken link in manage-knowledge-base.mdx

### DIFF
--- a/ja/use-dify/knowledge/knowledge-pipeline/manage-knowledge-base.mdx
+++ b/ja/use-dify/knowledge/knowledge-pipeline/manage-knowledge-base.mdx
@@ -11,7 +11,7 @@ title: "ステップ5：ナレッジベースの管理と活用"
 オーケストレーションしたパイプラインノードや設定の確認・修正が可能です。
 
 <Tip>
-詳細は[ナレッジ管理](/ja/use-dify/knowledge/knowledge-and-documents-maintenance/introduction)のガイドをご参照ください。
+詳細は[ナレッジ管理](/ja/use-dify/knowledge/manage-knowledge/maintain-knowledge-documents)のガイドをご参照ください。
 </Tip>
 
 ![ナレッジ管理](/images/knowledge-base/create-knowledge-pipeline-21.png)

--- a/zh/use-dify/knowledge/knowledge-pipeline/manage-knowledge-base.mdx
+++ b/zh/use-dify/knowledge/knowledge-pipeline/manage-knowledge-base.mdx
@@ -11,7 +11,7 @@ title: "步骤五：管理和使用知识库"
 浏览编排的流水线，并对节点和配置进行修改。
 
 <Tip>
-    你可前往[管理知识库文档](/zh/use-dify/knowledge/knowledge-and-documents-maintenance/introduction)，了解更多内容。
+    你可前往[管理知识库文档](/zh/use-dify/knowledge/manage-knowledge/maintain-knowledge-documents)，了解更多内容。
 </Tip>
 
 ![知识管理](/images/knowledge-base/create-knowledge-pipeline-21.png)


### PR DESCRIPTION
## Summary

Fixed a broken link in `ja/use-dify/knowledge/knowledge-pipeline/manage-knowledge-base.mdx`.

## Changes

| | URL |
|---|---|
| Before | `/ja/use-dify/knowledge/knowledge-and-documents-maintenance/introduction` |
| After | `/ja/use-dify/knowledge/manage-knowledge/maintain-knowledge-documents` |

## Verification in website
old link: https://docs.dify.ai/ja/use-dify/knowledge/knowledge-and-documents-maintenance/introduction
new link: https://docs.dify.ai/ja/use-dify/knowledge/manage-knowledge/maintain-knowledge-documents

### ref: English Document link
`manage-knowledge-base`: https://docs.dify.ai/en/use-dify/knowledge/knowledge-pipeline/manage-knowledge-base
Link in the page above: https://docs.dify.ai/en/use-dify/knowledge/manage-knowledge/maintain-knowledge-documents