### PR TITLE
chore: note environments.mdx manual translation requirement

### DIFF
--- a/.claude/skills/dify-docs-env-vars/SKILL.md
+++ b/.claude/skills/dify-docs-env-vars/SKILL.md
@@ -139,7 +139,7 @@ Use `.env.example` defaults (what Docker Compose users actually get), not Pydant
 
 ## Translation
 
-The automated translation pipeline does not cover environment variable documentation. After editing the English file, manually update `zh/self-host/configuration/environments.mdx` and `ja/self-host/configuration/environments.mdx` to match.
+The automated translation pipeline does not cover `en/self-host/configuration/environments.mdx`. After editing that English file, manually update `zh/self-host/configuration/environments.mdx` and `ja/self-host/configuration/environments.mdx` to match.
 
 ## Post-Writing Verification
 

--- a/.claude/skills/dify-docs-env-vars/SKILL.md
+++ b/.claude/skills/dify-docs-env-vars/SKILL.md
@@ -137,6 +137,10 @@ The script reports:
 
 Use `.env.example` defaults (what Docker Compose users actually get), not Pydantic code defaults.
 
+## Translation
+
+The automated translation pipeline does not cover environment variable documentation. After editing the English file, manually update `zh/self-host/configuration/environments.mdx` and `ja/self-host/configuration/environments.mdx` to match.
+
 ## Post-Writing Verification
 
 After completing the document:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 Documentation for Dify, built with Mintlify. English is the source language;
 Chinese and Japanese translations are generated automatically.
+Exception: `en/self-host/configuration/environments.mdx` is excluded from the translation pipeline and must be translated manually.
 
 ## Before Any Documentation Task
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This repository includes Claude Code skills in `.claude/skills/` that provide wr
 ### Guidelines
 
 - **One topic per PR.** Don't combine unrelated changes.
-- **English only.** Translations are handled automatically.
+- **English only.** Translations are handled automatically, except for `en/self-host/configuration/environments.mdx` which must be translated manually.
 - **Update navigation.** If you add a new page, add it to the English section of `docs.json`.
 - **Test locally.** Run `mintlify dev` to verify your changes render correctly before opening a PR.
 - **No secrets.** Never commit API keys, credentials, or `.env` files.


### PR DESCRIPTION
## Summary

  - Add manual translation exception note for `environments.mdx` to CLAUDE.md, README.md, and the `dify-docs-env-vars` skill
  - `environments.mdx` is excluded from the automated translation pipeline (`tools/translate/config.json`) but that wasn't documented anywhere contributors or AI assistants would see it