### PR TITLE
docs: add surface-coverage gate to the feature-research skill

### DIFF
--- a/.claude/skills/dify-docs-feature-research/SKILL.md
+++ b/.claude/skills/dify-docs-feature-research/SKILL.md
@@ -39,7 +39,9 @@ Run Phase 1 and Phase 2 in parallel: dispatch one subagent per phase. If subagen
 | Workflow orchestration in Flask routes and Celery tasks | dify | `api/controllers/`, `api/tasks/`, `api/services/` |
 | RAG and knowledge retrieval logic | dify | `api/core/rag/` |
 | Tool plugins | dify | `api/core/tools/` |
-| Frontend UI (all features; the web app was never split out) | dify | `web/app/components/workflow/nodes/<node-name>/` (kebab-case) |
+| Frontend UI (all features; the web app was never split out) | dify | nodes: `web/app/components/workflow/nodes/<node-name>/` (kebab-case); other features: `web/app/components/<area>/` |
+| UI labels / i18n strings | dify | `web/i18n/{en-US,zh-Hans,ja-JP}/` |
+| Feature flags + env defaults | dify | backend `api/configs/`; frontend `NEXT_PUBLIC_*`; shipped defaults `docker/.env.example`, `docker/envs/**` |
 
 3. Read the backend implementation:
    - The main node class (execution logic, `_run()` method)
@@ -51,13 +53,14 @@ Run Phase 1 and Phase 2 in parallel: dispatch one subagent per phase. If subagen
    - Default values and validation rules
    - **Permission-gated behavior (RBAC/ACL):** the effective gate is here — read the capability map (`web/utils/permission.ts`: `getAppACLCapabilities` / `getDatasetACLCapabilities`) and the UI that consumes it (e.g. a `canEdit` → read-only hook), and confirm it in a test environment. A backend `@rbac_permission_required` decorator can be looser than the frontend and never fire, so treat it as a lower bound. Permission labels for docs: `web/i18n/{en-US,zh-Hans,ja-JP}/permission-keys.json`.
 5. Trace the API surface: how the feature's output reaches the API response. Check controllers, response converters, and serialization (all in dify).
-6. Produce a summary of:
+6. **Coverage gate — account for every surface before concluding.** What users experience is the composition of backend + frontend + configuration; a conclusion read off a single surface is not a finding. A backend permission decorator can be looser than the frontend gate and never fire; a frontend option can be dead without its backend flag; a shipped default can disable the code path you just read. For each surface — backend, frontend UI, i18n labels, feature flags / env defaults, API, plugin SDK (plugin-facing features only) — record the files read, or `N/A` plus why that surface cannot affect this feature. Carry the filled table into the Phase 3 summary.
+7. Produce a summary of:
    - What the feature does (based on code, not existing docs)
    - What configuration options exist
    - What data types / values are supported
    - How results are returned to the user (UI, API, streaming)
    - Any notable edge cases or limitations visible in the code
-7. Flag inferred behavior per the rule in [Important](#important).
+8. Flag inferred behavior per the rule in [Important](#important).
 
 ### Phase 2: Community Feedback
 
@@ -110,6 +113,16 @@ Combine both phases into a structured research summary:
 - [API response structure]
 - [Edge cases or limitations]
 - [Unverified inferences — flagged for user testing]
+
+### Surface Coverage (from the Phase 1 coverage gate)
+| Surface | Files read, or N/A + why |
+|---------|--------------------------|
+| Backend | ... |
+| Frontend UI | ... |
+| i18n labels | ... |
+| Flags / env defaults | ... |
+| API | ... |
+| Plugin SDK | ... |
 
 ### Current Documentation
 - [What the existing page covers]


### PR DESCRIPTION
Feature research could conclude behavior from a single surface — e.g. a backend permission decorator that the frontend gate makes unreachable — because no step required accounting for the surfaces not read. User-visible behavior is the composition of backend, frontend, and configuration.

- New Phase 1 step 6 (coverage gate): before concluding, record per surface — backend, frontend UI, i18n labels, feature flags / env defaults, API, plugin SDK — either the files read or N/A plus why that surface cannot affect the feature.
- The Phase 3 summary template carries the resulting Surface Coverage table, so every research report shows what it stands on.
- The Phase 1 routing table gains the rows agents had no pointer for: non-node frontend paths, `web/i18n/`, and feature flags / env defaults.

Closes DC-37