### PR TITLE
docs: mention Tuning Engines gateway

### DIFF
--- a/en/use-dify/workspace/model-providers.mdx
+++ b/en/use-dify/workspace/model-providers.mdx
@@ -29,7 +29,7 @@ Only workspace admins and owners can configure model providers. The process is c
   <Step title="Add credentials">
     Enter your API key and any additional configuration required by the provider.
   </Step>
-  
+
   <Step title="Test and save">
     Dify validates your credentials before making the provider available to your workspace.
   </Step>
@@ -64,6 +64,9 @@ Only workspace admins and owners can configure model providers. The process is c
     **Optional**: Custom base URL for Azure OpenAI or proxies, Organization ID for organization-scoped usage
     
     **Available Models**: GPT-4, GPT-3.5-turbo, DALL-E, Whisper, Text embeddings
+
+    **OpenAI-compatible gateways**: If your organization routes model calls through a gateway, configure the gateway's base URL and key here. For example, Tuning Engines uses `https://api.tuningengines.com/v1` as the base URL, a tenant-scoped inference key as the API key, and model names that match the aliases enabled in Tuning Engines.
+
   </Tab>
   
   <Tab title="Anthropic">


### PR DESCRIPTION
Adds Tuning Engines as an example OpenAI-compatible gateway in the model provider docs, using a custom base URL, tenant-scoped inference key, and model aliases.