### PR TITLE
docs: add Vaultak runtime security integration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -147,7 +147,8 @@
                           "en/use-dify/monitor/integrations/integrate-weave",
                           "en/use-dify/monitor/integrations/integrate-arize",
                           "en/use-dify/monitor/integrations/integrate-phoenix",
-                          "en/use-dify/monitor/integrations/integrate-aliyun"
+                          "en/use-dify/monitor/integrations/integrate-aliyun",
+                          "en/use-dify/monitor/integrations/integrate-vaultak"
                         ]
                       }
                     ],
@@ -477,11 +478,11 @@
             "version": "Latest",
             "dropdowns": [
               {
-                "dropdown": "使用 Dify",
+                "dropdown": "\u4f7f\u7528 Dify",
                 "icon": "book-open",
                 "pages": [
                   {
-                    "group": "入门",
+                    "group": "\u5165\u95e8",
                     "expanded": false,
                     "pages": [
                       "zh/use-dify/getting-started/introduction",
@@ -491,20 +492,20 @@
                     "icon": "rocket"
                   },
                   {
-                    "group": "构建",
+                    "group": "\u6784\u5efa",
                     "pages": [
                       {
-                        "group": "工作流与对话流",
+                        "group": "\u5de5\u4f5c\u6d41\u4e0e\u5bf9\u8bdd\u6d41",
                         "pages": [
                           "zh/use-dify/build/workflow-chatflow",
                           "zh/use-dify/build/orchestrate-node",
                           {
-                            "group": "节点",
+                            "group": "\u8282\u70b9",
                             "expanded": false,
                             "pages": [
                               "zh/use-dify/nodes/user-input",
                               {
-                                "group": "触发器",
+                                "group": "\u89e6\u53d1\u5668",
                                 "pages": [
                                   "zh/use-dify/nodes/trigger/overview",
                                   "zh/use-dify/nodes/trigger/schedule-trigger",
@@ -538,7 +539,7 @@
                           "zh/use-dify/build/version-control",
                           "zh/use-dify/build/workflow-collaboration",
                           {
-                            "group": "调试",
+                            "group": "\u8c03\u8bd5",
                             "expanded": false,
                             "pages": [
                               "zh/use-dify/build/predefined-error-handling-logic",
@@ -552,7 +553,7 @@
                         "expanded": true
                       },
                       {
-                        "group": "基础应用",
+                        "group": "\u57fa\u7840\u5e94\u7528",
                         "pages": [
                           "zh/use-dify/build/agent",
                           "zh/use-dify/build/chatbot",
@@ -565,7 +566,7 @@
                     "icon": "hammer"
                   },
                   {
-                    "group": "发布",
+                    "group": "\u53d1\u5e03",
                     "expanded": false,
                     "pages": [
                       "zh/use-dify/publish/README",
@@ -586,14 +587,14 @@
                     "icon": "paper-plane"
                   },
                   {
-                    "group": "监控",
+                    "group": "\u76d1\u63a7",
                     "expanded": false,
                     "pages": [
                       "zh/use-dify/monitor/analysis",
                       "zh/use-dify/monitor/logs",
                       "zh/use-dify/monitor/annotation-reply",
                       {
-                        "group": "集成",
+                        "group": "\u96c6\u6210",
                         "pages": [
                           "zh/use-dify/monitor/integrations/integrate-langsmith",
                           "zh/use-dify/monitor/integrations/integrate-langfuse",
@@ -601,26 +602,27 @@
                           "zh/use-dify/monitor/integrations/integrate-weave",
                           "zh/use-dify/monitor/integrations/integrate-arize",
                           "zh/use-dify/monitor/integrations/integrate-phoenix",
-                          "zh/use-dify/monitor/integrations/integrate-aliyun"
+                          "zh/use-dify/monitor/integrations/integrate-aliyun",
+                          "zh/use-dify/monitor/integrations/integrate-vaultak"
                         ]
                       }
                     ],
                     "icon": "chart-line"
                   },
                   {
-                    "group": "知识库",
+                    "group": "\u77e5\u8bc6\u5e93",
                     "expanded": false,
                     "pages": [
                       "zh/use-dify/knowledge/readme",
                       {
-                        "group": "创建",
+                        "group": "\u521b\u5efa",
                         "pages": [
                           {
-                            "group": "快速创建",
+                            "group": "\u5feb\u901f\u521b\u5efa",
                             "pages": [
                               "zh/use-dify/knowledge/create-knowledge/introduction",
                               {
-                                "group": "导入数据",
+                                "group": "\u5bfc\u5165\u6570\u636e",
                                 "pages": [
                                   "zh/use-dify/knowledge/create-knowledge/import-text-data/readme",
                                   "zh/use-dify/knowledge/create-knowledge/import-text-data/sync-from-notion",
@@ -632,7 +634,7 @@
                             ]
                           },
                           {
-                            "group": "通过知识流水线创建",
+                            "group": "\u901a\u8fc7\u77e5\u8bc6\u6d41\u6c34\u7ebf\u521b\u5efa",
                             "pages": [
                               "zh/use-dify/knowledge/knowledge-pipeline/readme",
                               "zh/use-dify/knowledge/knowledge-pipeline/create-knowledge-pipeline",
@@ -644,7 +646,7 @@
                             ]
                           },
                           {
-                            "group": "连接外部知识库",
+                            "group": "\u8fde\u63a5\u5916\u90e8\u77e5\u8bc6\u5e93",
                             "pages": [
                               "zh/use-dify/knowledge/connect-external-knowledge-base",
                               "zh/use-dify/knowledge/external-knowledge-api"
@@ -653,7 +655,7 @@
                         ]
                       },
                       {
-                        "group": "管理",
+                        "group": "\u7ba1\u7406",
                         "pages": [
                           "zh/use-dify/knowledge/manage-knowledge/maintain-knowledge-documents",
                           "zh/use-dify/knowledge/metadata",
@@ -668,7 +670,7 @@
                     "icon": "book"
                   },
                   {
-                    "group": "工作区",
+                    "group": "\u5de5\u4f5c\u533a",
                     "expanded": false,
                     "pages": [
                       "zh/use-dify/workspace/readme",
@@ -680,7 +682,7 @@
                       "zh/use-dify/workspace/personal-account-management",
                       "zh/use-dify/workspace/subscription-management",
                       {
-                        "group": "API 扩展",
+                        "group": "API \u6269\u5c55",
                         "pages": [
                           "zh/use-dify/workspace/api-extension/api-extension",
                           "zh/use-dify/workspace/api-extension/external-data-tool-api-extension",
@@ -692,11 +694,11 @@
                     "icon": "briefcase"
                   },
                   {
-                    "group": "教程",
+                    "group": "\u6559\u7a0b",
                     "expanded": false,
                     "pages": [
                       {
-                        "group": "工作流 101",
+                        "group": "\u5de5\u4f5c\u6d41 101",
                         "pages": [
                           "zh/use-dify/tutorials/workflow-101/lesson-01",
                           "zh/use-dify/tutorials/workflow-101/lesson-02",
@@ -724,7 +726,7 @@
                 "icon": "server",
                 "pages": [
                   {
-                    "group": "快速开始",
+                    "group": "\u5feb\u901f\u5f00\u59cb",
                     "pages": [
                       "zh/self-host/quick-start/docker-compose",
                       "zh/self-host/quick-start/faqs"
@@ -732,7 +734,7 @@
                     "icon": "rocket"
                   },
                   {
-                    "group": "进阶部署",
+                    "group": "\u8fdb\u9636\u90e8\u7f72",
                     "pages": [
                       "zh/self-host/advanced-deployments/local-source-code",
                       "zh/self-host/advanced-deployments/start-the-frontend-docker-container"
@@ -740,14 +742,14 @@
                     "icon": "server"
                   },
                   {
-                    "group": "配置",
+                    "group": "\u914d\u7f6e",
                     "pages": [
                       "zh/self-host/configuration/environments"
                     ],
                     "icon": "gear"
                   },
                   {
-                    "group": "平台指南",
+                    "group": "\u5e73\u53f0\u6307\u5357",
                     "pages": [
                       "zh/self-host/platform-guides/bt-panel",
                       "zh/self-host/platform-guides/dify-premium"
@@ -755,7 +757,7 @@
                     "icon": "map"
                   },
                   {
-                    "group": "故障排除",
+                    "group": "\u6545\u969c\u6392\u9664",
                     "pages": [
                       "zh/self-host/troubleshooting/common-issues",
                       "zh/self-host/troubleshooting/docker-issues",
@@ -766,45 +768,45 @@
                     "icon": "wrench"
                   }
                 ],
-                "dropdown": "自托管"
+                "dropdown": "\u81ea\u6258\u7ba1"
               },
               {
                 "icon": "code",
                 "groups": [
                   {
-                    "group": "Chatbot 和 Agent",
+                    "group": "Chatbot \u548c Agent",
                     "openapi": "zh/api-reference/openapi_chat.json",
                     "icon": "comments"
                   },
                   {
-                    "group": "对话流",
+                    "group": "\u5bf9\u8bdd\u6d41",
                     "openapi": "zh/api-reference/openapi_chatflow.json",
                     "icon": "diagram-project"
                   },
                   {
-                    "group": "工作流",
+                    "group": "\u5de5\u4f5c\u6d41",
                     "openapi": "zh/api-reference/openapi_workflow.json",
                     "icon": "sitemap"
                   },
                   {
-                    "group": "知识库",
+                    "group": "\u77e5\u8bc6\u5e93",
                     "openapi": "zh/api-reference/openapi_knowledge.json",
                     "icon": "book"
                   },
                   {
-                    "group": "文本生成",
+                    "group": "\u6587\u672c\u751f\u6210",
                     "openapi": "zh/api-reference/openapi_completion.json",
                     "icon": "font"
                   }
                 ],
-                "dropdown": "API 文档"
+                "dropdown": "API \u6587\u6863"
               },
               {
-                "dropdown": "开发插件",
+                "dropdown": "\u5f00\u53d1\u63d2\u4ef6",
                 "icon": "code-pull-request",
                 "groups": [
                   {
-                    "group": "快速开始",
+                    "group": "\u5feb\u901f\u5f00\u59cb",
                     "pages": [
                       "zh/develop-plugin/getting-started/getting-started-dify-plugin",
                       "zh/develop-plugin/getting-started/cli"
@@ -812,10 +814,10 @@
                     "icon": "rocket"
                   },
                   {
-                    "group": "特性与规范",
+                    "group": "\u7279\u6027\u4e0e\u89c4\u8303",
                     "pages": [
                       {
-                        "group": "插件类型",
+                        "group": "\u63d2\u4ef6\u7c7b\u578b",
                         "pages": [
                           "zh/develop-plugin/features-and-specs/plugin-types/general-specifications",
                           "zh/develop-plugin/features-and-specs/plugin-types/model-designing-rules",
@@ -829,10 +831,10 @@
                         ]
                       },
                       {
-                        "group": "高级开发",
+                        "group": "\u9ad8\u7ea7\u5f00\u53d1",
                         "pages": [
                           {
-                            "group": "反向调用",
+                            "group": "\u53cd\u5411\u8c03\u7528",
                             "pages": [
                               "zh/develop-plugin/features-and-specs/advanced-development/bundle",
                               "zh/develop-plugin/features-and-specs/advanced-development/reverse-invocation",
@@ -849,7 +851,7 @@
                     "icon": "list-check"
                   },
                   {
-                    "group": "开发指南与示例",
+                    "group": "\u5f00\u53d1\u6307\u5357\u4e0e\u793a\u4f8b",
                     "pages": [
                       "zh/develop-plugin/dev-guides-and-walkthroughs/cheatsheet",
                       "zh/develop-plugin/dev-guides-and-walkthroughs/tool-plugin",
@@ -867,10 +869,10 @@
                     "icon": "code"
                   },
                   {
-                    "group": "发布",
+                    "group": "\u53d1\u5e03",
                     "pages": [
                       {
-                        "group": "标准",
+                        "group": "\u6807\u51c6",
                         "pages": [
                           "zh/develop-plugin/publishing/standards/contributor-covenant-code-of-conduct",
                           "zh/develop-plugin/publishing/standards/privacy-protection-guidelines",
@@ -878,7 +880,7 @@
                         ]
                       },
                       {
-                        "group": "上架插件市场",
+                        "group": "\u4e0a\u67b6\u63d2\u4ef6\u5e02\u573a",
                         "pages": [
                           "zh/develop-plugin/publishing/marketplace-listing/plugin-auto-publish-pr",
                           "zh/develop-plugin/publishing/marketplace-listing/release-overview",
@@ -888,7 +890,7 @@
                         ]
                       },
                       {
-                        "group": "常见问题",
+                        "group": "\u5e38\u89c1\u95ee\u9898",
                         "pages": [
                           "zh/develop-plugin/publishing/faq/faq"
                         ]
@@ -910,11 +912,11 @@
             "version": "Latest",
             "dropdowns": [
               {
-                "dropdown": "Dify を使う",
+                "dropdown": "Dify \u3092\u4f7f\u3046",
                 "icon": "book-open",
                 "pages": [
                   {
-                    "group": "はじめに",
+                    "group": "\u306f\u3058\u3081\u306b",
                     "expanded": false,
                     "pages": [
                       "ja/use-dify/getting-started/introduction",
@@ -924,20 +926,20 @@
                     "icon": "rocket"
                   },
                   {
-                    "group": "ビルド",
+                    "group": "\u30d3\u30eb\u30c9",
                     "pages": [
                       {
-                        "group": "ワークフローとチャットフロー",
+                        "group": "\u30ef\u30fc\u30af\u30d5\u30ed\u30fc\u3068\u30c1\u30e3\u30c3\u30c8\u30d5\u30ed\u30fc",
                         "pages": [
                           "ja/use-dify/build/workflow-chatflow",
                           "ja/use-dify/build/orchestrate-node",
                           {
-                            "group": "ノード",
+                            "group": "\u30ce\u30fc\u30c9",
                             "expanded": false,
                             "pages": [
                               "ja/use-dify/nodes/user-input",
                               {
-                                "group": "トリガー",
+                                "group": "\u30c8\u30ea\u30ac\u30fc",
                                 "pages": [
                                   "ja/use-dify/nodes/trigger/overview",
                                   "ja/use-dify/nodes/trigger/schedule-trigger",
@@ -971,7 +973,7 @@
                           "ja/use-dify/build/version-control",
                           "ja/use-dify/build/workflow-collaboration",
                           {
-                            "group": "デバッグ",
+                            "group": "\u30c7\u30d0\u30c3\u30b0",
                             "expanded": false,
                             "pages": [
                               "ja/use-dify/build/predefined-error-handling-logic",
@@ -985,7 +987,7 @@
                         "expanded": true
                       },
                       {
-                        "group": "基本アプリ",
+                        "group": "\u57fa\u672c\u30a2\u30d7\u30ea",
                         "pages": [
                           "ja/use-dify/build/agent",
                           "ja/use-dify/build/chatbot",
@@ -998,12 +1000,12 @@
                     "icon": "hammer"
                   },
                   {
-                    "group": "公開",
+                    "group": "\u516c\u958b",
                     "expanded": false,
                     "pages": [
                       "ja/use-dify/publish/README",
                       {
-                        "group": "Web アプリ",
+                        "group": "Web \u30a2\u30d7\u30ea",
                         "pages": [
                           "ja/use-dify/publish/webapp/workflow-webapp",
                           "ja/use-dify/publish/webapp/chatflow-webapp",
@@ -1019,14 +1021,14 @@
                     "icon": "paper-plane"
                   },
                   {
-                    "group": "モニタリング",
+                    "group": "\u30e2\u30cb\u30bf\u30ea\u30f3\u30b0",
                     "expanded": false,
                     "pages": [
                       "ja/use-dify/monitor/analysis",
                       "ja/use-dify/monitor/logs",
                       "ja/use-dify/monitor/annotation-reply",
                       {
-                        "group": "インテグレーション",
+                        "group": "\u30a4\u30f3\u30c6\u30b0\u30ec\u30fc\u30b7\u30e7\u30f3",
                         "pages": [
                           "ja/use-dify/monitor/integrations/integrate-langsmith",
                           "ja/use-dify/monitor/integrations/integrate-langfuse",
@@ -1034,26 +1036,27 @@
                           "ja/use-dify/monitor/integrations/integrate-weave",
                           "ja/use-dify/monitor/integrations/integrate-arize",
                           "ja/use-dify/monitor/integrations/integrate-phoenix",
-                          "ja/use-dify/monitor/integrations/integrate-aliyun"
+                          "ja/use-dify/monitor/integrations/integrate-aliyun",
+                          "ja/use-dify/monitor/integrations/integrate-vaultak"
                         ]
                       }
                     ],
                     "icon": "chart-line"
                   },
                   {
-                    "group": "ナレッジ",
+                    "group": "\u30ca\u30ec\u30c3\u30b8",
                     "expanded": false,
                     "pages": [
                       "ja/use-dify/knowledge/readme",
                       {
-                        "group": "作成",
+                        "group": "\u4f5c\u6210",
                         "pages": [
                           {
-                            "group": "クイック作成",
+                            "group": "\u30af\u30a4\u30c3\u30af\u4f5c\u6210",
                             "pages": [
                               "ja/use-dify/knowledge/create-knowledge/introduction",
                               {
-                                "group": "データのインポート",
+                                "group": "\u30c7\u30fc\u30bf\u306e\u30a4\u30f3\u30dd\u30fc\u30c8",
                                 "pages": [
                                   "ja/use-dify/knowledge/create-knowledge/import-text-data/readme",
                                   "ja/use-dify/knowledge/create-knowledge/import-text-data/sync-from-notion",
@@ -1065,7 +1068,7 @@
                             ]
                           },
                           {
-                            "group": "ナレッジパイプラインから作成",
+                            "group": "\u30ca\u30ec\u30c3\u30b8\u30d1\u30a4\u30d7\u30e9\u30a4\u30f3\u304b\u3089\u4f5c\u6210",
                             "pages": [
                               "ja/use-dify/knowledge/knowledge-pipeline/readme",
                               "ja/use-dify/knowledge/knowledge-pipeline/create-knowledge-pipeline",
@@ -1077,7 +1080,7 @@
                             ]
                           },
                           {
-                            "group": "外部ナレッジベースと連携",
+                            "group": "\u5916\u90e8\u30ca\u30ec\u30c3\u30b8\u30d9\u30fc\u30b9\u3068\u9023\u643a",
                             "pages": [
                               "ja/use-dify/knowledge/connect-external-knowledge-base",
                               "ja/use-dify/knowledge/external-knowledge-api"
@@ -1086,7 +1089,7 @@
                         ]
                       },
                       {
-                        "group": "管理",
+                        "group": "\u7ba1\u7406",
                         "pages": [
                           "ja/use-dify/knowledge/manage-knowledge/maintain-knowledge-documents",
                           "ja/use-dify/knowledge/metadata",
@@ -1101,7 +1104,7 @@
                     "icon": "book"
                   },
                   {
-                    "group": "ワークスペース",
+                    "group": "\u30ef\u30fc\u30af\u30b9\u30da\u30fc\u30b9",
                     "expanded": false,
                     "pages": [
                       "ja/use-dify/workspace/readme",
@@ -1113,7 +1116,7 @@
                       "ja/use-dify/workspace/personal-account-management",
                       "ja/use-dify/workspace/subscription-management",
                       {
-                        "group": "API 拡張",
+                        "group": "API \u62e1\u5f35",
                         "pages": [
                           "ja/use-dify/workspace/api-extension/api-extension",
                           "ja/use-dify/workspace/api-extension/external-data-tool-api-extension",
@@ -1125,11 +1128,11 @@
                     "icon": "briefcase"
                   },
                   {
-                    "group": "チュートリアル",
+                    "group": "\u30c1\u30e5\u30fc\u30c8\u30ea\u30a2\u30eb",
                     "expanded": false,
                     "pages": [
                       {
-                        "group": "ワークフロー 101",
+                        "group": "\u30ef\u30fc\u30af\u30d5\u30ed\u30fc 101",
                         "pages": [
                           "ja/use-dify/tutorials/workflow-101/lesson-01",
                           "ja/use-dify/tutorials/workflow-101/lesson-02",
@@ -1156,7 +1159,7 @@
                 "icon": "server",
                 "pages": [
                   {
-                    "group": "クイックスタート",
+                    "group": "\u30af\u30a4\u30c3\u30af\u30b9\u30bf\u30fc\u30c8",
                     "pages": [
                       "ja/self-host/quick-start/docker-compose",
                       "ja/self-host/quick-start/faqs"
@@ -1164,7 +1167,7 @@
                     "icon": "rocket"
                   },
                   {
-                    "group": "高度なデプロイ",
+                    "group": "\u9ad8\u5ea6\u306a\u30c7\u30d7\u30ed\u30a4",
                     "pages": [
                       "ja/self-host/advanced-deployments/local-source-code",
                       "ja/self-host/advanced-deployments/start-the-frontend-docker-container"
@@ -1172,14 +1175,14 @@
                     "icon": "server"
                   },
                   {
-                    "group": "設定",
+                    "group": "\u8a2d\u5b9a",
                     "pages": [
                       "ja/self-host/configuration/environments"
                     ],
                     "icon": "gear"
                   },
                   {
-                    "group": "プラットフォームガイド",
+                    "group": "\u30d7\u30e9\u30c3\u30c8\u30d5\u30a9\u30fc\u30e0\u30ac\u30a4\u30c9",
                     "pages": [
                       "ja/self-host/platform-guides/bt-panel",
                       "ja/self-host/platform-guides/dify-premium"
@@ -1187,7 +1190,7 @@
                     "icon": "map"
                   },
                   {
-                    "group": "トラブルシューティング",
+                    "group": "\u30c8\u30e9\u30d6\u30eb\u30b7\u30e5\u30fc\u30c6\u30a3\u30f3\u30b0",
                     "pages": [
                       "ja/self-host/troubleshooting/common-issues",
                       "ja/self-host/troubleshooting/docker-issues",
@@ -1198,45 +1201,45 @@
                     "icon": "wrench"
                   }
                 ],
-                "dropdown": "セルフホスティング"
+                "dropdown": "\u30bb\u30eb\u30d5\u30db\u30b9\u30c6\u30a3\u30f3\u30b0"
               },
               {
                 "icon": "code",
                 "groups": [
                   {
-                    "group": "ChatbotとAgent",
+                    "group": "Chatbot\u3068Agent",
                     "openapi": "ja/api-reference/openapi_chat.json",
                     "icon": "comments"
                   },
                   {
-                    "group": "チャットフロー",
+                    "group": "\u30c1\u30e3\u30c3\u30c8\u30d5\u30ed\u30fc",
                     "openapi": "ja/api-reference/openapi_chatflow.json",
                     "icon": "diagram-project"
                   },
                   {
-                    "group": "ワークフロー",
+                    "group": "\u30ef\u30fc\u30af\u30d5\u30ed\u30fc",
                     "openapi": "ja/api-reference/openapi_workflow.json",
                     "icon": "sitemap"
                   },
                   {
-                    "group": "ナレッジ",
+                    "group": "\u30ca\u30ec\u30c3\u30b8",
                     "openapi": "ja/api-reference/openapi_knowledge.json",
                     "icon": "book"
                   },
                   {
-                    "group": "テキスト ジェネレーター",
+                    "group": "\u30c6\u30ad\u30b9\u30c8 \u30b8\u30a7\u30cd\u30ec\u30fc\u30bf\u30fc",
                     "openapi": "ja/api-reference/openapi_completion.json",
                     "icon": "font"
                   }
                 ],
-                "dropdown": "APIアクセス"
+                "dropdown": "API\u30a2\u30af\u30bb\u30b9"
               },
               {
-                "dropdown": "プラグイン開発",
+                "dropdown": "\u30d7\u30e9\u30b0\u30a4\u30f3\u958b\u767a",
                 "icon": "code-pull-request",
                 "groups": [
                   {
-                    "group": "はじめに",
+                    "group": "\u306f\u3058\u3081\u306b",
                     "pages": [
                       "ja/develop-plugin/getting-started/getting-started-dify-plugin",
                       "ja/develop-plugin/getting-started/cli"
@@ -1244,10 +1247,10 @@
                     "icon": "rocket"
                   },
                   {
-                    "group": "特性と仕様",
+                    "group": "\u7279\u6027\u3068\u4ed5\u69d8",
                     "pages": [
                       {
-                        "group": "プラグインタイプ",
+                        "group": "\u30d7\u30e9\u30b0\u30a4\u30f3\u30bf\u30a4\u30d7",
                         "pages": [
                           "ja/develop-plugin/features-and-specs/plugin-types/general-specifications",
                           "ja/develop-plugin/features-and-specs/plugin-types/model-designing-rules",
@@ -1261,10 +1264,10 @@
                         ]
                       },
                       {
-                        "group": "高度な開発",
+                        "group": "\u9ad8\u5ea6\u306a\u958b\u767a",
                         "pages": [
                           {
-                            "group": "リバース呼び出し",
+                            "group": "\u30ea\u30d0\u30fc\u30b9\u547c\u3073\u51fa\u3057",
                             "pages": [
                               "ja/develop-plugin/features-and-specs/advanced-development/bundle",
                               "ja/develop-plugin/features-and-specs/advanced-development/reverse-invocation",
@@ -1281,7 +1284,7 @@
                     "icon": "list-check"
                   },
                   {
-                    "group": "開発ガイドとサンプル",
+                    "group": "\u958b\u767a\u30ac\u30a4\u30c9\u3068\u30b5\u30f3\u30d7\u30eb",
                     "pages": [
                       "ja/develop-plugin/dev-guides-and-walkthroughs/cheatsheet",
                       "ja/develop-plugin/dev-guides-and-walkthroughs/tool-plugin",
@@ -1299,10 +1302,10 @@
                     "icon": "code"
                   },
                   {
-                    "group": "公開",
+                    "group": "\u516c\u958b",
                     "pages": [
                       {
-                        "group": "標準",
+                        "group": "\u6a19\u6e96",
                         "pages": [
                           "ja/develop-plugin/publishing/standards/contributor-covenant-code-of-conduct",
                           "ja/develop-plugin/publishing/standards/privacy-protection-guidelines",
@@ -1310,7 +1313,7 @@
                         ]
                       },
                       {
-                        "group": "マーケットプレイスリスト",
+                        "group": "\u30de\u30fc\u30b1\u30c3\u30c8\u30d7\u30ec\u30a4\u30b9\u30ea\u30b9\u30c8",
                         "pages": [
                           "ja/develop-plugin/publishing/marketplace-listing/plugin-auto-publish-pr",
                           "ja/develop-plugin/publishing/marketplace-listing/release-overview",
@@ -1320,7 +1323,7 @@
                         ]
                       },
                       {
-                        "group": "よくある質問",
+                        "group": "\u3088\u304f\u3042\u308b\u8cea\u554f",
                         "pages": [
                           "ja/develop-plugin/publishing/faq/faq"
                         ]
@@ -1376,24 +1379,24 @@
       "destination": "/en/use-dify/getting-started/key-concepts#variables"
     },
     {
-      "source": "/zh/use-dify/build/variables#会话变量",
-      "destination": "/zh/use-dify/getting-started/key-concepts#变量"
+      "source": "/zh/use-dify/build/variables#\u4f1a\u8bdd\u53d8\u91cf",
+      "destination": "/zh/use-dify/getting-started/key-concepts#\u53d8\u91cf"
     },
     {
-      "source": "/ja/use-dify/build/variables#会話変数",
-      "destination": "/ja/use-dify/getting-started/key-concepts#変数"
+      "source": "/ja/use-dify/build/variables#\u4f1a\u8a71\u5909\u6570",
+      "destination": "/ja/use-dify/getting-started/key-concepts#\u5909\u6570"
     },
     {
       "source": "/en/guides/workflow/variables#conversation-variables",
       "destination": "/en/use-dify/getting-started/key-concepts#variables"
     },
     {
-      "source": "/zh-hans/guides/workflow/variables#会话变量",
-      "destination": "/zh/use-dify/getting-started/key-concepts#变量"
+      "source": "/zh-hans/guides/workflow/variables#\u4f1a\u8bdd\u53d8\u91cf",
+      "destination": "/zh/use-dify/getting-started/key-concepts#\u53d8\u91cf"
     },
     {
-      "source": "/ja-jp/guides/workflow/variables#会話変数",
-      "destination": "/ja/use-dify/getting-started/key-concepts#変数"
+      "source": "/ja-jp/guides/workflow/variables#\u4f1a\u8a71\u5909\u6570",
+      "destination": "/ja/use-dify/getting-started/key-concepts#\u5909\u6570"
     },
     {
       "source": "/en/guides/workflow/node/start",
@@ -1489,7 +1492,7 @@
     },
     {
       "source": "/zh-hans/guides/workflow/node/start",
-      "destination": "/zh/use-dify/getting-started/key-concepts#工作流"
+      "destination": "/zh/use-dify/getting-started/key-concepts#\u5de5\u4f5c\u6d41"
     },
     {
       "source": "/zh-hans/guides/workflow/node/user-input",
@@ -1581,7 +1584,7 @@
     },
     {
       "source": "/ja-jp/guides/workflow/node/start",
-      "destination": "/ja/use-dify/getting-started/key-concepts#ワークフロー"
+      "destination": "/ja/use-dify/getting-started/key-concepts#\u30ef\u30fc\u30af\u30d5\u30ed\u30fc"
     },
     {
       "source": "/ja-jp/guides/workflow/node/user-input",
@@ -2201,19 +2204,19 @@
     },
     {
       "source": "/zh-hans/guides/model-configuration/load-balancing",
-      "destination": "/zh/use-dify/workspace/model-providers#配置模型负载均衡"
+      "destination": "/zh/use-dify/workspace/model-providers#\u914d\u7f6e\u6a21\u578b\u8d1f\u8f7d\u5747\u8861"
     },
     {
       "source": "/ja-jp/guides/model-configuration/load-balancing",
-      "destination": "/ja/use-dify/workspace/model-providers#負荷分散の構成"
+      "destination": "/ja/use-dify/workspace/model-providers#\u8ca0\u8377\u5206\u6563\u306e\u69cb\u6210"
     },
     {
       "source": "/api-reference/datasets/get-knowledge-base-list",
       "destination": "/api-reference/knowledge-bases/list-knowledge-bases"
     },
     {
-      "source": "/api-reference/数据集/获取知识库列表",
-      "destination": "/api-reference/知识库/获取知识库列表"
+      "source": "/api-reference/\u6570\u636e\u96c6/\u83b7\u53d6\u77e5\u8bc6\u5e93\u5217\u8868",
+      "destination": "/api-reference/\u77e5\u8bc6\u5e93/\u83b7\u53d6\u77e5\u8bc6\u5e93\u5217\u8868"
     }
   ],
   "navbar": {

--- a/en/use-dify/monitor/integrations/integrate-vaultak.mdx
+++ b/en/use-dify/monitor/integrations/integrate-vaultak.mdx
@@ -1,0 +1,133 @@
+---
+title: Integrate with Vaultak
+sidebarTitle: Vaultak
+---
+
+### What is Vaultak
+
+Vaultak is a runtime security platform for AI agents. It intercepts every agent action, tool call, and LLM query in real time — scoring risk on a 0–10 scale, enforcing policy rules, masking PII in outputs, and automatically blocking dangerous behavior before it reaches your production systems.
+
+<Info>
+  For more details, please refer to [Vaultak](https://vaultak.com).
+</Info>
+
+### How to Configure Vaultak
+
+Unlike observability-only tools, Vaultak adds an active security layer between your application and Dify. It inspects user messages before they are sent to Dify, monitors the responses coming back, and enforces your policy rules at runtime.
+
+#### 1. Register and get your API key
+
+Sign up at [vaultak.com](https://vaultak.com). After logging in, copy your API key from the dashboard. It starts with `vtk_`.
+
+#### 2. Install the Vaultak SDK
+
+```bash
+pip install vaultak
+```
+
+#### 3. Wrap your Dify API calls with Vaultak
+
+Use Vaultak to inspect user input before it reaches Dify, and scan Dify's response for PII before it returns to your users.
+
+```python
+import requests
+from vaultak import Vaultak
+
+vt = Vaultak(api_key="vtk_...")
+
+def call_dify_securely(user_message: str, dify_app_key: str) -> dict:
+    # Score the user's message before sending it to Dify
+    result = vt.score_action(
+        action="dify_chat_message",
+        context={"query": user_message},
+    )
+    if result.score >= 7.0:
+        raise RuntimeError(
+            f"Request blocked by Vaultak — risk score {result.score:.1f}/10"
+        )
+
+    # Check against your policy rules
+    vt.check_policy(tool_name="dify_app", input_data=user_message)
+
+    # Send the request to Dify
+    response = requests.post(
+        "https://api.dify.ai/v1/chat-messages",
+        headers={
+            "Authorization": f"Bearer {dify_app_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "inputs": {},
+            "query": user_message,
+            "response_mode": "blocking",
+            "user": "end-user-id",
+        },
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    # Mask PII in Dify's response before returning it to your users
+    data["answer"] = vt.mask_pii(data.get("answer", ""))
+
+    return data
+```
+
+#### 4. Monitor results in your Vaultak dashboard
+
+Every scored request is visible at [app.vaultak.com](https://app.vaultak.com) in real time:
+risk scores, blocked requests, PII masking events, and policy violations. Configure or tighten
+policy rules there without changing your application code.
+
+### Using Vaultak with the Dify Workflow API
+
+For Dify Workflow or Agent applications, wrap the workflow run endpoint the same way:
+
+```python
+from vaultak import Vaultak
+import requests
+
+vt = Vaultak(api_key="vtk_...", )
+
+def run_dify_workflow(inputs: dict, dify_app_key: str) -> dict:
+    # Check inputs against policy before running the workflow
+    for key, value in inputs.items():
+        vt.check_policy(tool_name=f"dify_workflow_input:{key}", input_data=str(value))
+
+    response = requests.post(
+        "https://api.dify.ai/v1/workflows/run",
+        headers={
+            "Authorization": f"Bearer {dify_app_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "inputs": inputs,
+            "response_mode": "blocking",
+            "user": "end-user-id",
+        },
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    # Mask PII in all output fields
+    outputs = data.get("data", {}).get("outputs", {})
+    for key, value in outputs.items():
+        outputs[key] = vt.mask_pii(str(value))
+
+    return data
+```
+
+### Configuration Reference
+
+| Parameter | Description |
+|---|---|
+| `api_key` | Your Vaultak API key (starts with `vtk_`) |
+| `score_action(action, context)` | Risk-scores an action (0–10) before it executes |
+| `check_policy(tool_name, input_data)` | Checks input against your configured policy rules |
+| `mask_pii(text)` | Scans text for PII (names, emails, phone numbers, etc.) and masks it |
+| `alert(level, message)` | Sends an alert to your Vaultak dashboard |
+
+### Links
+
+- [Vaultak documentation](https://docs.vaultak.com)
+- [Vaultak dashboard](https://app.vaultak.com)
+- [Dify API reference](https://docs.dify.ai/api-reference)


### PR DESCRIPTION
## Summary

Adds a new integration guide for [Vaultak](https://vaultak.com) — a runtime security platform that adds real-time protection to Dify API calls by risk-scoring user inputs, enforcing policy rules, and masking PII in responses.

Install: `pip install vaultak`

## Changes

**`en/use-dify/monitor/integrations/integrate-vaultak.mdx`** (new)

Covers two integration patterns with complete code examples:
- **Chat API** (`POST /v1/chat-messages`) — score the user message before sending, mask PII in the response
- **Workflow API** (`POST /v1/workflows/run`) — check each workflow input against policy, mask PII in all output fields

Includes a configuration reference table and links to the Vaultak dashboard and Dify API reference.

**`docs.json`** — registers `integrate-vaultak` in the monitor/integrations nav group for all three language trees (`en`, `zh`, `ja`).

## Note on integration approach

Unlike the observability-only tools in this section (Langfuse, LangSmith, Arize, etc.), Vaultak sits between the application and the Dify API rather than receiving traces from Dify. The page makes this distinction clear in the opening section.

## Test plan

- [ ] Page renders correctly at `/en/use-dify/monitor/integrations/integrate-vaultak`
- [ ] Page appears in sidebar under Monitor → Integrations
- [ ] Code snippets are syntactically correct Python

🤖 Generated with [Claude Code](https://claude.ai/claude-code)