### PR TITLE
feat: scope release-branch edits to self-host and fix table conventions

### DIFF
--- a/.claude/skills/dify-docs-format-check/check-format-cjk.py
+++ b/.claude/skills/dify-docs-format-check/check-format-cjk.py
@@ -736,6 +736,8 @@ def check_ja_sentence_length(lines: list[str]) -> list[Violation]:
         if HEADING_RE.match(line):
             continue
         s = _strip_code_and_urls(line).strip()
+        # <br/> tags are line breaks, not prose: treat them as sentence boundaries
+        s = re.sub(r'<br\s*/?>', '。', s)
         if not CJK_RE.search(s):
             continue
         # split on Japanese sentence-ending punctuation, then count chars

--- a/.claude/skills/dify-docs-guides/SKILL.md
+++ b/.claude/skills/dify-docs-guides/SKILL.md
@@ -13,7 +13,7 @@ Not an entry point — run under `dify-docs-write`; this pack's rules and proced
 
 ## Scoping rules (S1)
 
-Match each target page to its reader persona (see Reader Personas below). `use-dify` pages exist as two product copies — `en/cloud/use-dify/` and `en/self-host/use-dify/` — with no shared pages and no cross-audience navigation. When the page exists in both, scope both: shared-content improvements land in both copies in the same pass; audience-specific blocks (plan gating, env-var callouts, Enterprise tips) stay per-copy. Exception — work on a `release/<version>` branch edits only the self-host copy; the cloud copy follows Cloud's own release lane (see the dify-docs-release-sync skill § Docs Branch).
+Match each target page to its reader persona (see Reader Personas below). `use-dify` pages exist as two product copies — `en/cloud/use-dify/` and `en/self-host/use-dify/` — with no shared pages and no cross-audience navigation. When the page exists in both, scope both: shared-content improvements land in both copies in the same pass; audience-specific blocks (plan gating, env-var callouts, Enterprise tips) stay per-copy. Exception — work on a `release/<version>` branch edits only the self-host copy, still in all three languages; what it excludes is the cloud copy, which follows Cloud's own release lane (see the dify-docs-release-sync skill § Docs Branch).
 
 ## S2 discovery — environment variables
 

--- a/.claude/skills/dify-docs-guides/SKILL.md
+++ b/.claude/skills/dify-docs-guides/SKILL.md
@@ -13,7 +13,7 @@ Not an entry point — run under `dify-docs-write`; this pack's rules and proced
 
 ## Scoping rules (S1)
 
-Match each target page to its reader persona (see Reader Personas below). `use-dify` pages exist as two product copies — `en/cloud/use-dify/` and `en/self-host/use-dify/` — with no shared pages and no cross-audience navigation. When the page exists in both, scope both: shared-content improvements land in both copies in the same pass; audience-specific blocks (plan gating, env-var callouts, Enterprise tips) stay per-copy.
+Match each target page to its reader persona (see Reader Personas below). `use-dify` pages exist as two product copies — `en/cloud/use-dify/` and `en/self-host/use-dify/` — with no shared pages and no cross-audience navigation. When the page exists in both, scope both: shared-content improvements land in both copies in the same pass; audience-specific blocks (plan gating, env-var callouts, Enterprise tips) stay per-copy. Exception — work on a `release/<version>` branch edits only the self-host copy; the cloud copy follows Cloud's own release lane (see the dify-docs-release-sync skill § Docs Branch).
 
 ## S2 discovery — environment variables
 

--- a/.claude/skills/dify-docs-release-sync/SKILL.md
+++ b/.claude/skills/dify-docs-release-sync/SKILL.md
@@ -198,6 +198,8 @@ After user approval (they may add, remove, or adjust items):
 
 Docs for an upcoming release integrate on that release's branch in dify-docs (`release/<version>`, cut from `main` when prep starts) — release doc PRs target it, never `main`; the branch merges into `main` when the release ships. Fixes to currently published docs still target `main` directly.
 
+**Copy scope follows the branch.** Release-branch work edits ONLY the `en/self-host/...` copy of dual-copy pages: the `en/cloud/...` copy describes the version Dify Cloud currently runs and updates on Cloud's own release lane, re-derived from the self-host diff when Cloud ships that version. Flag cloud-only pages (no self-host sibling) for that Cloud pass explicitly — the self-host diff won't carry them. Single-copy trees (`en/learn/`, `en/develop-plugin/`, `writing-guides/`, the API specs) ride the release branch. Main-targeting fixes edit both copies in the same pass.
+
 ### Reading Code at the Pinned Ref
 
 Verify against the Dify codebase (configured as an additional working directory) at the pinned upper ref: `git fetch --tags origin`, then read files with `git show <to>:<path>`. Never check out a branch in that tree — follow `writing-guides/index.md` section "Syncing the Dify codebase safely".
