### PR TITLE
docs: add permission-gate and writing-skill notes to feature-research

### DIFF
--- a/.claude/skills/dify-docs-feature-research/SKILL.md
+++ b/.claude/skills/dify-docs-feature-research/SKILL.md
@@ -58,6 +58,8 @@ Run Phase 1 and Phase 2 in parallel: dispatch one subagent per phase. If subagen
    - Any notable edge cases or limitations visible in the code
 7. Flag inferred behavior per the rule in [Important](#important).
 
+**Permission-gated behavior (RBAC/ACL).** To document what a permission lets a user do, read the *effective* gate — the frontend capability map (`web/utils/permission.ts`: `getAppACLCapabilities` / `getDatasetACLCapabilities`) plus the UI that consumes it (e.g. a `canEdit` → read-only hook) — and confirm it in a test environment. A single backend `@rbac_permission_required` decorator can be looser than the frontend and never fire, so treat it as a lower bound, not the answer. Permission display labels (for bolding in docs) come from `web/i18n/{en-US,zh-Hans,ja-JP}/permission-keys.json`.
+
 ### Phase 2: Community Feedback
 
 Search for user-reported problems and questions across these channels:
@@ -130,6 +132,7 @@ Present the summary to the user. STOP — do not start the writing phase until t
 ## Important
 
 - This skill produces research only. Do not start writing documentation until the user reviews the findings and confirms the scope.
+- When scope is confirmed and writing begins, load the writing skill for the target tree (`dify-docs-guides` for `use-dify` guides, `dify-cli-docs` for `en/cli/` pages, `dify-docs-env-vars` for env-var docs, `dify-docs-api-reference` for API specs) plus the style, formatting, and glossary guides — before the first edit. This skill carries none of the writing rules.
 - Flag code-inferred behavior as unverified. Ask the user to test before documenting as fact.
 - Distinguish bugs from documentation gaps. Documenting buggy behavior as intended causes more harm than leaving a gap.
 - Note issue numbers for traceability. The user may want to reference them when prioritizing what to cover.

--- a/.claude/skills/dify-docs-feature-research/SKILL.md
+++ b/.claude/skills/dify-docs-feature-research/SKILL.md
@@ -49,6 +49,7 @@ Run Phase 1 and Phase 2 in parallel: dispatch one subagent per phase. If subagen
    - Panel component (what configuration options users see)
    - Type definitions (data shape)
    - Default values and validation rules
+   - **Permission-gated behavior (RBAC/ACL):** the effective gate is here — read the capability map (`web/utils/permission.ts`: `getAppACLCapabilities` / `getDatasetACLCapabilities`) and the UI that consumes it (e.g. a `canEdit` → read-only hook), and confirm it in a test environment. A backend `@rbac_permission_required` decorator can be looser than the frontend and never fire, so treat it as a lower bound. Permission labels for docs: `web/i18n/{en-US,zh-Hans,ja-JP}/permission-keys.json`.
 5. Trace the API surface: how the feature's output reaches the API response. Check controllers, response converters, and serialization (all in dify).
 6. Produce a summary of:
    - What the feature does (based on code, not existing docs)
@@ -57,8 +58,6 @@ Run Phase 1 and Phase 2 in parallel: dispatch one subagent per phase. If subagen
    - How results are returned to the user (UI, API, streaming)
    - Any notable edge cases or limitations visible in the code
 7. Flag inferred behavior per the rule in [Important](#important).
-
-**Permission-gated behavior (RBAC/ACL).** To document what a permission lets a user do, read the *effective* gate — the frontend capability map (`web/utils/permission.ts`: `getAppACLCapabilities` / `getDatasetACLCapabilities`) plus the UI that consumes it (e.g. a `canEdit` → read-only hook) — and confirm it in a test environment. A single backend `@rbac_permission_required` decorator can be looser than the frontend and never fire, so treat it as a lower bound, not the answer. Permission display labels (for bolding in docs) come from `web/i18n/{en-US,zh-Hans,ja-JP}/permission-keys.json`.
 
 ### Phase 2: Community Feedback
 
@@ -132,7 +131,7 @@ Present the summary to the user. STOP — do not start the writing phase until t
 ## Important
 
 - This skill produces research only. Do not start writing documentation until the user reviews the findings and confirms the scope.
-- When scope is confirmed and writing begins, load the writing skill for the target tree (`dify-docs-guides` for `use-dify` guides, `dify-cli-docs` for `en/cli/` pages, `dify-docs-env-vars` for env-var docs, `dify-docs-api-reference` for API specs) plus the style, formatting, and glossary guides — before the first edit. This skill carries none of the writing rules.
+- When scope is confirmed and writing begins, load the writing skill for the target tree (`dify-docs-guides` for `use-dify` guides, `dify-cli-docs` for `en/cli/` pages, `dify-docs-env-vars` for env-var docs, `dify-docs-api-reference` for API specs) plus the writing guides (`writing-guides/style-guide.md`, `formatting-guide.md`, `glossary.md`) — before the first edit. This skill carries none of the writing rules.
 - Flag code-inferred behavior as unverified. Ask the user to test before documenting as fact.
 - Distinguish bugs from documentation gaps. Documenting buggy behavior as intended causes more harm than leaving a gap.
 - Note issue numbers for traceability. The user may want to reference them when prioritizing what to cover.


### PR DESCRIPTION
Two additions to the `dify-docs-feature-research` skill, both aimed at making permission-related docs more reliable and keeping research cleanly separated from writing.

**Permission-gated behavior.** Adds a note on how to document what a permission actually lets a user do: read the effective gate from the frontend capability map (`web/utils/permission.ts`: `getAppACLCapabilities` / `getDatasetACLCapabilities`) plus the UI that consumes it, and confirm it in a test environment, rather than trusting a single backend `@rbac_permission_required` decorator. This addresses a common failure mode: a backend decorator can be looser than the frontend and never fire in practice, so it implies a broader permission than users actually have. The note also points to `web/i18n/{en-US,zh-Hans,ja-JP}/permission-keys.json` as the source for the permission labels bolded in docs.

**Research-to-writing handoff.** This skill produces research only, so it adds an explicit reminder: once scope is confirmed and writing begins, load the writing skill for the target tree (`dify-docs-guides` for use-dify guides, `dify-cli-docs` for `en/cli/` pages, `dify-docs-env-vars` for env-var docs, `dify-docs-api-reference` for API specs) plus the style, formatting, and glossary guides before the first edit, since this skill carries none of the writing rules.

Both are additive notes placed in Phase 1 and the Important section; no existing guidance changes.

Closes DC-31