### PR TITLE
fix: correct card icons and contact-sales links on this release branch

### DIFF
--- a/en/cloud/use-dify/publish/webapp/web-app-settings.mdx
+++ b/en/cloud/use-dify/publish/webapp/web-app-settings.mdx
@@ -27,7 +27,7 @@ Make your web app look professional and recognizable:
   <Card title="Language Settings" icon="globe">
     Configure interface language for your target audience
   </Card>
-  <Card title="Legal Pages" icon="scale">
+  <Card title="Legal Pages" icon="scale-balanced">
     Add copyright information and privacy policy links for compliance
   </Card>
 </CardGroup>

--- a/en/self-host/use-dify/publish/webapp/web-app-settings.mdx
+++ b/en/self-host/use-dify/publish/webapp/web-app-settings.mdx
@@ -27,7 +27,7 @@ Make your web app look professional and recognizable:
   <Card title="Language Settings" icon="globe">
     Configure interface language for your target audience
   </Card>
-  <Card title="Legal Pages" icon="scale">
+  <Card title="Legal Pages" icon="scale-balanced">
     Add copyright information and privacy policy links for compliance
   </Card>
 </CardGroup>
@@ -54,7 +54,7 @@ Make your web app look professional and recognizable:
 Web apps are public by default. Anyone with the URL can open them, which works well for demos, public tools, and customer-facing applications.
 
 <Tip>
