### PR TITLE
feat: rebuild the doc issue form for triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: "\U0001F41B Dify product bug"
+    url: "https://github.com/langgenius/dify/issues/new/choose"
+    about: The problem is with Dify itself rather than the documentation.
   - name: "\U0001F4A1 Model Providers & Plugins"
     url: "https://github.com/langgenius/dify-official-plugins/issues/new/choose"
     about: Report issues with official plugins or model providers, you will need to provide the plugin version and other relevant details.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,76 +1,80 @@
-name: Documentation Change Request
-description: Suggest changes or improvements to the documentation
-title: "[DOCS]: "
+name: Documentation Issue
+description: Report incorrect, outdated, or missing content in the Dify docs
 labels: ["documentation"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to help us improve our documentation!
-  
-  - type: dropdown
-    id: type
-    attributes:
-      label: Type of Documentation Change
-      options:
-        - Error/Typo fix
-        - Content update
-        - New documentation
-        - Translation
-        - Reorganization
-        - Other
-    validations:
-      required: true
-  
   - type: input
     id: page
     attributes:
-      label: Documentation Page URL or Path
-      description: Please provide the URL or file path of the documentation page you're referring to.
-      placeholder: e.g., https://docs.dify.ai/getting-started or /getting-started.md
-    validations:
-      required: false
-  
-  - type: textarea
-    id: current
-    attributes:
-      label: Current Content
-      description: What does the documentation currently say?
-      placeholder: Paste the current content here...
-    validations:
-      required: false
-  
-  - type: textarea
-    id: suggestion
-    attributes:
-      label: Suggested Changes
-      description: What would you like to be changed or added?
-      placeholder: Describe your suggested changes...
+      label: Page URL
+      description: Link to the affected page. For missing docs, link the page where you expected to find the information.
+      placeholder: https://docs.dify.ai/en/cloud/use-dify/knowledge/readme
     validations:
       required: true
-  
-  - type: textarea
-    id: reason
+
+  - type: dropdown
+    id: type
     attributes:
-      label: Reason for Change
-      description: Why do you think this change would improve the documentation?
-      placeholder: Explain why this change would be helpful...
+      label: Issue type
+      options:
+        - Incorrect or outdated information
+        - Missing documentation
+        - Unclear explanation
+        - Broken link or image
+        - Translation issue (中文 / 日本語)
+        - Typo or formatting
     validations:
-      required: false
-  
+      required: true
+
+  - type: dropdown
+    id: product
+    attributes:
+      label: Product
+      description: Which Dify are you using?
+      options:
+        - Dify Cloud
+        - Self-hosted (Community Edition)
+        - Dify Enterprise
+        - Not product-specific
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Dify version
+      description: For self-hosted or Enterprise — the version you run, e.g. 1.15.0.
+
+  - type: dropdown
+    id: language
+    attributes:
+      label: Page language
+      options:
+        - English
+        - 中文
+        - 日本語
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What's wrong
+      description: Quote the current text and say what's incorrect, or describe what's missing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: correct
+    attributes:
+      label: What it should say
+      description: The correct information, if you know it — links, config snippets, and screenshots all help.
+
   - type: checkboxes
     id: terms
     attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our contribution guidelines
+      label: Checklist
       options:
-        - label: I agree to follow Dify's documentation [contribution guidelines](https://github.com/langgenius/dify/blob/0277a37fcad5ad86aeb239485c27fffd5cd90043/CONTRIBUTING.md)
+        - label: I have searched [existing issues](https://github.com/langgenius/dify-docs/issues?q=is%3Aissue), including closed ones.
           required: true
-        - label: I have searched for existing issues [search for existing issues](https://github.com/langgenius/dify/issues), including closed ones.
+        - label: I confirm that I am using English to submit this report. 【中文用户 & Non English User】请使用英语提交，否则会被关闭 ：）
           required: true
-        - label: I confirm that I am using English to submit this report, otherwise it will be closed.
-          required: true
-        - label: 【中文用户 & Non English User】请使用英语提交，否则会被关闭 ：）
-          required: true
-        - label: "Please do not modify this template :) and fill in all the required fields."
-          required: true
+        - label: If I open a PR for this, it will follow the [contributing guidelines](https://github.com/langgenius/dify-docs/blob/main/README.md#contributing) (all three languages in the same PR).
+          required: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -74,7 +74,7 @@ body:
       options:
         - label: I have searched [existing issues](https://github.com/langgenius/dify-docs/issues?q=is%3Aissue), including closed ones.
           required: true
-        - label: I confirm that I am using English to submit this report. 【中文用户 & Non English User】请使用英语提交，否则会被关闭 ：）
+        - label: I confirm that I am using English to submit this report. 【中文用户 & Non-English users】请使用英语提交，否则会被关闭。
           required: true
         - label: If I open a PR for this, it will follow the [contributing guidelines](https://github.com/langgenius/dify-docs/blob/main/README.md#contributing) (all three languages in the same PR).
           required: false


### PR DESCRIPTION
## What

Rebuilds `.github/ISSUE_TEMPLATE/docs.yml` as a triage-oriented intake form and adds a product-bug deflection link to the template chooser.

## Why

Doc reports were arriving without the three facts triage needs first: which product (Cloud / self-hosted / Enterprise), which version, and which language's page. The form also carried stale artifacts — a pre-restructure URL placeholder and contribution/search links pointing at langgenius/dify instead of this repo.

## Changes

- New required fields: page URL and product; optional version and page language (en / 中文 / 日本語)
- Issue types now cover the real categories: incorrect/outdated, missing, unclear, broken link or image, translation, typo/formatting
- "What's wrong" / "What it should say" replace the old free-form sections, so reports quote the current text and the proposed correction
- Checklist links fixed to point at this repo; the PR-willingness item links the all-three-languages contributing guidelines
- Template chooser: new "Dify product bug" contact link deflects product issues to langgenius/dify before they're filed here
- Dropped the `[DOCS]:` title prefix (redundant in a docs-only repo)