### PR TITLE
fix: correct API reference server URL so request examples render

### DIFF
--- a/en/api-reference/openapi_chat.json
+++ b/en/api-reference/openapi_chat.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "The base URL for the Chat App API. Replace {api_base_url} with the actual API base URL provided for your application.",
+      "url": "https://{api_base_url}",
+      "description": "Base URL of the Chat App API. For self-hosted deployments, replace it with your own API base URL.",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "Actual base URL of the API"
+          "default": "api.dify.ai/v1",
+          "description": "Host and path of the API base URL, without the `https://` prefix."
         }
       }
     }

--- a/en/api-reference/openapi_chatflow.json
+++ b/en/api-reference/openapi_chatflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "The base URL for the Chatflow App API. Replace {api_base_url} with the actual API base URL provided for your application.",
+      "url": "https://{api_base_url}",
+      "description": "Base URL of the Chatflow App API. For self-hosted deployments, replace it with your own API base URL.",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "Actual base URL of the API"
+          "default": "api.dify.ai/v1",
+          "description": "Host and path of the API base URL, without the `https://` prefix."
         }
       }
     }

--- a/en/api-reference/openapi_completion.json
+++ b/en/api-reference/openapi_completion.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "The base URL for the Completion App API. Replace {api_base_url} with the actual API base URL provided for your application.",
+      "url": "https://{api_base_url}",
+      "description": "Base URL of the Completion App API. For self-hosted deployments, replace it with your own API base URL.",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "Actual base URL of the API"
+          "default": "api.dify.ai/v1",
+          "description": "Host and path of the API base URL, without the `https://` prefix."
         }
       }
     }

--- a/en/api-reference/openapi_knowledge.json
+++ b/en/api-reference/openapi_knowledge.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{apiBaseUrl}",
-      "description": "The base URL for the Knowledge API.",
+      "url": "https://{api_base_url}",
+      "description": "Base URL of the Knowledge API. For self-hosted deployments, replace it with your own API base URL.",
       "variables": {
-        "apiBaseUrl": {
-          "default": "https://api.dify.ai/v1",
-          "description": "Actual base URL of the API"
+        "api_base_url": {
+          "default": "api.dify.ai/v1",
+          "description": "Host and path of the API base URL, without the `https://` prefix."
         }
       }
     }

--- a/en/api-reference/openapi_workflow.json
+++ b/en/api-reference/openapi_workflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "The base URL for the Workflow App API. Replace {api_base_url} with the actual API base URL.",
+      "url": "https://{api_base_url}",
+      "description": "Base URL of the Workflow App API. For self-hosted deployments, replace it with your own API base URL.",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "Actual base URL of the API"
+          "default": "api.dify.ai/v1",
+          "description": "Host and path of the API base URL, without the `https://` prefix."
         }
       }
     }

--- a/ja/api-reference/openapi_chat.json
+++ b/ja/api-reference/openapi_chat.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "チャットアプリ API のベース URL です。{api_base_url} をアプリケーションに提供された実際の API ベース URL に置き換えてください。",
+      "url": "https://{api_base_url}",
+      "description": "チャットアプリ API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API の実際のベース URL"
+          "default": "api.dify.ai/v1",
+          "description": "API ベース URL のホストとパス（`https://` を除く）。"
         }
       }
     }

--- a/ja/api-reference/openapi_chatflow.json
+++ b/ja/api-reference/openapi_chatflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "Chatflow アプリ API のベース URL です。{api_base_url} をアプリケーションに提供された実際の API ベース URL に置き換えてください。",
+      "url": "https://{api_base_url}",
+      "description": "Chatflow アプリ API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API の実際のベース URL"
+          "default": "api.dify.ai/v1",
+          "description": "API ベース URL のホストとパス（`https://` を除く）。"
         }
       }
     }

--- a/ja/api-reference/openapi_completion.json
+++ b/ja/api-reference/openapi_completion.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "テキスト生成アプリ API のベース URL です。{api_base_url} をアプリケーションに提供された実際の API ベース URL に置き換えてください。",
+      "url": "https://{api_base_url}",
+      "description": "テキスト生成アプリ API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API の実際のベース URL"
+          "default": "api.dify.ai/v1",
+          "description": "API ベース URL のホストとパス（`https://` を除く）。"
         }
       }
     }

