### PR TITLE
docs: update docker compose container list and add tool prerequisites (#843) (backport to release/1.15.0)

### DIFF
--- a/en/self-host/deploy/quick-start/docker-compose.mdx
+++ b/en/self-host/deploy/quick-start/docker-compose.mdx
@@ -32,8 +32,11 @@ Make sure your machine meets the following minimum system requirements.
 
     ```bash
     git clone --branch "$(curl -s https://api.github.com/repos/langgenius/dify/releases/latest | jq -r .tag_name)" https://github.com/langgenius/dify.git
-
     ```
+
+    <Info>
+      This command requires `git`, `curl`, and `jq`. If you see a `command not found` error, install the missing tool and run the command again.
+    </Info>
   </Step>
   <Step title="Start Dify">
 
@@ -62,27 +65,9 @@ Make sure your machine meets the following minimum system requirements.
 
         The following containers will be started:
 
-        - 5 core services: `api`, `worker`, `worker_beat`, `web`, `plugin_daemon`
+        - 6 core services: `api`, `api_websocket`, `worker`, `worker_beat`, `web`, `plugin_daemon`
         - 6 dependent components: `weaviate`, `db_postgres`, `redis`, `nginx`, `ssrf_proxy`, `sandbox`
-
-        You should see output similar to the following, showing the status and start time of each container:
-
-            ```bash
-            [+] Running 13/13
-            ✔ Network docker_ssrf_proxy_network  Created                                                                10.0s 
-            ✔ Network docker_default             Created                                                                 0.1s 
-            ✔ Container docker-sandbox-1         Started                                                                 0.3s 
-            ✔ Container docker-db_postgres-1     Healthy                                                                 2.8s 
-            ✔ Container docker-web-1             Started                                                                 0.3s 
-            ✔ Container docker-redis-1           Started                                                                 0.3s 
-            ✔ Container docker-ssrf_proxy-1      Started                                                                 0.4s 
-            ✔ Container docker-weaviate-1        Started                                                                 0.3s 
-            ✔ Container docker-worker_beat-1     Started                                                                 3.2s 
-            ✔ Container docker-api-1             Started                                                                 3.2s 
-            ✔ Container docker-worker-1          Started                                                                 3.2s 
-            ✔ Container docker-plugin_daemon-1   Started                                                                 3.2s 
-            ✔ Container docker-nginx-1           Started                                                                 3.4s 
-            ```
+        - 1 one-time task: `init_permissions`, which sets storage file permissions and exits when done (an `Exited` status is expected)
     
     4. Verify that all containers are running successfully:
 
@@ -90,22 +75,7 @@ Make sure your machine meets the following minimum system requirements.
         docker compose ps
         ```
 
-        You should see output similar to the following, with each container in the `Up` or `healthy` status:
-
-        ```bash
-        NAME                     IMAGE                                       COMMAND                  SERVICE         CREATED          STATUS                             PORTS
-        docker-api-1             langgenius/dify-api:1.10.1                  "/bin/bash /entrypoi…"   api             26 seconds ago   Up 22 seconds                      5001/tcp
-        docker-db_postgres-1     postgres:15-alpine                          "docker-entrypoint.s…"   db_postgres     26 seconds ago   Up 25 seconds (healthy)            5432/tcp
-        docker-nginx-1           nginx:latest                                "sh -c 'cp /docker-e…"   nginx           26 seconds ago   Up 22 seconds                      0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp
-        docker-plugin_daemon-1   langgenius/dify-plugin-daemon:0.4.1-local   "/bin/bash -c /app/e…"   plugin_daemon   26 seconds ago   Up 22 seconds                      0.0.0.0:5003->5003/tcp, :::5003->5003/tcp
-        docker-redis-1           redis:6-alpine                              "docker-entrypoint.s…"   redis           26 seconds ago   Up 25 seconds (health: starting)   6379/tcp
-        docker-sandbox-1         langgenius/dify-sandbox:0.2.12              "/main"                  sandbox         26 seconds ago   Up 25 seconds (health: starting)   
-        docker-ssrf_proxy-1      ubuntu/squid:latest                         "sh -c 'cp /docker-e…"   ssrf_proxy      26 seconds ago   Up 25 seconds                      3128/tcp
-        docker-weaviate-1        semitechnologies/weaviate:1.27.0            "/bin/weaviate --hos…"   weaviate        26 seconds ago   Up 25 seconds                      
-        docker-web-1             langgenius/dify-web:1.10.1                  "/bin/sh ./entrypoin…"   web             26 seconds ago   Up 25 seconds                      3000/tcp
-        docker-worker-1          langgenius/dify-api:1.10.1                  "/bin/bash /entrypoi…"   worker          26 seconds ago   Up 22 seconds                      5001/tcp
-        docker-worker_beat-1     langgenius/dify-api:1.10.1                  "/bin/bash /entrypoi…"   worker_beat     26 seconds ago   Up 22 seconds                      5001/tcp
-        ```
+        Each container should be in the `Up` or `healthy` status.
 
   </Step>
 </Steps>

--- a/ja/self-host/deploy/quick-start/docker-compose.mdx
+++ b/ja/self-host/deploy/quick-start/docker-compose.mdx
@@ -35,6 +35,10 @@ sidebarTitle: Docker Compose
     ```bash
     git clone --branch "$(curl -s https://api.github.com/repos/langgenius/dify/releases/latest | jq -r .tag_name)" https://github.com/langgenius/dify.git
     ```
+
+    <Info>
+      このコマンドには `git`、`curl`、`jq` が必要です。`command not found` エラーが表示された場合は、不足しているツールをインストールしてから再実行してください。
+    </Info>
   </Step>
   <Step title="Dify を起動">
 
@@ -63,27 +67,9 @@ sidebarTitle: Docker Compose
 
         以下のコンテナが起動します：
 
-        - 5 つのコアサービス：`api`、`worker`、`worker_beat`、`web`、`plugin_daemon`
+        - 6 つのコアサービス：`api`、`api_websocket`、`worker`、`worker_beat`、`web`、`plugin_daemon`
         - 6 つの依存コンポーネント：`weaviate`、`db_postgres`、`redis`、`nginx`、`ssrf_proxy`、`sandbox`
-
-        各コンテナのステータスと起動時間を示す以下のような出力が表示されます：
-
-            ```bash
-            [+] Running 13/13
-            ✔ Network docker_ssrf_proxy_network  Created                                                                10.0s 
-            ✔ Network docker_default             Created                                                                 0.1s 
-            ✔ Container docker-sandbox-1         Started                                                                 0.3s 
-            ✔ Container docker-db_postgres-1     Healthy                                                                 2.8s 
-            ✔ Container docker-web-1             Started                                                                 0.3s 
-            ✔ Container docker-redis-1           Started                                                                 0.3s 
-            ✔ Container docker-ssrf_proxy-1      Started                                                                 0.4s 
-            ✔ Container docker-weaviate-1        Started                                                                 0.3s 
-            ✔ Container docker-worker_beat-1     Started                                                                 3.2s 
-            ✔ Container docker-api-1             Started                                                                 3.2s 
-            ✔ Container docker-worker-1          Started                                                                 3.2s 
-            ✔ Container docker-plugin_daemon-1   Started                                                                 3.2s 
-            ✔ Container docker-nginx-1           Started                                                                 3.4s 
-            ```
+        - 1 つの一時タスク：`init_permissions`（ストレージのファイル権限を設定し、完了後に終了します。`Exited` と表示されるのは正常です）
 
     4. すべてのコンテナが正常に動作しているか確認します：
 
@@ -91,22 +77,7 @@ sidebarTitle: Docker Compose
         docker compose ps
         ```
 
-        各コンテナのステータスが `Up` または `healthy` となっている、以下のような出力が表示されます：
-
-        ```bash
-        NAME                     IMAGE                                       COMMAND                  SERVICE         CREATED          STATUS                             PORTS
-        docker-api-1             langgenius/dify-api:1.10.1                  "/bin/bash /entrypoi…"   api             26 seconds ago   Up 22 seconds                      5001/tcp
-        docker-db_postgres-1     postgres:15-alpine                          "docker-entrypoint.s…"   db_postgres     26 seconds ago   Up 25 seconds (healthy)            5432/tcp
-        docker-nginx-1           nginx:latest                                "sh -c 'cp /docker-e…"   nginx           26 seconds ago   Up 22 seconds                      0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp
-        docker-plugin_daemon-1   langgenius/dify-plugin-daemon:0.4.1-local   "/bin/bash -c /app/e…"   plugin_daemon   26 seconds ago   Up 22 seconds                      0.0.0.0:5003->5003/tcp, :::5003->5003/tcp
-        docker-redis-1           redis:6-alpine                              "docker-entrypoint.s…"   redis           26 seconds ago   Up 25 seconds (health: starting)   6379/tcp
-        docker-sandbox-1         langgenius/dify-sandbox:0.2.12              "/main"                  sandbox         26 seconds ago   Up 25 seconds (health: starting)   
-        docker-ssrf_proxy-1      ubuntu/squid:latest                         "sh -c 'cp /docker-e…"   ssrf_proxy      26 seconds ago   Up 25 seconds                      3128/tcp
-        docker-weaviate-1        semitechnologies/weaviate:1.27.0            "/bin/weaviate --hos…"   weaviate        26 seconds ago   Up 25 seconds                      
-        docker-web-1             langgenius/dify-web:1.10.1                  "/bin/sh ./entrypoin…"   web             26 seconds ago   Up 25 seconds                      3000/tcp
-        docker-worker-1          langgenius/dify-api:1.10.1                  "/bin/bash /entrypoi…"   worker          26 seconds ago   Up 22 seconds                      5001/tcp
-        docker-worker_beat-1     langgenius/dify-api:1.10.1                  "/bin/bash /entrypoi…"   worker_beat     26 seconds ago   Up 22 seconds                      5001/tcp
-        ```
+        各コンテナのステータスが `Up` または `healthy` になっていれば正常です。
   </Step>
 </Steps>
 

--- a/zh/self-host/deploy/quick-start/docker-compose.mdx
+++ b/zh/self-host/deploy/quick-start/docker-compose.mdx
@@ -35,6 +35,10 @@ sidebarTitle: Docker Compose
     ```bash
     git clone --branch "$(curl -s https://api.github.com/repos/langgenius/dify/releases/latest | jq -r .tag_name)" https://github.com/langgenius/dify.git
     ```
+
+    <Info>
+      此命令需要 `git`、`curl` 和 `jq`。如提示 `command not found`，安装缺少的工具后重新运行命令。
+    </Info>
   </Step>
   <Step title="启动 Dify">
 
@@ -63,27 +67,9 @@ sidebarTitle: Docker Compose
 
         启动以下容器：
 
-        - 5 个核心服务：`api`、`worker`、`worker_beat`、`web`、`plugin_daemon`
+        - 6 个核心服务：`api`、`api_websocket`、`worker`、`worker_beat`、`web`、`plugin_daemon`
         - 6 个依赖组件：`weaviate`、`db_postgres`、`redis`、`nginx`、`ssrf_proxy`、`sandbox`
-
-        应看到类似以下的输出，显示每个容器的状态和启动时间：
-
-            ```bash
-            [+] Running 13/13
-            ✔ Network docker_ssrf_proxy_network  Created                                                                10.0s 
-            ✔ Network docker_default             Created                                                                 0.1s 
-            ✔ Container docker-sandbox-1         Started                                                                 0.3s 
-            ✔ Container docker-db_postgres-1     Healthy                                                                 2.8s 
-            ✔ Container docker-web-1             Started                                                                 0.3s 
-            ✔ Container docker-redis-1           Started                                                                 0.3s 
-            ✔ Container docker-ssrf_proxy-1      Started                                                                 0.4s 
-            ✔ Container docker-weaviate-1        Started                                                                 0.3s 
-            ✔ Container docker-worker_beat-1     Started                                                                 3.2s 
-            ✔ Container docker-api-1             Started                                                                 3.2s 
-            ✔ Container docker-worker-1          Started                                                                 3.2s 
-            ✔ Container docker-plugin_daemon-1   Started                                                                 3.2s 
-            ✔ Container docker-nginx-1           Started                                                                 3.4s 
-            ```
+        - 1 个一次性任务：`init_permissions`，用于设置存储文件权限，完成后自动退出（状态显示为 `Exited` 是正常的）
 
     4. 验证所有容器是否成功运行：
 
@@ -91,22 +77,7 @@ sidebarTitle: Docker Compose
         docker compose ps
         ```
 
-        应看到类似以下的输出，每个容器的状态应为 `Up` 或 `healthy`：
-
-        ```bash
-        NAME                     IMAGE                                       COMMAND                  SERVICE         CREATED          STATUS                             PORTS
-        docker-api-1             langgenius/dify-api:1.10.1                  "/bin/bash /entrypoi…"   api             26 seconds ago   Up 22 seconds                      5001/tcp
-        docker-db_postgres-1     postgres:15-alpine                          "docker-entrypoint.s…"   db_postgres     26 seconds ago   Up 25 seconds (healthy)            5432/tcp
-        docker-nginx-1           nginx:latest                                "sh -c 'cp /docker-e…"   nginx           26 seconds ago   Up 22 seconds                      0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp
-        docker-plugin_daemon-1   langgenius/dify-plugin-daemon:0.4.1-local   "/bin/bash -c /app/e…"   plugin_daemon   26 seconds ago   Up 22 seconds                      0.0.0.0:5003->5003/tcp, :::5003->5003/tcp
-        docker-redis-1           redis:6-alpine                              "docker-entrypoint.s…"   redis           26 seconds ago   Up 25 seconds (health: starting)   6379/tcp
-        docker-sandbox-1         langgenius/dify-sandbox:0.2.12              "/main"                  sandbox         26 seconds ago   Up 25 seconds (health: starting)   
-        docker-ssrf_proxy-1      ubuntu/squid:latest                         "sh -c 'cp /docker-e…"   ssrf_proxy      26 seconds ago   Up 25 seconds                      3128/tcp
-        docker-weaviate-1        semitechnologies/weaviate:1.27.0            "/bin/weaviate --hos…"   weaviate        26 seconds ago   Up 25 seconds                      
-        docker-web-1             langgenius/dify-web:1.10.1                  "/bin/sh ./entrypoin…"   web             26 seconds ago   Up 25 seconds                      3000/tcp
-        docker-worker-1          langgenius/dify-api:1.10.1                  "/bin/bash /entrypoi…"   worker          26 seconds ago   Up 22 seconds                      5001/tcp
-        docker-worker_beat-1     langgenius/dify-api:1.10.1                  "/bin/bash /entrypoi…"   worker_beat     26 seconds ago   Up 22 seconds                      5001/tcp
-        ```
+        每个容器的状态应为 `Up` 或 `healthy`。
   </Step>
 </Steps>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `release/1.16.0` to `release/1.15.0`:

-  - [docs: update docker compose container list and add tool prerequisites (#843)](https://github.com/langgenius/dify-docs/pull/843)