### PR TITLE
docs: introduce the dify-docs-write pipeline skill; convert doc-type skills to rule packs

### DIFF
--- a/.claude/skills/dify-cli-docs/SKILL.md
+++ b/.claude/skills/dify-cli-docs/SKILL.md
@@ -1,28 +1,27 @@
 ---
 name: dify-cli-docs
 description: >
-  Use when drafting or editing any page under `en/cli/` in dify-docs.
-  Covers reader segments, the writing rules, content ownership, and
-  codebase-verification rules for the Dify CLI (`difyctl`) doc set. Triggers:
-  "draft a CLI page", "write difyctl docs", "edit a page in en/cli/".
+  Rule pack for the Dify CLI (`difyctl`) doc set — en/cli/. Covers reader
+  segments, the writing rules, content ownership, and codebase-verification
+  rules. Loaded by dify-docs-write; not an entry point.
 ---
 
 # Dify CLI Documentation
 
-## Workflow
+Not an entry point — run under `dify-docs-write`; this pack's rules implement its stages for `en/cli/` pages.
 
-1. Read the three writing guides (`style-guide.md`, `formatting-guide.md`, `glossary.md`) and mirror an existing `en/cli/` page of the same type.
-2. Confirm edition scope: CE-first; badge and defer Cloud-only content.
-3. Draft per the Command Reference structure.
-4. Apply the Writing rules and Content ownership (state each fact once, link elsewhere).
-5. Verify every behavior claim against `langgenius/dify` `cli/` on `origin/main`, read at a pinned SHA per `writing-guides/index.md` "Syncing the Dify codebase safely"; record that SHA in your report.
-6. Run post-writing verification (the numbered checks under Verification below).
+## Procedures by stage
+
+1. **S1**: Confirm edition scope: CE-first; badge and defer Cloud-only content (see Editions below).
+2. **S2/S7**: Verify every behavior claim against `langgenius/dify` `cli/` on `origin/main`, read at the pinned SHA per `writing-guides/index.md` "Syncing the Dify codebase safely"; record that SHA in your report.
+3. **S5**: Mirror an existing page of the same type (see Before starting); draft per the Command Reference structure; apply the Writing rules and Content ownership (state each fact once, link elsewhere).
+4. **S7 verifiers**: the numbered checks under Verification below, after the spine's check chain.
 
 **Critical (source of truth):** `cli/` on `origin/main` only. Never `feat/cli` or `cli/README.md`; both drift from shipped reality.
 
 ## Before starting
 
-Read `writing-guides/style-guide.md`, `formatting-guide.md`, `glossary.md`. For page structure, mirror an existing page of the same type (command reference → `en/cli/reference/apps.mdx`; task page → `en/cli/common-tasks.mdx`). For the IA, see `docs.json`.
+For page structure, mirror an existing page of the same type (command reference → `en/cli/reference/apps.mdx`; task page → `en/cli/common-tasks.mdx`). For the IA, see `docs.json`.
 
 ## Reader segments
 
