### PR TITLE
feat: add feature research skill, formatting rules, and   codebase freshness checks

### DIFF
--- a/.claude/skills/dify-docs-api-reference/SKILL.md
+++ b/.claude/skills/dify-docs-api-reference/SKILL.md
@@ -30,6 +30,11 @@ Backend developers integrating Dify apps or knowledge bases into their own appli
 
 ## Code Fidelity (Non-Negotiable)
 
+**Pull the latest Dify code** before auditing. In the Dify codebase directory:
+```bash
+git fetch origin && git checkout main && git pull origin main
+```
+
 **Every detail in the spec MUST be verifiable against the codebase.** When the spec disagrees with the code, the spec is wrong.
 
 ### What must match the code exactly

--- a/.claude/skills/dify-docs-env-vars/SKILL.md
+++ b/.claude/skills/dify-docs-env-vars/SKILL.md
@@ -19,6 +19,11 @@ Read these shared guides:
 
 ## Four-Step Process
 
+**Pull the latest Dify code** before tracing. In the Dify codebase directory:
+```bash
+git fetch origin && git checkout main && git pull origin main
+```
+
 **This process applies to every variable without exception.** Do not skip variables because they seem "obvious" — every variable must be traced, explained, and described.
 
 ### Step 1: Trace the Variable in the Codebase

--- a/.claude/skills/dify-docs-feature-research/SKILL.md
+++ b/.claude/skills/dify-docs-feature-research/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: dify-docs-feature-research
+description: "Research a Dify feature before writing or optimizing documentation. Use when starting any doc task that requires understanding a feature's implementation, user pain points, or community feedback. Triggers: 'research this feature', 'investigate the code for', 'what do users say about', 'let's understand how X works before writing', or any documentation task where the current docs are being rewritten or significantly expanded."
+---
+
+# Dify Feature Research
+
+Pre-writing research that combines codebase analysis with community feedback to ensure documentation is grounded in both technical reality and actual user needs.
+
+## Before Starting
+
+1. Ask the user which feature, node, or area to research.
+2. Confirm which branch of the Dify codebase to investigate (default: `main`).
+3. Check if the user has a specific doc page in mind for the rewrite.
+
+**Codebase location**: The Dify codebase is typically available as an additional working directory. If not, ask the user for the path.
+
+**Pull latest code** before investigating. In the Dify codebase directory:
+```bash
+git fetch origin && git checkout main && git pull origin main
+```
+If the user specified a different branch, substitute accordingly.
+
+**GitHub repo**: `langgenius/dify`
+
+## Research Process
+
+Run Phase 1 and Phase 2 in parallel using subagents where possible.
+
+### Phase 1: Codebase Investigation
+
+Locate and read the source code for the feature. Cover all three layers:
+
+**Backend implementation** — Find the core logic. For workflow nodes, check `api/dify_graph/nodes/<node_name>/`. Read:
+- The main node class (execution logic, `_run()` method)
+- Entity definitions (data models, enums, supported types)
+- Any template or streaming logic
+
+**Frontend UI** — Find the React components. For workflow nodes, check `web/app/components/workflow/nodes/<node_name>/`. Read:
+- Panel component (what configuration options users see)
+- Type definitions (data shape)
+- Default values and validation rules
+
+**API surface** — Trace how the feature's output reaches the API response. Check controllers, response converters, and serialization.
+
+Produce a summary of:
+- What the feature does (based on code, not existing docs)
+- What configuration options exist
+- What data types / values are supported
+- How results are returned to the user (UI, API, streaming)
+- Any notable edge cases or limitations visible in the code
+
+Flag any behavior inferred from code rather than observed in the running product.
+
+### Phase 2: Community Feedback
+
+Search for user-reported problems and questions across these channels:
+
+**GitHub Issues** — Run multiple searches with varied terms:
+```bash
+gh issue list --repo langgenius/dify --search "<feature name>" --limit 30
+gh issue list --repo langgenius/dify --search "<alternative name>" --limit 30
+gh search issues "<feature> <context>" --repo langgenius/dify --limit 20
+```
+
+**GitHub Discussions** — Search for related discussion topics:
+```bash
+gh api "repos/langgenius/dify/discussions?per_page=30" --jq '.[] | select(.title | test("<pattern>"; "i"))'
+```
+
+For each relevant issue or discussion, read the body and top comments to understand:
+- What the user was trying to do
+- What went wrong or was confusing
+- Whether it's a bug, missing feature, or documentation gap
+
+**Categorize findings** into:
+
+| Category | Description |
+|:---------|:------------|
+| **Documentation gap** | User couldn't find information that should be documented |
+| **Confusion** | User misunderstood behavior the docs should clarify |
+| **Bug** | Product defect — note but don't document workarounds as features |
+| **Feature request** | Missing capability — note but don't document as existing |
+
+### Phase 3: Synthesize
+
+Combine both phases into a structured research summary:
+
+```
+## Feature: [Name]
+
+### How It Works (from code)
+- [Key behaviors, configuration options, supported types]
+- [API response structure]
+- [Edge cases or limitations]
+- [Unverified inferences — flagged for user testing]
+
+### Current Documentation
+- [What the existing page covers]
+- [What it's missing]
+
+### Community Pain Points
+| Theme | Issues | Type | Doc impact |
+|-------|--------|------|------------|
+| ...   | #123   | gap  | Should document |
+
+### Recommended Documentation Scope
+- [What to add based on gaps]
+- [What to clarify based on confusion]
+- [What to explicitly omit and why (bugs, unreleased features)]
+```
+
+Present the summary to the user. Jointly decide what to include before starting the writing phase.
+
+## Important
+
+- This skill produces research only. Do not start writing documentation until the user reviews the findings and confirms the scope.
+- Flag code-inferred behavior as unverified. Ask the user to test before documenting as fact.
+- Distinguish bugs from documentation gaps. Documenting buggy behavior as intended causes more harm than leaving a gap.
+- Note issue numbers for traceability. The user may want to reference them when prioritizing what to cover.