-  On Dify Enterprise, you can restrict who opens a web app with authentication, member-level access, and external-user management. [Contact sales](https://udify.app/chat/QuwcpW1oBNcfeL55) to learn more.
+  On Dify Enterprise, you can restrict who opens a web app with authentication, member-level access, and external-user management. [Contact sales](https://share-na2.hsforms.com/14-09ff5HS92Sh4m3f4yrcw40s9fk) to learn more.
 </Tip>
 
 **Privacy and Legal**:

--- a/ja/cloud/use-dify/publish/webapp/web-app-settings.mdx
+++ b/ja/cloud/use-dify/publish/webapp/web-app-settings.mdx
@@ -29,7 +29,7 @@ Web アプリをプロフェッショナルで認識しやすいものにしま�
   <Card title="言語設定" icon="globe">
     対象ユーザーに合わせてインターフェース言語を設定します
   </Card>
-  <Card title="法的ページ" icon="scale">
+  <Card title="法的ページ" icon="scale-balanced">
     コンプライアンス対応のため、著作権情報やプライバシーポリシーのリンクを追加します
   </Card>
 </CardGroup>

--- a/ja/self-host/use-dify/publish/webapp/web-app-settings.mdx
+++ b/ja/self-host/use-dify/publish/webapp/web-app-settings.mdx
@@ -29,7 +29,7 @@ Web アプリをプロフェッショナルで認識しやすいものにしま�
   <Card title="言語設定" icon="globe">
     対象ユーザーに合わせてインターフェース言語を設定します
   </Card>
-  <Card title="法的ページ" icon="scale">
+  <Card title="法的ページ" icon="scale-balanced">
     コンプライアンス対応のため、著作権情報やプライバシーポリシーのリンクを追加します
   </Card>
 </CardGroup>
@@ -56,7 +56,7 @@ Web アプリをプロフェッショナルで認識しやすいものにしま�
 Web アプリはデフォルトで公開されています。URL を知っている人なら誰でも開けるため、デモ、公開ツール、顧客向けアプリケーションに適しています。
 
 <Tip>
-  Dify Enterprise では、認証、メンバー単位のアクセス、外部ユーザーの管理によって、Web アプリを開けるユーザーを制限できます。詳しくは [営業担当](https://udify.app/chat/QuwcpW1oBNcfeL55) までお問い合わせください。
+  Dify Enterprise では、認証、メンバー単位のアクセス、外部ユーザーの管理によって、Web アプリを開けるユーザーを制限できます。詳しくは [営業担当](https://share-na2.hsforms.com/176RpklY3TLeHo6qmuAdRKQ40s9fk) までお問い合わせください。
 </Tip>
 
 **プライバシーと法的設定**：

--- a/zh/cloud/use-dify/publish/webapp/web-app-settings.mdx
+++ b/zh/cloud/use-dify/publish/webapp/web-app-settings.mdx
@@ -29,7 +29,7 @@ Web 应用默认公开。任何拥有 URL 的人都可访问，适用于演示�
   <Card title="语言设置" icon="globe">
     为你的目标受众配置界面语言
   </Card>
-  <Card title="法律页面" icon="scale">
+  <Card title="法律页面" icon="scale-balanced">
     添加版权信息和隐私政策链接以符合合规要求
   </Card>
 </CardGroup>

--- a/zh/cloud/use-dify/workspace/app-management.mdx
+++ b/zh/cloud/use-dify/workspace/app-management.mdx
@@ -16,7 +16,7 @@ title: "管理应用"
   <Card title="复制与模板" icon="copy">
     创建变体或将现有应用作为新项目的模板使用
   </Card>
-  <Card title="导入与导出" icon="arrows-exchange">
+  <Card title="导入与导出" icon="right-left">
     使用 Dify 的领域特定语言格式在工作空间之间共享应用
   </Card>
   <Card title="生命周期管理" icon="recycle">

--- a/zh/self-host/use-dify/publish/webapp/web-app-settings.mdx
+++ b/zh/self-host/use-dify/publish/webapp/web-app-settings.mdx
@@ -29,7 +29,7 @@ Web 应用默认公开。任何拥有 URL 的人都可访问，适用于演示�
   <Card title="语言设置" icon="globe">
     为你的目标受众配置界面语言
   </Card>
-  <Card title="法律页面" icon="scale">
+  <Card title="法律页面" icon="scale-balanced">
     添加版权信息和隐私政策链接以符合合规要求
   </Card>
 </CardGroup>
@@ -56,7 +56,7 @@ Web 应用默认公开。任何拥有 URL 的人都可访问，适用于演示�
 Web 应用默认公开。任何拥有 URL 的人都可打开，适用于演示、公共工具和面向客户的应用。
 
 <Tip>
-  在 Dify Enterprise 中，你可以通过身份验证、成员级访问控制和外部用户管理来限制谁能打开 Web 应用。[联系销售](https://udify.app/chat/QuwcpW1oBNcfeL55) 了解更多。
+  在 Dify Enterprise 中，你可以通过身份验证、成员级访问控制和外部用户管理来限制谁能打开 Web 应用。[联系销售](https://share-na2.hsforms.com/1O3Rajx4URXm88UzneXYpCw40s9fk) 了解更多。
 </Tip>
 
 **隐私与法律信息**：

--- a/zh/self-host/use-dify/workspace/app-management.mdx
+++ b/zh/self-host/use-dify/workspace/app-management.mdx
@@ -16,7 +16,7 @@ title: "管理应用"
   <Card title="复制与模板" icon="copy">
     创建变体或将现有应用作为新项目的模板使用
   </Card>
-  <Card title="导入与导出" icon="arrows-exchange">
+  <Card title="导入与导出" icon="right-left">
     使用 Dify 的领域特定语言格式在工作空间之间共享应用
   </Card>
   <Card title="生命周期管理" icon="recycle">


### PR DESCRIPTION
icon="scale" and icon="arrows-exchange" are not FontAwesome 6 names, so the Legal Pages and Import & Export cards rendered with no icon at all. Use scale-balanced and right-left.

The Enterprise Tip on web-app-settings still linked the udify.app webapp; point each language at its own HubSpot sales form, per writing-guides/style-guide.md.

These reached main via #901 but were left behind when its backport was narrowed to the factual-fix commits, because they rode a commit that also carried the terminology sweep.

Refs DC-99, DC-129.