@@ -222,7 +224,7 @@ python3 "$DOCS/tools/api-pipeline/parity_check.py"  # prints "TOTAL PARITY ISSUE
 
 For each affected doc page, run `dify-docs-write` (row R5 update; S4 satisfied by the approved report; the `dify-docs-guides` pack loads automatically):
 1. Read the current doc and the relevant PR(s) for context
-2. Update content to reflect changes — both product copies (`en/cloud/...` and `en/self-host/...`) where the page exists in both; shared content lands in both, audience-specific blocks (plan gating, env-var callouts, Enterprise tips) stay per-copy
+2. Update content to reflect changes — copy scope per the Docs Branch rule above (release branch → self-host copy only); audience-specific blocks (plan gating, env-var callouts, Enterprise tips) stay per-copy
 
 ### Environment Variable Updates
 

--- a/.claude/skills/dify-docs-release-sync/SKILL.md
+++ b/.claude/skills/dify-docs-release-sync/SKILL.md
@@ -198,7 +198,7 @@ After user approval (they may add, remove, or adjust items):
 
 Docs for an upcoming release integrate on that release's branch in dify-docs (`release/<version>`, cut from `main` when prep starts) — release doc PRs target it, never `main`; the branch merges into `main` when the release ships. Fixes to currently published docs still target `main` directly.
 
-**Copy scope follows the branch.** Release-branch work edits ONLY the `en/self-host/...` copy of dual-copy pages: the `en/cloud/...` copy describes the version Dify Cloud currently runs and updates on Cloud's own release lane, re-derived from the self-host diff when Cloud ships that version. Flag cloud-only pages (no self-host sibling) for that Cloud pass explicitly — the self-host diff won't carry them. Single-copy trees (`en/learn/`, `en/develop-plugin/`, `writing-guides/`, the API specs) ride the release branch. Main-targeting fixes edit both copies in the same pass.
+**Copy scope follows the branch.** The split is cloud vs self-host, never English vs translations — every edit still ships en, zh, and ja together. Release-branch work edits ONLY the self-host copy (`{en,zh,ja}/self-host/...`) of dual-copy pages: the cloud copy (`{en,zh,ja}/cloud/...`) describes the version Dify Cloud currently runs and updates on Cloud's own release lane, re-derived from the self-host diff when Cloud ships that version. Flag cloud-only pages (no self-host sibling) for that Cloud pass explicitly — the self-host diff won't carry them. Single-copy trees (`learn/`, `develop-plugin/`, `writing-guides/`, the API specs) ride the release branch. Main-targeting fixes edit both copies in the same pass.
 
 ### Reading Code at the Pinned Ref
 