--- a/.claude/skills/dify-docs-guides/SKILL.md
+++ b/.claude/skills/dify-docs-guides/SKILL.md
@@ -49,6 +49,7 @@ This is a team effort. The user brings documentation expertise and user empathy;
 
 ## Verifying Feature Behavior
 
+- Pull the latest code before verifying. In the Dify codebase directory, run `git fetch origin && git checkout main && git pull origin main`. If the user specifies a different branch, substitute accordingly.
 - For existing features: verify against the `main` branch of the Dify codebase. The user will provide the codebase path or it will be configured as an additional working directory.
 - For new features: the user may specify a development branch. Code may be in flux—when behavior is ambiguous, ask rather than assume.
 - Trust the codebase over existing documentation. Existing docs may be outdated or inaccurate.

--- a/.claude/skills/dify-docs-terminology-check/SKILL.md
+++ b/.claude/skills/dify-docs-terminology-check/SKILL.md
@@ -22,6 +22,11 @@ codebase i18n files.
    ask the user for the local filesystem path to their Dify repo and use it for
    reading i18n files.
 
+   Pull the latest code before checking. In the Dify codebase directory:
+   ```bash
+   git fetch origin && git checkout <branch> && git pull origin <branch>
+   ```
+
 2. Detect changed documentation files by combining:
    - `git diff --name-only` (unstaged changes in tracked files)
    - `git diff --cached --name-only` (staged changes)

--- a/writing-guides/formatting-guide.md
+++ b/writing-guides/formatting-guide.md
@@ -59,7 +59,7 @@ Do not include trailing punctuation (colons, commas, periods) inside bold markup
 ### Quotation Marks
 
 - Do not use double quotation marks for emphasis. Use italics instead.
-- Reserve double quotation marks for direct citations.
+- Use double quotation marks for direct quotations and for referring to literal words or phrases when backticks are not more appropriate.
 
 ---
 
@@ -91,7 +91,7 @@ Use backticks for:
 - File paths and extensions: `` `.env` ``, `` `docker-compose.yml` ``
 - Configuration values: `` `streaming` ``, `` `true` ``
 - Special characters and delimiters: `` `\n\n` ``
-- Exact strings a user must type or match
+- Exact strings a user must type or match: `` `yes` ``, `` `DELETE` ``
 
 Do not use backticks for product names, UI labels, or general English words.
 

--- a/writing-guides/formatting-guide.md
+++ b/writing-guides/formatting-guide.md
@@ -56,6 +56,11 @@ Do not include trailing punctuation (colons, commas, periods) inside bold markup
 - Use sparingly — for semantic emphasis, alternative phrasings, or example values.
   - Example: `Both plugin triggers and webhook triggers make your workflow *event-driven*.`
 
+### Quotation Marks
+
+- Do not use double quotation marks for emphasis. Use italics instead.
+- Reserve double quotation marks for direct citations.
+
 ---
 
 ## Lists
@@ -86,6 +91,7 @@ Use backticks for:
 - File paths and extensions: `` `.env` ``, `` `docker-compose.yml` ``
 - Configuration values: `` `streaming` ``, `` `true` ``
 - Special characters and delimiters: `` `\n\n` ``
+- Exact strings a user must type or match
 
 Do not use backticks for product names, UI labels, or general English words.
 

--- a/writing-guides/index.md
+++ b/writing-guides/index.md
@@ -4,6 +4,7 @@
 
 | Task | Skill | Paths | References |
 |:-----|:------|:------|:-----------|
+| Research a feature before writing | dify-docs-feature-research | Dify codebase, GitHub Issues | — |
 | Write or improve a user guide | dify-docs-guides | `en/use-dify/`, `en/develop-plugin/`, `en/self-host/` | style-guide, formatting-guide, glossary |
 | Write or audit API reference specs | dify-docs-api-reference | `en/api-reference/` | style-guide, formatting-guide, glossary |
 | Write or audit env var docs | dify-docs-env-vars | `en/self-host/configuration/environments.mdx` | style-guide, formatting-guide, glossary |

--- a/writing-guides/index.md
+++ b/writing-guides/index.md
@@ -4,7 +4,7 @@
 
 | Task | Skill | Paths | References |
 |:-----|:------|:------|:-----------|
-| Research a feature before writing | dify-docs-feature-research | Dify codebase, GitHub Issues | — |
+| Research a feature before writing | dify-docs-feature-research | — | Dify codebase, GitHub Issues |
 | Write or improve a user guide | dify-docs-guides | `en/use-dify/`, `en/develop-plugin/`, `en/self-host/` | style-guide, formatting-guide, glossary |
 | Write or audit API reference specs | dify-docs-api-reference | `en/api-reference/` | style-guide, formatting-guide, glossary |
 | Write or audit env var docs | dify-docs-env-vars | `en/self-host/configuration/environments.mdx` | style-guide, formatting-guide, glossary |


### PR DESCRIPTION
  ## Summary

  - Add dify-docs-feature-research skill for standardized pre-writing research combining codebase analysis with GitHub Issues/Discussions feedback
  - Add quotation mark and backtick usage rules to the formatting guide
  - Require pulling latest Dify code before codebase checks across five skills (dify-docs-guides, dify-docs-terminology-check, dify-docs-env-vars, dify-docs-api-reference, dify-docs-feature-research)