--- a/ja/api-reference/openapi_knowledge.json
+++ b/ja/api-reference/openapi_knowledge.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{apiBaseUrl}",
-      "description": "Knowledge API のベース URL です。",
+      "url": "https://{api_base_url}",
+      "description": "Knowledge API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
       "variables": {
-        "apiBaseUrl": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API の実際のベース URL"
+        "api_base_url": {
+          "default": "api.dify.ai/v1",
+          "description": "API ベース URL のホストとパス（`https://` を除く）。"
         }
       }
     }

--- a/ja/api-reference/openapi_workflow.json
+++ b/ja/api-reference/openapi_workflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "Workflow App API のベース URL です。{api_base_url} を実際の API ベース URL に置き換えてください。",
+      "url": "https://{api_base_url}",
+      "description": "Workflow App API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API の実際のベース URL"
+          "default": "api.dify.ai/v1",
+          "description": "API ベース URL のホストとパス（`https://` を除く）。"
         }
       }
     }

--- a/zh/api-reference/openapi_chat.json
+++ b/zh/api-reference/openapi_chat.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "对话型应用 API 的基础 URL。请将 {api_base_url} 替换为你的应用实际提供的 API 基础 URL。",
+      "url": "https://{api_base_url}",
+      "description": "对话型应用 API 的基础 URL。自托管部署时，替换为你的 API 基础 URL。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API 的实际基础 URL"
+          "default": "api.dify.ai/v1",
+          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
         }
       }
     }

--- a/zh/api-reference/openapi_chatflow.json
+++ b/zh/api-reference/openapi_chatflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "工作流编排对话型应用 API 的基础 URL。请将 {api_base_url} 替换为你的应用实际提供的 API 基础 URL。",
+      "url": "https://{api_base_url}",
+      "description": "工作流编排对话型应用 API 的基础 URL。自托管部署时，替换为你的 API 基础 URL。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API 的实际基础 URL"
+          "default": "api.dify.ai/v1",
+          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
         }
       }
     }

--- a/zh/api-reference/openapi_completion.json
+++ b/zh/api-reference/openapi_completion.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "文本生成型应用 API 的基础 URL。请将 {api_base_url} 替换为你的应用实际提供的 API 基础 URL。",
+      "url": "https://{api_base_url}",
+      "description": "文本生成型应用 API 的基础 URL。自托管部署时，替换为你的 API 基础 URL。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API 的实际基础 URL"
+          "default": "api.dify.ai/v1",
+          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
         }
       }
     }

--- a/zh/api-reference/openapi_knowledge.json
+++ b/zh/api-reference/openapi_knowledge.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{apiBaseUrl}",
-      "description": "Knowledge API 的基础 URL。",
+      "url": "https://{api_base_url}",
+      "description": "Knowledge API 的基础 URL。自托管部署时，替换为你的 API 基础 URL。",
       "variables": {
-        "apiBaseUrl": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API 的实际基础 URL"
+        "api_base_url": {
+          "default": "api.dify.ai/v1",
+          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
         }
       }
     }

--- a/zh/api-reference/openapi_workflow.json
+++ b/zh/api-reference/openapi_workflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "工作流应用 API 的基础 URL。将 {api_base_url} 替换为实际的 API 基础 URL。",
+      "url": "https://{api_base_url}",
+      "description": "工作流应用 API 的基础 URL。自托管部署时，替换为你的 API 基础 URL。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API 的实际基础 URL"
+          "default": "api.dify.ai/v1",
+          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
         }
       }
     }


### PR DESCRIPTION
## Problem

Every API reference page briefly showed "A valid request URL is required to generate request examples" on load, and the Send Chat Message page (the only endpoint with multiple request examples) rendered a blank request example that never recovered.

The cause was the `servers[0].url` in all OpenAPI specs: a bare `{api_base_url}` token with no URL scheme. Mintlify can't parse a schemeless template as an absolute URL on first paint, so it failed to build the request example. Interacting with a control forced a re-render that resolved the variable default, which is why selecting from the dropdown cleared the error.

## Fix

Prefix the literal `https://` scheme onto the templated URL (`https://{api_base_url}`) and move the host and path into the variable default (`api.dify.ai/v1`). The template now parses as a valid URL on first paint, eliminating the error and the blank example, while keeping a server variable so the playground retains its editable Server (base URL) field for self-hosted users. The scheme is fixed to `https`, which is correct for browser-origin "Try it" requests anyway. zh and ja specs are updated in step, with the variable description translated.