### PR TITLE
fix: add redirect for broken install-self-hosted/readme link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1840,12 +1840,8 @@
       "destination": "/en/use-dify/tutorials/:slug*"
     },
     {
-      "source": "/en/getting-started/install-self-hosted/readme",
-      "destination": "/en/self-host/quick-start/docker-compose"
-    },
-    {
       "source": "/en/getting-started/install-self-hosted/:slug*",
-      "destination": "/en/self-host/dify-community/:slug*"
+      "destination": "/en/self-host/quick-start/docker-compose"
     },
     {
       "source": "/en/guides/workflow/:slug*",
@@ -1968,12 +1964,8 @@
       "destination": "/ja/use-dify/tutorials/:slug*"
     },
     {
-      "source": "/ja-jp/getting-started/install-self-hosted/readme",
-      "destination": "/ja/self-host/quick-start/docker-compose"
-    },
-    {
       "source": "/ja-jp/getting-started/install-self-hosted/:slug*",
-      "destination": "/ja/self-host/dify-community/:slug*"
+      "destination": "/ja/self-host/quick-start/docker-compose"
     },
     {
       "source": "/ja-jp/guides/workflow/:slug*",
@@ -2104,12 +2096,8 @@
       "destination": "/zh/use-dify/tutorials/:slug*"
     },
     {
-      "source": "/zh-hans/getting-started/install-self-hosted/readme",
-      "destination": "/zh/self-host/quick-start/docker-compose"
-    },
-    {
       "source": "/zh-hans/getting-started/install-self-hosted/:slug*",
-      "destination": "/zh/self-host/dify-community/:slug*"
+      "destination": "/zh/self-host/quick-start/docker-compose"
     },
     {
       "source": "/zh-hans/guides/workflow/:slug*",

--- a/docs.json
+++ b/docs.json
@@ -1840,6 +1840,10 @@
       "destination": "/en/use-dify/tutorials/:slug*"
     },
     {
+      "source": "/en/getting-started/install-self-hosted/readme",
+      "destination": "/en/self-host/quick-start/docker-compose"
+    },
+    {
       "source": "/en/getting-started/install-self-hosted/:slug*",
       "destination": "/en/self-host/dify-community/:slug*"
     },
@@ -1962,6 +1966,10 @@
     {
       "source": "/ja-jp/workshop/:slug*",
       "destination": "/ja/use-dify/tutorials/:slug*"
+    },
+    {
+      "source": "/ja-jp/getting-started/install-self-hosted/readme",
+      "destination": "/ja/self-host/quick-start/docker-compose"
     },
     {
       "source": "/ja-jp/getting-started/install-self-hosted/:slug*",
@@ -2094,6 +2102,10 @@
     {
       "source": "/zh-hans/workshop/:slug*",
       "destination": "/zh/use-dify/tutorials/:slug*"
+    },
+    {
+      "source": "/zh-hans/getting-started/install-self-hosted/readme",
+      "destination": "/zh/self-host/quick-start/docker-compose"
     },
     {
       "source": "/zh-hans/getting-started/install-self-hosted/:slug*",


### PR DESCRIPTION
  ## Summary

  - Fix wildcard redirects for `/en/getting-started/install-self-hosted/:slug*`, `/ja-jp/getting-started/install-self-hosted/:slug*`, and `/zh-hans/getting-started/install-self-hosted/:slug*`
  - The previous destination `/self-host/dify-community/:slug*` does not exist in this repo, causing all matched URLs to 404
  - Changed the fallback destination to `/self-host/quick-start/docker-compose`, the main self-hosting entry point