### PR TITLE
docs: document Rust local runtime rollout

### DIFF
--- a/en/self-host/deploy/configuration/environments.mdx
+++ b/en/self-host/deploy/configuration/environments.mdx
@@ -1404,6 +1404,35 @@ The remaining variables configure the bundled services or derive from your exist
 | `SHELLCTL_ENABLE_PATH_ISOLATION` | `true` | Kernel-enforced (Landlock) limits on which paths the sandbox can read and write. Requires Linux 5.13 or later; on older kernels the sandbox logs a warning and runs without it. Set in `docker/envs/core-services/local-sandbox.env`; `.env` values don't reach the sandbox container. |
 | `DIFY_AGENT_SHELL_REDACT_PATTERNS` | (empty) | JSON array of regex patterns masked out of shell output before the agent reads it, for secrets like API keys; the agent's internal bearer token is always masked. Set in `docker/envs/core-services/dify-agent.env`; Compose doesn't forward it from `.env`. |
 
+### Test the Optional Rust Local Runtime
+
+The Go local sandbox remains the default. To send a small percentage of new local sandbox bindings to the optional Rust runtime, start Docker Compose with its overlay:
+
+```bash
+cd docker
+DIFY_AGENT_LOCAL_SANDBOX_RUST_CANARY_PERCENT=1 \
+  docker compose \
+  -f docker-compose.yaml \
+  -f docker-compose.rust-runtime.yaml \
+  up -d --build
+```
+
+The overlay builds and starts the Rust service alongside the Go service. The two runtimes use separate SQLite, tmux, home, workspace, and snapshot state.
+
+| Variable | Default | Description |
+|---|---|---|
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_IMAGE` | `dify-agent-local-sandbox-rust:local` | Rust local sandbox image used by the Compose overlay. |
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_ENDPOINT` | (empty) | Rust service address. The overlay sets it to `http://local_sandbox_rust:5004`. Required when the canary percentage is greater than `0`. |
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_AUTH_TOKEN` | (empty) | Optional bearer token for Rust sandbox calls. When omitted, the overlay uses the Go sandbox token. |
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_CANARY_PERCENT` | `0` | Percentage of new, unowned bindings assigned to Rust, from `0` to `100`. The overlay defaults to `100` unless you set this variable. |
+| `DIFY_AGENT_LOCAL_SANDBOX_PREFLIGHT_TIMEOUT_SECONDS` | `1` | Rust health preflight timeout before a new binding falls back to Go. |
+
+The agent backend assigns only new, unowned bindings. Assignment is deterministic, and an unsuccessful Rust health preflight sends the new binding to Go. Existing Go resources keep their current representation. Rust-owned references use a `rust+` prefix and stay assigned to Rust for their full lifecycle. After a mutating request reaches one runtime, Dify never replays it against the other runtime.
+
+<Warning>
+To stop new Rust assignments, set `DIFY_AGENT_LOCAL_SANDBOX_RUST_CANARY_PERCENT=0` while keeping the Rust endpoint configured and its service running. Remove the overlay only after every `rust+` binding, workspace, and home snapshot has drained. Removing the Rust service earlier strands those resources.
+</Warning>
+
 ## Database Service
 
 These configure the database containers directly in Docker Compose.

--- a/ja/self-host/deploy/configuration/environments.mdx
+++ b/ja/self-host/deploy/configuration/environments.mdx
@@ -1396,6 +1396,35 @@ API が Agent バックエンドにアクセスするためのアドレスです
 | `SHELLCTL_ENABLE_PATH_ISOLATION` | `true` | カーネルレベルの Landlock でサンドボックスが読み書きできるパスを制限する。Linux 5.13 以降が必要。未対応のカーネルでは警告を記録し、分離なしで実行される。`docker/envs/core-services/local-sandbox.env` で設定する。`.env` の値はサンドボックスコンテナには渡されない。 |
 | `DIFY_AGENT_SHELL_REDACT_PATTERNS` | （空） | シェル出力を Agent が読む前にマスクする正規表現の JSON 配列。API キーなどの機密を保護する。Agent の内部トークンは常にマスクされる。`docker/envs/core-services/dify-agent.env` で設定する。Compose は `.env` からこの値を転送しない。 |
 
+### オプションの Rust ローカルランタイムのテスト
+
+Go ローカルサンドボックスが引き続きデフォルトです。新しいローカルサンドボックスのバインディングを一部だけ Rust に割り当てるには、Docker Compose のオーバーレイを使用します。
+
+```bash
+cd docker
+DIFY_AGENT_LOCAL_SANDBOX_RUST_CANARY_PERCENT=1 \
+  docker compose \
+  -f docker-compose.yaml \
+  -f docker-compose.rust-runtime.yaml \
+  up -d --build
+```
+
+オーバーレイは Go サービスを残したまま Rust サービスをビルドして起動します。2 つのランタイムは SQLite、tmux、Home、Workspace、Snapshot の状態を共有しません。
+
+| 変数 | デフォルト値 | 説明 |
+|---|---|---|
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_IMAGE` | `dify-agent-local-sandbox-rust:local` | Compose オーバーレイが使用する Rust ローカルサンドボックスイメージ。 |
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_ENDPOINT` | （空） | Rust サービスのアドレス。オーバーレイでは `http://local_sandbox_rust:5004` になる。カナリア比率が `0` より大きい場合は必須。 |
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_AUTH_TOKEN` | （空） | Rust サンドボックス呼び出し用の任意の Bearer トークン。未設定の場合、オーバーレイは Go サンドボックスのトークンを使用する。 |
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_CANARY_PERCENT` | `0` | 新規かつ所有先が未決定のバインディングを Rust に割り当てる比率。`0` から `100` まで。未設定の場合、オーバーレイのデフォルトは `100`。 |
+| `DIFY_AGENT_LOCAL_SANDBOX_PREFLIGHT_TIMEOUT_SECONDS` | `1` | Rust のヘルス事前確認のタイムアウト秒数。失敗すると新しいバインディングを Go に割り当てる。 |
+
+Agent バックエンドは、新規かつ所有先が未決定のバインディングだけにランタイムを割り当てます。割り当ては決定論的です。Rust のヘルス事前確認に失敗すると Go を使用します。既存の Go リソースの表現は変わりません。Rust が所有する参照には `rust+` プレフィックスが付きます。そのライフサイクル全体で Rust に固定されます。状態を変更するリクエストが一方のランタイムに到達した後、Dify はもう一方のランタイムでそのリクエストを再実行しません。
+
+<Warning>
+Rust への新規割り当てを停止するには、`DIFY_AGENT_LOCAL_SANDBOX_RUST_CANARY_PERCENT` を `0` に設定します。Rust のエンドポイント設定とサービスは維持してください。`rust+` プレフィックス付きの Binding、Workspace、Home Snapshot がすべて排出されてから、オーバーレイを削除してください。先に Rust サービスを削除すると、これらのリソースにアクセスできなくなります。
+</Warning>
+
 ## データベースサービス
 
 Docker Compose でデータベースコンテナを直接設定します。

