### PR TITLE
fix: use absolute server URL in API reference specs (#804) (backport to release/1.14.2)

### DIFF
--- a/en/api-reference/openapi_chat.json
+++ b/en/api-reference/openapi_chat.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "The base URL for the Chat App API. Replace {api_base_url} with the actual API base URL provided for your application.",
+      "url": "https://{api_base_url}",
+      "description": "Base URL of the Chat App API. For self-hosted deployments, replace it with your own API base URL.",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "Actual base URL of the API"
+          "default": "api.dify.ai/v1",
+          "description": "Host and path of the API base URL, without the `https://` prefix."
         }
       }
     }

--- a/en/api-reference/openapi_chatflow.json
+++ b/en/api-reference/openapi_chatflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "The base URL for the Chatflow App API. Replace {api_base_url} with the actual API base URL provided for your application.",
+      "url": "https://{api_base_url}",
+      "description": "Base URL of the Chatflow App API. For self-hosted deployments, replace it with your own API base URL.",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "Actual base URL of the API"
+          "default": "api.dify.ai/v1",
+          "description": "Host and path of the API base URL, without the `https://` prefix."
         }
       }
     }

--- a/en/api-reference/openapi_completion.json
+++ b/en/api-reference/openapi_completion.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "The base URL for the Completion App API. Replace {api_base_url} with the actual API base URL provided for your application.",
+      "url": "https://{api_base_url}",
+      "description": "Base URL of the Completion App API. For self-hosted deployments, replace it with your own API base URL.",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "Actual base URL of the API"
+          "default": "api.dify.ai/v1",
+          "description": "Host and path of the API base URL, without the `https://` prefix."
         }
       }
     }

--- a/en/api-reference/openapi_knowledge.json
+++ b/en/api-reference/openapi_knowledge.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{apiBaseUrl}",
-      "description": "The base URL for the Knowledge API.",
+      "url": "https://{api_base_url}",
+      "description": "Base URL of the Knowledge API. For self-hosted deployments, replace it with your own API base URL.",
       "variables": {
-        "apiBaseUrl": {
-          "default": "https://api.dify.ai/v1",
-          "description": "Actual base URL of the API"
+        "api_base_url": {
+          "default": "api.dify.ai/v1",
+          "description": "Host and path of the API base URL, without the `https://` prefix."
         }
       }
     }

--- a/en/api-reference/openapi_workflow.json
+++ b/en/api-reference/openapi_workflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "The base URL for the Workflow App API. Replace {api_base_url} with the actual API base URL.",
+      "url": "https://{api_base_url}",
+      "description": "Base URL of the Workflow App API. For self-hosted deployments, replace it with your own API base URL.",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "Actual base URL of the API"
+          "default": "api.dify.ai/v1",
+          "description": "Host and path of the API base URL, without the `https://` prefix."
         }
       }
     }

--- a/ja/api-reference/openapi_chat.json
+++ b/ja/api-reference/openapi_chat.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "チャットアプリ API のベース URL です。{api_base_url} をアプリケーションに提供された実際の API ベース URL に置き換えてください。",
+      "url": "https://{api_base_url}",
+      "description": "チャットアプリ API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API の実際のベース URL"
+          "default": "api.dify.ai/v1",
+          "description": "API ベース URL のホストとパス（`https://` を除く）。"
         }
       }
     }

--- a/ja/api-reference/openapi_chatflow.json
+++ b/ja/api-reference/openapi_chatflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "Chatflow アプリ API のベース URL です。{api_base_url} をアプリケーションに提供された実際の API ベース URL に置き換えてください。",
+      "url": "https://{api_base_url}",
+      "description": "Chatflow アプリ API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API の実際のベース URL"
+          "default": "api.dify.ai/v1",
+          "description": "API ベース URL のホストとパス（`https://` を除く）。"
         }
       }
     }

--- a/ja/api-reference/openapi_completion.json
+++ b/ja/api-reference/openapi_completion.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "テキスト生成アプリ API のベース URL です。{api_base_url} をアプリケーションに提供された実際の API ベース URL に置き換えてください。",
+      "url": "https://{api_base_url}",
+      "description": "テキスト生成アプリ API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API の実際のベース URL"
+          "default": "api.dify.ai/v1",
+          "description": "API ベース URL のホストとパス（`https://` を除く）。"
         }
       }
     }

