### PR TITLE
docs: restore the one hour default agent run time for 1.17.0

### DIFF
--- a/en/self-host/use-dify/build/new-agent/build.mdx
+++ b/en/self-host/use-dify/build/new-agent/build.mdx
@@ -199,9 +199,9 @@ To share the agent across workspaces, export it as a DSL file. Library skills re
 
 - **Time**
 
-    A single agent run is stopped after 20 minutes by default, whichever access point it starts from (web app, service API, or a workflow), and the unfinished reply is discarded.
+    A single agent run is stopped after 1 hour by default, whichever access point it starts from (web app, service API, or a workflow), and the unfinished reply is discarded.
 
-    If a run gets cut off, try again or break the task into smaller steps. To allow runs up to an hour, raise `APP_MAX_EXECUTION_TIME` and `WORKFLOW_MAX_EXECUTION_TIME` to `3600`; for longer runs, raise those two and `DIFY_AGENT_RUN_TIMEOUT_SECONDS` above the duration you need.
+    If a run gets cut off, try again or break the task into smaller steps. For longer runs, raise `APP_MAX_EXECUTION_TIME`, `WORKFLOW_MAX_EXECUTION_TIME`, and `DIFY_AGENT_RUN_TIMEOUT_SECONDS` above the duration you need.
 
     See [Environment Variables](/en/self-host/deploy/configuration/environments) for details on these variables.
 

--- a/ja/self-host/use-dify/build/new-agent/build.mdx
+++ b/ja/self-host/use-dify/build/new-agent/build.mdx
@@ -201,9 +201,9 @@ Agent をワークスペース間で共有するには、DSL ファイルとし�
 
 - **実行時間**
 
-    どのアクセスポイントから開始しても（Web アプリ、サービス API、ワークフロー）、1 回の実行はデフォルトで 20 分後に停止され、未完成の返信は破棄されます。
+    どのアクセスポイントから開始しても（Web アプリ、サービス API、ワークフロー）、1 回の実行はデフォルトで 1 時間後に停止され、未完成の返信は破棄されます。
 
-    実行が打ち切られた場合は、もう一度試すか、タスクを小さく分割してください。最長 1 時間まで許可するには、`APP_MAX_EXECUTION_TIME` と `WORKFLOW_MAX_EXECUTION_TIME` を `3600` に引き上げます。1 時間を超える場合は、この 2 つと `DIFY_AGENT_RUN_TIMEOUT_SECONDS` をいずれも目標の実行時間より高く設定します。
+    実行が打ち切られた場合は、もう一度試すか、タスクを小さく分割してください。より長く実行するには、`APP_MAX_EXECUTION_TIME`、`WORKFLOW_MAX_EXECUTION_TIME`、`DIFY_AGENT_RUN_TIMEOUT_SECONDS` をいずれも目標の実行時間より高く設定します。
 
     これらの変数の詳細は [環境変数](/ja/self-host/deploy/configuration/environments) を参照してください。
 

--- a/zh/self-host/use-dify/build/new-agent/build.mdx
+++ b/zh/self-host/use-dify/build/new-agent/build.mdx
@@ -201,9 +201,9 @@ Agent 工作时会直接修改面板中的配置，所有更改都会列在 **Bu
 
 - **时长**
 
-    单次 Agent 运行无论从哪个访问点发起（Web 应用、服务 API 或工作流），默认都会在 20 分钟后被终止，未完成的回复会被清除。
+    单次 Agent 运行无论从哪个访问点发起（Web 应用、服务 API 或工作流），默认都会在 1 小时后被终止，未完成的回复会被清除。
 
-    若运行被中断，可重试或把任务拆分成更小的步骤。要允许运行最长 1 小时，将 `APP_MAX_EXECUTION_TIME` 和 `WORKFLOW_MAX_EXECUTION_TIME` 调高到 `3600`；要运行更长时间，将这两个变量和 `DIFY_AGENT_RUN_TIMEOUT_SECONDS` 都调高到目标时长以上。
+    若运行被中断，可重试或把任务拆分成更小的步骤。要运行更长时间，将 `APP_MAX_EXECUTION_TIME`、`WORKFLOW_MAX_EXECUTION_TIME` 和 `DIFY_AGENT_RUN_TIMEOUT_SECONDS` 都调高到目标时长以上。
 
     这些变量的说明详见 [环境变量](/zh/self-host/deploy/configuration/environments)。
 


### PR DESCRIPTION
langgenius/dify#41065 (merged 2026-08-25, included in the 1.17.0 release) raised the default `APP_MAX_EXECUTION_TIME` and `WORKFLOW_MAX_EXECUTION_TIME` from 1200 to 3600 seconds, so the effective default ceiling for an agent run returns to one hour — the API-side watchdogs and the agent backend's deadline now align. The build page's Run Limits Time bullet is updated in all three languages: "stopped after 1 hour by default", with the remedy collapsed to a single step (raise all three variables above the duration you need for longer runs).

The env reference's corresponding rows (the 3600 defaults, the run-deadline interplay, and the new `DIFY_AGENT_OUTBOUND_HTTP_*` group) ride the `sync/execution-limits-41065` branch separately.