### PR TITLE
fix: update cli examples and move the agent data security notice (#919) (backport to release/1.16.1)

### DIFF
--- a/en/cli/install.mdx
+++ b/en/cli/install.mdx
@@ -80,20 +80,20 @@ description: Install difyctl with a one-line script or a manual binary download
 
     | Variable | Description | Example |
     | --- | --- | --- |
-    | `DIFY_VERSION` | The Dify release tag to install `difyctl` from, matching a tag on [Dify's Releases](https://github.com/langgenius/dify/releases).<br></br><br></br>Defaults to the latest release; set it to your server's release tag when your server isn't on the latest. | `1.15.0` |
-    | `DIFYCTL_VERSION` | Pin a specific `difyctl` build. Used only when `DIFY_VERSION` is unset. | `0.1.0-alpha` |
+    | `DIFY_VERSION` | The Dify release tag to install `difyctl` from, matching a tag on [Dify's Releases](https://github.com/langgenius/dify/releases).<br></br><br></br>Defaults to the latest release; set it to your server's release tag when your server isn't on the latest. | `1.16.1` |
+    | `DIFYCTL_VERSION` | Pin a specific `difyctl` build. Used only when `DIFY_VERSION` is unset. | `0.2.0-alpha` |
     | `DIFYCTL_PREFIX` | The install directory (default `~/.local`). The binary lands in `<prefix>/bin`. | `/usr/local` |
     
     For example:
     
     <CodeGroup>
     ```bash macOS / Linux
-    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.15.0 sh
+    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.16.1 sh
     ```
 
     ```powershell Windows
     # PowerShell has no inline form; this applies for the rest of your session
-    $env:DIFY_VERSION = "1.15.0"
+    $env:DIFY_VERSION = "1.16.1"
     irm https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install.ps1 | iex
     ```
     </CodeGroup>

--- a/en/self-host/use-dify/build/new-agent/build.mdx
+++ b/en/self-host/use-dify/build/new-agent/build.mdx
@@ -4,19 +4,11 @@ sidebarTitle: Build
 description: Create an agent and shape what it can do, by hand or by describing what you want
 ---
 
-<Warning>
-**Data Security Notice**
-
-Community Edition uses file-access controls to limit access to agent and session files when the same agent is exposed to multiple end users. These controls reduce the risk of cross-conversation data access through the filesystem, but the Agent runtime is not intended to provide a hardened security boundary between mutually untrusted users or workloads.
-
-If your deployment requires strong isolation or strict security or compliance controls, use separately hardened infrastructure or contact Dify to assess an appropriate Cloud or Enterprise option. For Dify Enterprise, [contact sales](https://share-na2.hsforms.com/14-09ff5HS92Sh4m3f4yrcw40s9fk) to learn more.
-</Warning>
-
-<Info>
+<Note>
 The new Agent is in beta. It's on by default on Docker Compose, with its runtime bundled in.
 
 For production, replace [`DIFY_AGENT_SERVER_SECRET_KEY`](/en/self-host/deploy/configuration/environments#dify_agent_server_secret_key) and [`DIFY_AGENT_API_TOKEN`](/en/self-host/deploy/configuration/environments#dify_agent_api_token) with your own random values.
-</Info>
+</Note>
 
 ## Create an Agent
 
@@ -199,6 +191,14 @@ Restoring a version rolls back the agent's configuration only. The sandbox envir
 </Note>
 
 From the **Access Point** tab, host it as a web app at a shareable link, embed it in your site, or call it from your code through the service API.
+
+<Warning>
+**Data Security Notice**
+
+Community Edition uses file-access controls to limit access to agent and session files when the same agent is exposed to multiple end users. These controls reduce the risk of cross-conversation data access through the filesystem, but the Agent runtime is not intended to provide a hardened security boundary between mutually untrusted users or workloads.
+
+If your deployment requires strong isolation or strict security or compliance controls, use separately hardened infrastructure or contact Dify to assess an appropriate Cloud or Enterprise option. For Dify Enterprise, [contact sales](https://share-na2.hsforms.com/14-09ff5HS92Sh4m3f4yrcw40s9fk) to learn more.
+</Warning>
 
 <Info>
 The agent's API is streaming only. Only the workspace owner and admins can turn API access on or off.

--- a/en/self-host/use-dify/build/new-agent/overview.mdx
+++ b/en/self-host/use-dify/build/new-agent/overview.mdx
@@ -12,11 +12,11 @@ Community Edition uses file-access controls to limit access to agent and session
 If your deployment requires strong isolation or strict security or compliance controls, use separately hardened infrastructure or contact Dify to assess an appropriate Cloud or Enterprise option. For Dify Enterprise, [contact sales](https://share-na2.hsforms.com/14-09ff5HS92Sh4m3f4yrcw40s9fk) to learn more.
 </Warning>
 
-<Info>
+<Note>
 The new Agent is in beta. It's on by default on Docker Compose, with its runtime bundled in.
 
 For production, replace [`DIFY_AGENT_SERVER_SECRET_KEY`](/en/self-host/deploy/configuration/environments#dify_agent_server_secret_key) and [`DIFY_AGENT_API_TOKEN`](/en/self-host/deploy/configuration/environments#dify_agent_api_token) with your own random values.
-</Info>
+</Note>
 
 An *Agent* is an AI worker you set up once and then put to work. It's a different kind of agent than the [classic Agent app](/en/self-host/use-dify/build/agent):
 

--- a/en/self-host/use-dify/nodes/agent.mdx
+++ b/en/self-host/use-dify/nodes/agent.mdx
@@ -119,12 +119,6 @@ description: Run an agent as a step in your workflow, reasoning and using tools 
 
   <Tab title="New Agent">
 
-  <Info>
-  The new Agent node is in beta and available in Workflow apps only. It's on by default on Docker Compose, with its runtime bundled in.
-
-  For production, replace [`DIFY_AGENT_SERVER_SECRET_KEY`](/en/self-host/deploy/configuration/environments#dify_agent_server_secret_key) and [`DIFY_AGENT_API_TOKEN`](/en/self-host/deploy/configuration/environments#dify_agent_api_token) with your own random values.
-  </Info>
-
   <Warning>
   **Data Security Notice**
 
@@ -132,6 +126,12 @@ description: Run an agent as a step in your workflow, reasoning and using tools 
 
   If your deployment requires strong isolation or strict security or compliance controls, use separately hardened infrastructure or contact Dify to assess an appropriate Cloud or Enterprise option. For Dify Enterprise, [contact sales](https://share-na2.hsforms.com/14-09ff5HS92Sh4m3f4yrcw40s9fk) to learn more.
   </Warning>
+
+  <Note>
+  The new Agent node is in beta and available in Workflow apps only. It's on by default on Docker Compose, with its runtime bundled in.
+
+  For production, replace [`DIFY_AGENT_SERVER_SECRET_KEY`](/en/self-host/deploy/configuration/environments#dify_agent_server_secret_key) and [`DIFY_AGENT_API_TOKEN`](/en/self-host/deploy/configuration/environments#dify_agent_api_token) with your own random values.
+  </Note>
 
   The new Agent node runs an [agent](/en/self-host/use-dify/build/new-agent/overview) as one step of a workflow. Unlike the classic node's model-with-tools setup, the agent arrives as a complete worker with its own capabilities and sandbox.
 

--- a/ja/cli/install.mdx
+++ b/ja/cli/install.mdx
@@ -82,20 +82,20 @@ description: ワンライナースクリプトまたは手動でのバイナリ�
 
     | 変数 | 説明 | 例 |
     | --- | --- | --- |
-    | `DIFY_VERSION` | `difyctl` を取得する Dify リリースタグ。[Dify Releases](https://github.com/langgenius/dify/releases) のタグと一致させる。<br></br><br></br>既定は最新リリース。サーバーが最新でない場合は、そのリリースタグを指定する。 | `1.15.0` |
-    | `DIFYCTL_VERSION` | 特定の `difyctl` ビルドに固定する。`DIFY_VERSION` が未設定のときのみ使用される。 | `0.1.0-alpha` |
+    | `DIFY_VERSION` | `difyctl` を取得する Dify リリースタグ。[Dify Releases](https://github.com/langgenius/dify/releases) のタグと一致させる。<br></br><br></br>既定は最新リリース。サーバーが最新でない場合は、そのリリースタグを指定する。 | `1.16.1` |
+    | `DIFYCTL_VERSION` | 特定の `difyctl` ビルドに固定する。`DIFY_VERSION` が未設定のときのみ使用される。 | `0.2.0-alpha` |
     | `DIFYCTL_PREFIX` | インストール先ディレクトリ（既定は `~/.local`）。バイナリは `<prefix>/bin` に配置される。 | `/usr/local` |
 
     例：
 
     <CodeGroup>
     ```bash macOS / Linux
-    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.15.0 sh
+    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.16.1 sh
     ```
 
     ```powershell Windows
     # PowerShell にインライン形式はなく、設定はそのセッションの間ずっと有効です
-    $env:DIFY_VERSION = "1.15.0"
+    $env:DIFY_VERSION = "1.16.1"
     irm https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install.ps1 | iex
     ```
     </CodeGroup>

--- a/ja/self-host/use-dify/build/new-agent/build.mdx
+++ b/ja/self-host/use-dify/build/new-agent/build.mdx
@@ -6,19 +6,11 @@ description: Agent を作成し、手動設定またはチャットでの対話�
 
 > このドキュメントは AI によって自動翻訳されています。不正確な部分がある場合は、[英語版](/en/self-host/use-dify/build/new-agent/build) を参照してください。
 
-<Warning>
-**データセキュリティに関する注意**
-
-Community Edition では、同一の Agent を複数のエンドユーザーに公開する場合、ファイルアクセス制御により Agent ファイルおよびセッションファイルへのアクセスを制限します。この制御は、ファイルシステムを介した会話間のデータアクセスリスクを低減しますが、Agent ランタイムは、相互に信頼できないユーザーやワークロード間に強固なセキュリティ境界を提供することを意図したものではありません。
-
-強力な隔離や、厳格なセキュリティおよびコンプライアンス管理を必要とするデプロイでは、別途セキュリティを強化したインフラ環境をご利用いただくか、Cloud / Enterprise プランをご検討ください。Enterprise プランの詳細は、[営業へのお問い合わせ](https://share-na2.hsforms.com/176RpklY3TLeHo6qmuAdRKQ40s9fk) よりご連絡ください。
-</Warning>
-
-<Info>
+<Note>
 新しい Agent は Community Edition のベータ機能です。ランタイムは Docker Compose デプロイに同梱され、デフォルトで有効です。
 
 本番環境では、[`DIFY_AGENT_SERVER_SECRET_KEY`](/ja/self-host/deploy/configuration/environments#dify_agent_server_secret_key) と [`DIFY_AGENT_API_TOKEN`](/ja/self-host/deploy/configuration/environments#dify_agent_api_token) を独自のランダムな値に置き換えてください。
-</Info>
+</Note>
 
 ## Agent の作成
 
@@ -201,6 +193,14 @@ Agent は作業しながら、設定した内容を「ビルドノート」（`b
 </Note>
 
 **アクセスポイント** タブでは、共有可能なリンクで Web アプリとして公開したり、自分のサイトに埋め込んだり、サービス API 経由でコードから呼び出したりできます。
+
+<Warning>
+**データセキュリティに関する注意**
+
+Community Edition では、同一の Agent を複数のエンドユーザーに公開する場合、ファイルアクセス制御により Agent ファイルおよびセッションファイルへのアクセスを制限します。この制御は、ファイルシステムを介した会話間のデータアクセスリスクを低減しますが、Agent ランタイムは、相互に信頼できないユーザーやワークロード間に強固なセキュリティ境界を提供することを意図したものではありません。
+
+強力な隔離や、厳格なセキュリティおよびコンプライアンス管理を必要とするデプロイでは、別途セキュリティを強化したインフラ環境をご利用いただくか、Cloud / Enterprise プランをご検討ください。Enterprise プランの詳細は、[営業へのお問い合わせ](https://share-na2.hsforms.com/176RpklY3TLeHo6qmuAdRKQ40s9fk) よりご連絡ください。
+</Warning>
 
 <Info>
 Agent の API はストリーミングにのみ対応しています。API アクセスのオン・オフを切り替えられるのは、ワークスペースのオーナーと管理者だけです。

--- a/ja/self-host/use-dify/build/new-agent/overview.mdx
+++ b/ja/self-host/use-dify/build/new-agent/overview.mdx
@@ -14,11 +14,11 @@ Community Edition では、同一の Agent を複数のエンドユーザーに�
 強力な隔離や、厳格なセキュリティおよびコンプライアンス管理を必要とするデプロイでは、別途セキュリティを強化したインフラ環境をご利用いただくか、Cloud / Enterprise プランをご検討ください。Enterprise プランの詳細は、[営業へのお問い合わせ](https://share-na2.hsforms.com/176RpklY3TLeHo6qmuAdRKQ40s9fk) よりご連絡ください。
 </Warning>
 
-<Info>
+<Note>
 新しい Agent は Community Edition のベータ機能です。ランタイムは Docker Compose デプロイに同梱され、デフォルトで有効です。
 
 本番環境では、[`DIFY_AGENT_SERVER_SECRET_KEY`](/ja/self-host/deploy/configuration/environments#dify_agent_server_secret_key) と [`DIFY_AGENT_API_TOKEN`](/ja/self-host/deploy/configuration/environments#dify_agent_api_token) を独自のランダムな値に置き換えてください。
-</Info>
+</Note>
 
 「Agent」は、一度セットアップすれば仕事を任せられる AI ワーカーです。[クラシック Agent アプリ](/ja/self-host/use-dify/build/agent) とは異なる、次の特徴を持つ Agent です：
 

--- a/ja/self-host/use-dify/nodes/agent.mdx
+++ b/ja/self-host/use-dify/nodes/agent.mdx
@@ -121,12 +121,6 @@ description: "ワークフローの 1 ステップとして Agent を実行し�
 
   <Tab title="新しい Agent">
 
-  <Info>
-  新しい Agent ノードはベータ版で、Workflow アプリでのみ使用できます。ランタイムは Docker Compose デプロイに同梱され、デフォルトで有効です。
-
-  本番環境では、[`DIFY_AGENT_SERVER_SECRET_KEY`](/ja/self-host/deploy/configuration/environments#dify_agent_server_secret_key) と [`DIFY_AGENT_API_TOKEN`](/ja/self-host/deploy/configuration/environments#dify_agent_api_token) を独自のランダムな値に置き換えてください。
-  </Info>
-
   <Warning>
   **データセキュリティに関する注意**
 
@@ -134,6 +128,12 @@ description: "ワークフローの 1 ステップとして Agent を実行し�
 
   強力な隔離や、厳格なセキュリティおよびコンプライアンス管理を必要とするデプロイでは、別途セキュリティを強化したインフラ環境をご利用いただくか、Cloud / Enterprise プランをご検討ください。Enterprise プランの詳細は、[営業へのお問い合わせ](https://share-na2.hsforms.com/176RpklY3TLeHo6qmuAdRKQ40s9fk) よりご連絡ください。
   </Warning>
+
+  <Note>
+  新しい Agent ノードはベータ版で、Workflow アプリでのみ使用できます。ランタイムは Docker Compose デプロイに同梱され、デフォルトで有効です。
+
+  本番環境では、[`DIFY_AGENT_SERVER_SECRET_KEY`](/ja/self-host/deploy/configuration/environments#dify_agent_server_secret_key) と [`DIFY_AGENT_API_TOKEN`](/ja/self-host/deploy/configuration/environments#dify_agent_api_token) を独自のランダムな値に置き換えてください。
+  </Note>
 
   新しい Agent ノードは、ワークフローの 1 ステップとして [Agent](/ja/self-host/use-dify/build/new-agent/overview) を実行します。モデルにツールを組み合わせるクラシックノードと違い、ここでは能力とサンドボックスを備えた一人前のワーカーに任せます。
 

--- a/zh/cli/install.mdx
+++ b/zh/cli/install.mdx
@@ -82,20 +82,20 @@ description: 用一行脚本或手动下载二进制文件安装 difyctl
 
     | 变量 | 说明 | 示例 |
     | --- | --- | --- |
-    | `DIFY_VERSION` | 用于安装 `difyctl` 的 Dify 发布标签，取自 [Dify Releases](https://github.com/langgenius/dify/releases)。<br></br><br></br>默认使用最新发布版本；当服务器不是最新版本时，将其设置为服务器的发布标签。 | `1.15.0` |
-    | `DIFYCTL_VERSION` | 固定使用特定的 `difyctl` 构建版本。仅在未设置 `DIFY_VERSION` 时生效。 | `0.1.0-alpha` |
+    | `DIFY_VERSION` | 用于安装 `difyctl` 的 Dify 发布标签，取自 [Dify Releases](https://github.com/langgenius/dify/releases)。<br></br><br></br>默认使用最新发布版本；当服务器不是最新版本时，将其设置为服务器的发布标签。 | `1.16.1` |
+    | `DIFYCTL_VERSION` | 固定使用特定的 `difyctl` 构建版本。仅在未设置 `DIFY_VERSION` 时生效。 | `0.2.0-alpha` |
     | `DIFYCTL_PREFIX` | 安装目录（默认 `~/.local`）。二进制文件会放在 `<prefix>/bin` 下。 | `/usr/local` |
 
     例如：
 
     <CodeGroup>
     ```bash macOS / Linux
-    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.15.0 sh
+    curl -fsSL https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install-cli.sh | DIFY_VERSION=1.16.1 sh
     ```
 
     ```powershell Windows
     # PowerShell 没有内联写法，该设置在当前会话剩余时间内生效
-    $env:DIFY_VERSION = "1.15.0"
+    $env:DIFY_VERSION = "1.16.1"
     irm https://raw.githubusercontent.com/langgenius/dify/main/cli/scripts/install.ps1 | iex
     ```
     </CodeGroup>

--- a/zh/self-host/use-dify/build/new-agent/build.mdx
+++ b/zh/self-host/use-dify/build/new-agent/build.mdx
@@ -6,19 +6,11 @@ description: 创建 Agent 并塑造它的能力，可逐项手动配置，也可
 
 > 本文档由 AI 自动翻译。如有任何不准确之处，请参考 [英文原版](/en/self-host/use-dify/build/new-agent/build)。
 
-<Warning>
-**数据安全提示**
-
-当 Community Edition 中的同一个 Agent 面向多个终端用户使用时，Dify 会通过文件访问控制限制对 Agent 文件和会话文件的访问。这些措施能够降低通过文件系统发生跨会话数据访问的风险，但 Agent 运行环境并非旨在为相互不信任的用户或工作负载提供经过加固的安全隔离边界。
-
-如果部署场景要求强隔离或严格的安全、合规控制，应采用单独加固的基础设施，或联系 Dify 评估适当的 Cloud 或 Enterprise 方案。Enterprise 方案详情，可 [联系销售](https://share-na2.hsforms.com/1O3Rajx4URXm88UzneXYpCw40s9fk) 咨询。
-</Warning>
-
-<Info>
+<Note>
 新 Agent 目前处于 Beta 阶段。它在 Docker Compose 部署中默认启用，运行时也已随部署打包。
 
 生产环境使用前，将 [`DIFY_AGENT_SERVER_SECRET_KEY`](/zh/self-host/deploy/configuration/environments#dify_agent_server_secret_key) 和 [`DIFY_AGENT_API_TOKEN`](/zh/self-host/deploy/configuration/environments#dify_agent_api_token) 替换为你自己的随机值。
-</Info>
+</Note>
 
 ## 创建 Agent
 
@@ -201,6 +193,14 @@ Agent 工作时会直接修改面板中的配置，所有更改都会列在 **Bu
 </Note>
 
 在 **访问点** 标签页中，可将它托管为 Web 应用并获得可分享的链接、嵌入你的网站，或在你的代码中通过服务 API 调用。
+
+<Warning>
+**数据安全提示**
+
+当 Community Edition 中的同一个 Agent 面向多个终端用户使用时，Dify 会通过文件访问控制限制对 Agent 文件和会话文件的访问。这些措施能够降低通过文件系统发生跨会话数据访问的风险，但 Agent 运行环境并非旨在为相互不信任的用户或工作负载提供经过加固的安全隔离边界。
+
+如果部署场景要求强隔离或严格的安全、合规控制，应采用单独加固的基础设施，或联系 Dify 评估适当的 Cloud 或 Enterprise 方案。Enterprise 方案详情，可 [联系销售](https://share-na2.hsforms.com/1O3Rajx4URXm88UzneXYpCw40s9fk) 咨询。
+</Warning>
 
 <Info>
 Agent 的 API 仅支持流式返回。只有工作空间所有者和管理员可开启或关闭 API 访问。

--- a/zh/self-host/use-dify/build/new-agent/overview.mdx
+++ b/zh/self-host/use-dify/build/new-agent/overview.mdx
@@ -14,11 +14,11 @@ description: 构建一次 Agent，既可作为独立应用使用，也可嵌入�
 如果部署场景要求强隔离或严格的安全、合规控制，应采用单独加固的基础设施，或联系 Dify 评估适当的 Cloud 或 Enterprise 方案。Enterprise 方案详情，可 [联系销售](https://share-na2.hsforms.com/1O3Rajx4URXm88UzneXYpCw40s9fk) 咨询。
 </Warning>
 
-<Info>
+<Note>
 新 Agent 目前处于 Beta 阶段。它在 Docker Compose 部署中默认启用，运行时也已随部署打包。
 
 生产环境使用前，将 [`DIFY_AGENT_SERVER_SECRET_KEY`](/zh/self-host/deploy/configuration/environments#dify_agent_server_secret_key) 和 [`DIFY_AGENT_API_TOKEN`](/zh/self-host/deploy/configuration/environments#dify_agent_api_token) 替换为你自己的随机值。
-</Info>
+</Note>
 
 Agent 是一名 AI 员工：设置一次，之后随时给它派活。它与 [经典 Agent 应用](/zh/self-host/use-dify/build/agent) 是不同类型的 Agent：
 

--- a/zh/self-host/use-dify/nodes/agent.mdx
+++ b/zh/self-host/use-dify/nodes/agent.mdx
@@ -121,12 +121,6 @@ description: 将 Agent 作为工作流中的一步运行，通过推理和调用
 
   <Tab title="新 Agent">
 
-  <Info>
-  新 Agent 节点目前处于 Beta 阶段，仅在 Workflow 应用中可用。它在 Docker Compose 部署中默认启用，运行时也已随部署打包。
-
-  生产环境使用前，将 [`DIFY_AGENT_SERVER_SECRET_KEY`](/zh/self-host/deploy/configuration/environments#dify_agent_server_secret_key) 和 [`DIFY_AGENT_API_TOKEN`](/zh/self-host/deploy/configuration/environments#dify_agent_api_token) 替换为你自己的随机值。
-  </Info>
-
   <Warning>
   **数据安全提示**
 
@@ -134,6 +128,12 @@ description: 将 Agent 作为工作流中的一步运行，通过推理和调用
 
   如果部署场景要求强隔离或严格的安全、合规控制，应采用单独加固的基础设施，或联系 Dify 评估适当的 Cloud 或 Enterprise 方案。Enterprise 方案详情，可 [联系销售](https://share-na2.hsforms.com/1O3Rajx4URXm88UzneXYpCw40s9fk) 咨询。
   </Warning>
+
+  <Note>
+  新 Agent 节点目前处于 Beta 阶段，仅在 Workflow 应用中可用。它在 Docker Compose 部署中默认启用，运行时也已随部署打包。
+
+  生产环境使用前，将 [`DIFY_AGENT_SERVER_SECRET_KEY`](/zh/self-host/deploy/configuration/environments#dify_agent_server_secret_key) 和 [`DIFY_AGENT_API_TOKEN`](/zh/self-host/deploy/configuration/environments#dify_agent_api_token) 替换为你自己的随机值。
+  </Note>
 
   新 Agent 节点将一个 [Agent](/zh/self-host/use-dify/build/new-agent/overview) 作为工作流中的一步来运行。与经典节点「模型加工具」的组合不同，这里请来的是一名自带能力和沙箱的完整员工。
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/1.16.1`:

-  - [fix: update cli examples and move the agent data security notice (#919)](https://github.com/langgenius/dify-docs/pull/919)