### PR TITLE
docs: document service api generation workflow

### DIFF
--- a/.claude/skills/dify-docs-api-reference/SKILL.md
+++ b/.claude/skills/dify-docs-api-reference/SKILL.md
@@ -31,7 +31,7 @@ Backend developers integrating Dify apps or knowledge bases via REST. Strong cod
 
 ## Spec Structure
 
-One spec per language — `{en,zh,ja}/api-reference/openapi_service.json` — is the spec of record. Edit it directly, in all three languages; `parity_check` enforces structural parity with en. (The five legacy per-app-type source specs and the merge pipeline that consolidated them are retired; recover from git history if needed.)
+Dify's generated `service-openapi.json` is the base contract. The three `{en,zh,ja}/api-reference/openapi_service.json` files are composed authoring outputs: edit presentation fields in all three languages, then recapture their reviewed overlays with `compose_service_api.py capture`. Capture ignores wire-contract edits, so paths, parameters, schemas, statuses, security, and deprecation always come from Dify. The composer applies the locale overlays back to the Dify base, and `parity_check` enforces structural parity with en. Never update an overlay fingerprint without rechecking the affected endpoint against runtime.
 
 App types map to `AppMode` values. The one mapping table (docs names, spec groups, key endpoints, and the modes the Service API does not cover) is `references/codebase-paths.md` § "AppMode ↔ app-type names" — use it, never memory.
 
