### PR TITLE
fix: correct weights field type in RetrievalModel from float to WeightedScore object

### DIFF
--- a/en/api-reference/openapi_knowledge.json
+++ b/en/api-reference/openapi_knowledge.json
@@ -1410,7 +1410,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -1471,7 +1473,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["tag_id", "name"],
+                "required": [
+                  "tag_id",
+                  "name"
+                ],
                 "properties": {
                   "tag_id": {
                     "type": "string",
@@ -1514,7 +1519,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["tag_id"],
+                "required": [
+                  "tag_id"
+                ],
                 "properties": {
                   "tag_id": {
                     "type": "string",
@@ -1547,7 +1554,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["target_id", "tag_ids"],
+                "required": [
+                  "target_id",
+                  "tag_ids"
+                ],
                 "properties": {
                   "target_id": {
                     "type": "string",
@@ -1588,7 +1598,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["target_id", "tag_id"],
+                "required": [
+                  "target_id",
+                  "tag_id"
+                ],
                 "properties": {
                   "target_id": {
                     "type": "string",
@@ -1645,8 +1658,13 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": { "type": "string", "format": "uuid" },
-                          "name": { "type": "string" }
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
                         }
                       }
                     },
@@ -1808,9 +1826,8 @@
             "nullable": true
           },
           "weights": {
-            "type": "number",
-            "format": "float",
-            "description": "The weight of semantic search in a hybrid search mode.",
+            "$ref": "#/components/schemas/WeightedScore",
+            "description": "Weighted score configuration for hybrid search mode.",
             "nullable": true
           }
         }
@@ -2924,25 +2941,64 @@
         "type": "object",
         "description": "Represents a child chunk in a hierarchical segmentation.",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "segment_id": { "type": "string", "format": "uuid" },
-          "content": { "type": "string" },
-          "word_count": { "type": "integer" },
-          "tokens": { "type": "integer" },
-          "index_node_id": { "type": "string" },
-          "index_node_hash": { "type": "string" },
-          "status": { "type": "string" },
-          "created_by": { "type": "string", "format": "uuid" },
-          "created_at": { "type": "integer", "format": "int64" },
-          "indexing_at": { "type": "integer", "format": "int64" },
-          "completed_at": { "type": "integer", "format": "int64" },
-          "error": { "type": "string", "nullable": true },
-          "stopped_at": { "type": "integer", "format": "int64", "nullable": true }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "segment_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "content": {
+            "type": "string"
+          },
+          "word_count": {
+            "type": "integer"
+          },
+          "tokens": {
+            "type": "integer"
+          },
+          "index_node_id": {
+            "type": "string"
+          },
+          "index_node_hash": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "indexing_at": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "completed_at": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "error": {
+            "type": "string",
+            "nullable": true
+          },
+          "stopped_at": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          }
         }
       },
       "CreateChildChunkRequest": {
         "type": "object",
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "properties": {
           "content": {
             "type": "string",
@@ -2952,7 +3008,9 @@
       },
       "UpdateChildChunkRequest": {
         "type": "object",
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "properties": {
           "content": {
             "type": "string",
@@ -2977,33 +3035,130 @@
               "$ref": "#/components/schemas/ChildChunk"
             }
           },
-          "total": { "type": "integer" },
-          "total_pages": { "type": "integer" },
-          "page": { "type": "integer" },
-          "limit": { "type": "integer" }
+          "total": {
+            "type": "integer"
+          },
+          "total_pages": {
+            "type": "integer"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          }
         }
       },
       "UploadFileResponse": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "name": { "type": "string" },
-          "size": { "type": "integer" },
-          "extension": { "type": "string" },
-          "url": { "type": "string", "format": "uri", "description": "Preview URL for the file." },
-          "download_url": { "type": "string", "format": "uri", "description": "Download URL for the file." },
-          "mime_type": { "type": "string" },
-          "created_by": { "type": "string", "format": "uuid" },
-          "created_at": { "type": "integer", "format": "int64" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "extension": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Preview URL for the file."
+          },
+          "download_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Download URL for the file."
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "int64"
+          }
         }
       },
       "Tag": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "name": { "type": "string" },
-          "type": { "type": "string", "example": "knowledge" },
-          "binding_count": { "type": "integer" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "example": "knowledge"
+          },
+          "binding_count": {
+            "type": "integer"
+          }
+        }
+      },
+      "WeightedScore": {
+        "type": "object",
+        "description": "Configuration for weighted score retrieval, used when reranking_mode is 'weighted_score'.",
+        "properties": {
+          "weight_type": {
+            "type": "string",
+            "description": "The weighting strategy.",
+            "enum": [
+              "semantic_first",
+              "keyword_first",
+              "customized"
+            ],
+            "nullable": true
+          },
+          "vector_setting": {
+            "$ref": "#/components/schemas/VectorSetting",
+            "nullable": true
+          },
+          "keyword_setting": {
+            "$ref": "#/components/schemas/KeywordSetting",
+            "nullable": true
+          }
+        }
+      },
+      "VectorSetting": {
+        "type": "object",
+        "description": "Vector (semantic) search weight configuration.",
+        "properties": {
+          "vector_weight": {
+            "type": "number",
+            "format": "float",
+            "description": "Weight assigned to vector (semantic) search results."
+          },
+          "embedding_provider_name": {
+            "type": "string",
+            "description": "The embedding model provider name."
+          },
+          "embedding_model_name": {
+            "type": "string",
+            "description": "The embedding model name."
+          }
+        }
+      },
+      "KeywordSetting": {
+        "type": "object",
+        "description": "Keyword search weight configuration.",
+        "properties": {
+          "keyword_weight": {
+            "type": "number",
+            "format": "float",
+            "description": "Weight assigned to keyword search results."
+          }
         }
       }
     }

