### PR TITLE
fix: align cloud goto-anything page with feature-preview gating

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -87,7 +87,6 @@
                               "en/cloud/use-dify/nodes/tools"
                             ]
                           },
-                          "en/cloud/use-dify/build/goto-anything",
                           "en/cloud/use-dify/build/shortcut-key",
                           "en/cloud/use-dify/build/version-control",
                           "en/cloud/use-dify/build/snippet",
@@ -114,7 +113,8 @@
                         ],
                         "expanded": false
                       },
-                      "en/cloud/use-dify/build/additional-features"
+                      "en/cloud/use-dify/build/additional-features",
+                      "en/cloud/use-dify/build/goto-anything"
                     ],
                     "icon": "hammer"
                   },
@@ -800,7 +800,6 @@
                               "en/self-host/use-dify/nodes/tools"
                             ]
                           },
-                          "en/self-host/use-dify/build/goto-anything",
                           "en/self-host/use-dify/build/shortcut-key",
                           "en/self-host/use-dify/build/version-control",
                           "en/self-host/use-dify/build/snippet",
@@ -837,7 +836,8 @@
                         ],
                         "expanded": false
                       },
-                      "en/self-host/use-dify/build/additional-features"
+                      "en/self-host/use-dify/build/additional-features",
+                      "en/self-host/use-dify/build/goto-anything"
                     ],
                     "icon": "hammer"
                   },
@@ -1478,7 +1478,6 @@
                               "zh/cloud/use-dify/nodes/tools"
                             ]
                           },
-                          "zh/cloud/use-dify/build/goto-anything",
                           "zh/cloud/use-dify/build/shortcut-key",
                           "zh/cloud/use-dify/build/version-control",
                           "zh/cloud/use-dify/build/snippet",
@@ -1505,7 +1504,8 @@
                         ],
                         "expanded": false
                       },
-                      "zh/cloud/use-dify/build/additional-features"
+                      "zh/cloud/use-dify/build/additional-features",
+                      "zh/cloud/use-dify/build/goto-anything"
                     ],
                     "icon": "hammer"
                   },
@@ -2191,7 +2191,6 @@
                               "zh/self-host/use-dify/nodes/tools"
                             ]
                           },
-                          "zh/self-host/use-dify/build/goto-anything",
                           "zh/self-host/use-dify/build/shortcut-key",
                           "zh/self-host/use-dify/build/version-control",
                           "zh/self-host/use-dify/build/snippet",
@@ -2228,7 +2227,8 @@
                         ],
                         "expanded": false
                       },
-                      "zh/self-host/use-dify/build/additional-features"
+                      "zh/self-host/use-dify/build/additional-features",
+                      "zh/self-host/use-dify/build/goto-anything"
                     ],
                     "icon": "hammer"
                   },
@@ -2869,7 +2869,6 @@
                               "ja/cloud/use-dify/nodes/tools"
                             ]
                           },
-                          "ja/cloud/use-dify/build/goto-anything",
                           "ja/cloud/use-dify/build/shortcut-key",
                           "ja/cloud/use-dify/build/version-control",
                           "ja/cloud/use-dify/build/snippet",
@@ -2896,7 +2895,8 @@
                         ],
                         "expanded": false
                       },
-                      "ja/cloud/use-dify/build/additional-features"
+                      "ja/cloud/use-dify/build/additional-features",
+                      "ja/cloud/use-dify/build/goto-anything"
                     ],
                     "icon": "hammer"
                   },
@@ -3582,7 +3582,6 @@
                               "ja/self-host/use-dify/nodes/tools"
                             ]
                           },
-                          "ja/self-host/use-dify/build/goto-anything",
                           "ja/self-host/use-dify/build/shortcut-key",
                           "ja/self-host/use-dify/build/version-control",
                           "ja/self-host/use-dify/build/snippet",
@@ -3619,7 +3618,8 @@
                         ],
                         "expanded": false
                       },
