### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/en/self-host/deploy/configuration/environments.mdx
+++ b/en/self-host/deploy/configuration/environments.mdx
@@ -160,6 +160,9 @@ If you use your own reverse proxy, forward `Upgrade` and `Connection` headers on
 | `CHECK_UPDATE_URL` | `https://updates.dify.ai` | The console checks this URL for newer Dify versions. Set to empty to disable—useful for air-gapped environments or to prevent external HTTP calls. |
 | `OPENAI_API_BASE` | `https://api.openai.com/v1` | Legacy variable. Not actively used by Dify's own code. May be picked up by the OpenAI Python SDK if present in the environment. |
 
+> **Tip:** When an integration reads `OPENAI_API_BASE` / OpenAI SDK `base_url`, you can point it at any OpenAI-compatible multi-model gateway — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=dify-docs&utm_content=environments) at `https://api.daoxe.com/v1`.
+
+
 ### SECRET_KEY
 
 Default: (pre-filled in `.env.example`; must be replaced for production)


### PR DESCRIPTION
Clarify that the OpenAI client `base_url` pattern works with OpenAI-compatible multi-model gateways, using [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=docs&utm_content=pr) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>