### PR TITLE
docs: add async response_mode to workflow API reference

### DIFF
--- a/en/api-reference/openapi_workflow.json
+++ b/en/api-reference/openapi_workflow.json
@@ -59,6 +59,16 @@
                     "user": "user_workflow_456"
                   }
                 },
+                "async_example": {
+                  "summary": "Request Example - Async mode",
+                  "value": {
+                    "inputs": {
+                      "query": "Process this long-running task"
+                    },
+                    "response_mode": "async",
+                    "user": "user_workflow_789"
+                  }
+                },
                 "with_file_array_variable": {
                   "summary": "Request Example - File array input",
                   "value": {
@@ -86,7 +96,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful response. The content type and structure depend on the `response_mode` parameter in the request.\n\n- If `response_mode` is `blocking`, returns `application/json` with a `WorkflowBlockingResponse` object.\n- If `response_mode` is `streaming`, returns `text/event-stream` with a stream of `ChunkWorkflowEvent` objects.",
+            "description": "Successful response. The content type and structure depend on the `response_mode` parameter in the request.\n\n- If `response_mode` is `blocking`, returns `application/json` with a `WorkflowBlockingResponse` object.\n- If `response_mode` is `streaming`, returns `text/event-stream` with a stream of `ChunkWorkflowEvent` objects.\n- If `response_mode` is `async` and an `Idempotency-Key` header was provided that matches a previous request, returns `application/json` with the cached `WorkflowAsyncResponse`.",
             "content": {
               "application/json": {
                 "schema": {
@@ -125,6 +135,31 @@
                   "streamingResponse": {
                     "summary": "Response Example - Streaming mode",
                     "value": "data: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"Translate this\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}} data: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 1, \"created_at\": 1705407629}} data: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}} data: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted — returned when `response_mode` is `async`. The workflow has been scheduled for execution. Use the `workflow_run_id` to poll for results via [Get Workflow Run Detail](/api-reference/workflows/get-workflow-run-detail).\n\nSupports an optional `Idempotency-Key` request header (max 64 characters). If the same key is sent again within 24 hours, the server returns `200` with the cached response instead of scheduling a duplicate run.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowAsyncResponse"
+                },
+                "examples": {
+                  "asyncResponse": {
+                    "summary": "Response Example - Async mode",
+                    "value": {
+                      "task_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "data": {
+                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "status": "scheduled",
+                        "created_at": 1705407629
+                      }
+                    }
                   }
                 }
               }
@@ -275,7 +310,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful response. The content type and structure depend on the `response_mode` parameter in the request.\n\n- If `response_mode` is `blocking`, returns `application/json` with a `WorkflowBlockingResponse` object.\n- If `response_mode` is `streaming`, returns `text/event-stream` with a stream of `ChunkWorkflowEvent` objects.",
+            "description": "Successful response. The content type and structure depend on the `response_mode` parameter in the request.\n\n- If `response_mode` is `blocking`, returns `application/json` with a `WorkflowBlockingResponse` object.\n- If `response_mode` is `streaming`, returns `text/event-stream` with a stream of `ChunkWorkflowEvent` objects.\n- If `response_mode` is `async` and an `Idempotency-Key` header was provided that matches a previous request, returns `application/json` with the cached `WorkflowAsyncResponse`.",
             "content": {
               "application/json": {
                 "schema": {
@@ -309,6 +344,31 @@
                 "schema": {
                   "type": "string",
                   "description": "A stream of Server-Sent Events (SSE). Each event is a JSON object prefixed with `data: ` and terminated by two newlines. See `ChunkWorkflowEvent` for possible event structures.\n\n**SSE Parsing Guide:** Each event is a line prefixed with `data: ` followed by a JSON object, terminated by `\\n\\n`. Strip the `data: ` prefix before parsing JSON. The `event` field inside the JSON determines the event type. The stream ends when a `workflow_finished` or `error` event is received. Ignore `ping` events (sent every 10 seconds to keep the connection alive). If an `error` event is received mid-stream, the stream terminates — parse the error object for details. Note that the HTTP status code is always `200` even when an error event occurs within the stream."
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted — returned when `response_mode` is `async`. The workflow has been scheduled for execution. Use the `workflow_run_id` to poll for results via [Get Workflow Run Detail](/api-reference/workflows/get-workflow-run-detail).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowAsyncResponse"
+                },
+                "examples": {
+                  "asyncResponse": {
+                    "summary": "Response Example - Async mode",
+                    "value": {
+                      "task_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "data": {
+                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "status": "scheduled",
+                        "created_at": 1705407629
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -1617,9 +1677,10 @@
             "type": "string",
             "enum": [
               "streaming",
-              "blocking"
+              "blocking",
+              "async"
             ],
-            "description": "Response mode. Use `blocking` for synchronous responses (Cloudflare timeout is `100 s`), or `streaming` for Server-Sent Events. When omitted, defaults to blocking behavior."
+            "description": "Response mode. Use `blocking` for synchronous responses (Cloudflare timeout is `100 s`), `streaming` for Server-Sent Events, or `async` for fire-and-forget execution that returns immediately with a `workflow_run_id` for polling. When omitted, defaults to blocking behavior."
           },
           "user": {
             "type": "string",
@@ -1687,6 +1748,46 @@
           },
           "data": {
             "$ref": "#/components/schemas/WorkflowFinishedData"
+          }
+        }
+      },
+      "WorkflowAsyncResponse": {
+        "type": "object",
+        "description": "Returned with HTTP 202 when `response_mode` is `async`. The workflow has been accepted and scheduled for background execution. Poll for results using the `workflow_run_id` with [Get Workflow Run Detail](/api-reference/workflows/get-workflow-run-detail). The status will progress from `scheduled` → `running` → `succeeded` / `failed`.",
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Task ID, same as `workflow_run_id` for async requests."
+          },
+          "workflow_run_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Persistent identifier for this workflow run. Use this with [Get Workflow Run Detail](/api-reference/workflows/get-workflow-run-detail) to poll for results."
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Workflow run ID."
+              },
+              "workflow_id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "ID of the workflow that was executed."
+              },
+              "status": {
+                "type": "string",
+                "enum": ["scheduled"],
+                "description": "Initial status. Will transition to `running`, then `succeeded` or `failed`."
+              },
+              "created_at": {
+                "type": "integer",
+                "description": "Unix timestamp of when the run was created."
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary

Add documentation for the new `response_mode: "async"` option in the workflow execution API, introduced in [langgenius/dify#35301](https://github.com/langgenius/dify/pull/35301).

### Changes to `en/api-reference/openapi_workflow.json`

- Add `"async"` to the `response_mode` enum in `WorkflowExecutionRequest` schema
- Update `response_mode` field description to explain async behavior
- Add request example for async mode
- Add `202 Accepted` response to both `/workflows/run` and `/workflows/{workflow_id}/run`
- Add `WorkflowAsyncResponse` component schema (returns `task_id`, `workflow_run_id`, and `data` with `status: "scheduled"`)
- Update `200` response descriptions to cover idempotency cache hits (duplicate async requests return 200 instead of 202)

### How async mode works

1. Client sends `POST /v1/workflows/run` with `"response_mode": "async"`
2. Server returns `202 Accepted` immediately with a `workflow_run_id`
3. Client polls `GET /v1/workflows/run/{workflow_run_id}` for results
4. Status progresses: `scheduled` → `running` → `succeeded` / `failed`
5. Optional `Idempotency-Key` header prevents duplicate executions on retry

## Test plan

- [ ] Verify `openapi_workflow.json` is valid JSON
- [ ] Verify Mintlify renders the new enum value, 202 response, and schema correctly