### PR TITLE
docs: move cookie-domain guidance to troubleshooting faq

### DIFF
--- a/en/self-host/quick-start/docker-compose.mdx
+++ b/en/self-host/quick-start/docker-compose.mdx
@@ -48,11 +48,6 @@ Make sure your machine meets the following minimum system requirements.
         ```bash
         cp .env.example .env  
         ```
-        <Note>
-            When the frontend and backend run on different subdomains, set `COOKIE_DOMAIN` to the site's top-level domain (e.g., `example.com`) and set `NEXT_PUBLIC_COOKIE_DOMAIN` to `1` in the `.env` file.
-
-            The frontend and backend must be under the same top-level domain to share authentication cookies.
-        </Note>
 
     3. Start the containers using the command that matches your Docker Compose version:
 
@@ -144,7 +139,7 @@ Make sure your machine meets the following minimum system requirements.
 
 Modify the environment variable values in your local `.env` file, then restart Dify to apply the changes:
 
-```
+```bash
 docker compose down
 docker compose up -d
 ```

--- a/en/self-host/quick-start/faqs.mdx
+++ b/en/self-host/quick-start/faqs.mdx
@@ -4,7 +4,7 @@ title: FAQs
 
 ## Deployment Methods
 
-### Install older version
+### Install Older Version
 
 Use the `--branch` flag to install a specific version:
 
@@ -14,7 +14,7 @@ git clone https://github.com/langgenius/dify.git --branch 0.15.3
 
 The rest of the setup is identical to installing the latest version.
 
-### Install using ZIP archive
+### Install Using ZIP Archive
 
 For network-restricted environments or when git is unavailable:
 
@@ -39,7 +39,7 @@ docker compose up -d
 
 ## Backup Procedures
 
-### Create backup before upgrading
+### Create Backup Before Upgrading
 
 Always backup before upgrading to prevent data loss:
 
@@ -48,3 +48,21 @@ cp -r dify "dify.bak.$(date +%Y%m%d%H%M%S)"
 ```
 
 This creates a timestamped backup for easy restoration.
+
+## Reverse Proxy Setup
+
+### Login Session Drops with Split Frontend and Backend Subdomains
+
+If you have split web and API across subdomains behind a reverse proxy (for example, `app.example.com` for the UI and `api.example.com` for the backend), authentication cookies cannot reach both hosts. Login appears to succeed, but the session is dropped on the next request.
+
+Set both variables in `.env`, then restart Dify:
+
+- **`COOKIE_DOMAIN`**: set to the shared top-level domain (e.g., `example.com`). Leading dots are optional.
+- **`NEXT_PUBLIC_COOKIE_DOMAIN`**: set to `1` to enable cross-subdomain cookies on the frontend.
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+Cookies cannot cross top-level domains, so the frontend and backend must share the same registrable domain. For full details, see [environment variables](/en/self-host/configuration/environments).

--- a/ja/self-host/quick-start/docker-compose.mdx
+++ b/ja/self-host/quick-start/docker-compose.mdx
@@ -1,12 +1,12 @@
 ---
-title: Docker ComposeでDifyをデプロイする
+title: Docker Compose で Dify をデプロイする
 sidebarTitle: Docker Compose
 ---
 
 <Note> ⚠️ このドキュメントは AI によって自動翻訳されています。不正確な部分がある場合は、[英語版](/en/self-host/quick-start/docker-compose) を参照してください。</Note>
 
 <Tip>
-    一般的なデプロイに関する質問については、[FAQ](/ja/self-host/quick-start/faqs)を参照してください。
+    一般的なデプロイに関する質問については、[FAQ](/ja/self-host/quick-start/faqs) を参照してください。
 </Tip>
 
 ## デプロイ前の準備
@@ -15,31 +15,30 @@ sidebarTitle: Docker Compose
 
 ### ハードウェア
 
-- CPU >= 2コア
+- CPU >= 2 コア
 - RAM >= 4 GiB
 
 ### ソフトウェア
 
