### PR TITLE
fix: correct backport PR template syntax and clear auto-assignee

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,8 @@
   "branchLabelMapping": {
     "^backport-to-(release/.+)$": "$1"
   },
-  "prTitle": "{commitMessages} (backport to {targetBranch})",
+  "prTitle": "{{commitMessages}} (backport to {{targetBranch}})",
+  "prDescription": "# Backport\n\nThis will backport the following commits from `{{sourceBranch}}` to `{{targetBranch}}`:\n\n- {{commitMessages}}",
   "targetPRLabels": ["backport"],
   "autoMerge": false
 }

--- a/.github/workflows/backport-clear-assignee.yml
+++ b/.github/workflows/backport-clear-assignee.yml
@@ -1,0 +1,18 @@
+name: Clear assignee on backport PRs
+on:
+  pull_request_target:
+    types: [assigned]
+permissions:
+  pull-requests: write
+jobs:
+  clear:
+    if: startsWith(github.event.pull_request.head.ref, 'backport/')
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - name: Remove the newly added assignee
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          USER: ${{ github.event.assignee.login }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR" --repo "$REPO" --remove-assignee "$USER"


### PR DESCRIPTION
Two follow-ups after the first real backport (#797).

## Template syntax

`prTitle` used single braces, which the tool renders literally (visible as `{commitMessages}` in #797's title). The tool uses Handlebars double-brace tokens, switched to `{{commitMessages}}` / `{{targetBranch}}`. Also added a custom `prDescription` that matches the existing body format and drops the "Backport tool documentation" footer.

## Auto-assignee workaround

`sorenlouv/backport-github-action` hardcodes the source PR's author as the backport PR's assignee. The action has no input to disable it and `.backportrc.json` cannot override it. Added a small companion workflow that listens for `pull_request_target: assigned` on `backport/*` head refs and removes the just-added assignee. The `assigned` → removal cycle does not loop because removal emits `unassigned`.