--- a/ja/api-reference/openapi_knowledge.json
+++ b/ja/api-reference/openapi_knowledge.json
@@ -1826,9 +1826,8 @@
             "nullable": true
           },
           "weights": {
-            "type": "number",
-            "format": "float",
-            "description": "ハイブリッド検索モードでのセマンティック検索の重み。",
+            "$ref": "#/components/schemas/WeightedScore",
+            "description": "Weighted score configuration for hybrid search mode.",
             "nullable": true
           }
         }
@@ -3101,6 +3100,60 @@
           },
           "binding_count": {
             "type": "integer"
+          }
+        }
+      },
+      "WeightedScore": {
+        "type": "object",
+        "description": "Configuration for weighted score retrieval, used when reranking_mode is 'weighted_score'.",
+        "properties": {
+          "weight_type": {
+            "type": "string",
+            "description": "The weighting strategy.",
+            "enum": [
+              "semantic_first",
+              "keyword_first",
+              "customized"
+            ],
+            "nullable": true
+          },
+          "vector_setting": {
+            "$ref": "#/components/schemas/VectorSetting",
+            "nullable": true
+          },
+          "keyword_setting": {
+            "$ref": "#/components/schemas/KeywordSetting",
+            "nullable": true
+          }
+        }
+      },
+      "VectorSetting": {
+        "type": "object",
+        "description": "Vector (semantic) search weight configuration.",
+        "properties": {
+          "vector_weight": {
+            "type": "number",
+            "format": "float",
+            "description": "Weight assigned to vector (semantic) search results."
+          },
+          "embedding_provider_name": {
+            "type": "string",
+            "description": "The embedding model provider name."
+          },
+          "embedding_model_name": {
+            "type": "string",
+            "description": "The embedding model name."
+          }
+        }
+      },
+      "KeywordSetting": {
+        "type": "object",
+        "description": "Keyword search weight configuration.",
+        "properties": {
+          "keyword_weight": {
+            "type": "number",
+            "format": "float",
+            "description": "Weight assigned to keyword search results."
           }
         }
       }

--- a/zh/api-reference/openapi_knowledge.json
+++ b/zh/api-reference/openapi_knowledge.json
@@ -1826,9 +1826,8 @@
             "nullable": true
           },
           "weights": {
-            "type": "number",
-            "format": "float",
-            "description": "混合搜索模式中语义搜索的权重。",
+            "$ref": "#/components/schemas/WeightedScore",
+            "description": "Weighted score configuration for hybrid search mode.",
             "nullable": true
           }
         }
@@ -3101,6 +3100,60 @@
           },
           "binding_count": {
             "type": "integer"
+          }
+        }
+      },
+      "WeightedScore": {
+        "type": "object",
+        "description": "Configuration for weighted score retrieval, used when reranking_mode is 'weighted_score'.",
+        "properties": {
+          "weight_type": {
+            "type": "string",
+            "description": "The weighting strategy.",
+            "enum": [
+              "semantic_first",
+              "keyword_first",
+              "customized"
+            ],
+            "nullable": true
+          },
+          "vector_setting": {
+            "$ref": "#/components/schemas/VectorSetting",
+            "nullable": true
+          },
+          "keyword_setting": {
+            "$ref": "#/components/schemas/KeywordSetting",
+            "nullable": true
+          }
+        }
+      },
+      "VectorSetting": {
+        "type": "object",
+        "description": "Vector (semantic) search weight configuration.",
+        "properties": {
+          "vector_weight": {
+            "type": "number",
+            "format": "float",
+            "description": "Weight assigned to vector (semantic) search results."
+          },
+          "embedding_provider_name": {
+            "type": "string",
+            "description": "The embedding model provider name."
+          },
+          "embedding_model_name": {
+            "type": "string",
+            "description": "The embedding model name."
+          }
+        }
+      },
+      "KeywordSetting": {
+        "type": "object",
+        "description": "Keyword search weight configuration.",
+        "properties": {
+          "keyword_weight": {
+            "type": "number",
+            "format": "float",
+            "description": "Weight assigned to keyword search results."
           }
         }
       }


### PR DESCRIPTION
## Problem

The `weights` field in the `RetrievalModel` schema was incorrectly typed as `number/float` in the OpenAPI specification:

```json
"weights": {
  "type": "number",
  "format": "float",
  "description": "The weight of semantic search in a hybrid search mode."
}
```

However, in the actual backend implementation (`api/services/entities/knowledge_entities/knowledge_entities.py`), `weights` is a complex nested object (`WeightModel`):

```python
class WeightModel(BaseModel):
    weight_type: Literal["semantic_first", "keyword_first", "customized"] | None = None
    vector_setting: WeightVectorSetting | None = None  # { vector_weight: float, embedding_provider_name: str, embedding_model_name: str }
    keyword_setting: WeightKeywordSetting | None = None  # { keyword_weight: float }
```

This discrepancy causes SDK generators (e.g., swagger-codegen, openapi-generator) to produce incorrect client code where `weights` is mapped to a primitive `float` instead of the correct object structure.

## Fix

- Added three new component schemas: `WeightedScore`, `VectorSetting`, `KeywordSetting`
- Changed `weights` in `RetrievalModel` from `type: number/float` to `$ref: '#/components/schemas/WeightedScore'`
- Applied the fix to all three language variants: `en`, `zh`, `ja`

## Affected Files

- `en/api-reference/openapi_knowledge.json`
- `zh/api-reference/openapi_knowledge.json`
- `ja/api-reference/openapi_knowledge.json`