### PR TITLE
fix: correct the backport runbook and default to non-fork pushes

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,5 +5,6 @@
   "prTitle": "{{commitMessages}} (backport to {{targetBranch}})",
   "prDescription": "# Backport\n\nThis will backport the following commits from `{{sourceBranch}}` to `{{targetBranch}}`:\n\n- {{commitMessages}}",
   "targetPRLabels": ["backport"],
+  "fork": false,
   "autoMerge": false
 }

--- a/.github/BACKPORT.md
+++ b/.github/BACKPORT.md
@@ -46,6 +46,10 @@ Without `gh`, put a token in `~/.backport/config.json` as
 The `BACKPORT_TOKEN` used by the workflow is a repository secret; it cannot
 be read locally and is unrelated to CLI auth.
 
+One edge: pushing a backport that touches `.github/workflows/` additionally
+requires the `workflow` scope, which the default `gh` token does not carry —
+grant it with `gh auth refresh -s workflow` if you hit that rejection.
+
 Gather and select interactively (targets passed at runtime, so any
 `release/*` works without editing config):
 
@@ -71,11 +75,11 @@ the PR.
 
 ## After merging
 
-Confirm the change reached every labelled branch by probing content:
+Confirm the change reached every labeled branch by probing content:
 
 ```bash
 git fetch origin
-git show origin/release/<v>:<path> | grep "<distinctive marker>"
+git show origin/release/<branch>:<path> | grep "<distinctive marker>"
 ```
 
 Squash-merged backports make `git log --grep` unreliable in both

--- a/.github/BACKPORT.md
+++ b/.github/BACKPORT.md
@@ -26,26 +26,57 @@ the source PR (finish it with the CLI below).
 > The label must exist before you can apply it. When labeling for a new branch
 > the first time, create the label (the labels box offers "Create new label").
 
-## Batch (many PRs at once)
+If a backport depends on another change landing on the target branch first,
+merge that prerequisite before the backport PR is created: a PR's checks run
+against the merge ref computed when the PR opens, and re-running a failed
+check replays that same ref. If the base moved after the PR opened, use
+**Update branch** on the backport PR to trigger a fresh run.
 
-One-time local auth: create `~/.backport/config.json` with
-`{ "accessToken": "<a GitHub token with repo scope>" }`.
+## Local CLI (batch work and conflicts)
 
-Then gather and select interactively (targets passed at runtime, so any
+Authenticate with your existing `gh` login — its token already carries the
+`repo` scope and org authorization:
+
+```bash
+npx backport --pr 792 --branch release/1.15.0 --githubToken "$(gh auth token)"
+```
+
+Without `gh`, put a token in `~/.backport/config.json` as
+`{ "githubToken": "<token with repo scope>" }` — the key is `githubToken`.
+The `BACKPORT_TOKEN` used by the workflow is a repository secret; it cannot
+be read locally and is unrelated to CLI auth.
+
+Gather and select interactively (targets passed at runtime, so any
 `release/*` works without editing config):
 
 ```bash
 # By query, then arrow-key multi-select the PRs:
 npx backport --pr-query "merged:>=2026-05-01 label:backport-pending" \
-  --branch release/1.16.0 --branch release/1.15.0
-# Or by path / single PR:
-npx backport --path en/self-host/use-dify --branch release/1.15.0
-npx backport --pr 792 --branch release/1.15.0
+  --branch release/1.16.0 --branch release/1.15.0 --githubToken "$(gh auth token)"
+# Or by path:
+npx backport --path en/self-host/use-dify --branch release/1.15.0 --githubToken "$(gh auth token)"
 ```
 
 ## Finishing a conflicting backport
 
 ```bash
-npx backport --pr <source-pr-number> --branch release/<branch>
-# resolve the conflict when prompted; the CLI pushes and opens the PR
+npx backport --pr <source-pr-number> --branch release/<branch> --githubToken "$(gh auth token)"
 ```
+
+The CLI works in its own clone at `~/.backport/repositories/<org>/<repo>`,
+not in the checkout you ran it from. When it pauses on conflicts: in a
+second terminal, `cd` into that clone, resolve and `git add` the files
+there, then return and press ENTER — the CLI commits, pushes, and opens
+the PR.
+
+## After merging
+
+Confirm the change reached every labelled branch by probing content:
+
+```bash
+git fetch origin
+git show origin/release/<v>:<path> | grep "<distinctive marker>"
+```
+
+Squash-merged backports make `git log --grep` unreliable in both
+directions — always check content, not commit messages.


### PR DESCRIPTION
Three defects in the local backport path, each hit in practice during the #901/#903 backports, plus one verification gap:

- The runbook's config example used `accessToken`; backport v12 only accepts `githubToken`, so following the doc failed at startup.
- It instructed creating a new PAT; the existing `gh` login token already carries `repo` scope and org authorization, so the CLI examples now pass `--githubToken "$(gh auth token)"`. Also clarified that the workflow's `BACKPORT_TOKEN` is a repository secret and unrelated to CLI auth.
- `.backportrc.json` left `fork` at its default (true), so the CLI pushed to a nonexistent personal fork and died. `"fork": false` matches what the workflow already does.
- New sections: resolve conflicts in the CLI's own clone at `~/.backport/repositories/<org>/<repo>`, merge prerequisites before the backport PR is created, and verify propagation by content after merging — #881 silently missed release/1.16.0 for two weeks.

Closes DC-143.