### PR TITLE
docs: extend the UI-repetition rule to discoverable behavior

### DIFF
--- a/.claude/skills/dify-docs-feature-research/SKILL.md
+++ b/.claude/skills/dify-docs-feature-research/SKILL.md
@@ -136,7 +136,7 @@ Combine both phases into a structured research summary:
 ### Recommended Documentation Scope
 - [What to add based on gaps]
 - [What to clarify based on confusion]
-- [What to explicitly omit and why (bugs, unreleased features)]
+- [What to explicitly omit and why (bugs, unreleased features, UI-discoverable mechanics)]
 ```
 
 Present the summary to the user. STOP — do not start the writing phase until the user reviews the findings and confirms the scope.
@@ -144,6 +144,7 @@ Present the summary to the user. STOP — do not start the writing phase until t
 ## Important
 
 - This skill produces research only. Do not start writing documentation until the user reviews the findings and confirms the scope.
+- Research findings exist to make the page's claims accurate, not to be exhaustively included. When recommending scope, apply the style guide's "Repeating the UI" filter: UI-discoverable mechanics stay out of the page unless especially consequential.
 - When scope is confirmed and writing begins, load the writing skill for the target tree (`dify-docs-guides` for `use-dify` guides, `dify-cli-docs` for `en/cli/` pages, `dify-docs-env-vars` for env-var docs, `dify-docs-api-reference` for API specs) plus the writing guides (`writing-guides/style-guide.md`, `formatting-guide.md`, `glossary.md`) — before the first edit. This skill carries none of the writing rules.
 - Flag code-inferred behavior as unverified. Ask the user to test before documenting as fact.
 - Distinguish bugs from documentation gaps. Documenting buggy behavior as intended causes more harm than leaving a gap.

--- a/writing-guides/style-guide.md
+++ b/writing-guides/style-guide.md
@@ -126,11 +126,11 @@ Where a Community Edition capability ends and Dify Enterprise extends it, add a 
 
 **Repeating context.** Don't restate conditions already established by the section heading or earlier prose. If a section is titled "Configure Webhooks", individual steps shouldn't keep saying "to configure webhooks." The first sentence after a heading should add new information, not paraphrase the heading.
 
-**Repeating the UI.** Don't describe interface elements users can see directly—default values, field labels, button names. Documentation provides context and rationale not visible in the UI.
+**Repeating the UI.** Don't describe what users can see or discover directly in the UI—default values, field labels, button names, and interaction mechanics the interface teaches on first contact (displayed keyboard hints, what selecting an item does, option lists inside a menu). Repeat a UI-discoverable fact only when it's especially consequential: data loss, permissions, or cost. Documentation provides context and rationale not visible in the UI.
 
 **Describing the documentation.** Don't narrate the page's own structure or the doc set like "This section covers". Readers want the product, not a tour of the page. Lead with what the user does or needs.
 
-**Information noise.** If content doesn't provide value beyond what the reader already knows or can see, it hinders rather than helps. Before including a detail, ask: does the reader need this to accomplish their goal? If the UI already communicates it, or it restates what the previous sentence implied, cut it.
+**Information noise.** If content doesn't provide value beyond what the reader already knows or can see, it hinders rather than helps. Before including a detail, ask: does the reader need this to accomplish their goal? If it repeats the UI (see above) or restates what the previous sentence implied, cut it.
 
 **Unnecessary second sentences.** When two sentences can be merged into one without losing readability, combine them. If the "how it works" can be folded into the "what it does," a separate sentence is noise. Apply case-by-case—don't sacrifice clarity for brevity.
 


### PR DESCRIPTION
The style guide's Repeating-the-UI rule covered visible elements but not interaction mechanics the interface teaches on first contact, so research-heavy rewrites kept re-documenting them. Cover discoverable behavior, add the consequential-fact exception (data loss, permissions, cost), point Information-noise at the rule instead of duplicating its UI clause, and gate the feature-research skill's scope recommendations on the same filter.