### PR TITLE
fix: correct translated anchor fragments in zh/ja datasource-plugin

### DIFF
--- a/ja/develop-plugin/dev-guides-and-walkthroughs/datasource-plugin.mdx
+++ b/ja/develop-plugin/dev-guides-and-walkthroughs/datasource-plugin.mdx
@@ -21,7 +21,7 @@ description: Dify 1.9.0以降のデータソースプラグインを構築し、
 Difyは3種類のデータソースプラグインをサポートしています：Webクローラー、オンラインドキュメント、オンラインドライブ。プラグインコードを実装する際、プラグインの機能を提供するクラスは特定のデータソースクラスを継承する必要があります。3種類のプラグインタイプはそれぞれ異なる親クラスに対応しています。
 
 <Info>
-  親クラスを継承してプラグイン機能を実装する方法については、[ツールプラグイン：ツールコードの準備](/ja/develop-plugin/dev-guides-and-walkthroughs/tool-plugin#4-prepare-tool-code)を参照してください。
+  親クラスを継承してプラグイン機能を実装する方法については、[ツールプラグイン：ツールコードの準備](/ja/develop-plugin/dev-guides-and-walkthroughs/tool-plugin#4-ツールコードの準備)を参照してください。
 </Info>
 
 各データソースプラグインタイプは複数のデータソースをサポートしています。例えば：
@@ -113,7 +113,7 @@ datasources:
 ```
 
 <Info>
-  プロバイダーYAMLファイルの作成について詳しくは、[ツールプラグイン：サードパーティサービス認証情報の完成](/ja/develop-plugin/dev-guides-and-walkthroughs/tool-plugin#2-complete-third-party-service-credentials)を参照してください。
+  プロバイダーYAMLファイルの作成について詳しくは、[ツールプラグイン：サードパーティサービス認証情報の完成](/ja/develop-plugin/dev-guides-and-walkthroughs/tool-plugin#2-サードパーティサービス認証情報の完成)を参照してください。
 </Info>
 
 <Info>

--- a/zh/develop-plugin/dev-guides-and-walkthroughs/datasource-plugin.mdx
+++ b/zh/develop-plugin/dev-guides-and-walkthroughs/datasource-plugin.mdx
@@ -21,7 +21,7 @@ description: 构建 Dify 1.9.0+ 数据源插件，将文档输入知识库管道
 Dify 支持三种类型的数据源插件：网页爬虫、在线文档和在线云盘。在实现插件代码时，提供插件功能的类必须继承自特定的数据源类。三种插件类型分别对应不同的父类。
 
 <Info>
-  要了解如何通过继承父类来实现插件功能，请参阅[工具插件：准备工具代码](/zh/develop-plugin/dev-guides-and-walkthroughs/tool-plugin#4-prepare-tool-code)。
+  要了解如何通过继承父类来实现插件功能，请参阅[工具插件：准备工具代码](/zh/develop-plugin/dev-guides-and-walkthroughs/tool-plugin#4-准备工具代码)。
 </Info>
 
 每种数据源插件类型支持多个数据源。例如：
@@ -113,7 +113,7 @@ datasources:
 ```
 
 <Info>
-  有关创建提供者 YAML 文件的更多信息，请参阅[工具插件：完善第三方服务凭据](/zh/develop-plugin/dev-guides-and-walkthroughs/tool-plugin#2-complete-third-party-service-credentials)。
+  有关创建提供者 YAML 文件的更多信息，请参阅[工具插件：完善第三方服务凭据](/zh/develop-plugin/dev-guides-and-walkthroughs/tool-plugin#2-完善第三方服务凭据)。
 </Info>
 
 <Info>


### PR DESCRIPTION
## Summary

Fix four broken anchors flagged by the CI internal link check (`tools/check-links.py --internal`) in the zh and ja `datasource-plugin` pages.

These pages link to `tool-plugin` section headings. The translation pipeline translated the link labels but left the anchor fragments in English (`#4-prepare-tool-code`, `#2-complete-third-party-service-credentials`). Because the zh/ja `tool-plugin` headings are translated, their generated slugs are localized, so the English fragments resolved to nonexistent anchors. The en page passed because its headings stay in English, which is why this only surfaced in the translated files.