--- a/ja/api-reference/openapi_knowledge.json
+++ b/ja/api-reference/openapi_knowledge.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{apiBaseUrl}",
-      "description": "Knowledge API のベース URL です。",
+      "url": "https://{api_base_url}",
+      "description": "Knowledge API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
       "variables": {
-        "apiBaseUrl": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API の実際のベース URL"
+        "api_base_url": {
+          "default": "api.dify.ai/v1",
+          "description": "API ベース URL のホストとパス（`https://` を除く）。"
         }
       }
     }

--- a/ja/api-reference/openapi_workflow.json
+++ b/ja/api-reference/openapi_workflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "Workflow App API のベース URL です。{api_base_url} を実際の API ベース URL に置き換えてください。",
+      "url": "https://{api_base_url}",
+      "description": "Workflow App API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API の実際のベース URL"
+          "default": "api.dify.ai/v1",
+          "description": "API ベース URL のホストとパス（`https://` を除く）。"
         }
       }
     }

--- a/zh/api-reference/openapi_chat.json
+++ b/zh/api-reference/openapi_chat.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "对话型应用 API 的基础 URL。请将 {api_base_url} 替换为你的应用实际提供的 API 基础 URL。",
+      "url": "https://{api_base_url}",
+      "description": "对话型应用 API 的基础 URL。自托管部署时，替换为你的 API 基础 URL。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API 的实际基础 URL"
+          "default": "api.dify.ai/v1",
+          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
         }
       }
     }

--- a/zh/api-reference/openapi_chatflow.json
+++ b/zh/api-reference/openapi_chatflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "工作流编排对话型应用 API 的基础 URL。请将 {api_base_url} 替换为你的应用实际提供的 API 基础 URL。",
+      "url": "https://{api_base_url}",
+      "description": "工作流编排对话型应用 API 的基础 URL。自托管部署时，替换为你的 API 基础 URL。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API 的实际基础 URL"
+          "default": "api.dify.ai/v1",
+          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
         }
       }
     }

--- a/zh/api-reference/openapi_completion.json
+++ b/zh/api-reference/openapi_completion.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "文本生成型应用 API 的基础 URL。请将 {api_base_url} 替换为你的应用实际提供的 API 基础 URL。",
+      "url": "https://{api_base_url}",
+      "description": "文本生成型应用 API 的基础 URL。自托管部署时，替换为你的 API 基础 URL。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API 的实际基础 URL"
+          "default": "api.dify.ai/v1",
+          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
         }
       }
     }

--- a/zh/api-reference/openapi_knowledge.json
+++ b/zh/api-reference/openapi_knowledge.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{apiBaseUrl}",
-      "description": "Knowledge API 的基础 URL。",
+      "url": "https://{api_base_url}",
+      "description": "Knowledge API 的基础 URL。自托管部署时，替换为你的 API 基础 URL。",
       "variables": {
-        "apiBaseUrl": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API 的实际基础 URL"
+        "api_base_url": {
+          "default": "api.dify.ai/v1",
+          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
         }
       }
     }

--- a/zh/api-reference/openapi_workflow.json
+++ b/zh/api-reference/openapi_workflow.json
@@ -7,12 +7,12 @@
   },
   "servers": [
     {
-      "url": "{api_base_url}",
-      "description": "工作流应用 API 的基础 URL。将 {api_base_url} 替换为实际的 API 基础 URL。",
+      "url": "https://{api_base_url}",
+      "description": "工作流应用 API 的基础 URL。自托管部署时，替换为你的 API 基础 URL。",
       "variables": {
         "api_base_url": {
-          "default": "https://api.dify.ai/v1",
-          "description": "API 的实际基础 URL"
+          "default": "api.dify.ai/v1",
+          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
         }
       }
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/1.14.2`:

-  - [fix: use absolute server URL in API reference specs (#804)](https://github.com/langgenius/dify-docs/pull/804)