-                      "ja/self-host/use-dify/build/additional-features"
+                      "ja/self-host/use-dify/build/additional-features",
+                      "ja/self-host/use-dify/build/goto-anything"
                     ],
                     "icon": "hammer"
                   },

--- a/docs.json
+++ b/docs.json
@@ -87,6 +87,7 @@
                               "en/cloud/use-dify/nodes/tools"
                             ]
                           },
+                          "en/cloud/use-dify/build/goto-anything",
                           "en/cloud/use-dify/build/shortcut-key",
                           "en/cloud/use-dify/build/version-control",
                           "en/cloud/use-dify/build/snippet",
@@ -1477,6 +1478,7 @@
                               "zh/cloud/use-dify/nodes/tools"
                             ]
                           },
+                          "zh/cloud/use-dify/build/goto-anything",
                           "zh/cloud/use-dify/build/shortcut-key",
                           "zh/cloud/use-dify/build/version-control",
                           "zh/cloud/use-dify/build/snippet",
@@ -2867,6 +2869,7 @@
                               "ja/cloud/use-dify/nodes/tools"
                             ]
                           },
+                          "ja/cloud/use-dify/build/goto-anything",
                           "ja/cloud/use-dify/build/shortcut-key",
                           "ja/cloud/use-dify/build/version-control",
                           "ja/cloud/use-dify/build/snippet",

--- a/en/cloud/use-dify/build/goto-anything.mdx
+++ b/en/cloud/use-dify/build/goto-anything.mdx
@@ -32,8 +32,6 @@ Type `/` to see every command, or keep typing to filter:
 
 | Command | What it does |
 |:---|:---|
-| `/create` / `/new` | describe an app and Dify builds it as a Workflow or Chatflow; pick the type yourself or choose **Auto** to let the AI decide |
-| `/refine` / `/improve` | describe a change and Dify applies it to the Workflow or Chatflow you're editing (only when one is open) |
 | `/go` | jump to a main section of the console |
 | `/docs` | open the help documentation |
 | `/community` | open the Discord community |

--- a/ja/cloud/use-dify/build/goto-anything.mdx
+++ b/ja/cloud/use-dify/build/goto-anything.mdx
@@ -34,8 +34,6 @@ macOS では `⌘ + K`、Windows/Linux では `Ctrl + K` を押すか、サイ�
 
 | コマンド | 動作 |
 |:---|:---|
-| `/create` / `/new` | アプリの説明から Workflow または Chatflow を生成。種類は自分で指定するか、**自動** で AI に任せる |
-| `/refine` / `/improve` | 説明した変更を、編集中の Workflow または Chatflow に適用（開いているときのみ） |
 | `/go` | コンソールの主要セクションへ移動 |
 | `/docs` | ヘルプドキュメントを開く |
 | `/community` | Discord コミュニティを開く |

--- a/zh/cloud/use-dify/build/goto-anything.mdx
+++ b/zh/cloud/use-dify/build/goto-anything.mdx
@@ -34,8 +34,6 @@ description: 通过快捷键快速搜索并跳转到应用、集成、知识库�
 
 | 命令 | 作用 |
 |:---|:---|
-| `/create` / `/new` | 描述你想要的应用，Dify 会将其生成为 Workflow 或 Chatflow；可自行指定类型，或选择 **自动**，让 AI 决定 |
-| `/refine` / `/improve` | 描述一处修改，Dify 会将其应用到你正在编辑的 Workflow 或 Chatflow（仅在打开时可用） |
 | `/go` | 跳转到控制台的主要板块 |
 | `/docs` | 打开帮助文档 |
 | `/community` | 打开 Discord 社区 |


### PR DESCRIPTION
Cloud production sets NEXT_PUBLIC_ENABLE_FEATURE_PREVIEW=false (saas-deploy), so the /create and /refine slash commands do not exist on Cloud. Remove their rows from the cloud command table (en/zh/ja) and add the page to the three cloud nav sections, mirroring the self-host position.

Closes DC-157