@@ -102,9 +101,7 @@ Source of truth is the code (per the Critical note above), not the docs or in-CL
 
 For project context (known bugs, decisions, what's shipped vs planned), ask the user.
 
-After writing, run these checks in order (per `writing-guides/index.md` "Post-Writing Verification"):
+S7 verifiers — run after the spine's check chain:
 
-1. Run the `dify-docs-format-check` skill on every changed page; its checker must print `Total violations: 0`.
-2. Run `python3 tools/check-links.py --internal`; it must print `Broken links: 0` and `Broken anchors: 0`.
-3. Run the `dify-docs-terminology-check` skill, then the `dify-docs-reader-test` skill.
-4. Confirm no owned fact is re-explained (check each changed page against the Content ownership table).
+1. Run `python3 tools/check-links.py --internal`; it must print `Broken links: 0` and `Broken anchors: 0`.
+2. Confirm no owned fact is re-explained (check each changed page against the Content ownership table).

--- a/.claude/skills/dify-docs-api-reference/SKILL.md
+++ b/.claude/skills/dify-docs-api-reference/SKILL.md
@@ -1,27 +1,29 @@
 ---
 name: dify-docs-api-reference
 description: >
-  Use when editing or auditing the Service API specs in the Dify docs
-  repo ({en,zh,ja}/api-reference/openapi_service.json), or on any task
-  touching API endpoint parameters, responses, error codes, status codes,
-  or examples.
+  Rule pack for the Service API specs
+  ({en,zh,ja}/api-reference/openapi_service.json): spec conventions,
+  app-type scoping, code-verification rules, and the audit machinery.
+  Writing and editing run under dify-docs-write; the standalone audit of an
+  existing spec ("audit the API spec") runs directly from this pack.
 ---
 
 # Dify API Reference Documentation
 
 OpenAPI specs for developers integrating Dify over REST. **The code is the source of truth: when the spec disagrees with the code, the spec is wrong.** Every detail you write must be traceable to a controller, model, or converter in the Dify codebase.
 
-## Workflow
+Not an entry point for writing — editing or creating specs runs under `dify-docs-write`; the procedures below implement its stages for the Service API specs.
 
-Work through these in order. Steps 1, 3, 4, and 5 are non-negotiable.
+**Standalone audit** (read-only, own trigger — no pipeline needed): auditing an existing spec is the app-type lens (procedure 1 below) plus [Verifying Against Code](#verifying-against-code) applied systematically from `references/audit-checklist.md`.
 
-Editing or creating a spec runs all five steps. Auditing an existing spec is steps 1 and 3 applied systematically from `references/audit-checklist.md`; the independent subagent audit in step 5 is required only when you have written or substantially changed an endpoint. **Substantially changed** = any change to paths, methods, parameters, schema fields or constraints, status codes, error codes, example values, or availability; only pure prose rewording (summaries, descriptions, translations) is exempt.
+## Procedures by stage
 
-1. **Set up and scope.** Read the shared guides (`writing-guides/style-guide.md`, `formatting-guide.md`, `glossary.md`). Pin the dify ref to verify against — `origin/main` by default, or the tag/dev branch the user names — and read code at that ref per `writing-guides/index.md` § "Syncing the Dify codebase safely"; never `git checkout` or `git pull` in a tree you have not confirmed is clean. Identify which app types the operation serves from the AppMode table in `references/codebase-paths.md`; every later check is filtered through that app-type lens (see [App-Type Scoping](#app-type-scoping)).
-2. **Write or edit to the conventions.** Apply `references/spec-conventions.md` for every element: summaries, operationId, descriptions, parameters, responses, error format, schemas, examples, tags, ordering. That file is the single source for formatting rules; do not reinvent them here.
-3. **Verify every detail against the code.** Nothing ships unverified (see [Verifying Against Code](#verifying-against-code)). Use `references/codebase-paths.md` to locate controllers, error definitions, and global handlers.
-4. **Flag suspected code bugs; never silently document them** (see [Flagging Suspected Bugs](#flagging-suspected-bugs)).
-5. **Run post-writing verification** (see [Post-Writing Verification](#post-writing-verification)): the post-writing checks always, plus the independent subagent audit for new or substantially-changed endpoints.
+All four are non-negotiable.
+
+1. **S1 — scope.** Identify which app types the operation serves from the AppMode table in `references/codebase-paths.md`; every later check is filtered through that app-type lens (see [App-Type Scoping](#app-type-scoping)). Read code at the ref pinned in S1 per `writing-guides/index.md` § "Syncing the Dify codebase safely"; never `git checkout` or `git pull` in a tree you have not confirmed is clean.
+2. **S5 — write or edit to the conventions.** Apply `references/spec-conventions.md` for every element: summaries, operationId, descriptions, parameters, responses, error format, schemas, examples, tags, ordering. That file is the single source for formatting rules; do not reinvent them here. `S6 modified per pack`: all three language specs are edited directly in the same pass (see [Spec Structure](#spec-structure)); `parity_check` replaces a separate translate step.
+3. **S2/S7 — verify every detail against the code.** Nothing ships unverified (see [Verifying Against Code](#verifying-against-code)). Use `references/codebase-paths.md` to locate controllers, error definitions, and global handlers. Flag suspected code bugs; never silently document them (see [Flagging Suspected Bugs](#flagging-suspected-bugs)).
+4. **S7 verifiers** (after the spine's check chain): the independent subagent audit — required for new or **substantially changed** endpoints — and the example/schema consistency pass (both under [S7 Verifiers](#s7-verifiers)). **Substantially changed** = any change to paths, methods, parameters, schema fields or constraints, status codes, error codes, example values, or availability; only pure prose rewording (summaries, descriptions, translations) is exempt.
 
 ## Reader Persona
 
@@ -82,9 +84,7 @@ The code is the source of truth, but the code itself can have bugs. When somethi
 
 Beyond fidelity, act as a professional API writer: challenge questionable decisions with reasoning, suggest developer-experience improvements (kept clearly separate from required fixes), and push back on conflicting instructions with evidence.
 
-## Post-Writing Verification
-
-Run the post-writing checks in `writing-guides/index.md#post-writing-verification`, then the two passes below.
+## S7 Verifiers
 
 ### Independent code audit (required for new or substantially-changed endpoints)
 

--- a/.claude/skills/dify-docs-env-vars/SKILL.md
+++ b/.claude/skills/dify-docs-env-vars/SKILL.md
@@ -25,7 +25,7 @@ python3 .claude/skills/dify-docs-env-vars/verify-env-docs.py \
 
 Pin exact tags or SHAs (e.g., `--compare-rev 1.14.1 1.15.0`), never a branch name. The script prints the vars **added / removed / default-changed** between the refs, then `=== NEW vars NOT documented and NOT in ignored-vars (<n>) — TRIAGE ===`, and exits 0. Every triage var must end the task either documented or in `ignored-vars.md` with a reason — never as silent backlog.
 
-## Procedure (S2 → S5)
+## Procedure (S2 → S6)
 
 Work through in order. **Every variable goes through steps 1–4 without exception** — do not skip a variable because it seems "obvious".
 

--- a/.claude/skills/dify-docs-env-vars/SKILL.md
+++ b/.claude/skills/dify-docs-env-vars/SKILL.md
@@ -1,30 +1,20 @@
 ---
 name: dify-docs-env-vars
 description: >
-  Use when writing, rewriting, or auditing environment variable documentation
-  for Dify self-hosted deployment. Applies to
-  en/self-host/deploy/configuration/environments.mdx. Covers the full process from
-  codebase tracing to user-facing descriptions.
+  Rule pack for the environment variable reference —
+  en/self-host/deploy/configuration/environments.mdx. Carries the tracing
+  procedure, description rules, verifier, and document structure. Loaded by
+  dify-docs-write; not an entry point. Its release-sync diff is a standalone
+  procedure invoked by dify-docs-release-sync.
 ---
 
 # Dify Environment Variable Documentation
 
-Work through the steps in order. **Every variable goes through steps 4–7 without exception** — do not skip a variable because it seems "obvious".
+Not an entry point — run under `dify-docs-write`; the procedure below implements its stages for `en/self-host/deploy/configuration/environments.mdx`. Read `references/style-overrides.md` (in this skill directory — env-var-specific style rules and description anti-patterns) together with this pack. Use the ref pinned at S1; cite it in the S4 scope report.
 
-## Step 1: Read first
+## Standalone procedure: release-sync diff
 
-1. `writing-guides/style-guide.md`
-2. `writing-guides/formatting-guide.md`
-3. `writing-guides/glossary.md`
-4. `references/style-overrides.md` (in this skill directory) — env-var-specific style rules and description anti-patterns
-
-## Step 2: Sync the Dify codebase
-
-Follow `writing-guides/index.md` section "Syncing the Dify codebase safely". Never run `git checkout` or `git pull` in the Dify working tree. Record the tag or SHA you verify against; cite it in your step 7 report.
-
-## Step 3 (release sync only): Diff the var set between releases
-
-Run this before any tracing. Per-PR detection misses vars from untagged PRs, and the verifier's Missing-from-docs list hides genuinely new vars inside old backlog.
+Invoked from `dify-docs-release-sync` only. Run this before any tracing. Per-PR detection misses vars from untagged PRs, and the verifier's Missing-from-docs list hides genuinely new vars inside old backlog.
 
 ```bash
 python3 .claude/skills/dify-docs-env-vars/verify-env-docs.py \
@@ -35,7 +25,11 @@ python3 .claude/skills/dify-docs-env-vars/verify-env-docs.py \
 
 Pin exact tags or SHAs (e.g., `--compare-rev 1.14.1 1.15.0`), never a branch name. The script prints the vars **added / removed / default-changed** between the refs, then `=== NEW vars NOT documented and NOT in ignored-vars (<n>) — TRIAGE ===`, and exits 0. Every triage var must end the task either documented or in `ignored-vars.md` with a reason — never as silent backlog.
 
-## Step 4: Trace each variable in the codebase
+## Procedure (S2 → S5)
+
+Work through in order. **Every variable goes through steps 1–4 without exception** — do not skip a variable because it seems "obvious".
+
+### Step 1 (S2): Trace each variable in the codebase
 
 When using subagents for tracing, assign 3–5 related variables per agent. Tracing depth depends on variable type:
 
@@ -52,11 +46,11 @@ Full trace:
 2. Find every usage — grep both the env var name and the Python attribute (`dify_config.VARIABLE_NAME`); read the surrounding code.
 3. Determine behavior when empty vs set — trace fallback chains; identify what breaks.
 
-## Step 5: Write a plain-language explanation
+### Step 2 (S2): Write a plain-language explanation
 
-Cover: what the variable does in practical terms; the specific features that depend on it (name them); what happens if left empty; what happens if set; key code file paths (no line numbers — they shift). This explanation goes into your step 7 report.
+Cover: what the variable does in practical terms; the specific features that depend on it (name them); what happens if left empty; what happens if set; key code file paths (no line numbers — they shift). This explanation goes into the S4 scope report.
 
-## Step 6: Write the user-facing description
+### Step 3 (S5): Write the user-facing description
 
 - Lead with the practical impact, not the technical mechanism
 - Name the features that require the variable (e.g., "Required for the Human Input node")
@@ -65,15 +59,17 @@ Cover: what the variable does in practical terms; the specific features that dep
 - Include relationships with other variables when relevant
 - Apply every rule in `references/style-overrides.md`
 
-## Step 7: Report and STOP
+### Step 4 (S4 contribution): Report
 
-Present to the user: the plain-language explanations, the proposed descriptions, and the codebase ref from step 2. **STOP — do not edit any documentation file until the user approves.**
+The S4 scope report presents: the plain-language explanations, the proposed descriptions, and the pinned ref. The spine's S4 gate applies.
 
-## Step 8: Edit the documentation
+### Step 5 (S5/S6): Edit the documentation
 
 Edit `en/self-host/deploy/configuration/environments.mdx` following [Document Structure](#document-structure). Update the `zh/` and `ja/` copies in the same pass, per `tools/translate/formatting-zh.md`, `tools/translate/formatting-ja.md`, and `writing-guides/glossary.md`.
 
-## Step 9: Run the verifier
+## S7 verifiers
+
+### Run the verifier
 
 The canonical command scans BOTH env sources — never pass only one:
 
@@ -88,9 +84,9 @@ python3 .claude/skills/dify-docs-env-vars/verify-env-docs.py \
 
 Output contract: on a fully clean doc the last line is `ALL CHECKS PASSED — documentation matches .env.example` and the script exits 0; otherwise it prints `TOTAL ISSUES: <n>` with per-category counts and exits 1.
 
-Pass bar for every task: **Extra in docs: 0** and **Default mismatches: 0**. **Missing from docs** is standing backlog and may stay nonzero, but no variable you touched may appear in it, and every step 3 triage var must be resolved.
+Pass bar for every task: **Extra in docs: 0** and **Default mismatches: 0**. **Missing from docs** is standing backlog and may stay nonzero, but no variable you touched may appear in it, and every release-sync-diff triage var must be resolved.
 
-## Step 10: Update `ignored-vars.md` if needed
+### Update `ignored-vars.md` if needed
 
 The verifier filters out variables listed in `ignored-vars.md` (in this skill directory). When you:
 
@@ -100,10 +96,6 @@ The verifier filters out variables listed in `ignored-vars.md` (in this skill di
 
 Every entry must include a source reference (PR, commit, or audit date).
 
-## Step 11: Post-writing checks
-
-Run the checks listed in `writing-guides/index.md#post-writing-verification`.
-
 ## Source of Truth
 
 After Dify PR #31586, the supported self-host knob surface is split across:
@@ -111,7 +103,7 @@ After Dify PR #31586, the supported self-host knob surface is split across:
 - `docker/.env.example` — essential startup values
 - `docker/envs/**/*.env.example` — categorized optional vars (core-services, databases, infrastructure, security, vectorstores, middleware)
 
-The verifier reads both — always use the canonical step 9 command, which passes both sources.
+The verifier reads both — always use the canonical verifier command above, which passes both sources.
 
 | Var location | Action |
 |---|---|
@@ -135,4 +127,4 @@ The doc groups variables by subsystem, broadly following the `docker/.env.exampl
 
 ## Reader Persona
 
-Same audience as `en/self-host/deploy/` documentation (see the `dify-docs-guides` skill): DevOps engineers and system administrators deploying Dify. Assume strong infrastructure knowledge. Readers are actively configuring a deployment and scanning for a specific variable, not reading linearly. They need to know what each variable does, when to change it, and what breaks if they get it wrong.
+Same audience as `en/self-host/deploy/` documentation (see the `dify-docs-guides` pack): DevOps engineers and system administrators deploying Dify. Assume strong infrastructure knowledge. Readers are actively configuring a deployment and scanning for a specific variable, not reading linearly. They need to know what each variable does, when to change it, and what breaks if they get it wrong.

--- a/.claude/skills/dify-docs-feature-research/SKILL.md
+++ b/.claude/skills/dify-docs-feature-research/SKILL.md
@@ -7,6 +7,15 @@ description: "Research a Dify feature before writing or optimizing documentation
 
 Pre-writing research that combines codebase analysis with community feedback to ensure documentation is grounded in both technical reality and actual user needs.
 
+## Depths
+
+When invoked from the `dify-docs-write` pipeline, its S1 supplies the feature, ref, and target pages — consume them instead of re-asking (Before Starting 1–3), and run at the depth the caller's row sets:
+
+- **full**: everything below.
+- **targeted**: Phase 1 scoped to the surfaces the caller names — the coverage gate still applies, with out-of-scope surfaces recorded as `N/A` plus why; Phase 2 runs when the caller's row requires it; otherwise skip it and say so in the summary.
+
+Standalone use (no caller): run Before Starting 1–3 and full depth.
+
 ## Before Starting
 
 1. Ask the user which feature, node, or area to research.
@@ -145,7 +154,7 @@ Present the summary to the user. STOP — do not start the writing phase until t
 
 - This skill produces research only. Do not start writing documentation until the user reviews the findings and confirms the scope.
 - Research findings exist to make the page's claims accurate, not to be exhaustively included. When recommending scope, apply the style guide's "Repeating the UI" filter: UI-discoverable mechanics stay out of the page unless especially consequential.
-- When scope is confirmed and writing begins, load the writing skill for the target tree (`dify-docs-guides` for `use-dify` guides, `dify-cli-docs` for `en/cli/` pages, `dify-docs-env-vars` for env-var docs, `dify-docs-api-reference` for API specs) plus the writing guides (`writing-guides/style-guide.md`, `formatting-guide.md`, `glossary.md`) — before the first edit. This skill carries none of the writing rules.
+- When scope is confirmed and writing begins, return to the `dify-docs-write` pipeline — it loads the doc-type rule pack and the writing guides. This skill carries none of the writing rules.
 - Flag code-inferred behavior as unverified. Ask the user to test before documenting as fact.
 - Distinguish bugs from documentation gaps. Documenting buggy behavior as intended causes more harm than leaving a gap.
 - Note issue numbers for traceability. The user may want to reference them when prioritizing what to cover.

--- a/.claude/skills/dify-docs-guides/SKILL.md
+++ b/.claude/skills/dify-docs-guides/SKILL.md
@@ -1,70 +1,35 @@
 ---
 name: dify-docs-guides
 description: >
-  Use when writing, improving, or reviewing Dify user guide documentation.
-  Covers pages in en/{cloud,self-host}/use-dify/, en/develop-plugin/, and en/self-host/deploy/.
-  Triggers: "write docs for [feature]", "improve this page",
-  "review this documentation section".
+  Rule pack for Dify user-guide pages — en/{cloud,self-host}/use-dify/,
+  en/develop-plugin/, and en/self-host/deploy/. Carries the reader personas
+  (master copy), audience-voice rules, dual-copy discipline, and env-var
+  presentation patterns. Loaded by dify-docs-write; not an entry point.
 ---
 
-# Dify Documentation Guides
+# User Guide Rules
 
-Follow the numbered workflow in order. Do not skip steps.
+Not an entry point — run under `dify-docs-write`; this pack's rules and procedures implement its stages for user-guide pages.
 
-## Step 1 — Read the guides
+## Scoping rules (S1)
 
-Read all three files before drafting or editing anything:
+Match each target page to its reader persona (see Reader Personas below). `use-dify` pages exist as two product copies — `en/cloud/use-dify/` and `en/self-host/use-dify/` — with no shared pages and no cross-audience navigation. When the page exists in both, scope both: shared-content improvements land in both copies in the same pass; audience-specific blocks (plan gating, env-var callouts, Enterprise tips) stay per-copy.
 
-1. `writing-guides/style-guide.md` — voice, tone, writing patterns. No overrides: it applies as written.
-2. `writing-guides/formatting-guide.md` — MDX formatting, Mintlify components.
-3. `writing-guides/glossary.md` — standardized terminology.
+## S2 discovery — environment variables
 
-If the task includes Chinese or Japanese content, also read `tools/translate/formatting-zh.md` or `tools/translate/formatting-ja.md` before writing that language.
+Check for feature-related environment variables. In the Dify codebase, run:
 
-## Step 2 — Research and verify
+```bash
+grep -rn "<FEATURE_KEYWORD>" docker/.env.example docker/envs/ api/configs/
+```
 
-1. Identify the target page(s) and match each to its reader persona (see Reader Personas below). `use-dify` pages exist as two product copies — `en/cloud/use-dify/` and `en/self-host/use-dify/` — with no shared pages and no cross-audience navigation. When the page exists in both, scope both: shared-content improvements land in both copies in the same pass; audience-specific blocks (plan gating, env-var callouts, Enterprise tips) stay per-copy.
-2. For a new feature page, or a rewrite that changes what the doc claims about behavior (not just wording), invoke the `dify-docs-feature-research` skill first and complete its research gate.
-3. Verify feature behavior against the Dify codebase, never against existing docs — existing docs may be outdated or wrong. Work in the Dify codebase directory configured for this session; if none is configured, ask the user for the path. Sync it per `writing-guides/index.md` section "Syncing the Dify codebase safely". For new features, use the development branch the user names; when code in flux is ambiguous, ask rather than assume.
-4. When rewriting an existing page, treat every carried-over claim as unverified: re-check permissions, defaults, option lists, navigation paths, and behavior against the code before keeping them. The most common failure mode is faithfully reproducing an outdated section.
-5. Code presence ≠ working feature. If behavior is inferred from code rather than observed in the running product, mark it unverified and ask the user to test before documenting it as fact.
-6. Check for feature-related environment variables. In the Dify codebase, run:
+Use the feature's name as it would appear in a variable (e.g. `COLLABORATION`); try 2–3 keyword variants before concluding. No matches → the feature has no env-var surface; skip the env-var guidance below. Matches → record each variable as mandatory or optional plus its default, and queue the `dify-docs-env-vars` pack's procedure in the S4 scope report, to update `en/self-host/deploy/configuration/environments.mdx` in the same session — that reference is the single source of truth for variable semantics.
 
-   ```bash
-   grep -rn "<FEATURE_KEYWORD>" docker/.env.example docker/envs/ api/configs/
-   ```
-
-   Use the feature's name as it would appear in a variable (e.g. `COLLABORATION`); try 2–3 keyword variants before concluding. No matches → the feature has no env-var surface; skip the env-var guidance in Step 4. Matches → record each variable as mandatory or optional plus its default, and invoke the `dify-docs-env-vars` skill in the same session to update `en/self-host/deploy/configuration/environments.mdx` — that reference is the single source of truth for variable semantics.
-
-## Step 3 — Report scope, then STOP
-
-If the task touches more than one page, or restructures a section (adds, moves, renames, or deletes pages or headings), report before editing:
-
-- the full path of every page you will touch
-- for each page, what changes and why
-- every claim from Step 2 you could not verify in code
-
-**STOP — do not edit any file until the user approves.** A single-page edit with no restructuring may proceed directly to Step 4, but any unverified claims must still be reported to the user, never written as fact.
-
-## Step 4 — Draft
+## Drafting rules (S5)
 
 1. Write for the persona of the page's path (see Reader Personas below).
 2. Never restate the page's own audience. Everyone on a self-host page is self-hosted and everyone on a cloud page is on Dify Cloud, so "On self-hosted deployments, …" and "On Dify Cloud, …" are banned on their own pages. Audience qualifiers are legitimate only on the audience-neutral trees (`en/learn/`, `en/api-reference/`, `en/cli/`, `en/develop-plugin/`), where they genuinely disambiguate. Two carve-outs are deliberate and stay: naming a different product (the `<Tip>` surfacing Dify Enterprise where a CE capability ends — see "Paid Feature Callouts" in the style guide), and a comparative-advantage claim, where the qualifier marks something this product has that the other lacks ("On Dify Cloud, many popular trigger integrations are pre-configured" — the point is the perk, not the scope). Scoping restatement is banned; advantage framing is not.
-3. If Step 2.6 found related environment variables, present them per Environment Variables in User Guides below.
-
-## Step 5 — Translate
-
-Every English change ships all three languages. Update `zh/` and `ja/` in the same pass per `tools/translate/formatting-{zh,ja}.md` and `writing-guides/glossary.md`.
-
-## Step 6 — Run the check chain
-
-Invoke these skills in order (the chain is defined in `writing-guides/index.md` section "Post-Writing Verification"). Do not restate their rules or hand-roll their checks — invoke them:
-
-1. `dify-docs-format-check`
-2. `dify-docs-terminology-check`
-3. `dify-docs-reader-test`
-
-Fix what they flag and re-run until each reports clean, then report the results to the user.
+3. If S2 discovery found related environment variables, present them per Environment Variables in User Guides below.
 
 ## Reader Personas
 
@@ -89,16 +54,16 @@ The user brings documentation expertise and user empathy; you bring AI domain kn
 
 ## Environment Variables in User Guides
 
-Applies when Step 2.6 found related variables. The two product copies fork — never mix the patterns:
+Applies when S2 discovery found related variables. The two product copies fork — never mix the patterns:
 
-- **Self-host copy** (`en/self-host/use-dify/`): name the mandatory variables and the values to set in a callout (rules below), and link to the reference. `environments.mdx` (maintained via `dify-docs-env-vars`) owns everything else: defaults, mechanisms (worker classes, proxy paths, scheme rules, fallbacks), interactions, and failure modes.
+- **Self-host copy** (`en/self-host/use-dify/`): name the mandatory variables and the values to set in a callout (rules below), and link to the reference. `environments.mdx` (maintained via the `dify-docs-env-vars` pack) owns everything else: defaults, mechanisms (worker classes, proxy paths, scheme rules, fallbacks), interactions, and failure modes.
 - **Cloud copy** (`en/cloud/use-dify/`): never any env-var content. A feature that is simply on in Dify Cloud gets nothing; a plan-limited feature gets the plan-gating pattern (`<Badge color="blue">Professional</Badge> and <Badge color="blue">Team</Badge>` in prose with a [Learn more](https://dify.ai/pricing) link — see "Paid Feature Callouts" in the style guide).
 
 In the self-host copy:
 
 1. Place the configuration in a callout, never a dedicated H2 section. Configuration enablement is an aside to the page's task flow, and the defaults and mechanics live one click away in the env reference.
 2. Pick the callout type: `<Note>` when the variables are mandatory (the feature does not work at all without them); `<Info>` when they only customize behavior that already works.
-3. Use this pattern — open with the feature state, never an audience qualifier (Step 4.2):
+3. Use this pattern — open with the feature state, never an audience qualifier (Drafting rule 2):
 
    ```mdx
    <Note>

--- a/.claude/skills/dify-docs-reader-test/SKILL.md
+++ b/.claude/skills/dify-docs-reader-test/SKILL.md
@@ -12,7 +12,7 @@ Verify a finished document by having a clean-context agent read it as the target
 
 ## Procedure
 
-1. **Get the persona.** Copy the reader persona verbatim from the writing skill used for the task: `dify-docs-guides` (Reader Personas, by document path), `dify-docs-env-vars` (Reader Persona), `dify-docs-api-reference` (Reader Persona), or `dify-cli-docs` (Reader segments). If the task used no writing skill with a persona, ask the user who the target reader is before dispatching.
+1. **Get the persona.** Copy the reader persona verbatim from the rule pack used for the task: `dify-docs-guides` (Reader Personas, by document path), `dify-docs-env-vars` (Reader Persona), `dify-docs-api-reference` (Reader Persona), or `dify-cli-docs` (Reader segments). If the task used no rule pack with a persona, ask the user who the target reader is before dispatching.
 2. **Dispatch one fresh subagent per document** with the Agent tool (`subagent_type: general-purpose`). Never run the test inline in the current conversation — this conversation contains the source context the reader must not have. The dispatch prompt is the template below verbatim, with two placeholders filled:
    - `{PATH}` — the absolute path to the finished document file. The input is the path, never pasted content: the test must run against the file on disk, not a possibly stale copy from the conversation.
    - `{PERSONA}` — the persona text from step 1, unmodified.

--- a/.claude/skills/dify-docs-release-sync/SKILL.md
+++ b/.claude/skills/dify-docs-release-sync/SKILL.md
@@ -12,7 +12,7 @@ description: >
 
 ## Overview
 
-Compares code changes between two Dify releases (or a release and a pinned commit), identifies documentation impact, generates a structured report, then executes updates after user approval. Three tracks: API reference (-> `dify-docs-api-reference`), help documentation (-> `dify-docs-guides`), and environment variables (-> `dify-docs-env-vars`).
+Compares code changes between two Dify releases (or a release and a pinned commit), identifies documentation impact, generates a structured report, then executes updates after user approval. Three tracks: API reference, help documentation, and environment variables. Execution runs through the `dify-docs-write` pipeline with the matching rule pack; the approved report from this skill satisfies its S4 scope gate (the pipeline prints `S4 satisfied upstream`).
 
 **Input**: Two version references, provided by the user. Always ask if not provided.
 - Post-release: `v1.13.2` and `v1.13.3` (both tags)
@@ -220,13 +220,13 @@ python3 "$DOCS/tools/api-pipeline/parity_check.py"  # prints "TOTAL PARITY ISSUE
 
 ### Help Documentation Updates
 
-For each affected doc page, use `dify-docs-guides` skill:
+For each affected doc page, run `dify-docs-write` (row R5 update; S4 satisfied by the approved report; the `dify-docs-guides` pack loads automatically):
 1. Read the current doc and the relevant PR(s) for context
 2. Update content to reflect changes — both product copies (`en/cloud/...` and `en/self-host/...`) where the page exists in both; shared content lands in both, audience-specific blocks (plan gating, env-var callouts, Enterprise tips) stay per-copy
 
 ### Environment Variable Updates
 
-For each affected variable group, use `dify-docs-env-vars` skill:
+For each affected variable group, run `dify-docs-write` (row R5; S4 satisfied by the approved report; the `dify-docs-env-vars` pack loads automatically — its standalone release-sync diff procedure supplies the variable set):
 1. Trace the variable in the release codebase
 2. Update `en/self-host/deploy/configuration/environments.mdx`
 3. Run that skill's verification script; it must report zero mismatches

--- a/.claude/skills/dify-docs-write/SKILL.md
+++ b/.claude/skills/dify-docs-write/SKILL.md
@@ -39,7 +39,7 @@ Every writing task runs the same eight stages. The work-type row sets each stage
 | `en/cli/` | `dify-cli-docs` |
 | any other path (e.g. `en/learn/`) | none — the writing guides alone govern |
 
-3. Read now, before any other work: `writing-guides/style-guide.md`, `writing-guides/formatting-guide.md`, `writing-guides/glossary.md`; the rule pack's SKILL.md plus every reference it names; `references/task-analysis.md` in this skill. If the task includes zh or ja content, also `tools/translate/formatting-zh.md` / `formatting-ja.md`.
+3. Read now, before any other work: `writing-guides/style-guide.md`, `writing-guides/formatting-guide.md`, `writing-guides/glossary.md`; the rule pack's SKILL.md plus every reference it names; `references/task-analysis.md` in this skill. If the task includes zh or ja content, also `tools/translate/formatting-{zh,ja}.md`.
 
 4. Print the route before starting S1: `ROUTE: row=<R#> pack=<name|none> pages=<paths>`.
 

--- a/.claude/skills/dify-docs-write/SKILL.md
+++ b/.claude/skills/dify-docs-write/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: dify-docs-write
+description: >
+  The entry point for writing or revising ANY documentation in this repo —
+  user guides, deployment pages, plugin-dev pages, API specs, the env-var
+  reference, CLI pages. Resolves the work type and doc type, then runs the
+  eight-stage pipeline (intake → research → task analysis → scope gate →
+  draft → translate → verify → close). Triggers: "write docs for X",
+  "document X", "update this page", "fix/correct this doc",
+  "rewrite/optimize X", "add a page for X".
+---
+
+# Docs Writing Pipeline
+
+Every writing task runs the same eight stages. The work-type row sets each stage's depth; the doc-type rule pack supplies surface-specific procedures. A stage either runs and ends with its deliverable, or prints why not — never a silent skip:
+
+- Skipped: `S<n>: N/A per <row>`
+- Modified: `S<n> modified per <row or pack>: <how>`
+
+## Step 1 — Route and load
+
+1. Pick the work-type row. Test predicates in order; first match wins:
+
+| Row | Work type | Entry predicate |
+|---|---|---|
+| R1 | Pre-release feature | The feature is in no shipped release (its code lives on a development branch or behind an unreleased tag) |
+| R2 | New page | A target page does not exist yet |
+| R3 | Correction | A named existing claim is wrong or outdated, and the fix adds or removes no sections |
+| R4 | Rewrite / optimization | The task changes page structure (sections added, removed, or reordered; pages split or merged) |
+| R5 | Update | Any other change to existing pages (shipped product change; new content within the existing structure) |
+
+2. Pick the rule pack from the target path; most specific match wins. Rule packs are not entry points — this skill loads them:
+
+| Target path | Rule pack |
+|---|---|
+| `en/self-host/deploy/configuration/environments.mdx` | `dify-docs-env-vars` |
+| `en/{cloud,self-host}/use-dify/`, `en/self-host/deploy/`, `en/develop-plugin/` | `dify-docs-guides` |
+| `{en,zh,ja}/api-reference/` | `dify-docs-api-reference` |
+| `en/cli/` | `dify-cli-docs` |
+| any other path (e.g. `en/learn/`) | none — the writing guides alone govern |
+
+3. Read now, before any other work: `writing-guides/style-guide.md`, `writing-guides/formatting-guide.md`, `writing-guides/glossary.md`; the rule pack's SKILL.md plus every reference it names; `references/task-analysis.md` in this skill. If the task includes zh or ja content, also `tools/translate/formatting-zh.md` / `formatting-ja.md`.
+
+4. Print the route before starting S1: `ROUTE: row=<R#> pack=<name|none> pages=<paths>`.
+
+Depth at a glance (the imperatives live in the stage sections below):
+
+| | S2 Research | S3 Task analysis | S4 Gate | S5 Draft |
+|---|---|---|---|---|
+| R1 pre-release | full, dev branch | full | STOP | outline gate + sections |
+| R2 new page | full | full | STOP | outline gate + sections |
+| R3 correction | claim only | three questions | report; STOP only if multi-page | single diff |
+| R4 rewrite | full + re-verify carried claims | full | STOP | outline gate + sections |
+| R5 update | targeted | delta | STOP | per-page diffs |
+
+## S1 — Intake
+
+1. Record the trigger (user request, issue, or release task) and the target pages. For any `use-dify` page, list BOTH audience copies' paths and scope shared vs per-copy changes (the guides pack's dual-copy rules).
+2. Pin the code ref per `writing-guides/index.md` § "Syncing the Dify codebase safely" (R1: the development branch the user names). Every later claim cites this ref.
+3. Deliverable — task header: `trigger | row | pack | pages | ref`.
+
+## S2 — Research
+
+1. By row:
+   - R1, R2, R4: invoke `dify-docs-feature-research` at **full** depth. R4 additionally treats every claim carried over from the current page as unverified and re-checks it.
+   - R5: invoke `dify-docs-feature-research` at **targeted** depth, scoped to the surfaces the change touches.
+   - R3: do not invoke the module. Verify the disputed claim directly at the pinned ref (`git show`) and record `file:line` evidence.
+2. Run every procedure the pack labels **S2 discovery** (e.g. the guides pack's env-var grep). Record each result, including "no match".
+3. Universal rules: verify against code, never against existing docs; code presence ≠ working feature — behavior inferred from code is flagged unverified, reported at S4, and never written as fact.
+4. Deliverable: the module's research summary, or the claim-verification note (R3), plus discovery results.
+
+## S3 — Task analysis
+
+1. Apply `references/task-analysis.md` at the row's depth: R1/R2/R4 **full**; R5 **delta**; R3 **three-question** (answers go inside the S4 report).
+2. Deliverable: task list and routed question list with stable IDs (`T1…`, `Q1…`) per the reference's output schema.
+
+## S4 — Scope gate
+
+1. Report: every page and its planned changes; all unverified claims; the question routing (per Q: docs / ui-finding / product-gap); any pack procedures queued by S2 discovery.
+2. STOP for approval. Two exceptions:
+   - R3 touching a single page: print the report and proceed.
+   - Arriving from an approved release-sync report: print `S4 satisfied upstream (release-sync report approved <date>)` and proceed.
+3. Deliverable: the scope report.
+
+## S5 — Draft
+
+1. The pack's procedures govern structure and content. No pack → the writing guides alone.
+2. R1/R2/R4, per page: outline gate first. Propose the sections; for each, what it includes AND deliberately excludes; and the rationale — each section cites a T/Q id, ordering follows the user journey, each exclusion states its reason. STOP for outline approval, then draft ONE section at a time, pausing for review after each.
+3. R5: draft and present per-page diffs. R3: present the single diff.
+4. Universal: uncertain content is omitted, never hedged — record each omission and what resolves it; frontmatter descriptions are written last; concept sections describe, task pages instruct, task lists state objectives. On any conflict, the writing guides win over this skill and over packs.
+5. Deliverable: approved outlines and drafted sections, or diffs.
+
+## S6 — Translate
+
+1. Every English change ships `zh/` and `ja/` in the same pass, per `tools/translate/formatting-{zh,ja}.md` and the glossary. Packs may modify this stage (the API pack edits all three specs directly and gates on `parity_check`).
+2. New pages: register navigation for all three languages in `docs.json` in the same PR.
+3. Deliverable: three languages done + navigation registered (or the printed modification).
+
+## S7 — Verify
+
+1. Run the check chain per `writing-guides/index.md` § "Post-Writing Verification": `dify-docs-format-check` → `dify-docs-terminology-check` → `dify-docs-reader-test`. Fix findings and re-run until each reports clean.
+2. Run every check the pack labels **S7 verifier**, gating on the success output each one names.
+3. Deliverable: the printed check results.
+
+## S8 — Close
+
+1. Report: what changed; unresolved items and follow-ups; glossary additions for new terms (or "none"); affected sibling copies (the cloud/self-host dual-copy trees).
+2. Deliverable: the closing report.

--- a/.claude/skills/dify-docs-write/references/task-analysis.md
+++ b/.claude/skills/dify-docs-write/references/task-analysis.md
@@ -1,0 +1,43 @@
+# Task Analysis & Reader Questions (S3)
+
+The pre-draft half of reader empathy: establish what readers are trying to do and what they will wonder, before any prose exists. (`dify-docs-reader-test` is the post-draft half.)
+
+## Output schema (every depth)
+
+```
+## Tasks
+- T1 [journey: set up | build | maintain | verify | consume]: I want to <objective>
+## Questions
+- Q1 (T1): <what the reader wonders or overlooks> — answer: <one sentence + evidence, or OPEN>
+  route: docs → <page/section> | ui-finding | product-gap
+```
+
+Rules: every task is a user objective passing the "I want to ___" test — never a feature description. Every question carries exactly one route. OPEN questions are never dropped; they go into the S4 report.
+
+## Depths
+
+**Full (R1 / R2 / R4)**
+
+1. Build the task list from the S2 research; cluster by journey. Cross-check against S2's community pain themes: each theme maps to a task, or is listed as explicitly out of scope.
+2. Question walk — per task, walk its steps in the product. At each step answer four fixed prompts; write "none" when a prompt yields nothing (the prompt must still be answered):
+   - **prereqs**: what must exist or be true before starting?
+   - **mid-task**: what does the reader wonder right here?
+   - **overlooked**: what detail, skipped now, breaks something later?
+   - **success**: how does the reader confirm it worked?
+3. Evidence check: answer immediately whatever S2 already answered, citing the evidence. Everything else is OPEN.
+
+**Delta (R5)**
+
+List only the tasks the change affects. For each, state what changes: steps, prereqs, limits, or outcome. Apply the four prompts to the changed steps only.
+
+**Three-question (R3)**
+
+Answer inside the S4 report: who is the reader; what task are they mid-way through; what must this text answer to keep them moving.
+
+## Routing tests
+
+- **docs** — the answer changes what the reader does and is not visible in the UI at the moment of need. Apply the style guide's "Repeating the UI" filter: UI-discoverable mechanics stay out of pages unless especially consequential.
+- **ui-finding** — the answer belongs at the moment of need (a label, placeholder, tooltip, empty state, or default). A UI→docs help link is justified only when the decision is consequential AND the answer does not fit in a sentence AND the reader can act on what they would read there.
+- **product-gap** — no good answer exists in the product or the docs.
+
+ui-finding and product-gap items go into the S4 and S8 reports for maintainers to route onward. Never compensate for them silently in docs prose.

--- a/writing-guides/index.md
+++ b/writing-guides/index.md
@@ -2,20 +2,12 @@
 
 ## Which Skill to Use
 
-| Task | Skill | Paths | References |
-|:-----|:------|:------|:-----------|
-| Research a feature before writing | dify-docs-feature-research | — | dify and graphon codebases (graphon owns built-in workflow nodes, engine, runtime, model_runtime; verify against the graphon version pinned in `dify/api/pyproject.toml`), GitHub Issues in both repos |
-| Write or improve a user guide | dify-docs-guides | `en/{cloud,self-host}/use-dify/`, `en/develop-plugin/`, `en/self-host/deploy/` | style-guide, formatting-guide, glossary |
-| Write or audit API reference specs | dify-docs-api-reference | `en/api-reference/` | style-guide, formatting-guide, glossary |
-| Write or audit env var docs | dify-docs-env-vars | `en/self-host/deploy/configuration/environments.mdx` | style-guide, formatting-guide, glossary |
-| Write or edit Dify CLI (`difyctl`) docs | dify-cli-docs | `en/cli/` | style-guide, formatting-guide, glossary |
-| Prepare doc updates for a Dify release | dify-docs-release-sync | — | dify codebase diffed between two pinned version refs; routes into the api-reference, guides, and env-vars skills |
+| Task | Skill |
+|:-----|:------|
+| Write or revise any documentation — guides, API specs, env vars, CLI pages, or anything else | dify-docs-write — resolves the work type, loads the doc-type rule pack, and runs the stage pipeline |
+| Prepare doc updates for a Dify release | dify-docs-release-sync — diffs the codebase between two pinned version refs, then hands execution to dify-docs-write |
 
-When paths overlap, the most specific match takes precedence.
-
-## Without a Skill
-
-If no skill matches your task (e.g., fixing a typo, updating navigation), follow the style guide and formatting guide directly.
+Everything else (research, rule packs, checks) is loaded by these two — start here, not there.
 
 ## Post-Writing Verification
 


### PR DESCRIPTION
- new .claude/skills/dify-docs-write: eight-stage writing pipeline with work-type routing predicates, per-row depth, and stage deliverables; references/task-analysis.md carries the S3 method
- dify-docs-guides, dify-docs-env-vars, dify-docs-api-reference, and dify-cli-docs become rule packs: entry workflows move to the pipeline, doc-type procedures and unique verifiers stay
- dify-docs-feature-research gains caller depth semantics (full/targeted) and hands back to the pipeline
- writing-guides/index.md router reduced to two entries; release-sync tracks execute via the pipeline with the scope gate satisfied by the approved report; reader-test persona pointer follows the pack naming

Behavior changes: API-spec tasks gain a scope-gate stop; CLI tasks gain the translate stage (en/cli ships all three languages).