### PR TITLE
fix: update README checkout example to release/1.14.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Our published documentation site only hosts the latest version of Dify. To view 
 ```bash
 git clone https://github.com/langgenius/dify-docs.git
 cd dify-docs
-git checkout release/1.14   # replace with the version you want
+git checkout release/1.14.x   # replace with the version you want
 npm i -g mintlify
 mintlify dev
 ```


### PR DESCRIPTION
## Summary
- Reflects the rename of `release/1.14` to `release/1.14.x` on origin.
- Keeps the local-preview instructions accurate now that the old branch name has been deleted from the remote.