@@ -39,7 +39,7 @@ Shared endpoints (file upload, audio, feedback, app info, parameters, meta, site
 
 Every operation carries `x-mint.href` (`/{lang}/api-reference/{en-tag-kebab}/{en-summary-kebab}` — English slugs in all languages for language-switcher parity) and `x-mint.metadata.title`/`sidebarTitle` (the translated summary; without them the sidebar shows the English slug). Set all of these when adding an operation, and keep the `tags` arrays index-aligned across languages.
 
-After structural edits (adding, removing, retitling, or reordering operations, or changing availability): update `memberships.json` and the app-type overview pages, then run `wire`, `check-coverage`, `lint_specs`, and `parity_check` per `tools/api-pipeline/README.md`. Description-only edits need the lints but not `wire`.
+After any spec edit, recapture and verify the locale overlays per `tools/api-pipeline/README.md`. After structural edits (adding, removing, retitling, or reordering operations, or changing availability), also update `memberships.json` and the app-type overview pages, then run `wire`, `check-coverage`, `lint_specs`, and `parity_check`. Description-only edits need no `wire`.
 
 ### App-Type Scoping
 

--- a/.claude/skills/dify-docs-api-reference/references/audit-checklist.md
+++ b/.claude/skills/dify-docs-api-reference/references/audit-checklist.md
@@ -47,7 +47,7 @@ After every fix batch, validate from the docs repo root:
 
 ```bash
 export DOCS="$(git rev-parse --show-toplevel)"
-python3 "$DOCS/tools/api-pipeline/lint_specs.py"    # success = prints "TOTAL ISSUES: 0"; its exit code stays 0 even with issues, so read the count
+python3 "$DOCS/tools/api-pipeline/lint_specs.py"    # success = prints "TOTAL ISSUES: 0" and exits 0
 python3 "$DOCS/tools/api-pipeline/parity_check.py"  # success = prints "TOTAL PARITY ISSUES: 0" and exits 0
 ```
 

--- a/.claude/skills/dify-docs-release-sync/SKILL.md
+++ b/.claude/skills/dify-docs-release-sync/SKILL.md
@@ -206,12 +206,12 @@ Verify against the Dify codebase (configured as an additional working directory)
 
 ### API Reference Updates
 
-The spec of record is `{en,zh,ja}/api-reference/openapi_service.json` — one hand-maintained spec per language, edited directly. Shared endpoints exist once, with availability noted in their descriptions; there are no per-app-type specs and no cross-spec propagation.
+The Dify-generated `service-openapi.json` is the base contract. `{en,zh,ja}/api-reference/openapi_service.json` are the composed, human-readable authoring outputs; locale overlays preserve presentation and localization. Shared endpoints exist once, with availability noted in their descriptions; there are no per-app-type specs and no cross-spec propagation.
 
 1. Dispatch audit agents with the `dify-docs-api-reference` skill, one per affected tag group: audit the group's endpoints against the code at the pinned ref, focusing on the report's changes but reading each touched endpoint fully (PRs have side effects).
-2. Apply fixes to the `en` spec, then mirror the same structural change into `zh` and `ja` (translate summaries and descriptions; keep wire strings verbatim).
+2. Compose the pinned Dify JSON with the current overlays. The generated JSON owns every wire-contract field. Apply presentation fixes to the `en` output, then mirror them into `zh` and `ja` (translate summaries and descriptions; keep wire strings verbatim). Recapture the overlays and rebuild; capture ignores wire-contract edits, and any changed upstream presentation value under an overlay must be reviewed rather than force-refreshed.
 3. If operations were added, removed, retitled, or reordered: update `tools/api-pipeline/memberships.json` (and the app-type overview pages) if availability changed, then regenerate navigation with `python3 "$DOCS/tools/api-pipeline/merge_specs.py" wire --lang en zh ja` (rewrites the `docs.json` API menus and redirects). Description-only edits skip this step.
-4. Run the gate from the docs repo root. The gate is each command's printed zero line, not its exit status — `lint_specs.py` exits 0 even with issues. Any nonzero printed count (or nonzero exit) blocks the track — fix and re-run:
+4. Run the gate from the docs repo root. Each command exits nonzero on failure and also prints its issue count. Any nonzero printed count or nonzero exit blocks the track — fix and re-run:
 
 ```bash
 export DOCS="$(git rev-parse --show-toplevel)"

--- a/tools/api-pipeline/README.md
+++ b/tools/api-pipeline/README.md
@@ -1,6 +1,8 @@
 # API Pipeline
 
-Tooling for the Service API reference. `{lang}/api-reference/openapi_service.json` is the hand-maintained spec of record per language: edit it directly. The Phase-1 merge machinery (`build`/`relink` modes, `resolutions.json`, `overrides/`) that consolidated the five legacy per-app-type specs is retired; recover it from git history when Phase 2 rebuilds the spec from R&D's generated spec plus docs-owned overlays.
+Tooling for the Service API reference. Dify's generated `service-openapi.json` is the base contract. Reviewed locale overlays add only localized prose, examples, Mintlify metadata, and published operation ID compatibility to produce `{lang}/api-reference/openapi_service.json`.
+
+The composed language specs remain the human-readable authoring surface. After editing them, recapture the overlays from the reviewed Dify ref. CI rebuilds the specs from Dify plus those overlays and rejects stale output or an upstream change hidden under an overlay.
 
 ## Layout
 
@@ -11,6 +13,11 @@ Tooling for the Service API reference. `{lang}/api-reference/openapi_service.jso
 | `memberships.json` | App type → supported operations; drives the app-type overview pages and the coverage check |
 | `lint_specs.py` | Example/schema, enum, link, and x-codeSamples lint |
 | `parity_check.py` | en/zh/ja structural parity (ops, params, responses, samples) |
+| `compose_service_api.py` | Captures and applies preconditioned locale overlays over Dify's generated contract |
+| `service_api_overlays/{en,zh,ja}.json` | Generated locale overlays; every replace/remove action fingerprints its reviewed upstream value |
+| `contract_alignment.py` | Generated-vs-composed wire-contract gate |
+| `operation_id_overrides.json` | Compatibility overlay for operation IDs already published as SDK method names |
+| `dify_ref.json` | Reviewed Dify commit and generated Service API spec digest used by CI |
 | `coverage_matrix.py`, `swagger_diff.py` | Code-vs-spec audit tooling, for runtime verification (read `openapi_service.json`) |
 
 ## Usage
@@ -21,13 +28,65 @@ python3 "$DOCS/tools/api-pipeline/merge_specs.py" wire --lang en zh ja
 python3 "$DOCS/tools/api-pipeline/merge_specs.py" check-coverage --lang en zh ja
 python3 "$DOCS/tools/api-pipeline/lint_specs.py"
 python3 "$DOCS/tools/api-pipeline/parity_check.py"
+python3 -m unittest discover -s "$DOCS/tools/api-pipeline" -p 'test_*.py'
 ```
 
-parity_check.py and check-coverage exit nonzero on failure; lint_specs.py exits nonzero only on missing files — gate on its printed `TOTAL ISSUES` count.
+Every command exits nonzero when its checks fail. `lint_specs.py` also prints a `TOTAL ISSUES` summary for local diagnosis.
+
+## Contract alignment
+
+Generate the Service API spec from the exact Dify commit recorded in `dify_ref.json`, then compare it with all three localized docs specs. Use a clean detached worktree so uncommitted application changes cannot affect the result:
+
+```bash
+export DIFY_REPO=/path/to/dify
+export DOCS="$(git rev-parse --show-toplevel)"
+export DIFY_REF="$(python3 -c 'import json; print(json.load(open("tools/api-pipeline/dify_ref.json"))["ref"])')"
+export DIFY="$(mktemp -d)/dify"
+export GENERATED_DIR="$(mktemp -d)"
+git -C "$DIFY_REPO" worktree add --detach "$DIFY" "$DIFY_REF"
+uv run --project "$DIFY/api" "$DIFY/api/dev/generate_swagger_specs.py" --output-dir "$GENERATED_DIR"
+python3 "$DOCS/tools/api-pipeline/compose_service_api.py" compose "$GENERATED_DIR/service-openapi.json"
+python3 "$DOCS/tools/api-pipeline/contract_alignment.py" "$GENERATED_DIR/service-openapi.json"
+git -C "$DIFY_REPO" worktree remove "$DIFY"
+```
+
+`compose_service_api.py compose` starts from the generated JSON and applies each locale overlay. An overlay action that replaces or removes an upstream value carries its SHA-256 fingerprint. If Dify changes that value, composition stops with a conflict. Changes outside overlay paths flow into the composed result and make the committed specs fail the current-output check. Every non-deprecated operation must also have localized Mintlify navigation metadata.
+
+`compose_service_api.py capture` deliberately copies only presentation fields (`summary`, `description`, examples, documentation extensions, operation tags, and published `operationId` values). It never captures routes, parameters, request or response schemas, media types, headers, status codes, security, or deprecation flags from the rendered docs. Editing those fields in a localized output cannot override Dify's generated contract; the next compose restores the generated values.
+
+The locale overlays also relocate Dify's generated `info.externalDocs` metadata to the OpenAPI 3.1 top-level `externalDocs` field. This presentation-only normalization keeps the composed document valid for Mintlify without changing the wire contract.
+
+The alignment gate requires zero wire-contract differences: matching OpenAPI versions, exact public path/method coverage, matching deprecation flags, and semantically equivalent effective authentication requirements, parameters, request encodings, request media types, response headers, schemas, and statuses. It also validates schemas against the declared OpenAPI dialect: 3.0 specs cannot use keywords or array-form types outside the OpenAPI 3.0 Schema Object subset, while 3.1 specs cannot use the legacy `nullable` keyword or boolean exclusive bounds. Descriptions, examples, enum ordering, `x-mint`, and `x-codeSamples` are presentation and localization data; any other vendor extension remains part of the compared contract.
+
+Previously published operation IDs are a compatibility contract because generated SDKs expose them as method names. `operation_id_overrides.json` preserves those IDs while new operations follow the generated contract.
+
+If the generated JSON does not describe runtime behavior correctly, fix the code-side OpenAPI annotations in Dify and regenerate. Do not encode a wire-contract correction in a locale overlay.
+
+`.github/workflows/check_service_api.yml` runs unit tests, example/link lint, localization parity, coverage, deterministic generation, composition, and contract alignment for every relevant pull request. The reviewed pin comes only from `dify_ref.json`. A daily scheduled run checks Dify `main`, and `repository_dispatch` or manual runs can supply another ref, so later upstream contract changes cannot remain invisible behind the pin.
+
+### Update the localized specs
+
+After reviewing a new Dify ref, compose the current overlays against it:
+
+```bash
+python3 "$DOCS/tools/api-pipeline/compose_service_api.py" compose "$GENERATED_DIR/service-openapi.json" --write
+```
+
+Unrelated upstream additions flow into the output. If the new contract touches an overlaid presentation value, review that location and update the localized spec deliberately. New operations require localized summaries, descriptions, tags, examples, and `x-mint` metadata before validation passes.
+
+After editing the three composed specs, capture a new reviewed overlay set, then immediately rebuild and run the gates:
+
+```bash
+python3 "$DOCS/tools/api-pipeline/compose_service_api.py" capture "$GENERATED_DIR/service-openapi.json"
+python3 "$DOCS/tools/api-pipeline/compose_service_api.py" compose "$GENERATED_DIR/service-openapi.json"
+python3 "$DOCS/tools/api-pipeline/contract_alignment.py" "$GENERATED_DIR/service-openapi.json"
+python3 "$DOCS/tools/api-pipeline/parity_check.py"
+python3 "$DOCS/tools/api-pipeline/lint_specs.py"
+```
 
 ## Editing the spec
 
-- Edit all three languages; `parity_check` enforces structural parity with en.
+- Edit all three composed language specs, then recapture their overlays; `parity_check` enforces structural parity with en.
 - Every operation carries `x-mint.href = /{lang}/api-reference/{en-tag-kebab}/{en-summary-kebab}` (English slugs in every language, so the language switcher can map pages) and `x-mint.metadata.title`/`sidebarTitle` = the translated summary (without them, the custom href makes Mintlify label the sidebar from the English slug). Set all of these when adding an operation.
 - The `tags` arrays must stay index-aligned across languages; `wire` maps translated tag labels by position and fails on a mismatch.
 - Shared endpoints exist once, with availability lines and mode notes in the description; there is no cross-spec propagation anymore.


### PR DESCRIPTION
## Summary

- document the generated-contract and locale-overlay workflow for Service API references
- update the API reference skill to require overlay capture and verification after spec edits
- update the release-sync skill to compose the pinned Dify contract before applying presentation changes
- clarify that lint failures return a nonzero exit code

Companion backend PR: https://github.com/langgenius/dify/pull/41248

## Validation

- 62 unit tests passed
- coverage check — 0 failures
- spec lint — 1,857 examples and 644 links checked, 0 issues
- parity check — 0 issues
- `merge_specs.py wire` — `docs.json` unchanged