### PR TITLE
docs: add disclaimer exception, EE-Tip renderings, NUL-safe checks

### DIFF
--- a/.claude/skills/dify-docs-format-check/SKILL.md
+++ b/.claude/skills/dify-docs-format-check/SKILL.md
@@ -49,7 +49,7 @@ Read-only audit of documentation formatting. Mechanical rules are enforced by tw
 
    - `H-ing-verb` (en): section-name gerunds (`Troubleshooting`, `Logging`, `Getting Started`, etc.) are exempt via the `SKIP_ING_HEADINGS` constant in `check-format-en.py`. If a flagged heading is a legitimate section concept, propose the addition to `SKIP_ING_HEADINGS` in your report — do not edit the script.
    - `I-alt-empty` (en): flags every empty alt as a prompt to confirm the image is genuinely decorative, not as a hard error.
-   - `CJK-disclaimer-missing`: the script looks for the translation disclaimer only within the ~10 lines below the frontmatter, so a disclaimer placed lower in the file still trips it.
+   - `CJK-disclaimer-missing`: the script looks for the translation disclaimer only within the ~10 lines below the frontmatter, so a disclaimer placed lower in the file still trips it. Pages whose frontmatter sets `mode: "custom"` or `mode: "frame"` are exempt — chrome-less landing pages carry no disclaimer (see the formatting guides' Translation Disclaimer exception).
    - `CJK-cross-lang-link`: `/en/...` links are flagged everywhere except on the disclaimer line, which is allowed to point at the English source.
 
 4. **Judgment review — `en/` files.** Digest of `writing-guides/formatting-guide.md` (section names in parentheses; the guide wins on conflict). Read each file and check:

--- a/.claude/skills/dify-docs-format-check/check-format-cjk.py
+++ b/.claude/skills/dify-docs-format-check/check-format-cjk.py
@@ -568,6 +568,12 @@ def check_cjk_disclaimer(lines: list[str], text: str, lang: str
     m = FM_RE.match(text)
     if not m:
         return vs
+    # Chrome-less landing pages (mode: custom/frame) carry no disclaimer
+    # by design — see tools/translate/formatting-{zh,ja}.md § Translation
+    # Disclaimer, Exception.
+    if re.search(r'^mode:\s*["\']?(custom|frame)["\']?\s*$',
+                 text[:m.end()], re.M):
+        return vs
     fm_end_line = text[:m.end()].count('\n')
     # scan next ~10 lines for the disclaimer
     needle = '本文档由 AI 自动翻译' if lang == 'zh' \

--- a/.claude/skills/dify-docs-terminology-check/SKILL.md
+++ b/.claude/skills/dify-docs-terminology-check/SKILL.md
@@ -43,9 +43,11 @@ Read-only audit. Verify that documentation terms match the glossary (general ter
 For each file in scope, in the docs repo:
 
 ```bash
-grep -noE '\*\*[^*]+\*\*' <file>    # bolded terms, prints line:**term**
-grep -nE '^#{2,3} ' <file>          # section headings, prints line:## Heading
+grep -anoE '\*\*[^*]+\*\*' <file>    # bolded terms, prints line:**term**
+grep -anE '^#{2,3} ' <file>          # section headings, prints line:## Heading
 ```
+
+The `-a` flag is required: some legacy zh/ja pages contain stray NUL bytes, and without it grep prints only `Binary file … matches` and silently drops the term inventory.
 
 Every bolded term and every heading is a candidate. Step 5 decides deterministically which are UI labels; do not pre-filter by intuition.
 

--- a/tools/translate/formatting-ja.md
+++ b/tools/translate/formatting-ja.md
@@ -177,6 +177,18 @@ Every translated page must include the translation disclaimer directly below the
 
 Keep the disclaimer regardless of whether the page has been human-reviewed. The English source is always the canonical version, and readers benefit from a consistent pointer to it on every translated page.
 
+**Exception:** Pages whose frontmatter sets `mode: "custom"` or `mode: "frame"` (the chrome-less landing pages: `home.mdx`, the two `use-dify/getting-started/introduction.mdx` pages, and `self-host/deploy/overview.mdx`) carry no disclaimer. Do not add one when creating or updating these pages.
+
+## Enterprise Tip Callouts
+
+The paid-feature `<Tip>` pattern (`writing-guides/style-guide.md` § Paid Feature Callouts) has a standard Japanese rendering. Keep "Dify Enterprise" in English and keep the contact-sales URL unchanged:
+
+```mdx
+<Tip>
+Dify Enterprise では、…できます。詳しくは [営業担当](https://udify.app/chat/QuwcpW1oBNcfeL55) までお問い合わせください。
+</Tip>
+```
+
 ## Translatable Elements
 
 These elements must be translated, not left in English:

--- a/tools/translate/formatting-zh.md
+++ b/tools/translate/formatting-zh.md
@@ -141,6 +141,18 @@ Every translated page must include the translation disclaimer directly below the
 
 Keep the disclaimer regardless of whether the page has been human-reviewed. The English source is always the canonical version, and readers benefit from a consistent pointer to it on every translated page.
 
+**Exception:** Pages whose frontmatter sets `mode: "custom"` or `mode: "frame"` (the chrome-less landing pages: `home.mdx`, the two `use-dify/getting-started/introduction.mdx` pages, and `self-host/deploy/overview.mdx`) carry no disclaimer. Do not add one when creating or updating these pages.
+
+## Enterprise Tip Callouts
+
+The paid-feature `<Tip>` pattern (`writing-guides/style-guide.md` § Paid Feature Callouts) has a standard Chinese rendering. Keep "Dify Enterprise" in English and keep the contact-sales URL unchanged:
+
+```mdx
+<Tip>
+在 Dify Enterprise 中，你可以…。如需了解更多，请 [联系销售](https://udify.app/chat/QuwcpW1oBNcfeL55)。
+</Tip>
+```
+
 ## Translatable Elements
 
 These elements must be translated, not left in English:


### PR DESCRIPTION
Encodes three maintainer-local rules into team-visible sources, each verified against origin/main before writing:

- **Translation-disclaimer exception** (`tools/translate/formatting-{zh,ja}.md`): pages whose frontmatter sets `mode: "custom"` or `mode: "frame"` — the chrome-less landing pages (`home.mdx`, the two `use-dify/getting-started/introduction.mdx` pages, `self-host/deploy/overview.mdx`) — deliberately carry no disclaimer. Exactly these 8 zh/ja pages lack one on main today; without the written exception, a translation pass would re-add them.
- **Enterprise `<Tip>` standard renderings**: the zh/ja sentences for the paid-feature Tip pattern (style guide § Paid Feature Callouts), taken from the live corpus — zh keeps "Dify Enterprise" in English (5/5 existing instances).
- **NUL-safe checks**: `check-format-cjk.py` now exempts custom/frame pages from `CJK-disclaimer-missing` (tested: exception page clean, disclaimer-less page still flagged); `dify-docs-terminology-check`'s inventory greps gain `-a` so NUL-corrupted legacy pages can't silently empty the term list.

Closes DC-59