### PR TITLE
style: drop trailing-whitespace and callout-blank-line format rules

### DIFF
--- a/.claude/skills/dify-docs-format-check-cjk/SKILL.md
+++ b/.claude/skills/dify-docs-format-check-cjk/SKILL.md
@@ -56,8 +56,8 @@ The script selects zh or ja rules based on the file path. Rules fall into three 
 - `C-no-language`, `C-blank-before`, `C-blank-after` — code block rules.
 - `Li-click-here`, `Li-http-external` — link rules.
 - `I-raw-img-tag`, `I-alt-too-long`, `I-caption-alt-mismatch`, `I-filename-*` — image rules (same set as the EN skill).
-- `M-tab-no-title`, `M-component-blank-before`, `M-component-blank-after` — Mintlify component rules.
-- `S-double-blank`, `S-trailing-whitespace` — spacing.
+- `M-tab-no-title` — Mintlify component rules.
+- `S-double-blank` — spacing.
 - `P-em-dash-spaces`, `P-en-dash-spaces` — general punctuation.
 
 **Shared CJK rules (zh + ja)**

--- a/.claude/skills/dify-docs-format-check-cjk/check-format-cjk.py
+++ b/.claude/skills/dify-docs-format-check-cjk/check-format-cjk.py
@@ -385,10 +385,6 @@ def check_images(lines: list[str]) -> list[Violation]:
 def check_mintlify(lines: list[str]) -> list[Violation]:
     vs: list[Violation] = []
     in_fence = False
-    callout_re = re.compile(r'^\s*<(Info|Tip|Note|Warning)\b[^>]*>',
-                            re.IGNORECASE)
-    closer_re = re.compile(r'^\s*</(Info|Tip|Note|Warning)>\s*$',
-                           re.IGNORECASE)
     tab_re = re.compile(r'<Tab(?:\s+[^>]*)?>')
     tab_title_re = re.compile(r'\btitle\s*=\s*"[^"]*"')
     for i, line in enumerate(lines, 1):
@@ -397,13 +393,6 @@ def check_mintlify(lines: list[str]) -> list[Violation]:
             continue
         if in_fence:
             continue
-        if callout_re.match(line) and i > 1 and lines[i - 2].strip() != '':
-            vs.append(Violation(i, 'M-component-blank-before',
-                                'Missing blank line before callout.'))
-        if closer_re.match(line) and i < len(lines) \
-                and lines[i].strip() != '':
-            vs.append(Violation(i, 'M-component-blank-after',
-                                'Missing blank line after callout.'))
         for m in tab_re.finditer(line):
             if not tab_title_re.search(m.group(0)):
                 vs.append(Violation(i, 'M-tab-no-title',
@@ -429,9 +418,6 @@ def check_spacing(lines: list[str]) -> list[Violation]:
                                     'Consecutive blank lines.'))
         else:
             blank_run = 0
-        if line != line.rstrip():
-            vs.append(Violation(i, 'S-trailing-whitespace',
-                                'Line has trailing whitespace.'))
     return vs
 
 

--- a/.claude/skills/dify-docs-format-check-en/SKILL.md
+++ b/.claude/skills/dify-docs-format-check-en/SKILL.md
@@ -88,7 +88,6 @@ The script checks these rules. Each violation includes the file path, line numbe
 **Mintlify Components**
 
 - `M-tab-no-title` — `<Tab>` without a `title` attribute.
-- `M-component-blank-before` / `M-component-blank-after` — missing blank line around `<Info>`, `<Tip>`, `<Note>`, or `<Warning>`.
 
 **UI Element References**
 
@@ -97,7 +96,6 @@ The script checks these rules. Each violation includes the file path, line numbe
 **Spacing**
 
 - `S-double-blank` — two or more consecutive blank lines.
-- `S-trailing-whitespace` — line ends with whitespace.
 
 **Punctuation**
 

--- a/.claude/skills/dify-docs-format-check-en/check-format-en.py
+++ b/.claude/skills/dify-docs-format-check-en/check-format-en.py
@@ -513,7 +513,6 @@ def check_images(lines: list[str]) -> list[Violation]:
 def check_mintlify_components(lines: list[str]) -> list[Violation]:
     vs: list[Violation] = []
     in_fence = False
-    callout_re = re.compile(r'^\s*<(Info|Tip|Note|Warning)\b[^>]*>', re.IGNORECASE)
     tab_no_title_re = re.compile(r'<Tab(?:\s+[^>]*)?>')
     tab_title_attr_re = re.compile(r'\btitle\s*=\s*"[^"]*"')
     for i, line in enumerate(lines, 1):
@@ -522,31 +521,11 @@ def check_mintlify_components(lines: list[str]) -> list[Violation]:
             continue
         if in_fence:
             continue
-        if callout_re.match(line):
-            if i > 1 and lines[i - 2].strip() != '':
-                vs.append(Violation(
-                    i, 'M-component-blank-before',
-                    'Missing blank line before Mintlify callout.'))
         for m in tab_no_title_re.finditer(line):
             if not tab_title_attr_re.search(m.group(0)):
                 vs.append(Violation(
                     i, 'M-tab-no-title',
                     '<Tab> element without a title attribute.'))
-    # end-of-component blank
-    closer_re = re.compile(r'^\s*</(Info|Tip|Note|Warning)>\s*$',
-                           re.IGNORECASE)
-    in_fence = False
-    for i, line in enumerate(lines, 1):
-        if FENCE_RE.match(line):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        if closer_re.match(line):
-            if i < len(lines) and lines[i].strip() != '':
-                vs.append(Violation(
-                    i, 'M-component-blank-after',
-                    'Missing blank line after Mintlify callout.'))
     return vs
 
 
@@ -590,10 +569,6 @@ def check_spacing(lines: list[str]) -> list[Violation]:
                     'Two or more consecutive blank lines.'))
         else:
             blank_run = 0
-        if line != line.rstrip():
-            vs.append(Violation(
-                i, 'S-trailing-whitespace',
-                'Line has trailing whitespace.'))
     return vs
 
 

--- a/writing-guides/formatting-guide.md
+++ b/writing-guides/formatting-guide.md
@@ -282,7 +282,6 @@ Configure at least one model provider in **System Settings** > **Model Providers
 </Info>
 ```
 
-- One blank line before and after the component.
 - Content inside can include bold, links, and other inline formatting.
 
 ### Tabs
@@ -380,7 +379,7 @@ Use for showing multiple code variants of the same operation:
 
 ## Spacing
 
-- **One blank line** between paragraphs, before/after headings, before/after components, before/after code blocks.
+- **One blank line** between paragraphs, before/after headings, before/after code blocks.
 - **No double blank lines** anywhere in the file.
 
 ---


### PR DESCRIPTION
## Summary

- Drop `S-trailing-whitespace` and `M-component-blank-before` / `M-component-blank-after` from both format-check linters (`check-format-en.py`, `check-format-cjk.py`) and their SKILL.md rule indices.
- Remove the matching prose from `writing-guides/formatting-guide.md`: the per-callout "one blank line before and after the component" line and the `before/after components` clause in the general Spacing rule.