### PR TITLE
fix: redirect unprefixed legacy URLs to their /en pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -5354,6 +5354,30 @@
     {
       "source": "/api-reference/:slug*",
       "destination": "/en/api-reference/guides/get-started"
+    },
+    {
+      "source": "/home",
+      "destination": "/en/home"
+    },
+    {
+      "source": "/quick-start",
+      "destination": "/en/quick-start"
+    },
+    {
+      "source": "/learn/:slug*",
+      "destination": "/en/learn/:slug*"
+    },
+    {
+      "source": "/cloud/:slug*",
+      "destination": "/en/cloud/:slug*"
+    },
+    {
+      "source": "/cli/:slug*",
+      "destination": "/en/cli/:slug*"
+    },
+    {
+      "source": "/develop-plugin/:slug*",
+      "destination": "/en/develop-plugin/:slug*"
     }
   ],
   "integrations": {


### PR DESCRIPTION
Google's top results for "dify docs" are unprefixed aliases of current pages (`/learn/key-concepts`, `/quick-start`) that render content but return HTTP 404 — status Google obeys. Adds six unprefixed→`/en/` redirect rules (`/home`, `/quick-start`, `/learn/*`, `/cloud/*`, `/cli/*`, `/develop-plugin/*`); `/self-host/*` and `/api-reference/*` equivalents already exist. All six verified on a local Mintlify server (307 → correct targets; production serves 308). Converts dying 404s into permanent redirects so their ranking signal consolidates onto the live pages.