### PR TITLE
chore: hide archived versions/ from published docs

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -7,6 +7,9 @@
 /tools/
 /writing-guides/
 
+# Archived version snapshots
+/versions/
+
 # Non-public utility files under public asset directories
 /assets/migrate_weaviate_collections.py
 /logo/convertor.html

--- a/docs.json
+++ b/docs.json
@@ -1660,14 +1660,6 @@
       "destination": "/ja/use-dify/workspace/subscription-management#dify-for-education"
     },
     {
-      "source": "/plugins/schema-definition/model",
-      "destination": "/versions/legacy/en/plugins/schema-definition/model/model-designing-rules"
-    },
-    {
-      "source": "/plugins/schema-definition",
-      "destination": "/versions/legacy/en/plugins/schema-definition/manifest"
-    },
-    {
       "source": "/zh-hans",
       "destination": "/zh/use-dify/getting-started/introduction"
     },


### PR DESCRIPTION
## Summary

- Add `/versions/` to `.mintignore` so archived release snapshots (2-8-x through 3-7-x, plus `legacy/`) are excluded from the Mintlify build and no longer surface in site search.
- Remove two stale redirects in `docs.json` that pointed into `versions/legacy/en/plugins/schema-definition/`. Those destination files do not exist in the repo and were already broken.