### PR TITLE
docs: add RustFS configuration documentation for S3 storage

### DIFF
--- a/en/self-host/deploy/configuration/environments.mdx
+++ b/en/self-host/deploy/configuration/environments.mdx
@@ -446,13 +446,33 @@ For all available schemes and their configuration options, see the [OpenDAL serv
 
 | Variable | Default | Description |
 |---|---|---|
-| `S3_ENDPOINT` | (empty) | S3 endpoint address. Required for non-AWS S3-compatible services (MinIO, etc.). |
+| `S3_ENDPOINT` | (empty) | S3 endpoint address. Required for non-AWS S3-compatible services (MinIO, RustFS, etc.). |
 | `S3_REGION` | `us-east-1` | S3 region. |
 | `S3_BUCKET_NAME` | `difyai` | S3 bucket name. |
 | `S3_ACCESS_KEY` | (empty) | S3 Access Key. Not needed when using IAM roles. |
 | `S3_SECRET_KEY` | (empty) | S3 Secret Key. Not needed when using IAM roles. |
 | `S3_ADDRESS_STYLE` | `auto` | S3 addressing style: `auto`, `path`, or `virtual`. Controls whether bucket names appear in the URL path (`path`) or as a subdomain (`virtual`). Only applies when `S3_USE_AWS_MANAGED_IAM` is `false`. |
 | `S3_USE_AWS_MANAGED_IAM` | `false` | Use AWS IAM roles (EC2 instance profile, ECS task role) instead of explicit access key/secret key. When enabled, credentials are auto-discovered from the instance metadata. |
+
+<Tip>
+**RustFS Configuration**
+
+When using [RustFS](https://rustfs.com/) as your S3-compatible storage:
+
+- Use port **9000** for the S3 API endpoint (not port 9001, which is the web console)
+- Set `S3_ADDRESS_STYLE` to `path` for proper bucket addressing
+- Example: `S3_ENDPOINT=http://your-rustfs-server:9000`
+
+```bash
+STORAGE_TYPE=s3
+S3_ENDPOINT=http://your-rustfs-server:9000
+S3_REGION=us-east-1
+S3_BUCKET_NAME=dify
+S3_ACCESS_KEY=your-access-key
+S3_SECRET_KEY=your-secret-key
+S3_ADDRESS_STYLE=path
+```
+</Tip>
 
 </Accordion>
 


### PR DESCRIPTION
## Description

[RustFS](https://github.com/rustfs/rustfs) is a S3-compatible object storage, and adding [RustFS](https://rustfs.com/) as a documented S3-compatible storage option for Dify self-hosted deployments.

### Changes

1. **S3_ENDPOINT description**: Added RustFS alongside MinIO as an example of S3-compatible service
2. **Configuration tip**: Added a dedicated tip section with RustFS-specific configuration details

### RustFS Configuration Details

The documentation includes important notes for RustFS users:
- **S3 API Port**: RustFS uses port 9000 for S3 API (not port 9001 which is the web console)
- **Address Style**: Must set `S3_ADDRESS_STYLE=path` for proper bucket addressing
- **Complete Example**: Provided a full configuration example

### Configuration Example

```bash
STORAGE_TYPE=s3
S3_ENDPOINT=http://your-rustfs-server:9000
S3_REGION=us-east-1
S3_BUCKET_NAME=dify
S3_ACCESS_KEY=your-access-key
S3_SECRET_KEY=your-secret-key
S3_ADDRESS_STYLE=path
```
