### PR TITLE
docs: document marketplace template status and update flow

### DIFF
--- a/en/use-dify/publish/publish-to-marketplace.mdx
+++ b/en/use-dify/publish/publish-to-marketplace.mdx
@@ -6,11 +6,11 @@ description: Publish your apps to Dify Marketplace and share them with the world
 
 Publish your apps as templates to Dify Marketplace, where other Dify users can discover and use them.
 
-## Submit Templates
+## Submit a Template
 
-To publish a template, submit it through the [Creator Center](https://creators.dify.ai) for review. Once approved, it will be listed on Marketplace.
+To publish a template, submit it through the [Creator Center](https://creators.dify.ai). After you submit, the template enters **Pending** status while we review it. Once approved, it's published to Marketplace.
 
-While your template is pending review, you can withdraw it anytime to make changes and resubmit.
+While a template is **Pending**, you can withdraw it at any time. Withdrawing returns it to **Draft**, where you can edit any part of the template before resubmitting.
 
 <Note>
 Before submission:
@@ -35,13 +35,25 @@ You can switch between your personal account and organizations anytime.
 
     In your app, click **Publish** > **Publish Update**, then click **Publish to Marketplace**.
 
-    This takes you to the Creator Center with your app file automatically uploaded — just fill in the template details and submit for review.
+    This takes you to the Creator Center with your app file automatically uploaded. Just fill in the template details and submit for review.
     </Tab>
 
     <Tab title="In the Creator Center">
     Export your app, then go to the Creator Center and upload the export file. Fill in the template details and submit for review.
     </Tab>
 </Tabs>
+
+## Update a Published Template
+
+How you update a published template depends on what you want to change.
+
+- **To change anything inside the app** (its prompts, tools, model settings, and so on)
+
+    Submit the updated app as a new template. This creates a separate listing rather than replacing the original, so you can manually unpublish the old version once the new one is published.
+
+- **To change only the listing** (such as the Overview or Setup steps)
+
+    Unpublish the template to take it off Marketplace and return it to **Draft**. Make your edits, then resubmit for review.
 
 ## Template Writing Guidelines
 
@@ -61,14 +73,13 @@ Keep the template library consistent and searchable.
 - Prompts / system messages
 - Messages shown to end-users
 
-If your template mainly targets non-English users, you can add a tag in the title. For example,
-`Stock Investment Analysis Copilot [ZH]`.
+If your template mainly targets non-English users, you can add a tag in the title. For example, `Stock Investment Analysis Copilot [ZH]`.
 
 ### Template Name & Icon
 
 From the name alone, users should know where it runs and what it does.
 
-- Use a short English phrase, typically 3-7 words.
+- Use a short English phrase, typically 3–7 words.
 - Recommended pattern: [Channel / target] + [core task], for example:
     - WeChat Customer Support Bot
     - CSV Data Analyzer with Natural Language
@@ -81,19 +92,19 @@ From the name alone, users should know where it runs and what it does.
 
 Help users discover your template when browsing or filtering by category.
 
-- Select only **1-3** categories that best describe your template.
+- Select only **1–3** categories that best describe your template.
 - Do not check every category just for exposure.
 
 ### Language
 
-Help users discover your template via language filters.
+Help users discover your template via the language filter.
 
-- Select the language(s) your template is designed for in real usage.
-- This refers to the language of the template's use case, input, or output — **not** the title or overview (which must be in English).
+- Select the language your template is designed for in real usage.
+- This refers to the language of the template's use case, input, or output, not the title or overview (which must be in English).
 
 ### Overview
 
-In 2-4 English sentences, explain what it does and who it is for.
+In 2–4 English sentences, explain what it does and who it is for.
 
 <Info>You don't need to list prerequisites, inputs, or outputs here.</Info>
 
@@ -102,7 +113,7 @@ In 2-4 English sentences, explain what it does and who it is for.
 1. Sentence 1: **What it does**
 
     A one-sentence summary of the main function.
-2. Sentence 2-3: **Who and when**
+2. Sentence 2–3: **Who and when**
 
     Typical user roles or scenarios (support team, marketers, founders, individual knowledge workers, etc.).
 
@@ -131,12 +142,12 @@ A new user should be able to get the template running in a few minutes just by f
     - Where to click in the UI
     - What to configure or fill in
 
-3. Aim for 3-8 steps. Too few feels incomplete; too many feels overwhelming.
+3. Aim for 3–8 steps. Too few feels incomplete; too many feels overwhelming.
 
-<Accordion title="Example: Setup Steps for Stock Investment Analysis Copilot (Yahoo Finance tools) ">
+<Accordion title="Example: Setup Steps for Stock Investment Analysis Copilot (Yahoo Finance tools)">
   1. Click **Use template** to copy the "Investment Analysis Copilot (Yahoo Finance)" agent into your workspace.
 
-  2. Go to **Settings → Model provider** and add your LLM API key. For example, OpenAI, Anthropic, or another supported provider.
+  2. Go to **Settings** > **Model Provider** and add your LLM API key. For example, OpenAI, Anthropic, or another supported provider.
 
   3. Open the agent's **Orchestrate** page and make sure the Yahoo Finance tools are enabled in the **Tools** section:
     - `yahoo Analytics`
@@ -155,7 +166,7 @@ A new user should be able to get the template running in a few minutes just by f
 ### Quick Checklist Before You Submit
 
 - The name is a short English phrase that clearly shows where it runs and what it does.
-- The overview uses 2-4 English sentences to explain the value and typical use cases.
-- Only 1-3 relevant categories are selected.
+- The overview uses 2–4 English sentences to explain the value and typical use cases.
+- Only 1–3 relevant categories are selected.
 - Setup steps are a clear numbered list.
 - Internal workflow texts and prompts are written in appropriate languages for your target users.

--- a/ja/use-dify/publish/publish-to-marketplace.mdx
+++ b/ja/use-dify/publish/publish-to-marketplace.mdx
@@ -10,9 +10,9 @@ description: "アプリを Dify マーケットプレイスに公開して世界
 
 ## テンプレートの提出
 
-テンプレートを公開するには、[クリエイターセンター](https://creators.dify.ai)から審査に提出します。承認されると、マーケットプレイスに掲載されます。
+テンプレートを公開するには、[クリエイターセンター](https://creators.dify.ai) から提出します。提出後、テンプレートは **Pending** ステータスになります。承認されると、マーケットプレイスに公開されます。
 
-テンプレートが審査待ちの間、いつでも取り下げて修正し、再提出できます。
+テンプレートが **Pending** の間は、いつでも取り下げられます。取り下げるとテンプレートは **Draft** に戻り、任意の部分を編集してから再提出できます。
 
 <Note>
 提出前に：
@@ -44,6 +44,18 @@ description: "アプリを Dify マーケットプレイスに公開して世界
     </Tab>
 </Tabs>
 
+## 公開済みテンプレートの更新
+
+公開済みテンプレートの更新方法は、変更内容によって異なります。
+
+- **アプリ本体を変更する場合**（プロンプト、ツール、モデル設定など）
+
+    更新したアプリを新しいテンプレートとして提出します。これは既存のテンプレートを置き換えるのではなく、別のテンプレートとして作成されます。新しいテンプレートの公開後、古いバージョンは手動で非公開にできます。
+
+- **掲載内容のみを変更する場合**（概要やセットアップ手順など）
+
+    テンプレートを非公開にして **Draft** に戻し、編集してから再提出します。
+
 ## テンプレート作成ガイドライン
 
 ### 言語の要件
@@ -62,8 +74,7 @@ description: "アプリを Dify マーケットプレイスに公開して世界
 - プロンプト / システムメッセージ
 - エンドユーザーに表示されるメッセージ
 
-テンプレートが主に英語以外のユーザーを対象とする場合は、タイトルにタグを追加できます。例えば、
-`Stock Investment Analysis Copilot [JA]`。
+テンプレートが主に英語以外のユーザーを対象とする場合は、タイトルにタグを追加できます。例えば、`Stock Investment Analysis Copilot [JA]`。
 
 ### テンプレート名とアイコン
 
@@ -90,7 +101,7 @@ description: "アプリを Dify マーケットプレイスに公開して世界
 ユーザーが言語フィルターでテンプレートを発見しやすくします。
 
 - テンプレートが実際の利用で対象とする言語を選択します。
-- これはテンプレートのユースケース、入力、または出力の言語を指します——タイトルや概要の言語（英語必須）では**ありません**。
+- これはテンプレートのユースケース、入力、または出力の言語を指します。タイトルや概要の言語（英語必須）では **ありません**。
 
 ### 概要
 
@@ -137,7 +148,7 @@ description: "アプリを Dify マーケットプレイスに公開して世界
 <Accordion title="例：Stock Investment Analysis Copilot（Yahoo Finance ツール）のセットアップ手順">
   1. Click **Use template** to copy the "Investment Analysis Copilot (Yahoo Finance)" agent into your workspace.
 
-  2. Go to **Settings → Model provider** and add your LLM API key. For example, OpenAI, Anthropic, or another supported provider.
+  2. Go to **Settings** > **Model Provider** and add your LLM API key. For example, OpenAI, Anthropic, or another supported provider.
 
   3. Open the agent's **Orchestrate** page and make sure the Yahoo Finance tools are enabled in the **Tools** section:
     - `yahoo Analytics`

--- a/zh/use-dify/publish/publish-to-marketplace.mdx
+++ b/zh/use-dify/publish/publish-to-marketplace.mdx
@@ -10,9 +10,9 @@ description: "将你的应用发布到 Dify 市场，与全世界分享"
 
 ## 提交模板
 
-若要发布模板，请通过[创作者中心](https://creators.dify.ai)提交审核。通过后，模板将在市场上架。
+若要发布模板，请通过 [创作者中心](https://creators.dify.ai) 提交。提交后，模板进入 **Pending** 状态。通过审核后，即可发布到市场。
 
-模板在等待审核期间，你可以随时撤回以进行修改并重新提交。
+模板处于 **Pending** 状态时，可随时撤回。撤回后，模板将回到 **Draft** 状态，你可修改任意内容后重新提交。
 
 <Note>
 提交前：
@@ -36,13 +36,25 @@ description: "将你的应用发布到 Dify 市场，与全世界分享"
     <Tab title="从 Dify Studio">
     在应用内部，点击 **发布** > **发布更新**，然后点击 **发布到市场**。
 
-    这将跳转到创作者中心，应用文件会自动上传——只需填写模板详情并提交审核。
+    这将跳转到创作者中心，应用文件会自动上传，只需填写模板详情并提交审核。
     </Tab>
 
     <Tab title="从创作者中心">
     导出你的应用，然后前往创作者中心上传导出文件。填写模板详情并提交审核。
     </Tab>
 </Tabs>
+
+## 更新已发布的模板
+
+更新已发布的模板时，具体方法取决于你要修改的内容。
+
+- **修改应用本身**（如提示词、工具、模型设置等）
+
+    将更新后的应用作为新模板提交。这会生成一个独立的模板，而非替换原有模板；新模板发布后，你可手动下架旧版本。
+
+- **仅修改展示内容**（如概述或设置步骤）
+
+    将模板下架，使其回到 **Draft** 状态，然后修改内容并重新提交审核。
 
 ## 模板填写指南
 
@@ -62,14 +74,13 @@ description: "将你的应用发布到 Dify 市场，与全世界分享"
 - 提示词 / 系统消息
 - 展示给终端用户的消息
 
-如果你的模板主要面向非英语用户，可以在标题中添加标签。例如，
-`Stock Investment Analysis Copilot [ZH]`。
+如果你的模板主要面向非英语用户，可在标题中添加标签。例如，`Stock Investment Analysis Copilot [ZH]`。
 
 ### 模板名称和图标
 
 仅从名称，用户就应该知道它在哪里运行以及做什么。
 
-- 使用简短的英文短语，通常为 3-7 个单词。
+- 使用简短的英文短语，通常为 3～7 个单词。
 - 推荐模式：[渠道 / 目标] + [核心任务]，例如：
     - WeChat Customer Support Bot
     - CSV Data Analyzer with Natural Language
@@ -82,7 +93,7 @@ description: "将你的应用发布到 Dify 市场，与全世界分享"
 
 帮助用户在浏览或按分类筛选时发现你的模板。
 
-- 仅选择 **1-3** 个最能描述你模板的分类。
+- 仅选择 **1～3** 个最能描述你模板的分类。
 - 不要为了增加曝光而勾选所有分类。
 
 ### 语言
@@ -90,11 +101,11 @@ description: "将你的应用发布到 Dify 市场，与全世界分享"
 帮助用户通过语言筛选发现你的模板。
 
 - 选择你的模板在实际使用中所面向的语言。
-- 这里指的是模板用例、输入或输出的语言——**而非**标题或概述的语言（这些必须使用英文）。
+- 这里指的是模板用例、输入或输出的语言，**而非** 标题或概述的语言（这些必须使用英文）。
 
 ### 概述
 
-用 2-4 句英文说明它做什么以及面向谁。
+用 2～4 句英文说明它做什么以及面向谁。
 
 <Info>你无需在此列出先决条件、输入或输出。</Info>
 
@@ -103,7 +114,7 @@ description: "将你的应用发布到 Dify 市场，与全世界分享"
 1. 第 1 句：**它做什么**
 
     一句话概括主要功能。
-2. 第 2-3 句：**面向谁、什么场景**
+2. 第 2～3 句：**面向谁、什么场景**
 
     典型用户角色或场景（客服团队、营销人员、创始人、个人知识工作者等）。
 
@@ -132,12 +143,12 @@ description: "将你的应用发布到 Dify 市场，与全世界分享"
     - 在界面中点击哪里
     - 需要配置或填写什么
 
-3. 目标 3-8 步。太少显得不完整，太多则会令人生畏。
+3. 目标 3～8 步。太少显得不完整，太多则会令人生畏。
 
 <Accordion title="示例：Stock Investment Analysis Copilot (Yahoo Finance) 的设置步骤">
   1. Click **Use template** to copy the "Investment Analysis Copilot (Yahoo Finance)" agent into your workspace.
 
-  2. Go to **Settings → Model provider** and add your LLM API key. For example, OpenAI, Anthropic, or another supported provider.
+  2. Go to **Settings** > **Model Provider** and add your LLM API key. For example, OpenAI, Anthropic, or another supported provider.
 
   3. Open the agent's **Orchestrate** page and make sure the Yahoo Finance tools are enabled in the **Tools** section:
     - `yahoo Analytics`
@@ -156,7 +167,7 @@ description: "将你的应用发布到 Dify 市场，与全世界分享"
 ### 提交前快速检查清单
 
 - 名称是一个简短的英文短语，能清楚地说明它在哪里运行、做什么。
-- 概述用 2-4 句英文解释价值和典型用例。
-- 仅选择了 1-3 个相关分类。
+- 概述用 2～4 句英文解释价值和典型用例。
+- 仅选择了 1～3 个相关分类。
 - 设置步骤是清晰的编号列表。
 - 工作流内部的文本和提示词使用了面向目标用户的适当语言。


### PR DESCRIPTION
## Summary

Updates the "Publish Apps to Marketplace" page to document the template review lifecycle and how to update a template after it is published, reflecting current Creator Center behavior.

## Changes

- **Submission status**: The Submit section now names the **Pending** review status and explains that withdrawing a submission returns it to **Draft** for editing.
- **Update a Published Template**: New section covering the two paths. Changing the app itself means resubmitting it as a new template; changing only the listing (Overview, Setup steps) means unpublishing to **Draft**, editing, and resubmitting.
- **Language field**: Guidance changed from multi-select to single-select.
- **Formatting cleanup**: Removed em dashes, corrected the Settings > Model Provider menu path, joined a hard-wrapped line, removed a trailing space, and switched numeric ranges to en dashes.