### PR TITLE
feat: add automated backporting to release branches

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,8 @@
+{
+  "branchLabelMapping": {
+    "^backport-to-(release/.+)$": "$1"
+  },
+  "prTitle": "{commitMessages} (backport to {targetBranch})",
+  "targetPRLabels": ["backport"],
+  "autoMerge": false
+}

--- a/.github/BACKPORT.md
+++ b/.github/BACKPORT.md
@@ -1,0 +1,39 @@
+# Backporting to release branches
+
+Backports merged `main` changes onto long-term `release/*` branches as PRs.
+Config lives in `.backportrc.json` and is shared by both methods below.
+
+## Immediate (one PR)
+
+Add a label `backport-to-release/<branch>` to the PR (before or after merge),
+e.g. `backport-to-release/1.14.x`. On merge, the Backport workflow opens a
+backport PR to that branch. Add multiple labels to fan out to several branches.
+A clean cherry-pick opens the PR automatically; a conflict instead comments on
+the source PR (finish it with the CLI below).
+
+> The label must exist before you can apply it. When labeling for a new branch
+> the first time, create the label (the labels box offers "Create new label").
+
+## Batch (many PRs at once)
+
+One-time local auth: create `~/.backport/config.json` with
+`{ "accessToken": "<a GitHub token with repo scope>" }`.
+
+Then gather and select interactively (targets passed at runtime, so any
+`release/*` works without editing config):
+
+```bash
+# By query, then arrow-key multi-select the PRs:
+npx backport --pr-query "merged:>=2026-05-01 label:backport-pending" \
+  --branch release/1.15.0 --branch release/1.14.x
+# Or by path / single PR:
+npx backport --path en/use-dify --branch release/1.14.x
+npx backport --pr 792 --branch release/1.14.x
+```
+
+## Finishing a conflicting backport
+
+```bash
+npx backport --pr <source-pr-number> --branch release/<branch>
+# resolve the conflict when prompted; the CLI pushes and opens the PR
+```

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -2,6 +2,9 @@ name: Backport merged PR
 on:
   pull_request_target:
     types: [labeled, closed]
+permissions:
+  contents: read
+  pull-requests: read
 jobs:
   backport:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,13 @@
+name: Backport merged PR
+on:
+  pull_request_target:
+    types: [labeled, closed]
+jobs:
+  backport:
+    if: github.event.pull_request.merged == true
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - uses: sorenlouv/backport-github-action@v12
+        with:
+          github_token: ${{ secrets.BACKPORT_TOKEN }}
+          auto_backport_label_prefix: backport-to-

--- a/.mintignore
+++ b/.mintignore
@@ -13,3 +13,9 @@
 # Non-public utility files under public asset directories
 /assets/migrate_weaviate_collections.py
 /logo/convertor.html
+
+# Internal contributor runbooks
+/.github/BACKPORT.md
+
+# Backport tooling config
+/.backportrc.json


### PR DESCRIPTION
## What

Automated backporting of merged `main` commits to long-term `release/*` branches, delivered as PRs.

- **`.backportrc.json`** — shared config for the [`sorenlouv/backport`](https://github.com/sorenlouv/backport) toolkit. A `backport-to-release/<branch>` label maps dynamically to that branch, so any `release/*` works with no list to maintain.
- **`.github/workflows/backport.yml`** — runs `sorenlouv/backport-github-action@v12` on PR merge and opens a backport PR per labeled branch. A clean cherry-pick opens the PR automatically; a conflict comments on the source PR instead of opening a broken one.
- **`.github/BACKPORT.md`** — internal runbook for the `npx backport` CLI (batch backports and finishing conflicts), excluded from the published site.

## Why

Optimization changes merge into `main` and publish immediately, but the `release/*` snapshot branches need the same fixes. This turns manual cherry-picking into a one-label action (immediate) or a single CLI pass (batch).

## Usage

- **Immediate:** add `backport-to-release/1.14.x` (and any other branch labels) to a PR. On merge, a backport PR opens to each.
- **Batch:** run `npx backport`, multi-select the merged PRs and target branches.