--- a/.claude/skills/dify-docs-terminology-check/SKILL.md
+++ b/.claude/skills/dify-docs-terminology-check/SKILL.md
@@ -63,6 +63,7 @@ For each candidate term (use the English term; for zh/ja files, take the candida
    git grep -nF '"<Term>"' "$REF" -- 'web/i18n/en-US/*.json'
    ```
    - Exact-value hit (e.g., `<REF>:web/i18n/en-US/common.json:285:  "menus.apps": "Studio",`) → it is a UI label; note the file and key.
+   - Multiple exact hits → the value is shared by several keys; pick by tracing which component the documented surface renders (`git grep -n '"<key>"' "$REF" -- 'web/app/**'`), and record which key you chose and why. Never assume the closest-looking key.
    - No hit → retry case-insensitively: `git grep -inF '<term>' "$REF" -- 'web/i18n/en-US/*.json'`. A hit here means the doc's casing or wording deviates from the UI string — flag it.
    - Still no hit → not a UI label. Headings fall out of scope here; bolded terms go to Step 6 (general terms) instead.
 3. Confirm the exact string at the key:

--- a/tools/translate/formatting-ja.md
+++ b/tools/translate/formatting-ja.md
@@ -195,7 +195,7 @@ These elements must be translated, not left in English:
 
 - **Tab titles:** `<Tab title="...">` values must use the Japanese UI label from the glossary.
 - **Frame captions and image alt text:** Translate both `<Frame caption="...">` and `![alt text]`.
-- **Bold UI labels:** When a UI label appears in **bold**, use the official Japanese translation from `web/i18n/ja-JP/`. Refer to the glossary.
+- **Bold UI labels:** When a UI label appears in **bold**, use the official Japanese translation from `web/i18n/ja-JP/`. Refer to the glossary. For labels not in the glossary, resolve the exact i18n key first (see the glossary's UI Labels section), then take the value at that key — never match by value across namespaces.
 - **Prompt examples:** Translate natural language text inside code blocks (using です/ます form). Keep variable placeholders (`{{variable_name}}`) unchanged.
 
 ## App-Type Names: Workflow and Chatflow

--- a/tools/translate/formatting-zh.md
+++ b/tools/translate/formatting-zh.md
@@ -159,7 +159,7 @@ These elements must be translated, not left in English:
 
 - **Tab titles:** Translate `<Tab title="...">` values. If the tab title contains a UI label, use the official Chinese UI label.
 - **Frame captions and image alt text:** Translate both `<Frame caption="...">` and `![alt text]`.
-- **Bold UI labels:** When a UI label appears in **bold**, use the official Chinese translation from `web/i18n/zh-Hans/`. Refer to the glossary.
+- **Bold UI labels:** When a UI label appears in **bold**, use the official Chinese translation from `web/i18n/zh-Hans/`. Refer to the glossary. For labels not in the glossary, resolve the exact i18n key first (see the glossary's UI Labels section), then take the value at that key — never match by value across namespaces.
 - **Prompt examples:** Translate natural language text inside code blocks. Keep variable placeholders (`{{variable_name}}`) unchanged.
 
 ## App-Type Names: Workflow and Chatflow

--- a/writing-guides/formatting-guide.md
+++ b/writing-guides/formatting-guide.md
@@ -353,7 +353,8 @@ Use for showing multiple code variants of the same operation:
 
 - Left-align columns by default using `:---`.
 - Use bold for header row content only when it adds clarity.
-- For multi-line content within cells, prefer lists or components. When manual line breaks are needed, use `<br/><br/><br/><br/>` between lines.
+- For multi-line content within cells, prefer lists or components. When manual line breaks are needed, use `<br/><br/>` between lines.
+- Split long description cells at semantic boundaries (what it does / default behavior / how to change it), one break per boundary — long cells hurt more in a table than an extra break does.
 - Mintlify components (`<Info>`, `<Note>`) can be embedded within table cells when necessary.
 
 ```markdown

--- a/writing-guides/glossary.md
+++ b/writing-guides/glossary.md
@@ -166,6 +166,8 @@ Terms appear in body text exactly as written in this table. Capitalize them furt
 
 Terms in this section must match the Dify product interface exactly. When these terms appear **bolded** in documentation, translations MUST use the corresponding UI string from the product.
 
+For a label not yet in this table, resolve its exact i18n key before writing any language's form: find the key whose en-US value matches on the surface you are documenting — several keys often share one value, so trace the rendering component (`git grep '<key>' -- 'web/app/**'`) to disambiguate — then take each language from that key. Never pick a translation by matching values across namespaces; a label whose key you cannot identify is unverified and must be flagged, not approximated.
+
 ### Sidebar & Navigation
 
 | English (UI) | Chinese (UI) | Japanese (UI) | i18n Key | Notes |


### PR DESCRIPTION
Process fixes from the CE 1.16.2 prep, independent of release content.

- `dify-docs-release-sync`: new copy-scope rule under Docs Branch — release-branch work edits only the `en/self-host/...` copy of dual-copy pages; the `en/cloud/...` copy describes what Dify Cloud currently runs and updates on Cloud's own release lane; single-copy trees ride the release branch; main-targeting fixes still edit both copies. During 1.16.2 prep the unqualified "both product copies" rule sent cloud-tree edits onto the CE release branch, which had to be reverted.
- `dify-docs-guides`: the dual-copy discipline rule gains the matching release-branch exception with a pointer to the rule's home.
- `writing-guides/formatting-guide.md` § Tables: manual cell breaks are `<br/><br/>` (corrects the previous `<br/><br/><br/><br/>` prescription), and long description cells split at semantic boundaries (what it does / default behavior / how to change it).
- `check-format-cjk.py`: the ja sentence-length check now treats `<br/>` tags as sentence boundaries instead of counting the markup toward the 80-character limit, which false-flagged table cells whose prose was well under the threshold.

Ref: DC-193