### PR TITLE
docs: link Firecrawl on pages where it appears as plain text

### DIFF
--- a/en/develop-plugin/dev-guides-and-walkthroughs/datasource-plugin.mdx
+++ b/en/develop-plugin/dev-guides-and-walkthroughs/datasource-plugin.mdx
@@ -24,7 +24,7 @@ Dify supports three types of data source plugins: web crawler, online document, 
 
 Each data source plugin type supports multiple data sources. For example:
 
-- **Web Crawler**: Jina Reader, FireCrawl
+- **Web Crawler**: Jina Reader, [Firecrawl](https://www.firecrawl.dev/)
 - **Online Document**: Notion, Confluence, GitHub
 - **Online Drive**: OneDrive, Google Drive, Box, AWS S3, Tencent COS
 

--- a/en/use-dify/knowledge/knowledge-pipeline/knowledge-pipeline-orchestration.mdx
+++ b/en/use-dify/knowledge/knowledge-pipeline/knowledge-pipeline-orchestration.mdx
@@ -123,7 +123,7 @@ Integrate with your Notion workspace to seamlessly import pages and databases, a
 
 ### Web Crawler
 
-Transform web content into formats that can be easily read by large language models. The knowledge base supports Jina Reader and Firecrawl.
+Transform web content into formats that can be easily read by large language models. The knowledge base supports Jina Reader and [Firecrawl](https://www.firecrawl.dev/).
 
 #### Jina Reader
 

--- a/en/use-dify/knowledge/knowledge-pipeline/upload-files.mdx
+++ b/en/use-dify/knowledge/knowledge-pipeline/upload-files.mdx
@@ -45,7 +45,7 @@ B: Click **Go to Add Documents** to add documents.
 ### Upload Process
 
 1. **Select Data Source**  
-   Choose from the data source types configured in your pipeline. Dify currently supports 4 types of data sources: File Upload (pdf, docx, etc.), Online Drive (Google Drive, OneDrive, etc.), Online Doc (Notion), and Web Crawler (Jina Reader, Firecrawl). 
+   Choose from the data source types configured in your pipeline. Dify currently supports 4 types of data sources: File Upload (pdf, docx, etc.), Online Drive (Google Drive, OneDrive, etc.), Online Doc (Notion), and Web Crawler (Jina Reader, [Firecrawl](https://www.firecrawl.dev/)). 
    Please visit [Dify Marketplace](https://marketplace.dify.ai/) to install additional data sources.
 
 2. **Fill in Processing Parameters and Preview**  


### PR DESCRIPTION
Several English docs mention Firecrawl as plain text. This adds a link to https://www.firecrawl.dev on three of them:
- `en/use-dify/knowledge/knowledge-pipeline/knowledge-pipeline-orchestration.mdx`
- `en/use-dify/knowledge/knowledge-pipeline/upload-files.mdx`
- `en/develop-plugin/dev-guides-and-walkthroughs/datasource-plugin.mdx` (also normalizes "FireCrawl" → "Firecrawl")

Note: the main `sync-from-website` page already links to firecrawl.dev, so it's left unchanged. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)