### PR TITLE
docs: 1.14.2 self-host fixes for credential purge and worker default

### DIFF
--- a/en/self-host/configuration/environments.mdx
+++ b/en/self-host/configuration/environments.mdx
@@ -1174,7 +1174,7 @@ These select which backend implementation handles workflow execution data. The d
 
 | Variable | Default | Description |
 |---|---|---|
-| `GRAPH_ENGINE_MIN_WORKERS` | `1` | Minimum workers per GraphEngine instance. |
+| `GRAPH_ENGINE_MIN_WORKERS` | `3` | Minimum workers per GraphEngine instance. |
 | `GRAPH_ENGINE_MAX_WORKERS` | `10` | Maximum workers per GraphEngine instance. |
 | `GRAPH_ENGINE_SCALE_UP_THRESHOLD` | `3` | Queue depth that triggers spawning additional workers. |
 | `GRAPH_ENGINE_SCALE_DOWN_IDLE_TIME` | `5.0` | Seconds of idle time before excess workers are removed. |

--- a/en/self-host/troubleshooting/common-issues.mdx
+++ b/en/self-host/troubleshooting/common-issues.mdx
@@ -115,7 +115,9 @@ Source code (from `api` directory):
 flask reset-encrypt-key-pair
 ```
 
-**Warning**: This is irreversible - existing encrypted data will be lost.
+<Warning>
+This is irreversible. Existing LLM credentials and tool credentials (built-in, custom, and MCP tools) are purged for every workspace and must be re-entered.
+</Warning>
 
 ## Workspace Management
 

--- a/ja/self-host/configuration/environments.mdx
+++ b/ja/self-host/configuration/environments.mdx
@@ -1174,7 +1174,7 @@ Dify はアカウント招待、パスワードリセット、ログインコー
 
 | 変数 | デフォルト値 | 説明 |
 |---|---|---|
-| `GRAPH_ENGINE_MIN_WORKERS` | `1` | GraphEngine インスタンスごとの最小ワーカー数。 |
+| `GRAPH_ENGINE_MIN_WORKERS` | `3` | GraphEngine インスタンスごとの最小ワーカー数。 |
 | `GRAPH_ENGINE_MAX_WORKERS` | `10` | GraphEngine インスタンスごとの最大ワーカー数。 |
 | `GRAPH_ENGINE_SCALE_UP_THRESHOLD` | `3` | 追加ワーカーの生成をトリガーするキュー深度。 |
 | `GRAPH_ENGINE_SCALE_DOWN_IDLE_TIME` | `5.0` | 余剰ワーカーが削除されるまでのアイドル時間（秒）。 |

--- a/ja/self-host/troubleshooting/common-issues.mdx
+++ b/ja/self-host/troubleshooting/common-issues.mdx
@@ -114,7 +114,9 @@ docker exec -it docker-api-1 flask reset-encrypt-key-pair
 flask reset-encrypt-key-pair
 ```
 
-**警告**：これは元に戻せません - 既存の暗号化データは失われます。
+<Warning>
+この操作は元に戻せません。すべてのワークスペースの LLM 認証情報とツール認証情報（ビルトイン、カスタム、MCP ツール）が削除されるため、再入力が必要です。
+</Warning>
 
 ## ワークスペース管理
 

--- a/zh/self-host/configuration/environments.mdx
+++ b/zh/self-host/configuration/environments.mdx
@@ -1174,7 +1174,7 @@ Dify 发送邮件用于账户邀请、密码重置、登录验证码和人工输
 
 | 变量 | 默认值 | 说明 |
 |---|---|---|
-| `GRAPH_ENGINE_MIN_WORKERS` | `1` | 每个 GraphEngine 实例的最小工作线程数。 |
+| `GRAPH_ENGINE_MIN_WORKERS` | `3` | 每个 GraphEngine 实例的最小工作线程数。 |
 | `GRAPH_ENGINE_MAX_WORKERS` | `10` | 每个 GraphEngine 实例的最大工作线程数。 |
 | `GRAPH_ENGINE_SCALE_UP_THRESHOLD` | `3` | 触发创建额外工作线程的队列深度。 |
 | `GRAPH_ENGINE_SCALE_DOWN_IDLE_TIME` | `5.0` | 多余工作线程在空闲此秒数后被移除。 |

--- a/zh/self-host/troubleshooting/common-issues.mdx
+++ b/zh/self-host/troubleshooting/common-issues.mdx
@@ -117,7 +117,9 @@ docker exec -it docker-api-1 flask reset-encrypt-key-pair
 flask reset-encrypt-key-pair
 ```
 
-**警告**：此操作不可逆 - 现有加密数据将丢失。
+<Warning>
+此操作不可逆。所有工作区的 LLM 凭据和工具凭据（内置、自定义、MCP 工具）将一并清除，需重新录入。
+</Warning>
 
 ## 工作空间管理
 


### PR DESCRIPTION
## Summary

Doc-side sync for two changes landing in Dify 1.14.2 that affect the self-host documentation.

- **`reset-encrypt-key-pair` troubleshooting warning**: the command now also purges tool credentials (built-in, custom, and MCP tools) in addition to LLM credentials. Warning text updated so operators know what they're losing before running it. Source: langgenius/dify#35843.
- **`GRAPH_ENGINE_MIN_WORKERS` default**: changed upstream from `1` to `3` so small parallel workflows get enough baseline workers without manual tuning. Source: langgenius/dify#35650.