### PR TITLE
docs: require user for file upload API

### DIFF
--- a/en/api-reference/openapi_chat.json
+++ b/en/api-reference/openapi_chat.json
@@ -481,7 +481,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "Required User identifier, defined by the developer's rules, must be unique within the application. The Service API does not share conversations created by the WebApp."
+                    "description": "Identifier for the end user, defined by your application's rules and unique within the app. Service API and WebApp user IDs are separate, even when identical."
                   }
                 }
               }

--- a/en/api-reference/openapi_chat.json
+++ b/en/api-reference/openapi_chat.json
@@ -470,7 +470,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -480,7 +481,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "User identifier, defined by the developer's rules, must be unique within the application."
+                    "description": "Required User identifier, defined by the developer's rules, must be unique within the application. The Service API does not share conversations created by the WebApp."
                   }
                 }
               }

--- a/en/api-reference/openapi_chatflow.json
+++ b/en/api-reference/openapi_chatflow.json
@@ -498,7 +498,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -508,7 +509,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "User identifier, defined by the developer's rules, must be unique within the application."
+                    "description": "Required User identifier, defined by the developer's rules, must be unique within the application. The Service API does not share conversations created by the WebApp."
                   }
                 }
               }

--- a/en/api-reference/openapi_chatflow.json
+++ b/en/api-reference/openapi_chatflow.json
@@ -509,7 +509,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "Required User identifier, defined by the developer's rules, must be unique within the application. The Service API does not share conversations created by the WebApp."
+                    "description": "Identifier for the end user, defined by your application's rules and unique within the app. Service API and WebApp user IDs are separate, even when identical."
                   }
                 }
               }

--- a/en/api-reference/openapi_completion.json
+++ b/en/api-reference/openapi_completion.json
@@ -443,7 +443,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -453,7 +454,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "User identifier, defined by the developer's rules, must be unique within the application."
+                    "description": "Required User identifier, defined by the developer's rules, must be unique within the application. The Service API does not share conversations created by the WebApp."
                   }
                 }
               }

--- a/en/api-reference/openapi_completion.json
+++ b/en/api-reference/openapi_completion.json
@@ -454,7 +454,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "Required User identifier, defined by the developer's rules, must be unique within the application. The Service API does not share conversations created by the WebApp."
+                    "description": "Identifier for the end user, defined by your application's rules and unique within the app. Service API and WebApp user IDs are separate, even when identical."
                   }
                 }
               }

--- a/en/api-reference/openapi_workflow.json
+++ b/en/api-reference/openapi_workflow.json
@@ -784,7 +784,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "Required User identifier, defined by the developer's rules, must be unique within the application. The Service API does not share conversations created by the WebApp."
+                    "description": "Identifier for the end user, defined by your application's rules and unique within the app. Service API and WebApp user IDs are separate, even when identical."
                   }
                 }
               }

--- a/en/api-reference/openapi_workflow.json
+++ b/en/api-reference/openapi_workflow.json
@@ -773,7 +773,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -783,7 +784,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "User identifier, defined by the developer's rules, must be unique within the application."
+                    "description": "Required User identifier, defined by the developer's rules, must be unique within the application. The Service API does not share conversations created by the WebApp."
                   }
                 }
               }

--- a/ja/api-reference/openapi_chat.json
+++ b/ja/api-reference/openapi_chat.json
@@ -470,7 +470,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -480,7 +481,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "ユーザー識別子。開発者のルールで定義され、アプリケーション内で一意である必要があります。"
+                    "description": "ユーザー識別子。開発者のルールで定義され、アプリケーション内で一意である必要があります。Service API と WebApp のユーザー ID は独立しており、値が同じでも同じユーザーを指しません。"
                   }
                 }
               }

--- a/ja/api-reference/openapi_chatflow.json
+++ b/ja/api-reference/openapi_chatflow.json
@@ -498,7 +498,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -508,7 +509,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "ユーザー識別子。開発者のルールで定義され、アプリケーション内で一意である必要があります。"
+                    "description": "ユーザー識別子。開発者のルールで定義され、アプリケーション内で一意である必要があります。Service API と WebApp のユーザー ID は独立しており、値が同じでも同じユーザーを指しません。"
                   }
                 }
               }

--- a/ja/api-reference/openapi_completion.json
+++ b/ja/api-reference/openapi_completion.json
@@ -443,7 +443,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -453,7 +454,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "ユーザー識別子。開発者のルールで定義され、アプリケーション内で一意である必要があります。"
+                    "description": "ユーザー識別子。開発者のルールで定義され、アプリケーション内で一意である必要があります。Service API と WebApp のユーザー ID は独立しており、値が同じでも同じユーザーを指しません。"
                   }
                 }
               }

--- a/ja/api-reference/openapi_workflow.json
+++ b/ja/api-reference/openapi_workflow.json
@@ -773,7 +773,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -783,7 +784,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "ユーザー識別子。開発者のルールで定義され、アプリケーション内で一意である必要があります。"
+                    "description": "ユーザー識別子。開発者のルールで定義され、アプリケーション内で一意である必要があります。Service API と WebApp のユーザー ID は独立しており、値が同じでも同じユーザーを指しません。"
                   }
                 }
               }

--- a/zh/api-reference/openapi_chat.json
+++ b/zh/api-reference/openapi_chat.json
@@ -470,7 +470,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -480,7 +481,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "用户标识符，由开发者定义的规则生成，必须在应用内唯一。"
+                    "description": "用户标识符，由开发者定义的规则生成，必须在应用内唯一。Service API 与 WebApp 的用户 ID 相互独立，即使取值相同也不指向同一用户。"
                   }
                 }
               }

--- a/zh/api-reference/openapi_chatflow.json
+++ b/zh/api-reference/openapi_chatflow.json
@@ -498,7 +498,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -508,7 +509,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "用户标识符，由开发者定义的规则生成，必须在应用内唯一。"
+                    "description": "用户标识符，由开发者定义的规则生成，必须在应用内唯一。Service API 与 WebApp 的用户 ID 相互独立，即使取值相同也不指向同一用户。"
                   }
                 }
               }

--- a/zh/api-reference/openapi_completion.json
+++ b/zh/api-reference/openapi_completion.json
@@ -443,7 +443,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -453,7 +454,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "用户标识符，由开发者定义的规则生成，必须在应用内唯一。"
+                    "description": "用户标识符，由开发者定义的规则生成，必须在应用内唯一。Service API 与 WebApp 的用户 ID 相互独立，即使取值相同也不指向同一用户。"
                   }
                 }
               }

--- a/zh/api-reference/openapi_workflow.json
+++ b/zh/api-reference/openapi_workflow.json
@@ -773,7 +773,8 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "file"
+                  "file",
+                  "user"
                 ],
                 "properties": {
                   "file": {
@@ -783,7 +784,7 @@
                   },
                   "user": {
                     "type": "string",
-                    "description": "用户标识符，由开发者定义的规则生成，必须在应用内唯一。"
+                    "description": "用户标识符，由开发者定义的规则生成，必须在应用内唯一。Service API 与 WebApp 的用户 ID 相互独立，即使取值相同也不指向同一用户。"
                   }
                 }
               }


### PR DESCRIPTION
## Summary

- Mark `user` as required for the shared `/files/upload` request schema in chat, chatflow, completion, and workflow API specs.
- Update the `user` field description to clarify uniqueness requirements and the separation between Service API and WebApp conversations.

## Impact

Developers using the Service API file upload endpoint now see the required end-user identifier contract consistently across app API references.