### PR TITLE
Clarify Arize and Phoenix integration positioning

### DIFF
--- a/en/cloud/use-dify/monitor/integrations/integrate-arize.mdx
+++ b/en/cloud/use-dify/monitor/integrations/integrate-arize.mdx
@@ -6,13 +6,11 @@ sidebarTitle: Arize
 
 ### What is Arize
 
-[Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-arize) provides observability, online and offline evaluation, monitoring, and experimentation for LLM and agent-driven applications. Use [Arize AX](https://arize.com/products/ax/) for the full-featured platform built for production teams, AI-native companies, and enterprises, available as managed cloud or enterprise self-hosted deployment.
+[Arize AX](https://arize.com/products/ax/) is [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-arize)'s full-featured platform for observability, online and offline evaluation, monitoring, and experimentation in LLM and agent-driven applications. Built for production teams, AI-native companies, and enterprises, it runs as a managed cloud service or an enterprise self-hosted deployment.
 
-For an open-source workflow for local development, experimentation, or single-container self-hosting, see Dify's [Phoenix integration](./integrate-phoenix). Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) explain how teams use traces to debug failures, evaluate agent behavior, and monitor model quality.
+If you'd rather run an open-source stack for experimentation or single-container self-hosting, set up the [Phoenix integration](/en/cloud/use-dify/monitor/integrations/integrate-phoenix) instead.
 
-<Info>
-For more details, please refer to [Arize AX](https://arize.com/products/ax/).
-</Info>
+Once traces are flowing, see Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for how to use them to debug failures, evaluate agent behavior, and monitor model quality.
 
 ### How to Configure Arize
 

--- a/en/cloud/use-dify/monitor/integrations/integrate-arize.mdx
+++ b/en/cloud/use-dify/monitor/integrations/integrate-arize.mdx
@@ -6,10 +6,12 @@ sidebarTitle: Arize
 
 ### What is Arize
 
-Enterprise-grade LLM observability, online & offline evaluation, monitoring, and experimentation—powered by OpenTelemetry. Purpose-built for LLM & agent-driven applications.
+[Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-arize) provides observability, online and offline evaluation, monitoring, and experimentation for LLM and agent-driven applications. Use [Arize AX](https://arize.com/products/ax/) for the full-featured platform built for production teams, AI-native companies, and enterprises, available as managed cloud or enterprise self-hosted deployment.
+
+For an open-source workflow for local development, experimentation, or single-container self-hosting, see Dify's [Phoenix integration](./integrate-phoenix). Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) explain how teams use traces to debug failures, evaluate agent behavior, and monitor model quality.
 
 <Info>
-For more details, please refer to [Arize](https://arize.com).
+For more details, please refer to [Arize AX](https://arize.com/products/ax/).
 </Info>
 
 ### How to Configure Arize

--- a/en/cloud/use-dify/monitor/integrations/integrate-phoenix.mdx
+++ b/en/cloud/use-dify/monitor/integrations/integrate-phoenix.mdx
@@ -6,10 +6,12 @@ sidebarTitle: Phoenix
 
 ### What is Phoenix
 
-Open-source & OpenTelemetry-based observability, evaluation, prompt engineering and experimentation platform for your LLM workflows and agents.
+[Arize Phoenix](https://arize.com/phoenix/) is the open-source and OpenTelemetry-based observability, evaluation, prompt engineering, and experimentation platform from [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-phoenix) for LLM workflows and agents.
+
+You can use Phoenix from a local development environment, host it on your own infrastructure, or run it as a single-container deployment. For the full-featured production platform built for AI-native teams and enterprises, use [Arize AX](https://arize.com/products/ax/) through Dify's [Arize integration](./integrate-arize), available as managed cloud or enterprise self-hosted deployment. Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) show how production traces can support debugging and evaluation workflows.
 
 <Info>
-For more details, please refer to [Phoenix](https://phoenix.arize.com).
+For more details, please refer to [Arize Phoenix](https://arize.com/phoenix/).
 </Info>
 
 ### How to Configure Phoenix

--- a/en/cloud/use-dify/monitor/integrations/integrate-phoenix.mdx
+++ b/en/cloud/use-dify/monitor/integrations/integrate-phoenix.mdx
@@ -6,13 +6,13 @@ sidebarTitle: Phoenix
 
 ### What is Phoenix
 
-[Arize Phoenix](https://arize.com/phoenix/) is the open-source and OpenTelemetry-based observability, evaluation, prompt engineering, and experimentation platform from [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-phoenix) for LLM workflows and agents.
+[Arize Phoenix](https://arize.com/phoenix/) is the open-source, OpenTelemetry-based platform from [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-phoenix) for observability, evaluation, prompt engineering, and experimentation with LLM workflows and agents.
 
-You can use Phoenix from a local development environment, host it on your own infrastructure, or run it as a single-container deployment. For the full-featured production platform built for AI-native teams and enterprises, use [Arize AX](https://arize.com/products/ax/) through Dify's [Arize integration](./integrate-arize), available as managed cloud or enterprise self-hosted deployment. Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) show how production traces can support debugging and evaluation workflows.
+Use Arize's hosted [Phoenix Cloud](#how-to-configure-phoenix-cloud), or self-host Phoenix on your own infrastructure (a single container is enough to start). Dify sends traces server-side, so a self-hosted endpoint must be reachable from the internet.
 
-<Info>
-For more details, please refer to [Arize Phoenix](https://arize.com/phoenix/).
-</Info>
+If you need the full-featured platform built for production teams, AI-native companies, and enterprises, set up [Arize AX](https://arize.com/products/ax/) through the [Arize integration](/en/cloud/use-dify/monitor/integrations/integrate-arize) instead.
+
+Once traces are flowing, see Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for how to use them to debug failures, evaluate agent behavior, and monitor model quality.
 
 ### How to Configure Phoenix
 

--- a/en/self-host/use-dify/monitor/integrations/integrate-arize.mdx
+++ b/en/self-host/use-dify/monitor/integrations/integrate-arize.mdx
@@ -6,10 +6,12 @@ sidebarTitle: Arize
 
 ### What is Arize
 
-Enterprise-grade LLM observability, online & offline evaluation, monitoring, and experimentation—powered by OpenTelemetry. Purpose-built for LLM & agent-driven applications.
+[Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-arize-self-host) provides observability, online and offline evaluation, monitoring, and experimentation for LLM and agent-driven applications. Use [Arize AX](https://arize.com/products/ax/) when you need the full-featured platform for production teams, AI-native companies, and enterprises, available as managed cloud or enterprise self-hosted deployment.
+
+For an OSS-friendly workflow for local development, experimentation, or self-hosting, see Dify's [Phoenix integration](./integrate-phoenix). Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) show how teams use traces to debug failures, evaluate agent behavior, and monitor model quality.
 
 <Info>
-For more details, please refer to [Arize](https://arize.com).
+For more details, please refer to [Arize AX](https://arize.com/products/ax/).
 </Info>
 
 ### How to Configure Arize

--- a/en/self-host/use-dify/monitor/integrations/integrate-arize.mdx
+++ b/en/self-host/use-dify/monitor/integrations/integrate-arize.mdx
@@ -6,13 +6,11 @@ sidebarTitle: Arize
 
 ### What is Arize
 
-[Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-arize-self-host) provides observability, online and offline evaluation, monitoring, and experimentation for LLM and agent-driven applications. Use [Arize AX](https://arize.com/products/ax/) when you need the full-featured platform for production teams, AI-native companies, and enterprises, available as managed cloud or enterprise self-hosted deployment.
+[Arize AX](https://arize.com/products/ax/) is [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-arize-self-host)'s full-featured platform for observability, online and offline evaluation, monitoring, and experimentation in LLM and agent-driven applications. Built for production teams, AI-native companies, and enterprises, it runs as a managed cloud service or an enterprise self-hosted deployment.
 
-For an OSS-friendly workflow for local development, experimentation, or self-hosting, see Dify's [Phoenix integration](./integrate-phoenix). Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) show how teams use traces to debug failures, evaluate agent behavior, and monitor model quality.
+If you'd rather run an open-source stack for local development, experimentation, or single-container self-hosting, set up the [Phoenix integration](/en/self-host/use-dify/monitor/integrations/integrate-phoenix) instead.
 
-<Info>
-For more details, please refer to [Arize AX](https://arize.com/products/ax/).
-</Info>
+Once traces are flowing, see Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for how to use them to debug failures, evaluate agent behavior, and monitor model quality.
 
 ### How to Configure Arize
 

--- a/en/self-host/use-dify/monitor/integrations/integrate-phoenix.mdx
+++ b/en/self-host/use-dify/monitor/integrations/integrate-phoenix.mdx
@@ -6,13 +6,13 @@ sidebarTitle: Phoenix
 
 ### What is Phoenix
 
-[Arize Phoenix](https://arize.com/phoenix/) is the open-source and OpenTelemetry-based observability, evaluation, prompt engineering, and experimentation platform from [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-phoenix-self-host). Use it for local development, experimentation, OSS workflows, and self-hosted deployments.
+[Arize Phoenix](https://arize.com/phoenix/) is the open-source, OpenTelemetry-based platform from [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-phoenix-self-host) for observability, evaluation, prompt engineering, and experimentation with LLM workflows and agents.
 
-For the full-featured production platform built for AI-native teams and enterprises, use [Arize AX](https://arize.com/products/ax/), available as managed cloud or enterprise self-hosted deployment. Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) explain how traces support evaluation workflows for agents and LLM applications.
+Run Phoenix locally during development, self-host it on your own infrastructure (a single container is enough to start), or use Arize's hosted [Phoenix Cloud](#how-to-configure-phoenix-cloud).
 
-<Info>
-For more details, please refer to [Arize Phoenix](https://arize.com/phoenix/).
-</Info>
+If you need the full-featured platform built for production teams, AI-native companies, and enterprises, set up [Arize AX](https://arize.com/products/ax/) through the [Arize integration](/en/self-host/use-dify/monitor/integrations/integrate-arize) instead.
+
+Once traces are flowing, see Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for how to use them to debug failures, evaluate agent behavior, and monitor model quality.
 
 ### How to Configure Phoenix
 

--- a/en/self-host/use-dify/monitor/integrations/integrate-phoenix.mdx
+++ b/en/self-host/use-dify/monitor/integrations/integrate-phoenix.mdx
@@ -6,10 +6,12 @@ sidebarTitle: Phoenix
 
 ### What is Phoenix
 
-Open-source & OpenTelemetry-based observability, evaluation, prompt engineering and experimentation platform for your LLM workflows and agents.
+[Arize Phoenix](https://arize.com/phoenix/) is the open-source and OpenTelemetry-based observability, evaluation, prompt engineering, and experimentation platform from [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-phoenix-self-host). Use it for local development, experimentation, OSS workflows, and self-hosted deployments.
+
+For the full-featured production platform built for AI-native teams and enterprises, use [Arize AX](https://arize.com/products/ax/), available as managed cloud or enterprise self-hosted deployment. Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) explain how traces support evaluation workflows for agents and LLM applications.
 
 <Info>
-For more details, please refer to [Phoenix](https://phoenix.arize.com).
+For more details, please refer to [Arize Phoenix](https://arize.com/phoenix/).
 </Info>
 
 ### How to Configure Phoenix

--- a/ja/cloud/use-dify/monitor/integrations/integrate-arize.mdx
+++ b/ja/cloud/use-dify/monitor/integrations/integrate-arize.mdx
@@ -7,11 +7,11 @@ title: Arize の統合
 
 ### 1 Arize とは
 
-エンタープライズグレードの LLM 可観測性、オンラインおよびオフライン評価、モニタリング、実験。OpenTelemetry によって支えられています。LLM およびエージェント駆動型アプリケーション向けに特別に設計されています。
+[Arize AX](https://arize.com/products/ax/) は、[Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-arize) が提供するフル機能プラットフォームです。LLM やエージェント駆動型アプリケーションの可観測性、オンライン・オフライン評価、モニタリング、実験に対応します。本番運用チームや AI ネイティブ企業、エンタープライズ向けに設計されており、マネージドクラウドまたはエンタープライズ向けセルフホストでデプロイできます。
 
-<Info>
-Arize の公式サイト：[https://arize.com](https://arize.com)
-</Info>
+実験や単一コンテナでのセルフホストに適したオープンソース構成が必要な場合は、代わりに [Phoenix 統合](/ja/cloud/use-dify/monitor/integrations/integrate-phoenix) を設定してください。
+
+トレースの送信が始まったら、Arize の [エージェント評価ガイド](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) と [LLM 評価ガイド](https://arize.com/resources/llm-evaluation/) を参照してください。障害のデバッグ、エージェント動作の評価、モデル品質のモニタリングにトレースを活用する方法を確認できます。
 
 ### 2 Arize の使い方
 

--- a/ja/cloud/use-dify/monitor/integrations/integrate-phoenix.mdx
+++ b/ja/cloud/use-dify/monitor/integrations/integrate-phoenix.mdx
@@ -7,11 +7,13 @@ title: Phoenix の統合
 
 ### 1 Phoenix とは
 
-オープンソースおよび OpenTelemetry ベースの可観測性、評価、プロンプトエンジニアリング、実験プラットフォームで、LLM ワークフローおよびエージェントに対応します。
+[Arize Phoenix](https://arize.com/phoenix/) は、[Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-phoenix) が提供するオープンソースのプラットフォームです。OpenTelemetry をベースに、LLM ワークフローとエージェントの可観測性、評価、プロンプトエンジニアリング、実験に対応します。
 
-<Info>
-Phoenix の公式サイト：[https://phoenix.arize.com](https://phoenix.arize.com)
-</Info>
+Arize がホストする [Phoenix Cloud](#3-phoenix-cloud-の使い方) を利用するか、自社インフラに Phoenix をセルフホストします（単一コンテナで起動できます）。トレースは Dify のサーバーから送信されるため、セルフホストの場合はエンドポイントがインターネットから到達できる必要があります。
+
+本番運用チームや AI ネイティブ企業、エンタープライズにはフル機能の [Arize AX](https://arize.com/products/ax/) が適しています。必要な場合は、代わりに [Arize 統合](/ja/cloud/use-dify/monitor/integrations/integrate-arize) を設定してください。
+
+トレースの送信が始まったら、Arize の [エージェント評価ガイド](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) と [LLM 評価ガイド](https://arize.com/resources/llm-evaluation/) を参照してください。障害のデバッグ、エージェント動作の評価、モデル品質のモニタリングにトレースを活用する方法を確認できます。
 
 ### 2 Phoenix の使い方
 

--- a/ja/self-host/use-dify/monitor/integrations/integrate-arize.mdx
+++ b/ja/self-host/use-dify/monitor/integrations/integrate-arize.mdx
@@ -7,11 +7,11 @@ title: Arize の統合
 
 ### 1 Arize とは
 
-エンタープライズグレードの LLM 可観測性、オンラインおよびオフライン評価、モニタリング、実験。OpenTelemetry によって支えられています。LLM およびエージェント駆動型アプリケーション向けに特別に設計されています。
+[Arize AX](https://arize.com/products/ax/) は、[Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-arize-self-host) が提供するフル機能プラットフォームです。LLM やエージェント駆動型アプリケーションの可観測性、オンライン・オフライン評価、モニタリング、実験に対応します。本番運用チームや AI ネイティブ企業、エンタープライズ向けに設計されており、マネージドクラウドまたはエンタープライズ向けセルフホストでデプロイできます。
 
-<Info>
-Arize の公式サイト：[https://arize.com](https://arize.com)
-</Info>
+ローカル開発や実験、単一コンテナでのセルフホストに適したオープンソース構成が必要な場合は、代わりに [Phoenix 統合](/ja/self-host/use-dify/monitor/integrations/integrate-phoenix) を設定してください。
+
+トレースの送信が始まったら、Arize の [エージェント評価ガイド](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) と [LLM 評価ガイド](https://arize.com/resources/llm-evaluation/) を参照してください。障害のデバッグ、エージェント動作の評価、モデル品質のモニタリングにトレースを活用する方法を確認できます。
 
 ### 2 Arize の使い方
 

--- a/ja/self-host/use-dify/monitor/integrations/integrate-phoenix.mdx
+++ b/ja/self-host/use-dify/monitor/integrations/integrate-phoenix.mdx
@@ -7,11 +7,13 @@ title: Phoenix の統合
 
 ### 1 Phoenix とは
 
-オープンソースおよび OpenTelemetry ベースの可観測性、評価、プロンプトエンジニアリング、実験プラットフォームで、LLM ワークフローおよびエージェントに対応します。
+[Arize Phoenix](https://arize.com/phoenix/) は、[Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-phoenix-self-host) が提供するオープンソースのプラットフォームです。OpenTelemetry をベースに、LLM ワークフローとエージェントの可観測性、評価、プロンプトエンジニアリング、実験に対応します。
 
-<Info>
-Phoenix の公式サイト：[https://phoenix.arize.com](https://phoenix.arize.com)
-</Info>
+開発中は Phoenix をローカルで実行できます。自社インフラに単一コンテナとしてセルフホストするか、Arize がホストする [Phoenix Cloud](#3-phoenix-cloud-の使い方) を利用することもできます。
+
+本番運用チームや AI ネイティブ企業、エンタープライズにはフル機能の [Arize AX](https://arize.com/products/ax/) が適しています。必要な場合は、代わりに [Arize 統合](/ja/self-host/use-dify/monitor/integrations/integrate-arize) を設定してください。
+
+トレースの送信が始まったら、Arize の [エージェント評価ガイド](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) と [LLM 評価ガイド](https://arize.com/resources/llm-evaluation/) を参照してください。障害のデバッグ、エージェント動作の評価、モデル品質のモニタリングにトレースを活用する方法を確認できます。
 
 ### 2 Phoenix の使い方
 

--- a/zh/cloud/use-dify/monitor/integrations/integrate-arize.mdx
+++ b/zh/cloud/use-dify/monitor/integrations/integrate-arize.mdx
@@ -6,11 +6,11 @@ title: 集成 Arize
 
 ### Arize 简介
 
-企业级 LLM 可观测性、在线和离线评估、监控和实验平台，基于 OpenTelemetry 构建，专为 LLM 和代理驱动的应用设计。
+[Arize AX](https://arize.com/products/ax/) 是 [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-arize) 推出的全功能平台，为 LLM 和 Agent 驱动的应用提供可观测性、在线与离线评估、监控和实验能力。它面向生产环境团队、AI 原生公司和企业，支持托管云与企业自部署两种部署方式。
 
-<Callout>
-Arize [官网介绍](https://arize.com)
-</Callout>
+如需用于实验或单容器自部署的开源方案，可改用 [Phoenix 集成](/zh/cloud/use-dify/monitor/integrations/integrate-phoenix)。
+
+追踪数据接入后，可参考 Arize 的 [Agent 评估指南](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) 和 [LLM 评估指南](https://arize.com/resources/llm-evaluation/)，了解如何用追踪数据调试故障、评估 Agent 行为、监控模型质量。
 
 ### 配置 Arize
 

--- a/zh/cloud/use-dify/monitor/integrations/integrate-phoenix.mdx
+++ b/zh/cloud/use-dify/monitor/integrations/integrate-phoenix.mdx
@@ -6,11 +6,13 @@ title: 集成 Phoenix
 
 ### Phoenix 简介
 
-开源且基于 OpenTelemetry 的可观测性、评估、提示工程和实验平台，适用于你的 LLM 工作流程和代理。
+[Arize Phoenix](https://arize.com/phoenix/) 是 [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-phoenix) 推出的开源平台，基于 OpenTelemetry 构建，为 LLM 工作流和 Agent 提供可观测性、评估、提示工程和实验能力。
 
-<Callout>
-Phoenix [官网介绍](https://phoenix.arize.com)
-</Callout>
+可使用 Arize 托管的 [Phoenix Cloud](#配置-phoenix-cloud)，也可在自有基础设施上自部署 Phoenix（单个容器即可运行）。Dify 从服务端发送追踪数据，因此自部署的端点需要能从公网访问。
+
+如需面向生产环境团队、AI 原生公司和企业的全功能平台，可改用 [Arize 集成](/zh/cloud/use-dify/monitor/integrations/integrate-arize) 接入 [Arize AX](https://arize.com/products/ax/)。
+
+追踪数据接入后，可参考 Arize 的 [Agent 评估指南](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) 和 [LLM 评估指南](https://arize.com/resources/llm-evaluation/)，了解如何用追踪数据调试故障、评估 Agent 行为、监控模型质量。
 
 ### 配置 Phoenix
 

--- a/zh/self-host/use-dify/monitor/integrations/integrate-arize.mdx
+++ b/zh/self-host/use-dify/monitor/integrations/integrate-arize.mdx
@@ -6,11 +6,11 @@ title: 集成 Arize
 
 ### Arize 简介
 
-企业级 LLM 可观测性、在线和离线评估、监控和实验平台，基于 OpenTelemetry 构建，专为 LLM 和代理驱动的应用设计。
+[Arize AX](https://arize.com/products/ax/) 是 [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-arize-self-host) 推出的全功能平台，为 LLM 和 Agent 驱动的应用提供可观测性、在线与离线评估、监控和实验能力。它面向生产环境团队、AI 原生公司和企业，支持托管云与企业自部署两种部署方式。
 
-<Callout>
-Arize [官网介绍](https://arize.com)
-</Callout>
+如需用于本地开发、实验或单容器自部署的开源方案，可改用 [Phoenix 集成](/zh/self-host/use-dify/monitor/integrations/integrate-phoenix)。
+
+追踪数据接入后，可参考 Arize 的 [Agent 评估指南](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) 和 [LLM 评估指南](https://arize.com/resources/llm-evaluation/)，了解如何用追踪数据调试故障、评估 Agent 行为、监控模型质量。
 
 ### 配置 Arize
 

--- a/zh/self-host/use-dify/monitor/integrations/integrate-phoenix.mdx
+++ b/zh/self-host/use-dify/monitor/integrations/integrate-phoenix.mdx
@@ -6,11 +6,13 @@ title: 集成 Phoenix
 
 ### Phoenix 简介
 
-开源且基于 OpenTelemetry 的可观测性、评估、提示工程和实验平台，适用于你的 LLM 工作流程和代理。
+[Arize Phoenix](https://arize.com/phoenix/) 是 [Arize AI](https://arize.com/?utm_source=dify-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrate-phoenix-self-host) 推出的开源平台，基于 OpenTelemetry 构建，为 LLM 工作流和 Agent 提供可观测性、评估、提示工程和实验能力。
 
-<Callout>
-Phoenix [官网介绍](https://phoenix.arize.com)
-</Callout>
+开发阶段可在本地运行 Phoenix，也可在自有基础设施上以单容器方式自部署，或使用 Arize 托管的 [Phoenix Cloud](#配置-phoenix-cloud)。
+
+如需面向生产环境团队、AI 原生公司和企业的全功能平台，可改用 [Arize 集成](/zh/self-host/use-dify/monitor/integrations/integrate-arize) 接入 [Arize AX](https://arize.com/products/ax/)。
+
+追踪数据接入后，可参考 Arize 的 [Agent 评估指南](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) 和 [LLM 评估指南](https://arize.com/resources/llm-evaluation/)，了解如何用追踪数据调试故障、评估 Agent 行为、监控模型质量。
 
 ### 配置 Phoenix
 


### PR DESCRIPTION
## Summary
- Clarifies the Dify integration pages for Arize AX and Arize Phoenix
- Keeps the existing Dify configuration steps intact
- Adds concise context for teams using trace data in evaluation workflows

## Why
The Dify docs include separate Arize and Phoenix integration pages. This update makes the AX and Phoenix paths easier to distinguish before setup: AX for full-featured managed cloud or enterprise self-hosted deployments, and Phoenix for open-source local or self-hosted workflows.

## Testing
- Docs-only change; not run.
