### PR TITLE
docs: add troubleshooting for the clone command null-branch failure

### DIFF
--- a/en/self-host/deploy/quick-start/docker-compose.mdx
+++ b/en/self-host/deploy/quick-start/docker-compose.mdx
@@ -36,6 +36,15 @@ Make sure your machine meets the following minimum system requirements.
 
     <Info>
       This command requires `git`, `curl`, and `jq`. If you see a `command not found` error, install the missing tool and run the command again.
+
+      When the clone fails with `fatal: Remote branch null not found in upstream origin`, retry with an explicit version, using the latest version number from [Dify releases](https://github.com/langgenius/dify/releases):
+
+      ```bash
+      git clone --branch <version> https://github.com/langgenius/dify.git
+      ```
+
+      See [Clone Fails with "Remote branch null not found"](/en/self-host/deploy/quick-start/faqs#clone-fails-with-remote-branch-null-not-found) for details.
+
     </Info>
   </Step>
   <Step title="Start Dify">

--- a/en/self-host/deploy/quick-start/faqs.mdx
+++ b/en/self-host/deploy/quick-start/faqs.mdx
@@ -27,6 +27,7 @@ unzip dify.zip && rm dify.zip
 Alternatively, download the ZIP on another device and transfer it manually.
 
 **To upgrade**:
+
 ```bash
 wget -O dify-latest.zip "$(curl -s https://api.github.com/repos/langgenius/dify/releases/latest | jq -r '.zipball_url')"
 unzip dify-latest.zip && rm dify-latest.zip
@@ -36,6 +37,18 @@ cd dify/docker
 docker compose pull
 docker compose up -d
 ```
+
+### Clone Fails with "Remote branch null not found"
+
+The clone command in [Deploy Dify with Docker Compose](/en/self-host/deploy/quick-start/docker-compose) resolves the latest Dify version through the GitHub API. When that request fails (usually due to GitHub's rate limit on unauthenticated requests), `jq` outputs `null`, and git reports `fatal: Remote branch null not found in upstream origin`.
+
+Clone with an explicit version instead. Find the latest version number on [Dify releases](https://github.com/langgenius/dify/releases), then run:
+
+```bash
+git clone --branch <version> https://github.com/langgenius/dify.git
+```
+
+Cloning without `--branch` also works. The Compose file on `main` pins the latest released images, so you still run release builds, but the deployment files themselves (the Compose file and environment templates) track development and can drift from the tagged release.
 
 ## Backup Procedures
 

--- a/ja/self-host/deploy/quick-start/docker-compose.mdx
+++ b/ja/self-host/deploy/quick-start/docker-compose.mdx
@@ -38,6 +38,15 @@ sidebarTitle: Docker Compose
 
     <Info>
       このコマンドには `git`、`curl`、`jq` が必要です。`command not found` エラーが表示された場合は、不足しているツールをインストールしてから再実行してください。
+
+      クローンが `fatal: Remote branch null not found in upstream origin` エラーで失敗したときは、[Dify releases](https://github.com/langgenius/dify/releases) で最新バージョンを確認し、バージョンを明示して再実行してください：
+
+      ```bash
+      git clone --branch <version> https://github.com/langgenius/dify.git
+      ```
+
+      詳細は [クローン時の「Remote branch null not found」エラー](/ja/self-host/deploy/quick-start/faqs#クローン時の「remote-branch-null-not-found」エラー) を参照してください。
+
     </Info>
   </Step>
   <Step title="Dify を起動">

--- a/ja/self-host/deploy/quick-start/faqs.mdx
+++ b/ja/self-host/deploy/quick-start/faqs.mdx
@@ -29,6 +29,7 @@ unzip dify.zip && rm dify.zip
 または、別のデバイスで ZIP をダウンロードして手動で転送することもできます。
 
 **アップグレードするには**：
+
 ```bash
 wget -O dify-latest.zip "$(curl -s https://api.github.com/repos/langgenius/dify/releases/latest | jq -r '.zipball_url')"
 unzip dify-latest.zip && rm dify-latest.zip
@@ -38,6 +39,18 @@ cd dify/docker
 docker compose pull
 docker compose up -d
 ```
+
+### クローン時の「Remote branch null not found」エラー
+
+[Docker Compose で Dify をデプロイする](/ja/self-host/deploy/quick-start/docker-compose) のクローンコマンドは、GitHub API を通じて Dify の最新バージョンを取得します。このリクエストが失敗すると（未認証リクエストに対する GitHub のレート制限が主な原因）、`jq` が `null` を出力し、git は `fatal: Remote branch null not found in upstream origin` を報告します。
+
+代わりに、バージョンを明示してクローンしてください。[Dify releases](https://github.com/langgenius/dify/releases) で最新バージョンを確認し、次のコマンドを実行します：
+
+```bash
+git clone --branch <version> https://github.com/langgenius/dify.git
+```
+
+`--branch` なしでもクローンできます。`main` ブランチの Compose ファイルは最新リリース版のイメージを指定しているため、起動されるのはリリース版です。ただし、Compose ファイルや環境変数テンプレートなどのデプロイ用ファイル自体は開発中の内容であり、リリース版と異なる場合があります。
 
 ## バックアップ手順
 

--- a/zh/self-host/deploy/quick-start/docker-compose.mdx
+++ b/zh/self-host/deploy/quick-start/docker-compose.mdx
@@ -38,6 +38,15 @@ sidebarTitle: Docker Compose
 
     <Info>
       此命令需要 `git`、`curl` 和 `jq`。如提示 `command not found`，安装缺少的工具后重新运行命令。
+
+      报 `fatal: Remote branch null not found in upstream origin` 错误时，改用显式版本号重试，最新版本号见 [Dify releases](https://github.com/langgenius/dify/releases)：
+
+      ```bash
+      git clone --branch <version> https://github.com/langgenius/dify.git
+      ```
+
+      详见 [克隆报错「Remote branch null not found」](/zh/self-host/deploy/quick-start/faqs#克隆报错「remote-branch-null-not-found」)。
+
     </Info>
   </Step>
   <Step title="启动 Dify">

--- a/zh/self-host/deploy/quick-start/faqs.mdx
+++ b/zh/self-host/deploy/quick-start/faqs.mdx
@@ -29,6 +29,7 @@ unzip dify.zip && rm dify.zip
 或者，在另一台设备上下载 ZIP 文件并手动传输。
 
 **升级方法**：
+
 ```bash
 wget -O dify-latest.zip "$(curl -s https://api.github.com/repos/langgenius/dify/releases/latest | jq -r '.zipball_url')"
 unzip dify-latest.zip && rm dify-latest.zip
@@ -38,6 +39,18 @@ cd dify/docker
 docker compose pull
 docker compose up -d
 ```
+
+### 克隆报错「Remote branch null not found」
+
+[使用 Docker Compose 部署 Dify](/zh/self-host/deploy/quick-start/docker-compose) 中的克隆命令通过 GitHub API 解析 Dify 最新版本号。该请求失败时（常见原因是 GitHub 对未认证请求的限流），`jq` 会输出 `null`，git 随即报 `fatal: Remote branch null not found in upstream origin`。
+
+改用显式版本号克隆。在 [Dify releases](https://github.com/langgenius/dify/releases) 页面查看最新版本号，然后运行：
+
+```bash
+git clone --branch <version> https://github.com/langgenius/dify.git
+```
+
+不加 `--branch` 直接克隆也可行：`main` 分支的 Compose 文件固定指向最新发布版镜像，运行的仍是正式版本。但 Compose 文件、环境变量模板等部署文件本身跟随开发进度，可能与发布版有出入。
 
 ## 备份程序
 


### PR DESCRIPTION
Discord feedback (Linear COM-13632): the quick-start clone command resolves the latest version via the GitHub API and degrades to git clone --branch null when the request fails. Add an action-first fallback with an explicit-version command to the Info callout, and a searchable FAQ entry explaining the failure and what a bare clone actually deploys, in all three languages. Also fix three pre-existing missing-blank-line violations in the touched files.

Ref: DC-222