### PR TITLE
docs: align skill import package guidance

### DIFF
--- a/en/self-host/use-dify/build/skills.mdx
+++ b/en/self-host/use-dify/build/skills.mdx
@@ -56,7 +56,7 @@ Attach up to 10 files per message: images up to 10 MB and other files up to 15 M
 
 ## Import a Skill
 
-To bring in a skill built elsewhere as a library skill, click **Import** and choose a `.zip` or `.skill` package that contains a `SKILL.md` file. The package can be up to 50 MB by default; you can change this limit with the [`UPLOAD_SKILL_FILE_SIZE_LIMIT`](/en/self-host/deploy/configuration/environments#upload_skill_file_size_limit) environment variable. Once imported, it arrives as a draft for you to review and publish.
+To bring in a skill built elsewhere as a library skill, click **Import** and choose a `.zip` or `.skill` package. The package needs a `SKILL.md` inside and can be up to 50 MB by default, adjustable with [`UPLOAD_SKILL_FILE_SIZE_LIMIT`](/en/self-host/deploy/configuration/environments#upload_skill_file_size_limit). Once imported, it arrives as a draft for you to review and publish.
 
 ## Tag a Skill
 

--- a/ja/self-host/use-dify/build/skills.mdx
+++ b/ja/self-host/use-dify/build/skills.mdx
@@ -58,10 +58,10 @@ Skill Builder とチャットすると、スキルの下書きを作成できま
 
 ## スキルのインポート
 
-ほかで作成したスキルをスキルライブラリに取り込むには、**Import** をクリックします。`SKILL.md` を含む `.zip` または `.skill` パッケージを選択してください。
-
-パッケージの上限はデフォルトで 50 MB です。
-[`UPLOAD_SKILL_FILE_SIZE_LIMIT`][upload-skill-file-size-limit] 環境変数で変更できます。
+ほかで作成したスキルをスキルライブラリに取り込むには、**Import** をクリックします。
+`.zip` または `.skill` パッケージを選択してください。
+パッケージには `SKILL.md` が必要です。
+サイズはデフォルトで最大 50 MB で、[`UPLOAD_SKILL_FILE_SIZE_LIMIT`][upload-skill-file-size-limit] で調整できます。
 インポートすると、確認して公開できるドラフトとして追加されます。
 
 ## スキルへのタグ付け

--- a/zh/self-host/use-dify/build/skills.mdx
+++ b/zh/self-host/use-dify/build/skills.mdx
@@ -58,7 +58,7 @@ Skill 可用于：
 
 ## 导入 Skill
 
-要把在其他地方构建的 Skill 加入 Skill 库，点击 **导入**，选择包含 `SKILL.md` 的 `.zip` 或 `.skill` 包。包大小默认不超过 50 MB；可通过 [`UPLOAD_SKILL_FILE_SIZE_LIMIT`](/zh/self-host/deploy/configuration/environments#upload_skill_file_size_limit) 环境变量调整。导入后，Skill 会以草稿状态加入 Skill 库，供你检查并发布。
+要把在其他地方构建的 Skill 加入 Skill 库，点击 **导入**，选择 `.zip` 或 `.skill` 包。包内需有 `SKILL.md`，大小默认不超过 50 MB，可通过 [`UPLOAD_SKILL_FILE_SIZE_LIMIT`](/zh/self-host/deploy/configuration/environments#upload_skill_file_size_limit) 调整。导入后，Skill 会以草稿状态加入 Skill 库，供你检查并发布。
 
 ## 为 Skill 添加标签
 


### PR DESCRIPTION
## Summary

- align the library Skill import package wording with the Agent Build guide
- clarify that the package needs a SKILL.md file and that the default 50 MB limit is configurable
- update English, Chinese, and Japanese together

## Checks

- English formatting check
- Chinese and Japanese formatting check
- git diff --check