--- a/zh/self-host/deploy/configuration/environments.mdx
+++ b/zh/self-host/deploy/configuration/environments.mdx
@@ -1400,6 +1400,35 @@ API 访问 Agent 后端所用的地址。在 Docker Compose 中保持默认值�
 | `SHELLCTL_ENABLE_PATH_ISOLATION` | `true` | 通过内核级 Landlock 机制限制沙箱可读写的路径。需要 Linux 5.13 及以上；内核不支持时，沙箱会记录警告并在无隔离状态下运行。在 `docker/envs/core-services/local-sandbox.env` 中设置；`.env` 中的值不会传给沙箱容器。 |
 | `DIFY_AGENT_SHELL_REDACT_PATTERNS` | （空） | JSON 正则数组，命中的内容会在 Agent 读取命令行输出前被遮盖，用于保护 API 密钥等机密；Agent 的内部令牌始终会被遮盖。在 `docker/envs/core-services/dify-agent.env` 中设置；Compose 不会从 `.env` 转发该值。 |
 
+### 测试可选的 Rust 本地运行时
+
+Go 本地沙箱仍为默认实现。如需将少量新建的本地沙箱绑定分配给可选的 Rust 运行时，请通过对应的 Docker Compose 覆盖文件启动服务：
+
+```bash
+cd docker
+DIFY_AGENT_LOCAL_SANDBOX_RUST_CANARY_PERCENT=1 \
+  docker compose \
+  -f docker-compose.yaml \
+  -f docker-compose.rust-runtime.yaml \
+  up -d --build
+```
+
+该覆盖文件会构建并启动 Rust 服务，同时保留 Go 服务。两个运行时分别使用独立的 SQLite、tmux、Home、Workspace 和 Snapshot 状态。
+
+| 变量 | 默认值 | 说明 |
+|---|---|---|
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_IMAGE` | `dify-agent-local-sandbox-rust:local` | Docker Compose 覆盖文件使用的 Rust 本地沙箱镜像。 |
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_ENDPOINT` | （空） | Rust 服务地址。覆盖文件会将其设为 `http://local_sandbox_rust:5004`。灰度比例大于 `0` 时必须配置。 |
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_AUTH_TOKEN` | （空） | Rust 沙箱调用使用的可选 Bearer 令牌。未设置时，覆盖文件使用 Go 沙箱的令牌。 |
+| `DIFY_AGENT_LOCAL_SANDBOX_RUST_CANARY_PERCENT` | `0` | 分配给 Rust 的新建且尚无归属绑定的百分比，取值范围为 `0` 至 `100`。如未设置，覆盖文件默认为 `100`。 |
+| `DIFY_AGENT_LOCAL_SANDBOX_PREFLIGHT_TIMEOUT_SECONDS` | `1` | Rust 健康预检的超时时间（秒）。预检失败时，新绑定会回退到 Go。 |
+
+Agent 后端只会为新建且尚无归属的绑定选择运行时。分配结果是确定性的；Rust 健康预检失败时，新绑定会分配给 Go。已有的 Go 资源保持原有表示方式。Rust 资源引用带有 `rust+` 前缀，并在整个生命周期内保持分配给 Rust。变更状态的请求到达一个运行时后，Dify 不会在另一个运行时重放该请求。
+
+<Warning>
+如需停止向 Rust 分配新绑定，请将 `DIFY_AGENT_LOCAL_SANDBOX_RUST_CANARY_PERCENT` 设为 `0`，同时保留 Rust 端点配置并继续运行 Rust 服务。所有带 `rust+` 前缀的 Binding、Workspace 和 Home Snapshot 都排空后，才能移除覆盖文件。提前移除 Rust 服务会导致这些资源无法访问。
+</Warning>
+
 ## 数据库服务
 
 这些变量直接在 Docker Compose 中配置数据库容器。


### PR DESCRIPTION
## Summary

- document the opt-in Docker Compose overlay for the Rust local sandbox runtime
- explain deterministic canary assignment, bounded preflight fallback, and sticky runtime ownership
- document the safe rollback and resource-drain procedure
- update the English, Chinese, and Japanese environment references together

Depends on [langgenius/dify#41070](https://github.com/langgenius/dify/pull/41070).

## Validation

- `python3 tools/check-links.py --internal`
- `python3 tools/translate/derive-termbase.py --check`
- `mintlify validate`
- `git diff --check`
