### PR TITLE
fix: repoint contact-sales links on the snippet pages (#902) (backport to release/1.16.1)

### DIFF
--- a/en/self-host/use-dify/build/snippet.mdx
+++ b/en/self-host/use-dify/build/snippet.mdx
@@ -66,5 +66,5 @@ What you can do with a snippet depends on your workspace role:
 Members with the Normal role don't see the snippet list.
 
 <Tip>
-On Dify Enterprise, administrators can reassign these permissions to custom roles. [Contact sales](https://udify.app/chat/QuwcpW1oBNcfeL55) to learn more.
+On Dify Enterprise, administrators can reassign these permissions to custom roles. [Contact sales](https://share-na2.hsforms.com/14-09ff5HS92Sh4m3f4yrcw40s9fk) to learn more.
 </Tip>

--- a/ja/self-host/use-dify/build/snippet.mdx
+++ b/ja/self-host/use-dify/build/snippet.mdx
@@ -67,5 +67,5 @@ description: 複数のワークフローでノードのグループを再利用�
 「Normal」ロールのメンバーには、スニペット一覧は表示されません。
 
 <Tip>
-Dify Enterprise では、管理者がこれらの権限をカスタムロールに割り当て直せます。詳しくは [営業へのお問い合わせ](https://udify.app/chat/QuwcpW1oBNcfeL55) をご覧ください。
+Dify Enterprise では、管理者がこれらの権限をカスタムロールに割り当て直せます。詳しくは [営業へのお問い合わせ](https://share-na2.hsforms.com/176RpklY3TLeHo6qmuAdRKQ40s9fk) をご覧ください。
 </Tip>

--- a/zh/self-host/use-dify/build/snippet.mdx
+++ b/zh/self-host/use-dify/build/snippet.mdx
@@ -67,5 +67,5 @@ Snippet 会以副本形式添加到画布上。在插入的节点中，为每个
 「Normal」角色的用户看不到 Snippet 列表。
 
 <Tip>
-在 Dify Enterprise 中，管理员可将这些权限重新分配给自定义角色。[联系销售](https://udify.app/chat/QuwcpW1oBNcfeL55) 了解更多。
+在 Dify Enterprise 中，管理员可将这些权限重新分配给自定义角色。[联系销售](https://share-na2.hsforms.com/1O3Rajx4URXm88UzneXYpCw40s9fk) 了解更多。
 </Tip>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/1.16.1`:

-  - [fix: repoint contact-sales links on the snippet pages (#902)](https://github.com/langgenius/dify-docs/pull/902)