### PR TITLE
fix: update minimum Python version from 3.10/3.11 to 3.12 across docs

### DIFF
--- a/en/develop-plugin/dev-guides-and-walkthroughs/develop-a-slack-bot-plugin.mdx
+++ b/en/develop-plugin/dev-guides-and-walkthroughs/develop-a-slack-bot-plugin.mdx
@@ -47,7 +47,7 @@ Slack is an open, real-time communication platform with a robust API. Among its 
 ### Prerequisites
 
 - **Dify plugin developing tool**: For more information, see [Initializing the Development Tool](/en/develop-plugin/getting-started/cli).
-- **Python environment (version ≥ 3.12)**: Refer to this [Python Installation Tutorial](https://pythontest.com/python/installing-python-3-11/) or ask an LLM for a complete setup guide.
+- **Python environment (version ≥ 3.12)**: Refer to the [Python official downloads page](https://www.python.org/downloads/) or ask an LLM for a complete setup guide.
 - Create a Slack App and Get an OAuth Token
 
 Go to the [Slack API platform](https://api.slack.com/apps), create a Slack app from scratch, and pick the workspace where it will be deployed.

--- a/en/develop-plugin/dev-guides-and-walkthroughs/develop-md-exporter.mdx
+++ b/en/develop-plugin/dev-guides-and-walkthroughs/develop-md-exporter.mdx
@@ -98,7 +98,7 @@ meta:
     - arm64
   runner:
     language: python
-    version: 3.11
+    version: 3.12
     entrypoint: main
 ```
 

--- a/en/develop-plugin/features-and-specs/advanced-development/bundle.mdx
+++ b/en/develop-plugin/features-and-specs/advanced-development/bundle.mdx
@@ -25,7 +25,7 @@ You can use the Dify CLI tool to package multiple plugins into a Bundle. Bundle 
 ### Prerequisites
 
 *   Dify plugin scaffolding tool
-*   Python environment, version ≥ 3.10
+*   Python environment, version ≥ 3.12
 
 For detailed instructions on how to prepare the plugin development scaffolding tool, please refer to [Initialize Development Tools](/en/develop-plugin/getting-started/cli).
 

--- a/en/develop-plugin/features-and-specs/plugin-types/plugin-info-by-manifest.mdx
+++ b/en/develop-plugin/features-and-specs/plugin-types/plugin-info-by-manifest.mdx
@@ -53,7 +53,7 @@ meta:
     - "arm64"
   runner:
     language: "python"
-    version: "3.10"
+    version: "3.12"
     entrypoint: "main"
 privacy: "./privacy.md"
 ```

--- a/en/self-host/troubleshooting/weaviate-v4-migration.mdx
+++ b/en/self-host/troubleshooting/weaviate-v4-migration.mdx
@@ -111,7 +111,7 @@ Choose the migration path that matches your deployment setup and current Weaviat
 
 - Currently running Weaviate 1.19
 - Docker + Docker Compose installed
-- Python 3.11+ available for the [schema migration script](https://github.com/langgenius/dify-docs/blob/main/assets/migrate_weaviate_collections.py)
+- Python 3.12+ available for the [schema migration script](https://github.com/langgenius/dify-docs/blob/main/assets/migrate_weaviate_collections.py)
 
 #### Step A1: Enable the Backup Module on Weaviate 1.19
 
@@ -274,7 +274,7 @@ sleep 15
    ```
 
 2. **Run the [migration script](https://github.com/langgenius/dify-docs/blob/main/assets/migrate_weaviate_collections.py)** either locally or inside the Worker container.\
-  **Option A: Run locally (if you have Python 3.11+ and dependencies installed)**:
+  **Option A: Run locally (if you have Python 3.12+ and dependencies installed)**:
 
    ```bash
    python3 migrate_weaviate_collections.py
@@ -329,7 +329,7 @@ sleep 15
 
 - Currently running Weaviate 1.27+ (including 1.33)
 - Docker + Docker Compose installed
-- Python 3.11+ for the [migration script](https://github.com/langgenius/dify-docs/blob/main/assets/migrate_weaviate_collections.py)
+- Python 3.12+ for the [migration script](https://github.com/langgenius/dify-docs/blob/main/assets/migrate_weaviate_collections.py)
 
 #### Step B1: Repair Orphaned LSM Data
 


### PR DESCRIPTION
## Summary
Updated all outdated Python version references (3.10, 3.11) to 3.12 across plugin development guides and self-host troubleshooting docs