### PR TITLE
fix: update cli install examples to this branch's versions

### DIFF
--- a/en/cli/install.mdx
+++ b/en/cli/install.mdx
@@ -80,20 +80,20 @@ description: Install difyctl with a one-line script or a manual binary download
 
     | Variable | Description | Example |
     | --- | --- | --- |
-    | `DIFY_VERSION` | The Dify release tag to install `difyctl` from, matching a tag on [Dify's Releases](https://github.com/langgenius/dify/releases).<br></br><br></br>Defaults to the latest release; set it to your server's release tag when your server isn't on the latest. | `1.15.0` |
-    | `DIFYCTL_VERSION` | Pin a specific `difyctl` build. Used only when `DIFY_VERSION` is unset. | `0.1.0-alpha` |
+    | `DIFY_VERSION` | The Dify release tag to install `difyctl` from, matching a tag on [Dify's Releases](https://github.com/langgenius/dify/releases).<br></br><br></br>Defaults to the latest release; set it to your server's release tag when your server isn't on the latest. | `1.16.0` |
+    | `DIFYCTL_VERSION` | Pin a specific `difyctl` build. Used only when `DIFY_VERSION` is unset. | `0.2.0-alpha` |
     | `DIFYCTL_PREFIX` | The install directory (default `~/.local`). The binary lands in `<prefix>/bin`. | `/usr/local` |
     
     For example:
     
     <CodeGroup>
     ```bash macOS / Linux
-    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.15.0 sh
+    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.16.0 sh
     ```
 
     ```powershell Windows
     # PowerShell has no inline form; this applies for the rest of your session
-    $env:DIFY_VERSION = "1.15.0"
+    $env:DIFY_VERSION = "1.16.0"
     irm https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install.ps1 | iex
     ```
     </CodeGroup>

--- a/ja/cli/install.mdx
+++ b/ja/cli/install.mdx
@@ -82,20 +82,20 @@ description: ワンライナースクリプトまたは手動でのバイナリ�
 
     | 変数 | 説明 | 例 |
     | --- | --- | --- |
-    | `DIFY_VERSION` | `difyctl` を取得する Dify リリースタグ。[Dify Releases](https://github.com/langgenius/dify/releases) のタグと一致させる。<br></br><br></br>既定は最新リリース。サーバーが最新でない場合は、そのリリースタグを指定する。 | `1.15.0` |
-    | `DIFYCTL_VERSION` | 特定の `difyctl` ビルドに固定する。`DIFY_VERSION` が未設定のときのみ使用される。 | `0.1.0-alpha` |
+    | `DIFY_VERSION` | `difyctl` を取得する Dify リリースタグ。[Dify Releases](https://github.com/langgenius/dify/releases) のタグと一致させる。<br></br><br></br>既定は最新リリース。サーバーが最新でない場合は、そのリリースタグを指定する。 | `1.16.0` |
+    | `DIFYCTL_VERSION` | 特定の `difyctl` ビルドに固定する。`DIFY_VERSION` が未設定のときのみ使用される。 | `0.2.0-alpha` |
     | `DIFYCTL_PREFIX` | インストール先ディレクトリ（既定は `~/.local`）。バイナリは `<prefix>/bin` に配置される。 | `/usr/local` |
 
     例：
 
     <CodeGroup>
     ```bash macOS / Linux
-    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.15.0 sh
+    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.16.0 sh
     ```
 
     ```powershell Windows
     # PowerShell にインライン形式はなく、設定はそのセッションの間ずっと有効です
-    $env:DIFY_VERSION = "1.15.0"
+    $env:DIFY_VERSION = "1.16.0"
     irm https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install.ps1 | iex
     ```
     </CodeGroup>

--- a/zh/cli/install.mdx
+++ b/zh/cli/install.mdx
@@ -82,20 +82,20 @@ description: 用一行脚本或手动下载二进制文件安装 difyctl
 
     | 变量 | 说明 | 示例 |
     | --- | --- | --- |
-    | `DIFY_VERSION` | 用于安装 `difyctl` 的 Dify 发布标签，取自 [Dify Releases](https://github.com/langgenius/dify/releases)。<br></br><br></br>默认使用最新发布版本；当服务器不是最新版本时，将其设置为服务器的发布标签。 | `1.15.0` |
-    | `DIFYCTL_VERSION` | 固定使用特定的 `difyctl` 构建版本。仅在未设置 `DIFY_VERSION` 时生效。 | `0.1.0-alpha` |
+    | `DIFY_VERSION` | 用于安装 `difyctl` 的 Dify 发布标签，取自 [Dify Releases](https://github.com/langgenius/dify/releases)。<br></br><br></br>默认使用最新发布版本；当服务器不是最新版本时，将其设置为服务器的发布标签。 | `1.16.0` |
+    | `DIFYCTL_VERSION` | 固定使用特定的 `difyctl` 构建版本。仅在未设置 `DIFY_VERSION` 时生效。 | `0.2.0-alpha` |
     | `DIFYCTL_PREFIX` | 安装目录（默认 `~/.local`）。二进制文件会放在 `<prefix>/bin` 下。 | `/usr/local` |
 
     例如：
 
     <CodeGroup>
     ```bash macOS / Linux
-    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.15.0 sh
+    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.16.0 sh
     ```
 
     ```powershell Windows
     # PowerShell 没有内联写法，该设置在当前会话剩余时间内生效
-    $env:DIFY_VERSION = "1.15.0"
+    $env:DIFY_VERSION = "1.16.0"
     irm https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install.ps1 | iex
     ```
     </CodeGroup>


### PR DESCRIPTION
The CLI install examples on this branch still showed `DIFY_VERSION=1.15.0` and `DIFYCTL_VERSION` `0.1.0-alpha`. difyctl 0.2.0-alpha's compatibility window starts at 1.16.0, so following the old examples installs a client that cannot connect to a 1.16.0 server.

This is the adapted counterpart of commit 10ea761e on `docs/agent-notice-and-cli-fixes` (main): examples point to this branch's own version, `DIFY_VERSION=1.16.0` with difyctl 0.2.0-alpha (asset verified on the 1.16.0 GitHub release). All three languages updated.

Ref DC-144.