### PR TITLE
docs: require a payoff in cross-reference links

### DIFF
--- a/writing-guides/style-guide.md
+++ b/writing-guides/style-guide.md
@@ -136,6 +136,6 @@ Where a Community Edition capability ends and Dify Enterprise extends it, add a 
 
 **Repetitive structures.** Vary sentence patterns across related sections to avoid a mechanical feel.
 
-**Vague cross-references.** Don't link to another page unless the reader gains something by clicking. If the current page already provides sufficient context, the link is noise. When linking, "see X for details" is fine if the surrounding context already makes clear what those details are. Only add a specific description when the context alone doesn't convey what the reader will find—otherwise the description itself becomes redundant.
+**Vague cross-references.** Don't link to another page unless the reader gains something by clicking. If the current page already provides sufficient context, the link is noise. When linking, never write a bare "see [X]" — give the link a payoff: "see [X] for details" when the surrounding context already makes clear what those details are, or name what the reader will find ("see [X] for the full flag table") when it doesn't.
 
 **Over-simplification.** Don't sacrifice clarity for brevity. Choose precision when a specific term prevents confusion, even if it's longer.


### PR DESCRIPTION
Tightens the "Vague cross-references" rule in the style guide so a bare "see [X]" is never acceptable on its own. The link now has to carry a payoff: "see [X] for details" when the surrounding context already makes the target obvious, or a phrase naming what the reader will find ("see [X] for the full flag table") when it doesn't.

The previous wording allowed "see X for details" but didn't rule out the bare "see [X]" form, which gives the reader no reason to click. One-line change to the existing bullet; no new section.