-| オペレーティングシステム              | 必要なソフトウェア                        | 備考 |  
-| :----------------------------- | :---------------------------------------- | :----- |  
-| macOS 10.14以降          | Docker Desktop                           | Docker仮想マシンを最低2つの仮想CPUと8 GiBのメモリで設定してください。<br></br><br></br>インストール手順については、[Mac用Docker Desktopのインストール](https://docs.docker.com/desktop/mac/install/)を参照してください。 |  
-| Linuxディストリビューション           | Docker 19.03+<br></br><br></br>Docker Compose 1.28+ | インストール手順については、[Docker Engineのインストール](https://docs.docker.com/engine/install/)および[Docker Composeのインストール](https://docs.docker.com/compose/install/)を参照してください。 |  
-| WSL 2が有効なWindows    | Docker Desktop                           | Linuxコンテナにバインドされるソースコードやデータは、Windowsファイルシステムではなく、Linuxファイルシステムに保存してください。<br></br><br></br>インストール手順については、[Windows用Docker Desktopのインストール](https://docs.docker.com/desktop/windows/install/#wsl-2-backend)を参照してください。 |  
-
+| オペレーティングシステム              | 必要なソフトウェア                        | 備考 |
+| :----------------------------- | :---------------------------------------- | :----- |
+| macOS 10.14 以降          | Docker Desktop                           | Docker 仮想マシンを最低 2 つの仮想 CPU と 8 GiB のメモリで設定してください。<br></br><br></br>インストール手順については、[Mac 用 Docker Desktop のインストール](https://docs.docker.com/desktop/mac/install/) を参照してください。 |
+| Linux ディストリビューション           | Docker 19.03+<br></br><br></br>Docker Compose 1.28+ | インストール手順については、[Docker Engine のインストール](https://docs.docker.com/engine/install/) および [Docker Compose のインストール](https://docs.docker.com/compose/install/) を参照してください。 |
+| WSL 2 が有効な Windows    | Docker Desktop                           | Linux コンテナにバインドされるソースコードやデータは、Windows ファイルシステムではなく、Linux ファイルシステムに保存してください。<br></br><br></br>インストール手順については、[Windows 用 Docker Desktop のインストール](https://docs.docker.com/desktop/windows/install/#wsl-2-backend) を参照してください。 |
 
 ## デプロイと起動
 
 <Steps>
-  <Step title="Difyをクローン">
-    Difyのソースコードをローカルマシンにクローンします。
+  <Step title="Dify をクローン">
+    Dify のソースコードをローカルマシンにクローンします。
 
     ```bash
     git clone --branch "$(curl -s https://api.github.com/repos/langgenius/dify/releases/latest | jq -r .tag_name)" https://github.com/langgenius/dify.git
     ```
   </Step>
-  <Step title="Difyを起動">
+  <Step title="Dify を起動">
 
-    1. Difyソースコード内の`docker`ディレクトリに移動します：
+    1. Dify ソースコード内の `docker` ディレクトリに移動します：
 
         ```bash
         cd dify/docker
@@ -50,13 +49,8 @@ sidebarTitle: Docker Compose
         ```bash
         cp .env.example .env  
         ```
-        <Note>
-            フロントエンドとバックエンドが異なるサブドメインで動作する場合は、`.env`ファイルで`COOKIE_DOMAIN`をサイトのトップレベルドメイン（例：`example.com`）に設定し、`NEXT_PUBLIC_COOKIE_DOMAIN`を`1`に設定してください。
 
-            認証Cookieを共有するためには、フロントエンドとバックエンドが同じトップレベルドメイン下にある必要があります。
-        </Note>
-
-    3. お使いのDocker Composeバージョンに合わせたコマンドでコンテナを起動します：
+    3. お使いの Docker Compose バージョンに合わせたコマンドでコンテナを起動します：
 
         <CodeGroup>
           ```bash Docker Compose V2
@@ -68,13 +62,13 @@ sidebarTitle: Docker Compose
         </CodeGroup>
 
         <Tip>
-          `docker compose version`を実行してDocker Composeのバージョンを確認してください。
-        </Tip>        
+          `docker compose version` を実行して Docker Compose のバージョンを確認してください。
+        </Tip>
 
         以下のコンテナが起動されます：
 
-        - 5つのコアサービス：`api`、`worker`、`worker_beat`、`web`、`plugin_daemon`
-        - 6つの依存コンポーネント：`weaviate`、`db_postgres`、`redis`、`nginx`、`ssrf_proxy`、`sandbox`
+        - 5 つのコアサービス：`api`、`worker`、`worker_beat`、`web`、`plugin_daemon`
+        - 6 つの依存コンポーネント：`weaviate`、`db_postgres`、`redis`、`nginx`、`ssrf_proxy`、`sandbox`
 
         各コンテナのステータスと起動時間を示す以下のような出力が表示されるはずです：
 
@@ -132,7 +126,7 @@ sidebarTitle: Docker Compose
     http://your_server_ip/install
     ```
 
-2. 管理者アカウントの設定が完了したら、以下のアドレスでDifyにログインします：
+2. 管理者アカウントの設定が完了したら、以下のアドレスで Dify にログインします：
 
     ```bash
     # ローカル環境
@@ -144,23 +138,23 @@ sidebarTitle: Docker Compose
 
 ## カスタマイズ
 
-ローカルの`.env`ファイルの環境変数値を変更し、Difyを再起動して変更を適用します：
+ローカルの `.env` ファイルの環境変数値を変更し、Dify を再起動して変更を適用します：
 
-```
+```bash
 docker compose down
 docker compose up -d
 ```
 
 <Tip>
-  詳細については、[環境変数](/ja/self-host/configuration/environments)を参照してください。
+  詳細については、[環境変数](/ja/self-host/configuration/environments) を参照してください。
 </Tip>
 
 ## アップグレード
 
-アップグレード手順はリリースによって異なる場合があります。[Releases](https://github.com/langgenius/dify/releases)ページで提供されている対象バージョンのアップグレードガイドを参照してください。
+アップグレード手順はリリースによって異なる場合があります。[Releases](https://github.com/langgenius/dify/releases) ページで提供されている対象バージョンのアップグレードガイドを参照してください。
 
 <Note>
 
-  アップグレード後、`.env.example`ファイルが変更されているかどうかを確認し、それに応じてローカルの`.env`ファイルを更新してください。
+  アップグレード後、`.env.example` ファイルが変更されているかどうかを確認し、それに応じてローカルの `.env` ファイルを更新してください。
 
 </Note>

--- a/ja/self-host/quick-start/faqs.mdx
+++ b/ja/self-host/quick-start/faqs.mdx
@@ -18,7 +18,7 @@ git clone https://github.com/langgenius/dify.git --branch 0.15.3
 
 ### ZIP アーカイブを使用したインストール
 
-ネットワーク制限がある環境やgitが利用できない場合：
+ネットワーク制限がある環境や git が利用できない場合：
 
 ```bash
 # 最新リリースをダウンロード
@@ -26,7 +26,7 @@ wget -O dify.zip "$(curl -s https://api.github.com/repos/langgenius/dify/release
 unzip dify.zip && rm dify.zip
 ```
 
-または、別のデバイスでZIPをダウンロードして手動で転送することもできます。
+または、別のデバイスで ZIP をダウンロードして手動で転送することもできます。
 
 **アップグレードするには**：
 ```bash
@@ -50,3 +50,21 @@ cp -r dify "dify.bak.$(date +%Y%m%d%H%M%S)"
 ```
 
 これにより、復元しやすいタイムスタンプ付きのバックアップが作成されます。
+
+## リバースプロキシ設定
+
+### フロントエンドとバックエンドが異なるサブドメインで動作する場合のログインセッション切れ
+
+Web と API を異なるサブドメインに分けてリバースプロキシ経由で公開している場合、認証 Cookie が両方のホストに届きません。たとえば UI が `app.example.com`、バックエンドが `api.example.com` の構成です。ログインは成功したように見えても、次のリクエストでセッションが切れます。
+
+`.env` で両方の変数を設定し、Dify を再起動してください：
+
+- **`COOKIE_DOMAIN`**：共有するトップレベルドメインを指定します（例：`example.com`）。先頭のドットは省略可能です。
+- **`NEXT_PUBLIC_COOKIE_DOMAIN`**：`1` を設定すると、フロントエンドでサブドメイン間の Cookie 共有が有効になります。
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+Cookie はトップレベルドメインを越えて共有できないため、フロントエンドとバックエンドは同じ登録可能ドメイン内にある必要があります。詳細は [環境変数](/ja/self-host/configuration/environments) を参照してください。

--- a/zh/self-host/quick-start/docker-compose.mdx
+++ b/zh/self-host/quick-start/docker-compose.mdx
@@ -6,7 +6,7 @@ sidebarTitle: Docker Compose
 <Note> ⚠️ 本文档由 AI 自动翻译。如有任何不准确之处，请参考 [英文原版](/en/self-host/quick-start/docker-compose)。</Note>
 
 <Tip>
-    如需了解常见部署问题，请参阅[常见问题解答](/zh/self-host/quick-start/faqs)。
+    如需了解常见部署问题，请参阅 [常见问题解答](/zh/self-host/quick-start/faqs)。
 </Tip>
 
 ## 部署前准备
@@ -50,11 +50,6 @@ sidebarTitle: Docker Compose
         ```bash
         cp .env.example .env  
         ```
-        <Note>
-            当前端和后端运行在不同子域名时，需要在 `.env` 文件中将 `COOKIE_DOMAIN` 设置为站点的顶级域名（例如 `example.com`），并将 `NEXT_PUBLIC_COOKIE_DOMAIN` 设置为 `1`。
-
-            前端和后端必须位于同一顶级域名下才能共享认证 Cookie。
-        </Note>
 
     3. 根据你的 Docker Compose 版本选择相应命令启动容器：
 
@@ -146,13 +141,13 @@ sidebarTitle: Docker Compose
 
 修改本地 `.env` 文件中的环境变量值，然后重启 Dify 以应用更改：
 
-```
+```bash
 docker compose down
 docker compose up -d
 ```
 
 <Tip>
-  更多信息请参阅[环境变量](/zh/self-host/configuration/environments)。
+  更多信息请参阅 [环境变量](/zh/self-host/configuration/environments)。
 </Tip>
 
 ## 升级

--- a/zh/self-host/quick-start/faqs.mdx
+++ b/zh/self-host/quick-start/faqs.mdx
@@ -4,7 +4,6 @@ title: 常见问题
 
 <Note> ⚠️ 本文档由 AI 自动翻译。如有任何不准确之处，请参考 [英文原版](/en/self-host/quick-start/faqs)。</Note>
 
-
 ## 部署方法
 
 ### 安装旧版本
@@ -51,3 +50,21 @@ cp -r dify "dify.bak.$(date +%Y%m%d%H%M%S)"
 ```
 
 这将创建一个带时间戳的备份，便于轻松恢复。
+
+## 反向代理配置
+
+### 前端和后端使用不同子域名时登录会话失效
+
+若已将 Web 和 API 拆分到不同子域名并部署在反向代理之后（例如 `app.example.com` 用于 UI，`api.example.com` 用于后端），认证 Cookie 无法同时到达两个主机。登录看似成功，但下一次请求时会话即丢失。
+
+在 `.env` 中设置以下两个变量，然后重启 Dify：
+
+- **`COOKIE_DOMAIN`**：设为前后端共享的顶级域名（例如 `example.com`），前导点可省略。
+- **`NEXT_PUBLIC_COOKIE_DOMAIN`**：设为 `1`，启用前端的跨子域名 Cookie。
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+Cookie 无法跨顶级域名共享，因此前端和后端必须位于同一可注册域名下。详见 [环境变量](/zh/self-host/configuration/environments)。


### PR DESCRIPTION
## Summary

- Moves the cross-subdomain cookie-domain guidance from the Docker Compose quick-start callout to a new "Reverse Proxy Setup" entry in the FAQ. The original placement targets readers at the wrong moment: the issue surfaces at login-failure time after a reverse-proxy deployment, not at the `.env`-edit step during install. The FAQ entry is symptom-anchored ("Login Session Drops with Split Frontend and Backend Subdomains") so operators searching for the bug find it.
- Mirrored across en, zh, and ja.
- Cleans up pre-existing formatting issues in the same six files: heading title case, trailing whitespace, code-block spacing, missing bash language tags, and CJK-Latin spacing throughout the Japanese page.

`COOKIE_DOMAIN` and `NEXT_PUBLIC_COOKIE_DOMAIN` remain fully documented in the env vars reference, which the new FAQ entry links to.