### PR TITLE
docs: align shared service api schemas

### DIFF
--- a/en/api-reference/openapi_service.json
+++ b/en/api-reference/openapi_service.json
@@ -1,25 +1,19 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.1.0",
   "info": {
+    "description": "REST API for Dify applications and knowledge bases. Before calling it, create and publish the app or create the knowledge base in Dify. Send requests to the Service API endpoint shown in Dify's API access panel (its path ends in `/v1`) with `Authorization: Bearer <key>`. For app endpoints, open the published app, choose **API Access** in the left navigation, and create an app API key there; it is scoped to that app. Start with `GET /info` to discover its mode, then `GET /parameters` to discover the keys and types expected in `inputs`. For knowledge endpoints, create a knowledge base API key under **Knowledge** > **Service API**; it can access every knowledge base visible to its creator unless API access is disabled for one. Start with `GET /datasets`. Resource IDs such as `dataset_id`, `document_id`, and `workflow_id` come from the corresponding create or list responses identified in each field description. See [Get started](/en/api-reference/guides/get-started) for an end-to-end first call.\n\n**First authenticated request.** For Dify Cloud, set `api_base_url` to `api.dify.ai/v1`. Samples default to HTTPS. For self-hosted Dify, copy the full Service API endpoint from the API access panel, remove its `https://` or `http://` scheme when substituting `{api_base_url}`, and, for HTTP deployments, change the sample prefix to `http://`. Keep keys on your backend. Test an app key with:\n\n```bash\ncurl https://api.dify.ai/v1/info \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\nTest a knowledge base key with:\n\n```bash\ncurl 'https://api.dify.ai/v1/datasets?page=1&limit=20' \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\n**Dify terms.** A Chatbot is a basic conversational app. Chatflow adds a visual workflow to a conversation. Workflow is a non-conversational visual automation. Legacy Agent and new Agent apps let a model choose tools. Annotation reply matches a user's question against saved question-answer pairs and returns the saved answer. A knowledge pipeline is a visual ingestion workflow whose datasource nodes read files, provider pages, drives, or websites before indexing them. The `mode` returned by `GET /info` tells you which app endpoint family to use; every operation also begins with an availability line. `doc_form` selects the chunk structure: `text_model` for flat chunks, `hierarchical_model` for parent-child chunks, or `qa_model` for question-answer chunks. `indexing_technique` selects `high_quality` embedding-based indexing or `economy` keyword indexing.",
     "title": "Dify Service API",
-    "description": "REST API for Dify applications and knowledge bases. Application endpoints authenticate with an app API key; knowledge endpoints authenticate with a dataset API key.",
-    "version": "1.0.0"
+    "version": "1.0"
   },
   "servers": [
     {
-      "url": "https://{api_base_url}",
-      "description": "Base URL of the Dify Service API. For self-hosted deployments, replace it with your own API base URL.",
-      "variables": {
-        "api_base_url": {
-          "default": "api.dify.ai/v1",
-          "description": "Host and path of the API base URL, without the `https://` prefix."
-        }
-      }
+      "url": "/v1",
+      "description": "The Service API base path. Samples default to HTTPS: replace `{api_base_url}` with the host and `/v1` path, without a scheme (for example, `api.dify.ai/v1`). For a self-hosted HTTP endpoint, also change the sample's `https://` prefix to `http://`."
     }
   ],
   "security": [
     {
-      "ApiKeyAuth": []
+      "Bearer": []
     }
   ],
   "tags": [
@@ -13205,41 +13199,2269 @@
     }
   },
   "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "API_KEY",
-        "description": "Every request authenticates with an API key: `Authorization: Bearer {API_KEY}`. App endpoints take an app API key; knowledge endpoints take a knowledge base API key ([Get Started](/en/api-reference/guides/get-started)).\n\nKeep keys server-side; never embed them in client code. Requests with a missing or invalid key fail with HTTP `401` (`unauthorized`)."
+    "responses": {
+      "AppInvokeQuotaExceededError": {
+        "description": "AppInvokeQuotaExceededError"
+      },
+      "Exception": {
+        "description": "Exception"
+      },
+      "HTTPException": {
+        "description": "HTTPException"
+      },
+      "MaskError": {
+        "description": "When any error occurs on mask"
+      },
+      "ParseError": {
+        "description": "When a mask can't be parsed"
+      },
+      "PluginRuntimeError": {
+        "description": "PluginRuntimeError"
+      },
+      "ValueError": {
+        "description": "ValueError"
       }
     },
-    "responses": {
-      "SuccessResult": {
-        "description": "Operation successful.",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
+    "schemas": {
+      "AnnotationListQuery": {
+        "properties": {
+          "keyword": {
+            "default": "",
+            "description": "Keyword to filter annotations by question or answer content.",
+            "type": "string"
+          },
+          "limit": {
+            "default": 20,
+            "description": "Number of items per page.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number for pagination.",
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "AppInfoResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Application name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Application description."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Application tags."
+          },
+          "mode": {
+            "type": "string",
+            "description": "Application mode. `completion` for text generation apps, `chat` for basic chat apps, `agent-chat` for agent-based apps, `advanced-chat` for Chatflow apps, `workflow` for Workflow apps, `agent` for New Agent apps."
+          },
+          "author_name": {
+            "type": "string",
+            "description": "Name of the application author."
+          }
+        }
+      },
+      "AppMetaResponse": {
+        "type": "object",
+        "properties": {
+          "tool_icons": {
+            "type": "object",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "title": "Icon URL",
                   "type": "string",
-                  "description": "Operation result. Always `success`."
+                  "format": "url",
+                  "description": "URL of the icon."
+                },
+                {
+                  "$ref": "#/components/schemas/ToolIconDetail"
                 }
+              ]
+            },
+            "description": "Tool icons. Keys are tool names."
+          }
+        }
+      },
+      "AudioBinaryResponse": {
+        "format": "binary",
+        "type": "string"
+      },
+      "BinaryFileResponse": {
+        "format": "binary",
+        "type": "string"
+      },
+      "ChatRequestPayload": {
+        "properties": {
+          "auto_generate_name": {
+            "default": true,
+            "description": "Auto-generate the conversation title. If `false`, use the Rename Conversation API with `auto_generate: true` to generate the title asynchronously.",
+            "type": "boolean"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Conversation ID to continue a conversation. Omit this field or pass an empty string to start a new conversation, then pass the returned `conversation_id` in subsequent requests."
+          },
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Files for multimodal input. New clients should implement two canonical forms only: use `transfer_method: remote_url` with `url` for a public file URL, or upload through [Upload File](/en/api-reference/files/upload-file) and use `transfer_method: local_file` with the returned `id` as `upload_file_id`. Other generated `anyOf` combinations exist only for backward compatibility with stored legacy references."
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "Values for app-defined variables. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover expected variable names and types.",
+            "type": "object"
+          },
+          "query": {
+            "description": "User input or question content.",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Response mode. `streaming` uses Server-Sent Events; `blocking` returns after completion. New Agent app mode supports streaming only. When omitted, non-Agent apps run in blocking mode and new Agent apps stream."
+          },
+          "workflow_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Published workflow version ID to execute for advanced chat. If omitted, the app's current published workflow is used."
+          }
+        },
+        "required": [
+          "inputs",
+          "query"
+        ],
+        "type": "object"
+      },
+      "ChildChunkListQuery": {
+        "properties": {
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Search keyword."
+          },
+          "limit": {
+            "default": 20,
+            "description": "Number of items per page. Server caps at `100`.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number to retrieve.",
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "CompletionRequestPayload": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Files for multimodal input. New clients should implement two canonical forms only: use `transfer_method: remote_url` with `url` for a public file URL, or upload through [Upload File](/en/api-reference/files/upload-file) and use `transfer_method: local_file` with the returned `id` as `upload_file_id`. Other generated `anyOf` combinations exist only for backward compatibility with stored legacy references."
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "Values for app-defined variables. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover expected variable names and types.",
+            "type": "object"
+          },
+          "query": {
+            "default": "",
+            "description": "User input or prompt content.",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Response mode. `streaming` uses Server-Sent Events; `blocking` returns after completion. When omitted, the request runs in blocking mode."
+          }
+        },
+        "required": [
+          "inputs"
+        ],
+        "type": "object"
+      },
+      "ConversationListQuery": {
+        "properties": {
+          "last_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "The ID of the last record on the current page. Used to fetch the next page."
+          },
+          "limit": {
+            "default": 20,
+            "description": "Number of records to return.",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "sort_by": {
+            "default": "-updated_at",
+            "description": "Sorting field. Use the `-` prefix for descending order.",
+            "enum": [
+              "-created_at",
+              "-updated_at",
+              "created_at",
+              "updated_at"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ConversationRenamePayload": {
+        "anyOf": [
+          {
+            "properties": {
+              "auto_generate": {
+                "description": "Automatically generate the conversation name. When `true`, the `name` field is ignored.",
+                "enum": [
+                  true
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Conversation name. Required when `auto_generate` is `false`."
               }
             },
-            "examples": {
-              "success": {
-                "summary": "Response Example",
-                "value": {
-                  "result": "success"
+            "required": [
+              "auto_generate"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "auto_generate": {
+                "default": false,
+                "description": "Automatically generate the conversation name. When `true`, the `name` field is ignored.",
+                "enum": [
+                  false
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "pattern": ".*\\S.*",
+                "type": "string",
+                "description": "Conversation name."
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "auto_generate": {
+            "default": false,
+            "description": "Automatically generate the conversation name. When `true`, the `name` field is ignored.",
+            "type": "boolean"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Conversation name. Required when `auto_generate` is `false`."
+          }
+        },
+        "type": "object"
+      },
+      "ConversationVariableUpdatePayload": {
+        "properties": {
+          "value": {
+            "description": "The new value for the variable. Must match the variable's expected type."
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "ConversationVariablesQuery": {
+        "properties": {
+          "last_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "The ID of the last record on the current page. Used to fetch the next page."
+          },
+          "limit": {
+            "default": 20,
+            "description": "Number of records to return.",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "variable_name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter variables by a specific name."
+          }
+        },
+        "type": "object"
+      },
+      "DatasetListQuery": {
+        "properties": {
+          "include_all": {
+            "default": false,
+            "description": "Whether to include all knowledge bases regardless of permissions.",
+            "type": "boolean"
+          },
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Search keyword to filter by name."
+          },
+          "limit": {
+            "default": 20,
+            "description": "Number of items per page. Server caps at `100`.",
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number to retrieve.",
+            "type": "integer"
+          },
+          "tag_ids": {
+            "description": "Tag IDs to filter by.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "DatasourcePluginsQuery": {
+        "properties": {
+          "is_published": {
+            "default": true,
+            "description": "Whether to retrieve nodes from the published or draft pipeline. `true` returns nodes from the published version, `false` returns nodes from the draft.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentGetQuery": {
+        "properties": {
+          "metadata": {
+            "default": "all",
+            "description": "`all` returns all fields including metadata. `only` returns only `id`, `doc_type`, and `doc_metadata`. `without` returns all fields except `doc_metadata`.",
+            "enum": [
+              "all",
+              "only",
+              "without"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentListQuery": {
+        "properties": {
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Search keyword to filter by document name."
+          },
+          "limit": {
+            "default": 20,
+            "description": "Number of items per page. Server caps at `100`.",
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number to retrieve.",
+            "type": "integer"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "archived",
+                  "available",
+                  "disabled",
+                  "error",
+                  "indexing",
+                  "paused",
+                  "queuing"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by display status."
+          }
+        },
+        "type": "object"
+      },
+      "EndUserDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "End user ID."
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Tenant ID."
+          },
+          "app_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "Application ID."
+          },
+          "type": {
+            "type": "string",
+            "description": "End user type. Always `service-api` for Service API users."
+          },
+          "external_user_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "The `user` identifier provided in API requests (e.g., the `user` field in [Send Chat Message](/en/api-reference/chat-messages/send-chat-message))."
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "description": "End user name."
+          },
+          "is_anonymous": {
+            "type": "boolean",
+            "description": "Whether the user is anonymous. `true` when no `user` identifier was provided in the original API request."
+          },
+          "session_id": {
+            "type": "string",
+            "description": "Session identifier. Defaults to the `external_user_id` value."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Last update timestamp."
+          }
+        }
+      },
+      "EventStreamResponse": {
+        "type": "string"
+      },
+      "FeedbackListQuery": {
+        "properties": {
+          "limit": {
+            "default": 20,
+            "description": "Number of records per page.",
+            "maximum": 101,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number for pagination.",
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "FilePreviewQuery": {
+        "properties": {
+          "as_attachment": {
+            "default": false,
+            "description": "If `true`, forces the file to download as an attachment instead of previewing in browser.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "HumanInputContent": {
+        "type": "object",
+        "description": "Execution content from a Human Input node, including form definition and submission data.",
+        "properties": {
+          "workflow_run_id": {
+            "type": "string",
+            "description": "ID of the workflow run this content belongs to."
+          },
+          "submitted": {
+            "type": "boolean",
+            "description": "Whether the human input form has been submitted."
+          },
+          "type": {
+            "type": "string",
+            "description": "`human_input` for human input content."
+          },
+          "form_definition": {
+            "nullable": true,
+            "description": "Form definition from the Human Input node. `null` when the content represents a submission response.",
+            "$ref": "#/components/schemas/HumanInputFormDefinition"
+          },
+          "form_submission_data": {
+            "nullable": true,
+            "description": "Submitted form data. `null` when the form has not been submitted yet.",
+            "$ref": "#/components/schemas/HumanInputFormSubmissionData"
+          }
+        }
+      },
+      "HumanInputFormDefinition": {
+        "type": "object",
+        "description": "Definition of a human input form rendered by a Human Input node.",
+        "properties": {
+          "form_id": {
+            "type": "string",
+            "description": "Unique form identifier."
+          },
+          "node_id": {
+            "type": "string",
+            "description": "ID of the Human Input node that generated this form."
+          },
+          "node_title": {
+            "type": "string",
+            "description": "Title of the Human Input node."
+          },
+          "form_content": {
+            "type": "string",
+            "description": "Markdown or text content displayed with the form."
+          },
+          "inputs": {
+            "type": "array",
+            "description": "Input fields in the form.",
+            "items": {
+              "$ref": "#/components/schemas/FormInput"
+            }
+          },
+          "actions": {
+            "type": "array",
+            "description": "Action buttons available on the form.",
+            "items": {
+              "$ref": "#/components/schemas/UserAction"
+            }
+          },
+          "display_in_ui": {
+            "type": "boolean",
+            "description": "Whether the form should be displayed in the UI."
+          },
+          "form_token": {
+            "type": "string",
+            "nullable": true,
+            "description": "Token for form submission authentication."
+          },
+          "resolved_default_values": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Resolved default values for form inputs, keyed by output variable name."
+          },
+          "expiration_time": {
+            "type": "integer",
+            "description": "Unix timestamp when the form expires."
+          }
+        }
+      },
+      "HumanInputFormSubmissionData": {
+        "type": "object",
+        "description": "Data from a submitted human input form.",
+        "properties": {
+          "node_id": {
+            "type": "string",
+            "description": "ID of the Human Input node."
+          },
+          "node_title": {
+            "type": "string",
+            "description": "Title of the Human Input node."
+          },
+          "rendered_content": {
+            "type": "string",
+            "description": "Rendered content of the form submission."
+          },
+          "action_id": {
+            "type": "string",
+            "description": "ID of the action button that was clicked."
+          },
+          "action_text": {
+            "type": "string",
+            "description": "Display text of the action button that was clicked."
+          }
+        }
+      },
+      "HumanInputFormSubmitPayload": {
+        "properties": {
+          "action": {
+            "description": "ID of the action button the recipient selected. Must match one of the `id` values from the form's `user_actions` list.",
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "description": "Submitted human input values keyed by output variable name. Use a string for paragraph or select input values, a file mapping for file inputs, and a list of file mappings for file-list inputs. Local file mappings use `transfer_method=local_file` with `upload_file_id`; remote file mappings use `transfer_method=remote_url` with `url` or `remote_url`.",
+            "examples": [
+              {
+                "attachment": {
+                  "transfer_method": "local_file",
+                  "type": "document",
+                  "upload_file_id": "4e0d1b87-52f2-49f6-b8c6-95cd9c954b3e"
+                },
+                "attachments": [
+                  {
+                    "transfer_method": "local_file",
+                    "type": "document",
+                    "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee"
+                  },
+                  {
+                    "transfer_method": "remote_url",
+                    "type": "document",
+                    "url": "https://example.com/report.pdf"
+                  }
+                ],
+                "decision": "approve"
+              }
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "action",
+          "inputs"
+        ],
+        "type": "object"
+      },
+      "JSONObject": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "MessageFeedbackPayload": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional text feedback providing additional detail."
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "enum": [
+                  "dislike",
+                  "like"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Feedback rating. Set to `null` to revoke previously submitted feedback."
+          }
+        },
+        "type": "object"
+      },
+      "MessageListQuery": {
+        "properties": {
+          "conversation_id": {
+            "description": "Conversation ID.",
+            "type": "string"
+          },
+          "first_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "The ID of the first chat record on the current page. Omit this value to fetch the latest messages; for subsequent pages, use the first message ID from the current list to fetch older messages."
+          },
+          "limit": {
+            "default": 20,
+            "description": "Number of chat history messages to return per request.",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "conversation_id"
+        ],
+        "type": "object"
+      },
+      "RetrievalModel": {
+        "type": "object",
+        "required": [
+          "search_method",
+          "reranking_enable",
+          "top_k",
+          "score_threshold_enabled"
+        ],
+        "properties": {
+          "search_method": {
+            "type": "string",
+            "description": "Search method used for retrieval.",
+            "enum": [
+              "keyword_search",
+              "semantic_search",
+              "full_text_search",
+              "hybrid_search"
+            ]
+          },
+          "reranking_enable": {
+            "type": "boolean",
+            "description": "Whether reranking is enabled."
+          },
+          "reranking_model": {
+            "type": "object",
+            "description": "Reranking model configuration.",
+            "properties": {
+              "reranking_provider_name": {
+                "type": "string",
+                "description": "Reranking model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/cohere/cohere`). A bare name like `cohere` expands to `langgenius/<name>/<name>` and works only for langgenius-published plugins.\n\nGet valid values from the `provider` field of [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=rerank`."
+              },
+              "reranking_model_name": {
+                "type": "string",
+                "description": "Name of the reranking model."
+              }
+            }
+          },
+          "reranking_mode": {
+            "type": "string",
+            "enum": [
+              "reranking_model",
+              "weighted_score"
+            ],
+            "nullable": true,
+            "description": "Reranking mode. Required when `reranking_enable` is `true`."
+          },
+          "top_k": {
+            "type": "integer",
+            "description": "Maximum number of results to return."
+          },
+          "score_threshold_enabled": {
+            "type": "boolean",
+            "description": "Whether score threshold filtering is enabled."
+          },
+          "score_threshold": {
+            "type": "number",
+            "nullable": true,
+            "description": "Minimum similarity score for results. Only effective when `score_threshold_enabled` is `true`."
+          },
+          "weights": {
+            "type": "object",
+            "nullable": true,
+            "description": "Weight configuration for hybrid search.",
+            "properties": {
+              "weight_type": {
+                "type": "string",
+                "description": "Strategy for balancing semantic and keyword search weights.",
+                "enum": [
+                  "semantic_first",
+                  "keyword_first",
+                  "customized"
+                ]
+              },
+              "vector_setting": {
+                "type": "object",
+                "description": "Semantic search weight settings.",
+                "properties": {
+                  "vector_weight": {
+                    "type": "number",
+                    "description": "Weight assigned to semantic (vector) search results."
+                  },
+                  "embedding_provider_name": {
+                    "type": "string",
+                    "description": "Provider of the embedding model used for vector search."
+                  },
+                  "embedding_model_name": {
+                    "type": "string",
+                    "description": "Name of the embedding model used for vector search."
+                  }
+                }
+              },
+              "keyword_setting": {
+                "type": "object",
+                "description": "Keyword search weight settings.",
+                "properties": {
+                  "keyword_weight": {
+                    "type": "number",
+                    "description": "Weight assigned to keyword search results."
+                  }
+                }
+              }
+            }
+          },
+          "metadata_filtering_conditions": {
+            "type": "object",
+            "nullable": true,
+            "description": "Restrict retrieval to chunks whose document metadata matches the given conditions. Conditions are evaluated server-side against document metadata fields.",
+            "properties": {
+              "logical_operator": {
+                "type": "string",
+                "enum": [
+                  "and",
+                  "or"
+                ],
+                "default": "and",
+                "nullable": true,
+                "description": "How to combine multiple conditions."
+              },
+              "conditions": {
+                "type": "array",
+                "nullable": true,
+                "description": "List of metadata conditions to evaluate.",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "comparison_operator"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Metadata field name to compare against."
+                    },
+                    "comparison_operator": {
+                      "type": "string",
+                      "description": "Comparison to apply, by metadata type:\n\n- String or array metadata: `contains`, `not contains`, `start with`, `end with`, `is`, `is not`, `empty`, `not empty`, `in`, `not in`\n- Numeric metadata: `=`, `≠`, `>`, `<`, `≥`, `≤`\n- Time metadata: `before`, `after`",
+                      "enum": [
+                        "contains",
+                        "not contains",
+                        "start with",
+                        "end with",
+                        "is",
+                        "is not",
+                        "empty",
+                        "not empty",
+                        "in",
+                        "not in",
+                        "=",
+                        "≠",
+                        ">",
+                        "<",
+                        "≥",
+                        "≤",
+                        "before",
+                        "after"
+                      ]
+                    },
+                    "value": {
+                      "nullable": true,
+                      "description": "Value to compare against. Type depends on `comparison_operator`: string for most string operators, array of strings for `in` and `not in`, number for numeric operators, and omitted for `empty` and `not empty`.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
           }
         }
-      }
-    },
-    "schemas": {
+      },
+      "RetrieverResource": {
+        "type": "object",
+        "description": "Citation and attribution information for a retriever resource.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique ID of the retriever resource."
+          },
+          "message_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the message this resource belongs to."
+          },
+          "position": {
+            "type": "integer",
+            "description": "Position of the resource in the list."
+          },
+          "dataset_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the knowledge base."
+          },
+          "dataset_name": {
+            "type": "string",
+            "description": "Name of the knowledge base."
+          },
+          "document_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the document."
+          },
+          "document_name": {
+            "type": "string",
+            "description": "Name of the document."
+          },
+          "data_source_type": {
+            "type": "string",
+            "description": "Type of the data source."
+          },
+          "segment_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the specific chunk within the document."
+          },
+          "score": {
+            "type": "number",
+            "format": "float",
+            "description": "Similarity score of the resource."
+          },
+          "hit_count": {
+            "type": "integer",
+            "description": "Number of times this chunk was hit."
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "Word count of the chunk."
+          },
+          "segment_position": {
+            "type": "integer",
+            "description": "Position of the chunk within the document."
+          },
+          "index_node_hash": {
+            "type": "string",
+            "description": "Hash of the index node."
+          },
+          "content": {
+            "type": "string",
+            "description": "Content snippet from the resource."
+          },
+          "summary": {
+            "type": "string",
+            "nullable": true,
+            "description": "Summary of the chunk content."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Creation timestamp (Unix epoch seconds)."
+          }
+        }
+      },
+      "SegmentListQuery": {
+        "properties": {
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Search keyword."
+          },
+          "limit": {
+            "default": 20,
+            "description": "Number of items per page. Server caps at `100`.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number to retrieve.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "status": {
+            "description": "Filter chunks by indexing status, such as `completed`, `indexing`, or `error`.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "SimpleResultResponse": {
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "Operation result."
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object"
+      },
+      "TextToAudioPayload": {
+        "properties": {
+          "message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Message ID. Takes priority over `text` when both are provided."
+          },
+          "streaming": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Reserved for compatibility; TTS response streaming is determined by the provider output."
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Speech content to convert."
+          },
+          "voice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Voice to use for text-to-speech. Available voices depend on the TTS provider configured for this app. Omit to use the app's configured voice when available; that value is exposed by [Get App Parameters](/en/api-reference/applications/get-app-parameters) as `text_to_speech.voice`."
+          }
+        },
+        "type": "object"
+      },
+      "WorkflowBlockingResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/WorkflowFinishedBlockingResponse"
+          },
+          {
+            "$ref": "#/components/schemas/WorkflowPausedBlockingResponse"
+          }
+        ]
+      },
+      "WorkflowEventsQuery": {
+        "properties": {
+          "continue_on_pause": {
+            "default": false,
+            "description": "Set to `true` to keep the stream open across multiple `workflow_paused` events, which is useful when the workflow has more than one Human Input node in sequence. By default, the stream closes after the first pause.",
+            "type": "boolean"
+          },
+          "include_state_snapshot": {
+            "default": false,
+            "description": "When `true`, replay from the persisted state snapshot to include a status summary of already-executed nodes before streaming new events.",
+            "type": "boolean"
+          },
+          "user": {
+            "description": "End-user identifier that originally triggered the run. Must match the creator of the run.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "type": "object"
+      },
+      "WorkflowFinishedBlockingDataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "Creation time as a Unix timestamp in seconds."
+          },
+          "elapsed_time": {
+            "format": "float",
+            "type": "number",
+            "description": "Total time elapsed in seconds."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error message if the workflow failed."
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Finish time as a Unix timestamp in seconds; `null` if not finished."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Workflow run ID."
+          },
+          "outputs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output data from the workflow."
+          },
+          "status": {
+            "enum": [
+              "failed",
+              "partial-succeeded",
+              "stopped",
+              "succeeded"
+            ],
+            "type": "string",
+            "description": "Final workflow execution status."
+          },
+          "total_steps": {
+            "type": "integer",
+            "description": "Total number of workflow steps executed."
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Total tokens consumed across all nodes."
+          },
+          "workflow_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Workflow ID."
+          }
+        },
+        "required": [
+          "created_at",
+          "elapsed_time",
+          "error",
+          "finished_at",
+          "id",
+          "outputs",
+          "status",
+          "total_steps",
+          "total_tokens",
+          "workflow_id"
+        ],
+        "type": "object"
+      },
+      "WorkflowFinishedBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WorkflowFinishedBlockingDataResponse",
+            "description": "Data returned when the workflow finishes."
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Task ID for the in-progress execution. Use this with [Stop Workflow Task](/en/api-reference/workflow-runs/stop-workflow-task) to cancel a running workflow. Only valid during execution."
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Persistent identifier for this workflow run record. Use this with [Get Workflow Run Detail](/en/api-reference/workflow-runs/get-workflow-run-detail) to retrieve results after execution."
+          }
+        },
+        "required": [
+          "data",
+          "task_id",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "Blocking response returned after a workflow execution finishes."
+      },
+      "WorkflowLogQuery": {
+        "properties": {
+          "created_at__after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter logs created after this ISO 8601 timestamp.",
+            "format": "date-time"
+          },
+          "created_at__before": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter logs created before this ISO 8601 timestamp.",
+            "format": "date-time"
+          },
+          "created_by_account": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by a workspace member's email address. Despite the historical field name, the runtime resolves this value as an email, not an account ID."
+          },
+          "created_by_end_user_session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by an end-user session ID. Obtain it from `session_id` in [Get End User Info](/en/api-reference/end-users/get-end-user-info); for Service API users it normally matches the request's `user` value."
+          },
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Keyword to search in logs."
+          },
+          "limit": {
+            "default": 20,
+            "description": "Number of items per page.",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number for pagination.",
+            "maximum": 99999,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "failed",
+                  "stopped",
+                  "succeeded"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by execution status."
+          }
+        },
+        "type": "object"
+      },
+      "WorkflowPauseReasonResponse": {
+        "additionalProperties": true,
+        "description": "Public details explaining why a blocking workflow execution paused.",
+        "properties": {
+          "TYPE": {
+            "type": "string",
+            "description": "Pause reason type."
+          },
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "Actions available in the Human Input form."
+          },
+          "approval_channels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Configured approval channels."
+          },
+          "display_in_ui": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether the pause reason should be displayed in the UI."
+          },
+          "expiration_time": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unix timestamp when the Human Input form expires."
+          },
+          "form_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Content displayed with the Human Input form."
+          },
+          "form_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Human Input form ID."
+          },
+          "form_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Access token used with the Human Input Form API."
+          },
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "Input fields in the Human Input form."
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Message explaining why the workflow paused."
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the workflow node that paused."
+          },
+          "node_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Title of the workflow node that paused."
+          },
+          "resolved_default_values": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "Resolved default values for the form inputs."
+          }
+        },
+        "required": [
+          "TYPE"
+        ],
+        "type": "object"
+      },
+      "WorkflowPausedBlockingDataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "Creation time as a Unix timestamp in seconds."
+          },
+          "elapsed_time": {
+            "format": "float",
+            "type": "number",
+            "description": "Total time elapsed in seconds."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error message if the workflow failed."
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Finish time as a Unix timestamp in seconds; `null` if not finished."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Workflow run ID."
+          },
+          "outputs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output data from the workflow."
+          },
+          "paused_nodes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "IDs of workflow nodes waiting for input."
+          },
+          "reasons": {
+            "items": {
+              "$ref": "#/components/schemas/WorkflowPauseReasonResponse"
+            },
+            "type": "array",
+            "description": "Reasons the workflow paused, including Human Input form details."
+          },
+          "status": {
+            "const": "paused",
+            "type": "string",
+            "description": "Workflow execution status, fixed as `paused`."
+          },
+          "total_steps": {
+            "type": "integer",
+            "description": "Total number of workflow steps executed."
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Total tokens consumed across all nodes."
+          },
+          "workflow_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Workflow ID."
+          }
+        },
+        "required": [
+          "created_at",
+          "elapsed_time",
+          "error",
+          "finished_at",
+          "id",
+          "outputs",
+          "paused_nodes",
+          "reasons",
+          "status",
+          "total_steps",
+          "total_tokens",
+          "workflow_id"
+        ],
+        "type": "object"
+      },
+      "WorkflowPausedBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WorkflowPausedBlockingDataResponse",
+            "description": "Data returned when the workflow pauses for input."
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Task ID for the in-progress execution. Use this with [Stop Workflow Task](/en/api-reference/workflow-runs/stop-workflow-task) to cancel a running workflow. Only valid during execution."
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Persistent identifier for this workflow run record. Use this with [Get Workflow Run Detail](/en/api-reference/workflow-runs/get-workflow-run-detail) to retrieve results after execution."
+          }
+        },
+        "required": [
+          "data",
+          "task_id",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "Blocking response returned when a workflow execution is waiting for human input."
+      },
+      "WorkflowRunPayload": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method: `remote_url` for a file URL or persisted uploaded-file reference, `local_file` for an uploaded file.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method: `remote_url` for a file URL or persisted uploaded-file reference, `local_file` for an uploaded file.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method: `remote_url` for a file URL or persisted uploaded-file reference, `local_file` for an uploaded file.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method: `remote_url` for a file URL or persisted uploaded-file reference, `local_file` for an uploaded file.",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "File list for workflow system file inputs. Available when file upload is enabled for the workflow. To attach a local file, first upload it via [Upload File](/en/api-reference/files/upload-file) and use the returned `id` as `upload_file_id` with `transfer_method: local_file`."
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "Key-value pairs for workflow input variables. Values for file-type variables should be arrays of file objects with `type`, `transfer_method`, and either `url` or `upload_file_id`. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover the variable names and types expected by your app.",
+            "type": "object"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Response mode. Use `blocking` for synchronous responses or `streaming` for Server-Sent Events. When omitted, the request runs in blocking mode."
+          }
+        },
+        "required": [
+          "inputs"
+        ],
+        "type": "object"
+      },
       "ChatRequest": {
         "type": "object",
         "required": [
@@ -13806,88 +16028,6 @@
           }
         }
       },
-      "RetrieverResource": {
-        "type": "object",
-        "description": "Citation and attribution information for a retriever resource.",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Unique ID of the retriever resource."
-          },
-          "message_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ID of the message this resource belongs to."
-          },
-          "position": {
-            "type": "integer",
-            "description": "Position of the resource in the list."
-          },
-          "dataset_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ID of the knowledge base."
-          },
-          "dataset_name": {
-            "type": "string",
-            "description": "Name of the knowledge base."
-          },
-          "document_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ID of the document."
-          },
-          "document_name": {
-            "type": "string",
-            "description": "Name of the document."
-          },
-          "data_source_type": {
-            "type": "string",
-            "description": "Type of the data source."
-          },
-          "segment_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ID of the specific chunk within the document."
-          },
-          "score": {
-            "type": "number",
-            "format": "float",
-            "description": "Similarity score of the resource."
-          },
-          "hit_count": {
-            "type": "integer",
-            "description": "Number of times this chunk was hit."
-          },
-          "word_count": {
-            "type": "integer",
-            "description": "Word count of the chunk."
-          },
-          "segment_position": {
-            "type": "integer",
-            "description": "Position of the chunk within the document."
-          },
-          "index_node_hash": {
-            "type": "string",
-            "description": "Hash of the index node."
-          },
-          "content": {
-            "type": "string",
-            "description": "Content snippet from the resource."
-          },
-          "summary": {
-            "type": "string",
-            "nullable": true,
-            "description": "Summary of the chunk content."
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Creation timestamp (Unix epoch seconds)."
-          }
-        }
-      },
       "FileUploadResponse": {
         "type": "object",
         "properties": {
@@ -13966,59 +16106,6 @@
             "type": "string",
             "nullable": true,
             "description": "Unused; always `null`."
-          }
-        }
-      },
-      "EndUserDetail": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "End user ID."
-          },
-          "tenant_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Tenant ID."
-          },
-          "app_id": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true,
-            "description": "Application ID."
-          },
-          "type": {
-            "type": "string",
-            "description": "End user type. Always `service-api` for Service API users."
-          },
-          "external_user_id": {
-            "type": "string",
-            "nullable": true,
-            "description": "The `user` identifier provided in API requests (e.g., the `user` field in [Send Chat Message](/en/api-reference/chat-messages/send-chat-message))."
-          },
-          "name": {
-            "type": "string",
-            "nullable": true,
-            "description": "End user name."
-          },
-          "is_anonymous": {
-            "type": "boolean",
-            "description": "Whether the user is anonymous. `true` when no `user` identifier was provided in the original API request."
-          },
-          "session_id": {
-            "type": "string",
-            "description": "Session identifier. Defaults to the `external_user_id` value."
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Creation timestamp."
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Last update timestamp."
           }
         }
       },
@@ -14584,34 +16671,6 @@
           }
         }
       },
-      "AppInfoResponse": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Application name."
-          },
-          "description": {
-            "type": "string",
-            "description": "Application description."
-          },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Application tags."
-          },
-          "mode": {
-            "type": "string",
-            "description": "Application mode. `completion` for text generation apps, `chat` for basic chat apps, `agent-chat` for agent-based apps, `advanced-chat` for Chatflow apps, `workflow` for Workflow apps, `agent` for New Agent apps."
-          },
-          "author_name": {
-            "type": "string",
-            "description": "Name of the application author."
-          }
-        }
-      },
       "UserInputFormItem": {
         "type": "object",
         "oneOf": [
@@ -14720,28 +16779,6 @@
               "type": "string"
             },
             "description": "List of selectable values for this form control."
-          }
-        }
-      },
-      "AppMetaResponse": {
-        "type": "object",
-        "properties": {
-          "tool_icons": {
-            "type": "object",
-            "additionalProperties": {
-              "oneOf": [
-                {
-                  "title": "Icon URL",
-                  "type": "string",
-                  "format": "url",
-                  "description": "URL of the icon."
-                },
-                {
-                  "$ref": "#/components/schemas/ToolIconDetail"
-                }
-              ]
-            },
-            "description": "Tool icons. Keys are tool names."
           }
         }
       },
@@ -16693,114 +18730,6 @@
           }
         }
       },
-      "HumanInputContent": {
-        "type": "object",
-        "description": "Execution content from a Human Input node, including form definition and submission data.",
-        "properties": {
-          "workflow_run_id": {
-            "type": "string",
-            "description": "ID of the workflow run this content belongs to."
-          },
-          "submitted": {
-            "type": "boolean",
-            "description": "Whether the human input form has been submitted."
-          },
-          "type": {
-            "type": "string",
-            "description": "`human_input` for human input content."
-          },
-          "form_definition": {
-            "nullable": true,
-            "description": "Form definition from the Human Input node. `null` when the content represents a submission response.",
-            "$ref": "#/components/schemas/HumanInputFormDefinition"
-          },
-          "form_submission_data": {
-            "nullable": true,
-            "description": "Submitted form data. `null` when the form has not been submitted yet.",
-            "$ref": "#/components/schemas/HumanInputFormSubmissionData"
-          }
-        }
-      },
-      "HumanInputFormDefinition": {
-        "type": "object",
-        "description": "Definition of a human input form rendered by a Human Input node.",
-        "properties": {
-          "form_id": {
-            "type": "string",
-            "description": "Unique form identifier."
-          },
-          "node_id": {
-            "type": "string",
-            "description": "ID of the Human Input node that generated this form."
-          },
-          "node_title": {
-            "type": "string",
-            "description": "Title of the Human Input node."
-          },
-          "form_content": {
-            "type": "string",
-            "description": "Markdown or text content displayed with the form."
-          },
-          "inputs": {
-            "type": "array",
-            "description": "Input fields in the form.",
-            "items": {
-              "$ref": "#/components/schemas/FormInput"
-            }
-          },
-          "actions": {
-            "type": "array",
-            "description": "Action buttons available on the form.",
-            "items": {
-              "$ref": "#/components/schemas/UserAction"
-            }
-          },
-          "display_in_ui": {
-            "type": "boolean",
-            "description": "Whether the form should be displayed in the UI."
-          },
-          "form_token": {
-            "type": "string",
-            "nullable": true,
-            "description": "Token for form submission authentication."
-          },
-          "resolved_default_values": {
-            "type": "object",
-            "additionalProperties": true,
-            "description": "Resolved default values for form inputs, keyed by output variable name."
-          },
-          "expiration_time": {
-            "type": "integer",
-            "description": "Unix timestamp when the form expires."
-          }
-        }
-      },
-      "HumanInputFormSubmissionData": {
-        "type": "object",
-        "description": "Data from a submitted human input form.",
-        "properties": {
-          "node_id": {
-            "type": "string",
-            "description": "ID of the Human Input node."
-          },
-          "node_title": {
-            "type": "string",
-            "description": "Title of the Human Input node."
-          },
-          "rendered_content": {
-            "type": "string",
-            "description": "Rendered content of the form submission."
-          },
-          "action_id": {
-            "type": "string",
-            "description": "ID of the action button that was clicked."
-          },
-          "action_text": {
-            "type": "string",
-            "description": "Display text of the action button that was clicked."
-          }
-        }
-      },
       "FormInput": {
         "type": "object",
         "description": "A form input field definition.",
@@ -16993,24 +18922,6 @@
             }
           }
         ]
-      },
-      "WorkflowBlockingResponse": {
-        "type": "object",
-        "properties": {
-          "task_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Task ID for the in-progress execution. Use this with [Stop Workflow Task](/en/api-reference/workflow-runs/stop-workflow-task) to cancel a running workflow. Only valid during execution."
-          },
-          "workflow_run_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Persistent identifier for this workflow run record. Use this with [Get Workflow Run Detail](/en/api-reference/workflow-runs/get-workflow-run-detail) to retrieve results after execution."
-          },
-          "data": {
-            "$ref": "#/components/schemas/WorkflowFinishedData"
-          }
-        }
       },
       "ChunkWorkflowEvent": {
         "type": "object",
@@ -19483,189 +21394,19 @@
             "description": "Last update timestamp (Unix epoch in seconds)."
           }
         }
-      },
-      "RetrievalModel": {
-        "type": "object",
-        "required": [
-          "search_method",
-          "reranking_enable",
-          "top_k",
-          "score_threshold_enabled"
-        ],
-        "properties": {
-          "search_method": {
-            "type": "string",
-            "description": "Search method used for retrieval.",
-            "enum": [
-              "keyword_search",
-              "semantic_search",
-              "full_text_search",
-              "hybrid_search"
-            ]
-          },
-          "reranking_enable": {
-            "type": "boolean",
-            "description": "Whether reranking is enabled."
-          },
-          "reranking_model": {
-            "type": "object",
-            "description": "Reranking model configuration.",
-            "properties": {
-              "reranking_provider_name": {
-                "type": "string",
-                "description": "Reranking model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/cohere/cohere`). A bare name like `cohere` expands to `langgenius/<name>/<name>` and works only for langgenius-published plugins.\n\nGet valid values from the `provider` field of [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=rerank`."
-              },
-              "reranking_model_name": {
-                "type": "string",
-                "description": "Name of the reranking model."
-              }
-            }
-          },
-          "reranking_mode": {
-            "type": "string",
-            "enum": [
-              "reranking_model",
-              "weighted_score"
-            ],
-            "nullable": true,
-            "description": "Reranking mode. Required when `reranking_enable` is `true`."
-          },
-          "top_k": {
-            "type": "integer",
-            "description": "Maximum number of results to return."
-          },
-          "score_threshold_enabled": {
-            "type": "boolean",
-            "description": "Whether score threshold filtering is enabled."
-          },
-          "score_threshold": {
-            "type": "number",
-            "nullable": true,
-            "description": "Minimum similarity score for results. Only effective when `score_threshold_enabled` is `true`."
-          },
-          "weights": {
-            "type": "object",
-            "nullable": true,
-            "description": "Weight configuration for hybrid search.",
-            "properties": {
-              "weight_type": {
-                "type": "string",
-                "description": "Strategy for balancing semantic and keyword search weights.",
-                "enum": [
-                  "semantic_first",
-                  "keyword_first",
-                  "customized"
-                ]
-              },
-              "vector_setting": {
-                "type": "object",
-                "description": "Semantic search weight settings.",
-                "properties": {
-                  "vector_weight": {
-                    "type": "number",
-                    "description": "Weight assigned to semantic (vector) search results."
-                  },
-                  "embedding_provider_name": {
-                    "type": "string",
-                    "description": "Provider of the embedding model used for vector search."
-                  },
-                  "embedding_model_name": {
-                    "type": "string",
-                    "description": "Name of the embedding model used for vector search."
-                  }
-                }
-              },
-              "keyword_setting": {
-                "type": "object",
-                "description": "Keyword search weight settings.",
-                "properties": {
-                  "keyword_weight": {
-                    "type": "number",
-                    "description": "Weight assigned to keyword search results."
-                  }
-                }
-              }
-            }
-          },
-          "metadata_filtering_conditions": {
-            "type": "object",
-            "nullable": true,
-            "description": "Restrict retrieval to chunks whose document metadata matches the given conditions. Conditions are evaluated server-side against document metadata fields.",
-            "properties": {
-              "logical_operator": {
-                "type": "string",
-                "enum": [
-                  "and",
-                  "or"
-                ],
-                "default": "and",
-                "nullable": true,
-                "description": "How to combine multiple conditions."
-              },
-              "conditions": {
-                "type": "array",
-                "nullable": true,
-                "description": "List of metadata conditions to evaluate.",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "name",
-                    "comparison_operator"
-                  ],
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "Metadata field name to compare against."
-                    },
-                    "comparison_operator": {
-                      "type": "string",
-                      "description": "Comparison to apply, by metadata type:\n\n- String or array metadata: `contains`, `not contains`, `start with`, `end with`, `is`, `is not`, `empty`, `not empty`, `in`, `not in`\n- Numeric metadata: `=`, `≠`, `>`, `<`, `≥`, `≤`\n- Time metadata: `before`, `after`",
-                      "enum": [
-                        "contains",
-                        "not contains",
-                        "start with",
-                        "end with",
-                        "is",
-                        "is not",
-                        "empty",
-                        "not empty",
-                        "in",
-                        "not in",
-                        "=",
-                        "≠",
-                        ">",
-                        "<",
-                        "≥",
-                        "≤",
-                        "before",
-                        "after"
-                      ]
-                    },
-                    "value": {
-                      "nullable": true,
-                      "description": "Value to compare against. Type depends on `comparison_operator`: string for most string operators, array of strings for `in` and `not in`, number for numeric operators, and omitted for `empty` and `not empty`.",
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        {
-                          "type": "number"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "bearerFormat": "API_KEY",
+        "description": "Use the Service API key as a Bearer token in the Authorization header.",
+        "scheme": "bearer",
+        "type": "http"
       }
     }
+  },
+  "externalDocs": {
+    "description": "Get started guide",
+    "url": "/en/api-reference/guides/get-started"
   }
 }

--- a/ja/api-reference/openapi_service.json
+++ b/ja/api-reference/openapi_service.json
@@ -1,25 +1,19 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.1.0",
   "info": {
+    "description": "Dify アプリケーションとナレッジベースのための REST API です。呼び出す前に、Dify でアプリを作成して公開するか、ナレッジベースを作成してください。リクエストは Dify の API アクセス画面に表示される Service API エンドポイント（パス末尾は `/v1`）へ送り、`Authorization: Bearer <キー>` で認証します。アプリ系エンドポイントでは、公開済みアプリを開き、左側のナビゲーションで **API アクセス** を選択してアプリ API キーを作成します。このキーはそのアプリだけに有効です。まず `GET /info` でモードを確認し、次に `GET /parameters` で `inputs` に必要なキーと型を取得します。ナレッジ系エンドポイントでは、**ナレッジ** > **Service API** でナレッジベース API キーを作成します。個別のナレッジベースで API アクセスを無効にしていない限り、キー作成者から見えるすべてのナレッジベースにアクセスできます。最初に `GET /datasets` を呼び出してください。`dataset_id`、`document_id`、`workflow_id` などのリソース ID は、各フィールド説明が示す作成または一覧取得レスポンスから取得します。最初の呼び出しの手順は[はじめに](/ja/api-reference/guides/get-started)を参照してください。\n\n**最初の認証済みリクエスト。** Dify Cloud の `api_base_url` は `api.dify.ai/v1` で、例は HTTPS を前提としています。セルフホスト版では API アクセス画面から Service API エンドポイント全体をコピーし、`{api_base_url}` に代入する際は `https://` または `http://` のスキームを除いてください。HTTP の場合は、例の接頭辞も `http://` に変更します。キーはバックエンドだけに保存します。アプリキーをテストするには：\n\n```bash\ncurl https://api.dify.ai/v1/info \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\nナレッジベースキーをテストするには：\n\n```bash\ncurl 'https://api.dify.ai/v1/datasets?page=1&limit=20' \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\n**Dify の用語。** チャットボットは基本的な会話アプリです。Chatflow は会話にビジュアルワークフローを追加します。Workflow は非会話型のビジュアル自動化です。旧 Agent と新しい Agent アプリでは、モデルがツールを選択します。アノテーション返信はユーザーの質問を保存済みの質問と回答のペアに照合し、保存済み回答を返します。ナレッジパイプラインはビジュアルな取り込みワークフローで、データソースノードがインデックス作成前にファイル、プロバイダーページ、ドライブ、Web サイトを読み込みます。`GET /info` が返す `mode` により使用するアプリエンドポイント群が決まり、各操作の冒頭にも対象範囲が記載されています。 `doc_form` はチャンク構造を選びます。`text_model` はフラットなチャンク、`hierarchical_model` は親子チャンク、`qa_model` は質問と回答のチャンクです。`indexing_technique` は埋め込みベースの `high_quality` インデックス、またはキーワードベースの `economy` インデックスを選びます。",
     "title": "Dify サービス API",
-    "description": "Dify アプリケーションとナレッジベースのための REST API です。アプリケーション系エンドポイントはアプリの API キーで、ナレッジ系エンドポイントはナレッジベースの API キーで認証します。",
-    "version": "1.0.0"
+    "version": "1.0"
   },
   "servers": [
     {
-      "url": "https://{api_base_url}",
-      "description": "Dify サービス API のベース URL です。セルフホスト環境では、独自の API ベース URL に置き換えてください。",
-      "variables": {
-        "api_base_url": {
-          "default": "api.dify.ai/v1",
-          "description": "API ベース URL のホストとパス（`https://` を除く）。"
-        }
-      }
+      "url": "/v1",
+      "description": "Service API のベースパスです。例は HTTPS を前提としています。`{api_base_url}` はスキームを除いたデプロイ先ホストと `/v1` パスに置き換えてください（例：`api.dify.ai/v1`）。セルフホストのエンドポイントが HTTP の場合は、例の `https://` も `http://` に変更してください。"
     }
   ],
   "security": [
     {
-      "ApiKeyAuth": []
+      "Bearer": []
     }
   ],
   "tags": [
@@ -13205,41 +13199,2269 @@
     }
   },
   "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "API_KEY",
-        "description": "すべてのリクエストは API キーで認証します：`Authorization: Bearer {API_KEY}`。アプリのエンドポイントにはアプリの API キーを、ナレッジのエンドポイントにはナレッジベースの API キーを使用します（[Dify API クイックスタート](/ja/api-reference/guides/get-started)）。\n\nキーはサーバーサイドで保管し、クライアントコードには決して埋め込まないでください。キーが欠落または無効なリクエストは HTTP `401`（`unauthorized`）で失敗します。"
+    "responses": {
+      "AppInvokeQuotaExceededError": {
+        "description": "アプリ呼び出しクォータ超過エラー。"
+      },
+      "Exception": {
+        "description": "例外。"
+      },
+      "HTTPException": {
+        "description": "HTTP 例外。"
+      },
+      "MaskError": {
+        "description": "マスクでエラーが発生した場合に返されます。"
+      },
+      "ParseError": {
+        "description": "マスクを解析できない場合に返されます。"
+      },
+      "PluginRuntimeError": {
+        "description": "プラグインランタイムエラー。"
+      },
+      "ValueError": {
+        "description": "値エラー。"
       }
     },
-    "responses": {
-      "SuccessResult": {
-        "description": "操作が成功しました。",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
+    "schemas": {
+      "AnnotationListQuery": {
+        "properties": {
+          "keyword": {
+            "default": "",
+            "description": "質問または回答の内容でアノテーションをフィルタリングするためのキーワードです。",
+            "type": "string"
+          },
+          "limit": {
+            "default": 20,
+            "description": "1 ページあたりの件数です。",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "ページネーションのページ番号。",
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "AppInfoResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "アプリケーション名。"
+          },
+          "description": {
+            "type": "string",
+            "description": "アプリケーションの説明。"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "アプリケーションタグ。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "アプリケーションモード。`completion` はテキスト生成アプリ、`chat` は基本チャットアプリ、`agent-chat` はエージェントベースのアプリ、`advanced-chat` は Chatflow アプリ、`workflow` は Workflow アプリです、`agent` は新しい Agent アプリです。"
+          },
+          "author_name": {
+            "type": "string",
+            "description": "アプリケーション作成者の名前。"
+          }
+        }
+      },
+      "AppMetaResponse": {
+        "type": "object",
+        "properties": {
+          "tool_icons": {
+            "type": "object",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "title": "Icon URL",
                   "type": "string",
-                  "description": "操作結果。常に `success` です。"
+                  "format": "url",
+                  "description": "アイコンの URL。"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolIconDetail"
                 }
+              ]
+            },
+            "description": "ツールアイコン。キーはツール名です。"
+          }
+        }
+      },
+      "AudioBinaryResponse": {
+        "format": "binary",
+        "type": "string"
+      },
+      "BinaryFileResponse": {
+        "format": "binary",
+        "type": "string"
+      },
+      "ChatRequestPayload": {
+        "properties": {
+          "auto_generate_name": {
+            "default": true,
+            "description": "会話タイトルを自動生成するかどうか。`false` の場合は、会話名変更 API で `auto_generate: true` を指定してタイトルを非同期生成できます。",
+            "type": "boolean"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "会話を継続するための会話 ID。このフィールドを省略するか空文字列を渡すと新しい会話が開始されます。以降のリクエストでは返された `conversation_id` を渡します。"
+          },
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "マルチモーダル入力に使用するファイルです。新しいクライアントは 2 つの標準形式だけを実装してください。公開ファイル URL には `transfer_method: remote_url` と `url` を使用します。ローカルファイルは[ファイルをアップロード](/ja/api-reference/files/upload-file)でアップロードし、`transfer_method: local_file` と、返された `id` を指定する `upload_file_id` を使用します。生成されたその他の `anyOf` の組み合わせは、保存済みの旧形式参照との後方互換性のためだけに存在します。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "アプリ定義変数の値です。想定される変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。",
+            "type": "object"
+          },
+          "query": {
+            "description": "ユーザー入力または質問の内容。",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "レスポンスモード。`streaming` は Server-Sent Events（SSE）を使用し、`blocking` は完了後に返します。新しい Agent アプリモードはストリーミングのみをサポートします。省略すると、Agent 以外はブロッキング、新しい Agent はストリーミングで実行されます。"
+          },
+          "workflow_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "高度なチャットで実行する公開済みワークフローバージョン ID。省略すると、アプリの現在の公開済みワークフローを使用します。"
+          }
+        },
+        "required": [
+          "inputs",
+          "query"
+        ],
+        "type": "object"
+      },
+      "ChildChunkListQuery": {
+        "properties": {
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "検索キーワードです。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "取得するページ番号。",
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "CompletionRequestPayload": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "マルチモーダル入力に使用するファイルです。新しいクライアントは 2 つの標準形式だけを実装してください。公開ファイル URL には `transfer_method: remote_url` と `url` を使用します。ローカルファイルは[ファイルをアップロード](/ja/api-reference/files/upload-file)でアップロードし、`transfer_method: local_file` と、返された `id` を指定する `upload_file_id` を使用します。生成されたその他の `anyOf` の組み合わせは、保存済みの旧形式参照との後方互換性のためだけに存在します。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "アプリ定義変数の値です。想定される変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。",
+            "type": "object"
+          },
+          "query": {
+            "default": "",
+            "description": "ユーザー入力またはプロンプトの内容。",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "レスポンスモード。`streaming` は Server-Sent Events（SSE）を使用し、`blocking` は完了後に返します。省略するとブロッキングモードで実行されます。"
+          }
+        },
+        "required": [
+          "inputs"
+        ],
+        "type": "object"
+      },
+      "ConversationListQuery": {
+        "properties": {
+          "last_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "現在のページの最後のレコード ID。次のページの取得に使用します。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "返すレコード数です。",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "sort_by": {
+            "default": "-updated_at",
+            "description": "並べ替えフィールド。降順にするには `-` 接頭辞を使用します。",
+            "enum": [
+              "-created_at",
+              "-updated_at",
+              "created_at",
+              "updated_at"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ConversationRenamePayload": {
+        "anyOf": [
+          {
+            "properties": {
+              "auto_generate": {
+                "description": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。",
+                "enum": [
+                  true
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "会話名。`auto_generate` が `false` の場合は必須です。"
               }
             },
-            "examples": {
-              "success": {
-                "summary": "レスポンス例",
-                "value": {
-                  "result": "success"
+            "required": [
+              "auto_generate"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "auto_generate": {
+                "default": false,
+                "description": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。",
+                "enum": [
+                  false
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "pattern": ".*\\S.*",
+                "type": "string",
+                "description": "会話名。"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "auto_generate": {
+            "default": false,
+            "description": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。",
+            "type": "boolean"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "会話名。`auto_generate` が `false` の場合は必須です。"
+          }
+        },
+        "type": "object"
+      },
+      "ConversationVariableUpdatePayload": {
+        "properties": {
+          "value": {
+            "description": "変数の新しい値。変数の期待される型と一致する必要があります。"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "ConversationVariablesQuery": {
+        "properties": {
+          "last_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "現在のページの最後のレコード ID。次のページの取得に使用します。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "返すレコード数です。",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "variable_name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "指定した名前で変数をフィルタリングします。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetListQuery": {
+        "properties": {
+          "include_all": {
+            "default": false,
+            "description": "権限に関係なくすべてのナレッジベースを含めるかどうかです。",
+            "type": "boolean"
+          },
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "名前でフィルタリングする検索キーワードです。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "取得するページ番号。",
+            "type": "integer"
+          },
+          "tag_ids": {
+            "description": "絞り込みに使用するタグ ID。",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "DatasourcePluginsQuery": {
+        "properties": {
+          "is_published": {
+            "default": true,
+            "description": "公開済みまたはドラフトのナレッジパイプラインからノードを取得するかどうか。`true` は公開済みバージョン、`false` はドラフトのノードを返します。",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentGetQuery": {
+        "properties": {
+          "metadata": {
+            "default": "all",
+            "description": "`all` はメタデータを含むすべてのフィールドを返します。`only` は `id`、`doc_type`、`doc_metadata` のみを返します。`without` は `doc_metadata` を除くすべてのフィールドを返します。",
+            "enum": [
+              "all",
+              "only",
+              "without"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentListQuery": {
+        "properties": {
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント名でフィルタリングするための検索キーワードです。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "取得するページ番号。",
+            "type": "integer"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "archived",
+                  "available",
+                  "disabled",
+                  "error",
+                  "indexing",
+                  "paused",
+                  "queuing"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "表示ステータスでフィルタリングします。"
+          }
+        },
+        "type": "object"
+      },
+      "EndUserDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "エンドユーザー ID。"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "テナント ID。"
+          },
+          "app_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "アプリケーション ID。"
+          },
+          "type": {
+            "type": "string",
+            "description": "エンドユーザーのタイプ。Service API ユーザーの場合は常に `service-api` です。"
+          },
+          "external_user_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "API リクエストで提供された `user` 識別子です（例：[チャットメッセージを送信](/ja/api-reference/chat-messages/send-chat-message) の `user` フィールド）。"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "description": "エンドユーザー名。"
+          },
+          "is_anonymous": {
+            "type": "boolean",
+            "description": "ユーザーが匿名かどうかを示します。元の API リクエストで `user` 識別子が提供されなかった場合、`true` になります。"
+          },
+          "session_id": {
+            "type": "string",
+            "description": "セッション識別子。デフォルトは `external_user_id` の値です。"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "作成タイムスタンプ。"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "最終更新タイムスタンプ。"
+          }
+        }
+      },
+      "EventStreamResponse": {
+        "type": "string"
+      },
+      "FeedbackListQuery": {
+        "properties": {
+          "limit": {
+            "default": 20,
+            "description": "1 ページあたりのレコード数。",
+            "maximum": 101,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "ページネーションのページ番号。",
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "FilePreviewQuery": {
+        "properties": {
+          "as_attachment": {
+            "default": false,
+            "description": "`true` の場合、ブラウザでプレビューせず、ファイルを添付ファイルとして強制的にダウンロードします。",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "HumanInputContent": {
+        "type": "object",
+        "description": "人間の入力ノードからの実行コンテンツです。フォーム定義と送信データを含みます。",
+        "properties": {
+          "workflow_run_id": {
+            "type": "string",
+            "description": "このコンテンツが属するワークフロー実行の ID です。"
+          },
+          "submitted": {
+            "type": "boolean",
+            "description": "人間の入力フォームが送信されたかどうかです。"
+          },
+          "type": {
+            "type": "string",
+            "description": "`human_input` は人間の入力コンテンツを示します。"
+          },
+          "form_definition": {
+            "nullable": true,
+            "description": "人間の入力ノードからのフォーム定義です。コンテンツが送信レスポンスを表す場合は `null` です。",
+            "$ref": "#/components/schemas/HumanInputFormDefinition"
+          },
+          "form_submission_data": {
+            "nullable": true,
+            "description": "送信されたフォームデータです。フォームがまだ送信されていない場合は `null` です。",
+            "$ref": "#/components/schemas/HumanInputFormSubmissionData"
+          }
+        }
+      },
+      "HumanInputFormDefinition": {
+        "type": "object",
+        "description": "人間の入力ノードによってレンダリングされる人間の入力フォームの定義です。",
+        "properties": {
+          "form_id": {
+            "type": "string",
+            "description": "フォームの一意識別子です。"
+          },
+          "node_id": {
+            "type": "string",
+            "description": "このフォームを生成した人間の入力ノードの ID です。"
+          },
+          "node_title": {
+            "type": "string",
+            "description": "人間の入力ノードのタイトルです。"
+          },
+          "form_content": {
+            "type": "string",
+            "description": "フォームと共に表示される Markdown またはテキストコンテンツです。"
+          },
+          "inputs": {
+            "type": "array",
+            "description": "フォーム内の入力フィールドです。",
+            "items": {
+              "$ref": "#/components/schemas/FormInput"
+            }
+          },
+          "actions": {
+            "type": "array",
+            "description": "フォームで利用可能なアクションボタンです。",
+            "items": {
+              "$ref": "#/components/schemas/UserAction"
+            }
+          },
+          "display_in_ui": {
+            "type": "boolean",
+            "description": "フォームを UI に表示するかどうかです。"
+          },
+          "form_token": {
+            "type": "string",
+            "nullable": true,
+            "description": "フォーム送信認証用のトークンです。"
+          },
+          "resolved_default_values": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "出力変数名をキーとする、フォーム入力の解決済みデフォルト値です。"
+          },
+          "expiration_time": {
+            "type": "integer",
+            "description": "フォームが期限切れになる Unix タイムスタンプです。"
+          }
+        }
+      },
+      "HumanInputFormSubmissionData": {
+        "type": "object",
+        "description": "送信された人間の入力フォームからのデータです。",
+        "properties": {
+          "node_id": {
+            "type": "string",
+            "description": "人間の入力ノードの ID です。"
+          },
+          "node_title": {
+            "type": "string",
+            "description": "人間の入力ノードのタイトルです。"
+          },
+          "rendered_content": {
+            "type": "string",
+            "description": "フォーム送信のレンダリングされた内容です。"
+          },
+          "action_id": {
+            "type": "string",
+            "description": "クリックされたアクションボタンの ID です。"
+          },
+          "action_text": {
+            "type": "string",
+            "description": "クリックされたアクションボタンの表示テキストです。"
+          }
+        }
+      },
+      "HumanInputFormSubmitPayload": {
+        "properties": {
+          "action": {
+            "description": "受信者が選択したアクションボタンの ID。フォームの `user_actions` リストにある `id` 値のいずれかと一致する必要があります。",
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "description": "出力変数名をキーとする送信済み人工入力値。段落または選択入力には文字列、ファイル入力にはファイルマッピング、ファイルリスト入力にはファイルマッピングのリストを使用します。ローカルファイルは `transfer_method=local_file` と `upload_file_id`、リモートファイルは `transfer_method=remote_url` と `url` または `remote_url` を使用します。",
+            "examples": [
+              {
+                "attachment": {
+                  "transfer_method": "local_file",
+                  "type": "document",
+                  "upload_file_id": "4e0d1b87-52f2-49f6-b8c6-95cd9c954b3e"
+                },
+                "attachments": [
+                  {
+                    "transfer_method": "local_file",
+                    "type": "document",
+                    "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee"
+                  },
+                  {
+                    "transfer_method": "remote_url",
+                    "type": "document",
+                    "url": "https://example.com/report.pdf"
+                  }
+                ],
+                "decision": "approve"
+              }
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "action",
+          "inputs"
+        ],
+        "type": "object"
+      },
+      "JSONObject": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "MessageFeedbackPayload": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "追加の詳細を提供する任意のテキストフィードバック。"
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "enum": [
+                  "dislike",
+                  "like"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "フィードバック評価。以前送信したフィードバックを取り消すには `null` に設定します。"
+          }
+        },
+        "type": "object"
+      },
+      "MessageListQuery": {
+        "properties": {
+          "conversation_id": {
+            "description": "会話 ID。",
+            "type": "string"
+          },
+          "first_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "現在のページの最初のチャットレコード ID。最新メッセージを取得する場合は省略します。次のページでは、現在のリストの最初のメッセージ ID を使って古いメッセージを取得します。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "リクエストごとに返すチャット履歴メッセージの数です。",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "conversation_id"
+        ],
+        "type": "object"
+      },
+      "RetrievalModel": {
+        "type": "object",
+        "required": [
+          "search_method",
+          "reranking_enable",
+          "top_k",
+          "score_threshold_enabled"
+        ],
+        "properties": {
+          "search_method": {
+            "type": "string",
+            "description": "検索に使用される検索メソッドです。",
+            "enum": [
+              "keyword_search",
+              "semantic_search",
+              "full_text_search",
+              "hybrid_search"
+            ]
+          },
+          "reranking_enable": {
+            "type": "boolean",
+            "description": "リランキングが有効かどうかです。"
+          },
+          "reranking_model": {
+            "type": "object",
+            "description": "リランキングモデルの設定です。",
+            "properties": {
+              "reranking_provider_name": {
+                "type": "string",
+                "description": "リランクモデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/cohere/cohere`）。`cohere` のような短縮名は `langgenius/<name>/<name>` に展開され、langgenius が公開したプラグインでのみ機能します。\n\n有効な値は [利用可能なモデルを取得](/ja/api-reference/models/get-available-models) で `model_type=rerank` を指定した際の `provider` フィールドから取得します。"
+              },
+              "reranking_model_name": {
+                "type": "string",
+                "description": "リランキングモデル名です。"
+              }
+            }
+          },
+          "reranking_mode": {
+            "type": "string",
+            "enum": [
+              "reranking_model",
+              "weighted_score"
+            ],
+            "nullable": true,
+            "description": "リランキングモードです。`reranking_enable` が `true` の場合は必須です。"
+          },
+          "top_k": {
+            "type": "integer",
+            "description": "返す結果の最大数です。"
+          },
+          "score_threshold_enabled": {
+            "type": "boolean",
+            "description": "スコア閾値フィルタリングが有効かどうかです。"
+          },
+          "score_threshold": {
+            "type": "number",
+            "nullable": true,
+            "description": "結果の最小関連性スコアです。`score_threshold_enabled` が `true` の場合にのみ有効です。"
+          },
+          "weights": {
+            "type": "object",
+            "nullable": true,
+            "description": "ハイブリッド検索の重み設定です。",
+            "properties": {
+              "weight_type": {
+                "type": "string",
+                "description": "セマンティック検索とキーワード検索の重みを調整するための戦略です。",
+                "enum": [
+                  "semantic_first",
+                  "keyword_first",
+                  "customized"
+                ]
+              },
+              "vector_setting": {
+                "type": "object",
+                "description": "セマンティック検索の重み設定です。",
+                "properties": {
+                  "vector_weight": {
+                    "type": "number",
+                    "description": "セマンティック（ベクトル）検索結果に割り当てられた重みです。"
+                  },
+                  "embedding_provider_name": {
+                    "type": "string",
+                    "description": "ベクトル検索に使用される埋め込みモデルのプロバイダーです。"
+                  },
+                  "embedding_model_name": {
+                    "type": "string",
+                    "description": "ベクトル検索に使用される埋め込みモデルの名前です。"
+                  }
+                }
+              },
+              "keyword_setting": {
+                "type": "object",
+                "description": "キーワード検索の重み設定です。",
+                "properties": {
+                  "keyword_weight": {
+                    "type": "number",
+                    "description": "キーワード検索結果に割り当てられた重みです。"
+                  }
+                }
+              }
+            }
+          },
+          "metadata_filtering_conditions": {
+            "type": "object",
+            "nullable": true,
+            "description": "ドキュメントのメタデータが指定した条件に一致するチャンクのみを取得対象に絞り込みます。条件はサーバーサイドで評価されます。",
+            "properties": {
+              "logical_operator": {
+                "type": "string",
+                "enum": [
+                  "and",
+                  "or"
+                ],
+                "default": "and",
+                "nullable": true,
+                "description": "複数の条件を組み合わせる方法です。"
+              },
+              "conditions": {
+                "type": "array",
+                "nullable": true,
+                "description": "評価するメタデータ条件のリストです。",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "comparison_operator"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "比較対象とするメタデータフィールド名です。"
+                    },
+                    "comparison_operator": {
+                      "type": "string",
+                      "description": "適用する比較方法です。メタデータのタイプ別：\n\n- 文字列または配列のメタデータ：`contains`、`not contains`、`start with`、`end with`、`is`、`is not`、`empty`、`not empty`、`in`、`not in`\n- 数値メタデータ：`=`、`≠`、`>`、`<`、`≥`、`≤`\n- 時刻メタデータ：`before`、`after`",
+                      "enum": [
+                        "contains",
+                        "not contains",
+                        "start with",
+                        "end with",
+                        "is",
+                        "is not",
+                        "empty",
+                        "not empty",
+                        "in",
+                        "not in",
+                        "=",
+                        "≠",
+                        ">",
+                        "<",
+                        "≥",
+                        "≤",
+                        "before",
+                        "after"
+                      ]
+                    },
+                    "value": {
+                      "nullable": true,
+                      "description": "比較対象の値です。型は `comparison_operator` によって異なります。ほとんどの文字列演算子では文字列、`in` および `not in` では文字列配列、数値演算子では数値、`empty` および `not empty` では省略します。",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
           }
         }
-      }
-    },
-    "schemas": {
+      },
+      "RetrieverResource": {
+        "type": "object",
+        "description": "検索リソースの引用および帰属情報です。",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "検索リソースの一意の ID。"
+          },
+          "message_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "このリソースが属するメッセージの ID。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "リスト内のリソースの位置。"
+          },
+          "dataset_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ナレッジベース ID。"
+          },
+          "dataset_name": {
+            "type": "string",
+            "description": "ナレッジベース名。"
+          },
+          "document_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ドキュメント ID。"
+          },
+          "document_name": {
+            "type": "string",
+            "description": "ドキュメント名。"
+          },
+          "data_source_type": {
+            "type": "string",
+            "description": "データソースのタイプ。"
+          },
+          "segment_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ドキュメント内の特定のチャンクの ID。"
+          },
+          "score": {
+            "type": "number",
+            "format": "float",
+            "description": "リソースの関連性スコア。"
+          },
+          "hit_count": {
+            "type": "integer",
+            "description": "このチャンクがヒットした回数。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "チャンクの単語数。"
+          },
+          "segment_position": {
+            "type": "integer",
+            "description": "ドキュメント内のチャンクの位置。"
+          },
+          "index_node_hash": {
+            "type": "string",
+            "description": "インデックスノードのハッシュ。"
+          },
+          "content": {
+            "type": "string",
+            "description": "リソースからのコンテンツスニペット。"
+          },
+          "summary": {
+            "type": "string",
+            "nullable": true,
+            "description": "チャンクコンテンツの要約。"
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "int64",
+            "description": "作成タイムスタンプ（Unix エポック秒）。"
+          }
+        }
+      },
+      "SegmentListQuery": {
+        "properties": {
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "検索キーワードです。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "取得するページ番号。",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "status": {
+            "description": "`completed`、`indexing`、`error` などのインデックス状態でチャンクを絞り込みます。",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "SimpleResultResponse": {
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "操作結果。"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object"
+      },
+      "TextToAudioPayload": {
+        "properties": {
+          "message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "メッセージ ID。両方を指定した場合は `text` より優先されます。"
+          },
+          "streaming": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "互換性のために予約されています。TTS レスポンスのストリーミングはプロバイダーの出力によって決まります。"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "変換する音声内容。"
+          },
+          "voice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "テキスト読み上げに使用する音声です。利用可能な音声は、このアプリに設定された TTS プロバイダーによって異なります。省略すると、利用可能な場合はアプリに設定された音声を使用します。この値は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)の `text_to_speech.voice` で確認できます。"
+          }
+        },
+        "type": "object"
+      },
+      "WorkflowBlockingResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/WorkflowFinishedBlockingResponse"
+          },
+          {
+            "$ref": "#/components/schemas/WorkflowPausedBlockingResponse"
+          }
+        ]
+      },
+      "WorkflowEventsQuery": {
+        "properties": {
+          "continue_on_pause": {
+            "default": false,
+            "description": "`true` にすると、複数の `workflow_paused` イベントにまたがってストリームを開いたままにします。複数の人工入力ノードが連続するワークフローで便利です。デフォルトでは最初の一時停止後にストリームを閉じます。",
+            "type": "boolean"
+          },
+          "include_state_snapshot": {
+            "default": false,
+            "description": "`true` の場合、永続化された状態スナップショットからリプレイし、新しいイベントのストリーミング開始前に実行済みノードのステータスサマリーを含めます。",
+            "type": "boolean"
+          },
+          "user": {
+            "description": "最初に実行をトリガーしたエンドユーザー識別子。実行の作成者と一致する必要があります。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "type": "object"
+      },
+      "WorkflowFinishedBlockingDataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "作成時刻（Unix 秒タイムスタンプ）。"
+          },
+          "elapsed_time": {
+            "format": "float",
+            "type": "number",
+            "description": "合計経過時間（秒）です。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ワークフローが失敗した場合のエラーメッセージです。"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "終了時刻（Unix 秒タイムスタンプ）。未終了の場合は `null`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "ワークフロー実行 ID です。"
+          },
+          "outputs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ワークフローからの出力データです。"
+          },
+          "status": {
+            "enum": [
+              "failed",
+              "partial-succeeded",
+              "stopped",
+              "succeeded"
+            ],
+            "type": "string",
+            "description": "ワークフロー実行の最終ステータスです。"
+          },
+          "total_steps": {
+            "type": "integer",
+            "description": "実行されたワークフローの合計ステップ数です。"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "全ノードで消費された合計トークン数です。"
+          },
+          "workflow_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "ワークフロー ID です。"
+          }
+        },
+        "required": [
+          "created_at",
+          "elapsed_time",
+          "error",
+          "finished_at",
+          "id",
+          "outputs",
+          "status",
+          "total_steps",
+          "total_tokens",
+          "workflow_id"
+        ],
+        "type": "object"
+      },
+      "WorkflowFinishedBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WorkflowFinishedBlockingDataResponse",
+            "description": "ワークフロー完了時に返されるデータ。"
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "進行中の実行のタスク ID です。[ワークフロータスクを停止](/ja/api-reference/workflow-runs/stop-workflow-task) と組み合わせて、実行中のワークフローをキャンセルします。実行中のみ有効です。"
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "このワークフロー実行記録の永続的な識別子です。[ワークフロー実行詳細を取得](/ja/api-reference/workflow-runs/get-workflow-run-detail) と組み合わせて、実行後に結果を取得します。"
+          }
+        },
+        "required": [
+          "data",
+          "task_id",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "ワークフロー実行の完了後に返されるブロッキングレスポンスです。"
+      },
+      "WorkflowLogQuery": {
+        "properties": {
+          "created_at__after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "この ISO 8601 タイムスタンプ以降に作成されたログをフィルタリングします。",
+            "format": "date-time"
+          },
+          "created_at__before": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "この ISO 8601 タイムスタンプ以前に作成されたログをフィルタリングします。",
+            "format": "date-time"
+          },
+          "created_by_account": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークスペースメンバーのメールアドレスで絞り込みます。歴史的なフィールド名とは異なり、ランタイムはこの値をアカウント ID ではなくメールアドレスとして解決します。"
+          },
+          "created_by_end_user_session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "エンドユーザーのセッション ID で絞り込みます。[エンドユーザー情報を取得](/ja/api-reference/end-users/get-end-user-info) の `session_id` から取得できます。Service API ユーザーでは通常、リクエストの `user` と同じ値です。"
+          },
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ログ内を検索するキーワードです。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "1 ページあたりの件数です。",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "ページネーションのページ番号。",
+            "maximum": 99999,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "failed",
+                  "stopped",
+                  "succeeded"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "実行ステータスでフィルタリングします。"
+          }
+        },
+        "type": "object"
+      },
+      "WorkflowPauseReasonResponse": {
+        "additionalProperties": true,
+        "description": "ブロッキングワークフロー実行が一時停止した理由の公開情報です。",
+        "properties": {
+          "TYPE": {
+            "type": "string",
+            "description": "一時停止理由のタイプです。"
+          },
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "人間の入力フォームで利用できるアクションです。"
+          },
+          "approval_channels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "設定された承認チャネルです。"
+          },
+          "display_in_ui": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "一時停止理由を UI に表示するかどうかを示します。"
+          },
+          "expiration_time": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人間の入力フォームの有効期限を示す Unix タイムスタンプです。"
+          },
+          "form_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人間の入力フォームに表示する内容です。"
+          },
+          "form_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人間の入力フォーム ID です。"
+          },
+          "form_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人間の入力フォーム API で使用するアクセストークンです。"
+          },
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "人間の入力フォームの入力フィールドです。"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフローが一時停止した理由を説明するメッセージです。"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "一時停止したワークフローノード ID です。"
+          },
+          "node_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "一時停止したワークフローノードのタイトルです。"
+          },
+          "resolved_default_values": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "フォーム入力で解決されたデフォルト値です。"
+          }
+        },
+        "required": [
+          "TYPE"
+        ],
+        "type": "object"
+      },
+      "WorkflowPausedBlockingDataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "作成時刻（Unix 秒タイムスタンプ）。"
+          },
+          "elapsed_time": {
+            "format": "float",
+            "type": "number",
+            "description": "合計経過時間（秒）です。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ワークフローが失敗した場合のエラーメッセージです。"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "終了時刻（Unix 秒タイムスタンプ）。未終了の場合は `null`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "ワークフロー実行 ID です。"
+          },
+          "outputs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ワークフローからの出力データです。"
+          },
+          "paused_nodes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "入力待ちのワークフローノード ID です。"
+          },
+          "reasons": {
+            "items": {
+              "$ref": "#/components/schemas/WorkflowPauseReasonResponse"
+            },
+            "type": "array",
+            "description": "人間の入力フォームの詳細を含む、ワークフローの一時停止理由です。"
+          },
+          "status": {
+            "const": "paused",
+            "type": "string",
+            "description": "ワークフロー実行ステータスは `paused` 固定です。"
+          },
+          "total_steps": {
+            "type": "integer",
+            "description": "実行されたワークフローの合計ステップ数です。"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "全ノードで消費された合計トークン数です。"
+          },
+          "workflow_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "ワークフロー ID です。"
+          }
+        },
+        "required": [
+          "created_at",
+          "elapsed_time",
+          "error",
+          "finished_at",
+          "id",
+          "outputs",
+          "paused_nodes",
+          "reasons",
+          "status",
+          "total_steps",
+          "total_tokens",
+          "workflow_id"
+        ],
+        "type": "object"
+      },
+      "WorkflowPausedBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WorkflowPausedBlockingDataResponse",
+            "description": "ワークフローが入力待ちで一時停止したときに返されるデータ。"
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "進行中の実行のタスク ID です。[ワークフロータスクを停止](/ja/api-reference/workflow-runs/stop-workflow-task) と組み合わせて、実行中のワークフローをキャンセルします。実行中のみ有効です。"
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "このワークフロー実行記録の永続的な識別子です。[ワークフロー実行詳細を取得](/ja/api-reference/workflow-runs/get-workflow-run-detail) と組み合わせて、実行後に結果を取得します。"
+          }
+        },
+        "required": [
+          "data",
+          "task_id",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "ワークフロー実行が人間の入力を待機している場合に返されるブロッキングレスポンスです。"
+      },
+      "WorkflowRunPayload": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフローのシステムファイル入力の一覧です。ワークフローでファイルアップロードが有効な場合に使用できます。ローカルファイルを添付するには、まず[ファイルをアップロード](/ja/api-reference/files/upload-file)し、返された `id` を `upload_file_id` に指定して、`transfer_method` を `local_file` に設定します。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "ワークフロー入力変数のキーと値のペアです。ファイル型変数の値は、`type`、`transfer_method`、および `url` または `upload_file_id` を含むファイルオブジェクトの配列にします。アプリが要求する変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。",
+            "type": "object"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "レスポンスモード。同期レスポンスには `blocking`、Server-Sent Events（SSE）には `streaming` を使用します。省略するとブロッキングモードで実行されます。"
+          }
+        },
+        "required": [
+          "inputs"
+        ],
+        "type": "object"
+      },
       "ChatRequest": {
         "type": "object",
         "required": [
@@ -13806,88 +16028,6 @@
           }
         }
       },
-      "RetrieverResource": {
-        "type": "object",
-        "description": "検索リソースの引用および帰属情報です。",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "検索リソースの一意の ID。"
-          },
-          "message_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "このリソースが属するメッセージの ID。"
-          },
-          "position": {
-            "type": "integer",
-            "description": "リスト内のリソースの位置。"
-          },
-          "dataset_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ナレッジベース ID。"
-          },
-          "dataset_name": {
-            "type": "string",
-            "description": "ナレッジベース名。"
-          },
-          "document_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ドキュメント ID。"
-          },
-          "document_name": {
-            "type": "string",
-            "description": "ドキュメント名。"
-          },
-          "data_source_type": {
-            "type": "string",
-            "description": "データソースのタイプ。"
-          },
-          "segment_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ドキュメント内の特定のチャンクの ID。"
-          },
-          "score": {
-            "type": "number",
-            "format": "float",
-            "description": "リソースの関連性スコア。"
-          },
-          "hit_count": {
-            "type": "integer",
-            "description": "このチャンクがヒットした回数。"
-          },
-          "word_count": {
-            "type": "integer",
-            "description": "チャンクの単語数。"
-          },
-          "segment_position": {
-            "type": "integer",
-            "description": "ドキュメント内のチャンクの位置。"
-          },
-          "index_node_hash": {
-            "type": "string",
-            "description": "インデックスノードのハッシュ。"
-          },
-          "content": {
-            "type": "string",
-            "description": "リソースからのコンテンツスニペット。"
-          },
-          "summary": {
-            "type": "string",
-            "nullable": true,
-            "description": "チャンクコンテンツの要約。"
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "int64",
-            "description": "作成タイムスタンプ（Unix エポック秒）。"
-          }
-        }
-      },
       "FileUploadResponse": {
         "type": "object",
         "properties": {
@@ -13966,59 +16106,6 @@
             "type": "string",
             "nullable": true,
             "description": "未使用です。常に `null` になります。"
-          }
-        }
-      },
-      "EndUserDetail": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "エンドユーザー ID。"
-          },
-          "tenant_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "テナント ID。"
-          },
-          "app_id": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true,
-            "description": "アプリケーション ID。"
-          },
-          "type": {
-            "type": "string",
-            "description": "エンドユーザーのタイプ。Service API ユーザーの場合は常に `service-api` です。"
-          },
-          "external_user_id": {
-            "type": "string",
-            "nullable": true,
-            "description": "API リクエストで提供された `user` 識別子です（例：[チャットメッセージを送信](/ja/api-reference/chat-messages/send-chat-message) の `user` フィールド）。"
-          },
-          "name": {
-            "type": "string",
-            "nullable": true,
-            "description": "エンドユーザー名。"
-          },
-          "is_anonymous": {
-            "type": "boolean",
-            "description": "ユーザーが匿名かどうかを示します。元の API リクエストで `user` 識別子が提供されなかった場合、`true` になります。"
-          },
-          "session_id": {
-            "type": "string",
-            "description": "セッション識別子。デフォルトは `external_user_id` の値です。"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "作成タイムスタンプ。"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "最終更新タイムスタンプ。"
           }
         }
       },
@@ -14584,34 +16671,6 @@
           }
         }
       },
-      "AppInfoResponse": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "アプリケーション名。"
-          },
-          "description": {
-            "type": "string",
-            "description": "アプリケーションの説明。"
-          },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "アプリケーションタグ。"
-          },
-          "mode": {
-            "type": "string",
-            "description": "アプリケーションモード。`completion` はテキスト生成アプリ、`chat` は基本チャットアプリ、`agent-chat` はエージェントベースのアプリ、`advanced-chat` は Chatflow アプリ、`workflow` は Workflow アプリです、`agent` は新しい Agent アプリです。"
-          },
-          "author_name": {
-            "type": "string",
-            "description": "アプリケーション作成者の名前。"
-          }
-        }
-      },
       "UserInputFormItem": {
         "type": "object",
         "oneOf": [
@@ -14720,28 +16779,6 @@
               "type": "string"
             },
             "description": "このフォームコントロールの選択可能な値のリスト。"
-          }
-        }
-      },
-      "AppMetaResponse": {
-        "type": "object",
-        "properties": {
-          "tool_icons": {
-            "type": "object",
-            "additionalProperties": {
-              "oneOf": [
-                {
-                  "title": "Icon URL",
-                  "type": "string",
-                  "format": "url",
-                  "description": "アイコンの URL。"
-                },
-                {
-                  "$ref": "#/components/schemas/ToolIconDetail"
-                }
-              ]
-            },
-            "description": "ツールアイコン。キーはツール名です。"
           }
         }
       },
@@ -16693,114 +18730,6 @@
           }
         }
       },
-      "HumanInputContent": {
-        "type": "object",
-        "description": "人間の入力ノードからの実行コンテンツです。フォーム定義と送信データを含みます。",
-        "properties": {
-          "workflow_run_id": {
-            "type": "string",
-            "description": "このコンテンツが属するワークフロー実行の ID です。"
-          },
-          "submitted": {
-            "type": "boolean",
-            "description": "人間の入力フォームが送信されたかどうかです。"
-          },
-          "type": {
-            "type": "string",
-            "description": "`human_input` は人間の入力コンテンツを示します。"
-          },
-          "form_definition": {
-            "nullable": true,
-            "description": "人間の入力ノードからのフォーム定義です。コンテンツが送信レスポンスを表す場合は `null` です。",
-            "$ref": "#/components/schemas/HumanInputFormDefinition"
-          },
-          "form_submission_data": {
-            "nullable": true,
-            "description": "送信されたフォームデータです。フォームがまだ送信されていない場合は `null` です。",
-            "$ref": "#/components/schemas/HumanInputFormSubmissionData"
-          }
-        }
-      },
-      "HumanInputFormDefinition": {
-        "type": "object",
-        "description": "人間の入力ノードによってレンダリングされる人間の入力フォームの定義です。",
-        "properties": {
-          "form_id": {
-            "type": "string",
-            "description": "フォームの一意識別子です。"
-          },
-          "node_id": {
-            "type": "string",
-            "description": "このフォームを生成した人間の入力ノードの ID です。"
-          },
-          "node_title": {
-            "type": "string",
-            "description": "人間の入力ノードのタイトルです。"
-          },
-          "form_content": {
-            "type": "string",
-            "description": "フォームと共に表示される Markdown またはテキストコンテンツです。"
-          },
-          "inputs": {
-            "type": "array",
-            "description": "フォーム内の入力フィールドです。",
-            "items": {
-              "$ref": "#/components/schemas/FormInput"
-            }
-          },
-          "actions": {
-            "type": "array",
-            "description": "フォームで利用可能なアクションボタンです。",
-            "items": {
-              "$ref": "#/components/schemas/UserAction"
-            }
-          },
-          "display_in_ui": {
-            "type": "boolean",
-            "description": "フォームを UI に表示するかどうかです。"
-          },
-          "form_token": {
-            "type": "string",
-            "nullable": true,
-            "description": "フォーム送信認証用のトークンです。"
-          },
-          "resolved_default_values": {
-            "type": "object",
-            "additionalProperties": true,
-            "description": "出力変数名をキーとする、フォーム入力の解決済みデフォルト値です。"
-          },
-          "expiration_time": {
-            "type": "integer",
-            "description": "フォームが期限切れになる Unix タイムスタンプです。"
-          }
-        }
-      },
-      "HumanInputFormSubmissionData": {
-        "type": "object",
-        "description": "送信された人間の入力フォームからのデータです。",
-        "properties": {
-          "node_id": {
-            "type": "string",
-            "description": "人間の入力ノードの ID です。"
-          },
-          "node_title": {
-            "type": "string",
-            "description": "人間の入力ノードのタイトルです。"
-          },
-          "rendered_content": {
-            "type": "string",
-            "description": "フォーム送信のレンダリングされた内容です。"
-          },
-          "action_id": {
-            "type": "string",
-            "description": "クリックされたアクションボタンの ID です。"
-          },
-          "action_text": {
-            "type": "string",
-            "description": "クリックされたアクションボタンの表示テキストです。"
-          }
-        }
-      },
       "FormInput": {
         "type": "object",
         "description": "フォーム入力フィールドの定義です。",
@@ -16993,24 +18922,6 @@
             }
           }
         ]
-      },
-      "WorkflowBlockingResponse": {
-        "type": "object",
-        "properties": {
-          "task_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "進行中の実行のタスク ID です。[ワークフロータスクを停止](/ja/api-reference/workflow-runs/stop-workflow-task) と組み合わせて、実行中のワークフローをキャンセルします。実行中のみ有効です。"
-          },
-          "workflow_run_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "このワークフロー実行記録の永続的な識別子です。[ワークフロー実行詳細を取得](/ja/api-reference/workflow-runs/get-workflow-run-detail) と組み合わせて、実行後に結果を取得します。"
-          },
-          "data": {
-            "$ref": "#/components/schemas/WorkflowFinishedData"
-          }
-        }
       },
       "ChunkWorkflowEvent": {
         "type": "object",
@@ -19483,189 +21394,19 @@
             "description": "最終更新タイムスタンプ（Unix エポック、秒単位）です。"
           }
         }
-      },
-      "RetrievalModel": {
-        "type": "object",
-        "required": [
-          "search_method",
-          "reranking_enable",
-          "top_k",
-          "score_threshold_enabled"
-        ],
-        "properties": {
-          "search_method": {
-            "type": "string",
-            "description": "検索に使用される検索メソッドです。",
-            "enum": [
-              "keyword_search",
-              "semantic_search",
-              "full_text_search",
-              "hybrid_search"
-            ]
-          },
-          "reranking_enable": {
-            "type": "boolean",
-            "description": "リランキングが有効かどうかです。"
-          },
-          "reranking_model": {
-            "type": "object",
-            "description": "リランキングモデルの設定です。",
-            "properties": {
-              "reranking_provider_name": {
-                "type": "string",
-                "description": "リランクモデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/cohere/cohere`）。`cohere` のような短縮名は `langgenius/<name>/<name>` に展開され、langgenius が公開したプラグインでのみ機能します。\n\n有効な値は [利用可能なモデルを取得](/ja/api-reference/models/get-available-models) で `model_type=rerank` を指定した際の `provider` フィールドから取得します。"
-              },
-              "reranking_model_name": {
-                "type": "string",
-                "description": "リランキングモデル名です。"
-              }
-            }
-          },
-          "reranking_mode": {
-            "type": "string",
-            "enum": [
-              "reranking_model",
-              "weighted_score"
-            ],
-            "nullable": true,
-            "description": "リランキングモードです。`reranking_enable` が `true` の場合は必須です。"
-          },
-          "top_k": {
-            "type": "integer",
-            "description": "返す結果の最大数です。"
-          },
-          "score_threshold_enabled": {
-            "type": "boolean",
-            "description": "スコア閾値フィルタリングが有効かどうかです。"
-          },
-          "score_threshold": {
-            "type": "number",
-            "nullable": true,
-            "description": "結果の最小関連性スコアです。`score_threshold_enabled` が `true` の場合にのみ有効です。"
-          },
-          "weights": {
-            "type": "object",
-            "nullable": true,
-            "description": "ハイブリッド検索の重み設定です。",
-            "properties": {
-              "weight_type": {
-                "type": "string",
-                "description": "セマンティック検索とキーワード検索の重みを調整するための戦略です。",
-                "enum": [
-                  "semantic_first",
-                  "keyword_first",
-                  "customized"
-                ]
-              },
-              "vector_setting": {
-                "type": "object",
-                "description": "セマンティック検索の重み設定です。",
-                "properties": {
-                  "vector_weight": {
-                    "type": "number",
-                    "description": "セマンティック（ベクトル）検索結果に割り当てられた重みです。"
-                  },
-                  "embedding_provider_name": {
-                    "type": "string",
-                    "description": "ベクトル検索に使用される埋め込みモデルのプロバイダーです。"
-                  },
-                  "embedding_model_name": {
-                    "type": "string",
-                    "description": "ベクトル検索に使用される埋め込みモデルの名前です。"
-                  }
-                }
-              },
-              "keyword_setting": {
-                "type": "object",
-                "description": "キーワード検索の重み設定です。",
-                "properties": {
-                  "keyword_weight": {
-                    "type": "number",
-                    "description": "キーワード検索結果に割り当てられた重みです。"
-                  }
-                }
-              }
-            }
-          },
-          "metadata_filtering_conditions": {
-            "type": "object",
-            "nullable": true,
-            "description": "ドキュメントのメタデータが指定した条件に一致するチャンクのみを取得対象に絞り込みます。条件はサーバーサイドで評価されます。",
-            "properties": {
-              "logical_operator": {
-                "type": "string",
-                "enum": [
-                  "and",
-                  "or"
-                ],
-                "default": "and",
-                "nullable": true,
-                "description": "複数の条件を組み合わせる方法です。"
-              },
-              "conditions": {
-                "type": "array",
-                "nullable": true,
-                "description": "評価するメタデータ条件のリストです。",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "name",
-                    "comparison_operator"
-                  ],
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "比較対象とするメタデータフィールド名です。"
-                    },
-                    "comparison_operator": {
-                      "type": "string",
-                      "description": "適用する比較方法です。メタデータのタイプ別：\n\n- 文字列または配列のメタデータ：`contains`、`not contains`、`start with`、`end with`、`is`、`is not`、`empty`、`not empty`、`in`、`not in`\n- 数値メタデータ：`=`、`≠`、`>`、`<`、`≥`、`≤`\n- 時刻メタデータ：`before`、`after`",
-                      "enum": [
-                        "contains",
-                        "not contains",
-                        "start with",
-                        "end with",
-                        "is",
-                        "is not",
-                        "empty",
-                        "not empty",
-                        "in",
-                        "not in",
-                        "=",
-                        "≠",
-                        ">",
-                        "<",
-                        "≥",
-                        "≤",
-                        "before",
-                        "after"
-                      ]
-                    },
-                    "value": {
-                      "nullable": true,
-                      "description": "比較対象の値です。型は `comparison_operator` によって異なります。ほとんどの文字列演算子では文字列、`in` および `not in` では文字列配列、数値演算子では数値、`empty` および `not empty` では省略します。",
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        {
-                          "type": "number"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "bearerFormat": "API_KEY",
+        "description": "Service API キーを Authorization ヘッダーの Bearer トークンとして使用します。",
+        "scheme": "bearer",
+        "type": "http"
       }
     }
+  },
+  "externalDocs": {
+    "description": "クイックスタートガイド",
+    "url": "/ja/api-reference/guides/get-started"
   }
 }

--- a/tools/api-pipeline/service_api_overlays/en.json
+++ b/tools/api-pipeline/service_api_overlays/en.json
@@ -1,0 +1,1298 @@
+{
+  "version": 1,
+  "language": "en",
+  "description": "Reviewed locale overlay applied to Dify's generated Service API OpenAPI base. Replace/remove actions pin the upstream value with source_sha256.",
+  "actions": [
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/title",
+      "source_sha256": "eb84fea86ba7ca8a051d796765be892d20a92ecd050e29212f7498902bab4536"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AudioBinaryResponse/title",
+      "source_sha256": "ef754dee1a457218bc6c216dbd5138062dae750a388d7af5791b480dbf56c417"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BinaryFileResponse/title",
+      "source_sha256": "40ee4d6aa1f0027872e6b1bea14f0389f51e33afdf6edbf84edc04f56b572787"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/auto_generate_name/title",
+      "source_sha256": "3ed483bca55763140ff1d72d40e67e287249200e1fa7c544a8cf98312bcff07d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "Files for multimodal input. New clients should implement two canonical forms only: use `transfer_method: remote_url` with `url` for a public file URL, or upload through [Upload File](/en/api-reference/files/upload-file) and use `transfer_method: local_file` with the returned `id` as `upload_file_id`. Other generated `anyOf` combinations exist only for backward compatibility with stored legacy references."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "Values for app-defined variables. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover expected variable names and types."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/title",
+      "source_sha256": "737ed654af2d15b7259a6742f94f2f965deeff0143b24f8c6394a335a43318e6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/title",
+      "source_sha256": "b1c6a7020550b6caf74316c4f6f0d9a79bb59b5fe961a3d65331855b2e4fa238"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "Files for multimodal input. New clients should implement two canonical forms only: use `transfer_method: remote_url` with `url` for a public file URL, or upload through [Upload File](/en/api-reference/files/upload-file) and use `transfer_method: local_file` with the returned `id` as `upload_file_id`. Other generated `anyOf` combinations exist only for backward compatibility with stored legacy references."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "Values for app-defined variables. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover expected variable names and types."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/title",
+      "source_sha256": "af0367558fbca9f02fe0c6614e89b0fbaddd2d5462f4aa34f224f2cdf7e90469"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/properties/last_id/title",
+      "source_sha256": "6f0775443ca28929399d056640ab02a09c28ea42cb79273e233d978894adf007"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/properties/sort_by/title",
+      "source_sha256": "695dcf2c05fdac5102823497cf8cf570e1c99dfe97158227ffaff0f4e51de4d5"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/title",
+      "source_sha256": "3be276dca8054bfc8650a2ade49e121930f782c4e579f179616aa36c69da49a3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/0/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/0",
+      "context_sha256": "7796d8ececea2ec336a2a0a0edd7c48487ce70b34b87c42f095c92c68f1fd88d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/0/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/0",
+      "context_sha256": "7796d8ececea2ec336a2a0a0edd7c48487ce70b34b87c42f095c92c68f1fd88d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/name/description",
+      "value": "Conversation name.",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/title",
+      "source_sha256": "5007bf01416d1203f9aeac8979d407c9432d6420dfba585d65249853164be8b6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayload/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayload/title",
+      "source_sha256": "ab9aedc458ad087c3e8f47e9d46c7180ff78e73b058595f23c06153749e8d9be"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/last_id/title",
+      "source_sha256": "6f0775443ca28929399d056640ab02a09c28ea42cb79273e233d978894adf007"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/variable_name/title",
+      "source_sha256": "78dbc71b7dd3b9881202bb123af942baa3ea39b55fcfdd3957757e099d1599d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/title",
+      "source_sha256": "d1e08414749216d358acfde1760dab99902f7d272b4334dc742b0c6e0f3fa9a1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/include_all/title",
+      "source_sha256": "0ed407edf20b9a0cd51edb26d336b83ab00e4b98009f3bd0c0b98c6c5aa670ee"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/tag_ids/title",
+      "source_sha256": "185b1bbb86d24865700f4807ef17e5b4cfb00f26b994b81ed2961a16a08296b8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/title",
+      "source_sha256": "fc0d9565af1ad1839448481672b9f23de466a6299631b453b5d8e7e2739696fa"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginsQuery/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginsQuery/title",
+      "source_sha256": "63246588db3edc622fc9aeef4dc8cdfe80ccee0f8e90d4df88b85d9b5a09db16"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentGetQuery/properties/metadata/title",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentGetQuery/title",
+      "source_sha256": "5bf6699a8622e02e2a3b8e018716aafbf0954fdd617b00106f71e00082084999"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/title",
+      "source_sha256": "ed2db5c64b168833d59052e05d0a006c0c7f1f83ada31a1dbf4c7a06e48fceda"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EventStreamResponse/title",
+      "source_sha256": "cb598d0c9427cccc89d63f389617e8966efeffc6cf0b9bad1c5823624bf470d3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FeedbackListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FeedbackListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FeedbackListQuery/title",
+      "source_sha256": "2ee2ef5a0b8833947992d468c455c3ec9722d91f0512455ef418a2ca9fa97e89"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FilePreviewQuery/properties/as_attachment/title",
+      "source_sha256": "4002a1980adbcfbe63aee5f634bd84eeacc78ae334a3020996076d5508bacecd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FilePreviewQuery/title",
+      "source_sha256": "34f058141cf139f35d0840e326719c0af503c33e745ab65d911e0449050fe2b2"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/properties/action/title",
+      "source_sha256": "5efcc1e437cbeada52653f133121f3ca259b84b74a51e15c277b4de93f11bd75"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/title",
+      "source_sha256": "38a626e4a4e1642a39e35116d44bec129a532a22191e06434ecc3c9b4c51c3d3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayload/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayload/title",
+      "source_sha256": "dc826ad9804a26c2e92124a2d20c938b54f7e6abf59d8fbccb326f20ac4e7c70"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/properties/first_id/title",
+      "source_sha256": "68654ca965f8b8a40a044427a6a4214508ab4b57019715ec0cc768900bf0c36a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/title",
+      "source_sha256": "17997d5395df2c93391badf0ba144f4ca86426f5b37ae14fd35d9c873a56e906"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/title",
+      "source_sha256": "0cd59385c6acbfa47454f1681728f3753d5b551e24e8ca993624fd336f64d154"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleResultResponse/properties/result/description",
+      "value": "Operation result."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultResponse/title",
+      "source_sha256": "412feb3d6da0cbf2901a8634d7612e513ffb59141b7369d0048187cfca1c7a73"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/streaming/title",
+      "source_sha256": "99c855ec96bb79eda46be7218b5ac2045b607b2135c1181034e6746519b88b06"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayload/properties/voice/description",
+      "source_sha256": "093f32f71464b6ee988240562bff4f647ec3d81381328089f3daaf171c1bd766",
+      "value": "Voice to use for text-to-speech. Available voices depend on the TTS provider configured for this app. Omit to use the app's configured voice when available; that value is exposed by [Get App Parameters](/en/api-reference/applications/get-app-parameters) as `text_to_speech.voice`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/voice/title",
+      "source_sha256": "75d5a120334e208c41bdff270efdb5ed48de029fa6a9399b5897166f2dc6baf2"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/title",
+      "source_sha256": "21460ec2d744ed638ddcc8912fa8e504c6ad781a6a7ad4206976f4aeb17aaab9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowBlockingResponse/description",
+      "source_sha256": "a616ccd4fc71f888b9aa8dd25540afa1deb4a3727760e49447263a524f64ef16"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowBlockingResponse/title",
+      "source_sha256": "8a25c0876465560ae896727bbc84bd3049455ecae245a7ca10fd82e274c2fda1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/continue_on_pause/title",
+      "source_sha256": "d6d9fa184ceedc0b96bf45750f3c618382d5333d440102854924100831a4a84f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/include_state_snapshot/title",
+      "source_sha256": "7fabce975428617138849051994fe0dc6669293e76360e5d9cee9d09c1a03547"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/user/title",
+      "source_sha256": "f59d0ea2e8ec813b4add7a45f4e4fc4fecaa18239ba84fc70f8f2cead37130a8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/title",
+      "source_sha256": "ac939e3eecf5e3d6748a4d3ac0dab3ce62375741fd86a8792107bc7717712f0d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/created_at/description",
+      "value": "Creation time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/elapsed_time/description",
+      "value": "Total time elapsed in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/error/description",
+      "value": "Error message if the workflow failed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/finished_at/description",
+      "value": "Finish time as a Unix timestamp in seconds; `null` if not finished."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/id/description",
+      "value": "Workflow run ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/outputs/description",
+      "value": "Output data from the workflow."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/outputs/title",
+      "source_sha256": "d65ed4159859975e88dbd98c69421ec1e5cc195d03f8dfcec429a5d57839e838"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/status/description",
+      "value": "Final workflow execution status."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_steps/description",
+      "value": "Total number of workflow steps executed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_tokens/description",
+      "value": "Total tokens consumed across all nodes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/workflow_id/description",
+      "value": "Workflow ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/title",
+      "source_sha256": "715157795d8b380fe94a30469f534ca7e40f109bd65d1ec378d791502db81bcf"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/description",
+      "value": "Blocking response returned after a workflow execution finishes."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/data/description",
+      "value": "Data returned when the workflow finishes."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/task_id/description",
+      "value": "Task ID for the in-progress execution. Use this with [Stop Workflow Task](/en/api-reference/workflow-runs/stop-workflow-task) to cancel a running workflow. Only valid during execution."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/workflow_run_id/description",
+      "value": "Persistent identifier for this workflow run record. Use this with [Get Workflow Run Detail](/en/api-reference/workflow-runs/get-workflow-run-detail) to retrieve results after execution."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/title",
+      "source_sha256": "a3ed654a469e4180e8e79784db67190c5dd4f590779e15c864e7db896d6a6946"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_at__after/title",
+      "source_sha256": "66af12cf87894c0818ccc99f5710b4e4886762fea4da609d42c02086aa622bbf"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_at__before/title",
+      "source_sha256": "d2911b94dc373196a26acd55709a42953d6611c21e3fec634b34111330a51130"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_account/description",
+      "source_sha256": "bcaada8c9cffa4545d1b0cd31daf2dae5469fa4a5dea4c4132f00b75fbab4f6b",
+      "value": "Filter by a workspace member's email address. Despite the historical field name, the runtime resolves this value as an email, not an account ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_account/title",
+      "source_sha256": "bb80a09792cf6f229771c8acdbcc36f0cbeaeda2eb98ef66fcb06f913dc24acb"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_end_user_session_id/description",
+      "source_sha256": "ddb44f946885bab9411c2a482ce74067d2c19427bca4b958b093b20852d1dc2d",
+      "value": "Filter by an end-user session ID. Obtain it from `session_id` in [Get End User Info](/en/api-reference/end-users/get-end-user-info); for Service API users it normally matches the request's `user` value."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_end_user_session_id/title",
+      "source_sha256": "d65d9417ceeb07b07990c78354dcc83959969aae9589193f460122424e608d36"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/title",
+      "source_sha256": "1fc771938e6b956e7dbd44e362a07ecf4da3fb4c964abe9cde1371eff7a5f8a0"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/description",
+      "source_sha256": "90c9e7c5b68590bfea68a876fad8e9833c393fb91cab1e806f21e9323c3b804a",
+      "value": "Public details explaining why a blocking workflow execution paused."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/TYPE/description",
+      "value": "Pause reason type."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/TYPE/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/actions/description",
+      "value": "Actions available in the Human Input form."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/actions/title",
+      "source_sha256": "aa6d82bdb3cc1d9a5e542ae2669fef27690019ab5d7b20f17d9f1331a6a942fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/approval_channels/description",
+      "value": "Configured approval channels."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/approval_channels/title",
+      "source_sha256": "e8dc5bb01a260360a49a9e3ee2b7e7ecc9e6b4f68aaf2bf205e3a4bcfc747d63"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/display_in_ui/description",
+      "value": "Whether the pause reason should be displayed in the UI."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/display_in_ui/title",
+      "source_sha256": "8c71965fd96e6f8b785ae269402727f478472205a018ad31c70fd0860c046614"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/expiration_time/description",
+      "value": "Unix timestamp when the Human Input form expires."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_content/description",
+      "value": "Content displayed with the Human Input form."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_id/description",
+      "value": "Human Input form ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_id/title",
+      "source_sha256": "fafd71c45b122dd8a3264f51789d5b76c7b77ff8dc669263056f89c55464dd7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_token/description",
+      "value": "Access token used with the Human Input Form API."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_token/title",
+      "source_sha256": "7a13fbb60d7b9386e1e508b9270fcf384926bf6ed214f4b6523f46e5946f2c67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/inputs/description",
+      "value": "Input fields in the Human Input form."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/message/description",
+      "value": "Message explaining why the workflow paused."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/message/title",
+      "source_sha256": "be1af94c8c00110d748345ea5e25cfc3aca39055ab9101ab1d8d551928445819"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_id/description",
+      "value": "ID of the workflow node that paused."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_title/description",
+      "value": "Title of the workflow node that paused."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/resolved_default_values/description",
+      "value": "Resolved default values for the form inputs."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/title",
+      "source_sha256": "9b007e71d5352bde7ac68262e0a05063c7163b0c97899d94b2b620cec553363f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/created_at/description",
+      "value": "Creation time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/elapsed_time/description",
+      "value": "Total time elapsed in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/error/description",
+      "value": "Error message if the workflow failed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/finished_at/description",
+      "value": "Finish time as a Unix timestamp in seconds; `null` if not finished."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/id/description",
+      "value": "Workflow run ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/outputs/description",
+      "value": "Output data from the workflow."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/outputs/title",
+      "source_sha256": "d65ed4159859975e88dbd98c69421ec1e5cc195d03f8dfcec429a5d57839e838"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/paused_nodes/description",
+      "value": "IDs of workflow nodes waiting for input."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/paused_nodes/title",
+      "source_sha256": "1be2bcf1f1cac22fee5004654f91685bb8d677de3e9c946a311420a413e25f98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/reasons/description",
+      "value": "Reasons the workflow paused, including Human Input form details."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/reasons/title",
+      "source_sha256": "c9f903172d68246eaeee2c130b732b3b5596a22100ff964b1a54aa9351f20b08"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/status/description",
+      "value": "Workflow execution status, fixed as `paused`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_steps/description",
+      "value": "Total number of workflow steps executed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_tokens/description",
+      "value": "Total tokens consumed across all nodes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/workflow_id/description",
+      "value": "Workflow ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/title",
+      "source_sha256": "c9be2fdf427b0563c3a8674597c4524748092125b87659a9a6b10fb2f93e85c7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/description",
+      "value": "Blocking response returned when a workflow execution is waiting for human input."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/data/description",
+      "value": "Data returned when the workflow pauses for input."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/task_id/description",
+      "value": "Task ID for the in-progress execution. Use this with [Stop Workflow Task](/en/api-reference/workflow-runs/stop-workflow-task) to cancel a running workflow. Only valid during execution."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/workflow_run_id/description",
+      "value": "Persistent identifier for this workflow run record. Use this with [Get Workflow Run Detail](/en/api-reference/workflow-runs/get-workflow-run-detail) to retrieve results after execution."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/title",
+      "source_sha256": "dbfd757fad089c9351abf34e0ded1ad305716aa9cf964d9dc5dabecd6141e448"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/description",
+      "source_sha256": "2b389dd61c5418f868e8d3f5f8741a3cbfb1b9e4fb15604bdc8e72f0c2649974",
+      "value": "File list for workflow system file inputs. Available when file upload is enabled for the workflow. To attach a local file, first upload it via [Upload File](/en/api-reference/files/upload-file) and use the returned `id` as `upload_file_id` with `transfer_method: local_file`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/inputs/description",
+      "source_sha256": "048d45b6175968d587d71c3ac5f810521aafb994d9f016b592b5a23e353f186f",
+      "value": "Key-value pairs for workflow input variables. Values for file-type variables should be arrays of file objects with `type`, `transfer_method`, and either `url` or `upload_file_id`. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover the variable names and types expected by your app."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/title",
+      "source_sha256": "610156d74f8171372740a56b3a96632a903151f9cbfcc6f0ada83493fd50cf49"
+    },
+    {
+      "op": "add",
+      "path": "/externalDocs",
+      "value": {
+        "description": "Get started guide",
+        "url": "/en/api-reference/guides/get-started"
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/info/description",
+      "source_sha256": "f9f832328876efa29dc9214aea03bd3c0816deb597e87b5ab1548adb3ec57d9c",
+      "value": "REST API for Dify applications and knowledge bases. Before calling it, create and publish the app or create the knowledge base in Dify. Send requests to the Service API endpoint shown in Dify's API access panel (its path ends in `/v1`) with `Authorization: Bearer <key>`. For app endpoints, open the published app, choose **API Access** in the left navigation, and create an app API key there; it is scoped to that app. Start with `GET /info` to discover its mode, then `GET /parameters` to discover the keys and types expected in `inputs`. For knowledge endpoints, create a knowledge base API key under **Knowledge** > **Service API**; it can access every knowledge base visible to its creator unless API access is disabled for one. Start with `GET /datasets`. Resource IDs such as `dataset_id`, `document_id`, and `workflow_id` come from the corresponding create or list responses identified in each field description. See [Get started](/en/api-reference/guides/get-started) for an end-to-end first call.\n\n**First authenticated request.** For Dify Cloud, set `api_base_url` to `api.dify.ai/v1`. Samples default to HTTPS. For self-hosted Dify, copy the full Service API endpoint from the API access panel, remove its `https://` or `http://` scheme when substituting `{api_base_url}`, and, for HTTP deployments, change the sample prefix to `http://`. Keep keys on your backend. Test an app key with:\n\n```bash\ncurl https://api.dify.ai/v1/info \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\nTest a knowledge base key with:\n\n```bash\ncurl 'https://api.dify.ai/v1/datasets?page=1&limit=20' \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\n**Dify terms.** A Chatbot is a basic conversational app. Chatflow adds a visual workflow to a conversation. Workflow is a non-conversational visual automation. Legacy Agent and new Agent apps let a model choose tools. Annotation reply matches a user's question against saved question-answer pairs and returns the saved answer. A knowledge pipeline is a visual ingestion workflow whose datasource nodes read files, provider pages, drives, or websites before indexing them. The `mode` returned by `GET /info` tells you which app endpoint family to use; every operation also begins with an availability line. `doc_form` selects the chunk structure: `text_model` for flat chunks, `hierarchical_model` for parent-child chunks, or `qa_model` for question-answer chunks. `indexing_technique` selects `high_quality` embedding-based indexing or `economy` keyword indexing."
+    },
+    {
+      "op": "replace",
+      "path": "/info/title",
+      "source_sha256": "1318c329cc79d19aa64673e792c48efc513698cbfe14eb073d1dd04e4078ce41",
+      "value": "Dify Service API"
+    },
+    {
+      "op": "add",
+      "path": "/servers/0/description",
+      "value": "The Service API base path. Samples default to HTTPS: replace `{api_base_url}` with the host and `/v1` path, without a scheme (for example, `api.dify.ai/v1`). For a self-hosted HTTP endpoint, also change the sample's `https://` prefix to `http://`.",
+      "context_path": "/servers/0",
+      "context_sha256": "b2eba7fd15014a5006b8aab50754d9ebc6a0fef2888e7152982afdcc613dbedf"
+    },
+    {
+      "op": "replace",
+      "path": "/tags",
+      "source_sha256": "21a2a3bc7749afffc03e82ff6a69e38a43a86dabf578b46577c2d605501f9023",
+      "value": [
+        {
+          "name": "Chat Messages",
+          "description": "Operations related to chat messages and interactions."
+        },
+        {
+          "name": "Files",
+          "description": "File upload and preview operations."
+        },
+        {
+          "name": "End Users",
+          "description": "Operations related to end user information."
+        },
+        {
+          "name": "Feedback",
+          "description": "User feedback operations."
+        },
+        {
+          "name": "Conversations",
+          "description": "Operations related to managing conversations."
+        },
+        {
+          "name": "Audio",
+          "description": "Text-to-Speech and Speech-to-Text operations."
+        },
+        {
+          "name": "Applications",
+          "description": "Operations to retrieve application settings and information."
+        },
+        {
+          "name": "Annotations",
+          "description": "Operations related to managing annotations for direct replies."
+        },
+        {
+          "name": "Human Input",
+          "description": "Endpoints for resuming paused workflows that require human input."
+        },
+        {
+          "name": "Workflow Runs",
+          "description": "Operations for executing and managing workflows."
+        },
+        {
+          "name": "Completion Messages",
+          "description": "Operations related to text generation and completion."
+        },
+        {
+          "name": "Knowledge Bases",
+          "description": "Operations for managing knowledge bases, including creation, configuration, and retrieval."
+        },
+        {
+          "name": "Documents",
+          "description": "Operations for creating, updating, and managing documents within a knowledge base."
+        },
+        {
+          "name": "Chunks",
+          "description": "Operations for managing document chunks and child chunks."
+        },
+        {
+          "name": "Metadata",
+          "description": "Operations for managing knowledge base metadata fields and document metadata values."
+        },
+        {
+          "name": "Tags",
+          "description": "Operations for managing knowledge base tags and tag bindings."
+        },
+        {
+          "name": "Models",
+          "description": "Operations for retrieving available models."
+        },
+        {
+          "name": "Knowledge Pipeline",
+          "description": "Operations for managing and running knowledge pipelines, including datasource plugins and pipeline execution."
+        }
+      ]
+    }
+  ]
+}

--- a/tools/api-pipeline/service_api_overlays/ja.json
+++ b/tools/api-pipeline/service_api_overlays/ja.json
@@ -1,0 +1,2050 @@
+{
+  "version": 1,
+  "language": "ja",
+  "description": "Reviewed locale overlay applied to Dify's generated Service API OpenAPI base. Replace/remove actions pin the upstream value with source_sha256.",
+  "actions": [
+    {
+      "op": "replace",
+      "path": "/components/responses/AppInvokeQuotaExceededError/description",
+      "source_sha256": "2428762a7b92a1c51b4693b34f7d458b5504b57568f1f174361a82c175ba50f0",
+      "value": "アプリ呼び出しクォータ超過エラー。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/Exception/description",
+      "source_sha256": "abaf89ae2e45284cb7f10d51a1e9c617333da6d4c3a1022b7ab2e4af37a6e6f8",
+      "value": "例外。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/HTTPException/description",
+      "source_sha256": "3b1dc5c7df507397267d7c45af18e125f26395e1ce27f44e4e1757fdb72fc166",
+      "value": "HTTP 例外。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/MaskError/description",
+      "source_sha256": "b8a66eadd4bd9b72f732516cb7a54a804cdf8835c8a2b5092769c924a4288f35",
+      "value": "マスクでエラーが発生した場合に返されます。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/ParseError/description",
+      "source_sha256": "f94ad88a2ce87124a14622952328245be9d6d2164c0525ad28b6f89af6cce128",
+      "value": "マスクを解析できない場合に返されます。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/PluginRuntimeError/description",
+      "source_sha256": "54884de15922cd1e6a3c193e8cf2c3c840b431f2ecb93c7f2841d03d9afe29ea",
+      "value": "プラグインランタイムエラー。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/ValueError/description",
+      "source_sha256": "aedbd4afd2977a291063bee1272366e7411eec87998693fac977fabbd76f1c00",
+      "value": "値エラー。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationListQuery/properties/keyword/description",
+      "source_sha256": "5fd30b8249e33765d94bb777c6421570c4fb1faf94ab41cbac0d1e0b7f763233",
+      "value": "質問または回答の内容でアノテーションをフィルタリングするためのキーワードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationListQuery/properties/limit/description",
+      "source_sha256": "b7269c3371993ac98a8701b8579faa800b2770dee55d626ceb1f74b35a4ba2c7",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationListQuery/properties/page/description",
+      "source_sha256": "60c2f027f5bd9e882b5ea965c3bdfd7d624017802cdb80bd0b8b6000aa775c62",
+      "value": "ページネーションのページ番号。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/title",
+      "source_sha256": "eb84fea86ba7ca8a051d796765be892d20a92ecd050e29212f7498902bab4536"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AudioBinaryResponse/title",
+      "source_sha256": "ef754dee1a457218bc6c216dbd5138062dae750a388d7af5791b480dbf56c417"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BinaryFileResponse/title",
+      "source_sha256": "40ee4d6aa1f0027872e6b1bea14f0389f51e33afdf6edbf84edc04f56b572787"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/auto_generate_name/description",
+      "source_sha256": "e5973e5a893cd7bdbc306bccb9e8dad1cc4cdd20f63d801ac823cd1d07119df8",
+      "value": "会話タイトルを自動生成するかどうか。`false` の場合は、会話名変更 API で `auto_generate: true` を指定してタイトルを非同期生成できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/auto_generate_name/title",
+      "source_sha256": "3ed483bca55763140ff1d72d40e67e287249200e1fa7c544a8cf98312bcff07d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/conversation_id/description",
+      "source_sha256": "27e05c95b7ec09544d57afd7b24bb352c65a4bce2ab5f86401b97d3c5d7a4511",
+      "value": "会話を継続するための会話 ID。このフィールドを省略するか空文字列を渡すと新しい会話が開始されます。以降のリクエストでは返された `conversation_id` を渡します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "マルチモーダル入力に使用するファイルです。新しいクライアントは 2 つの標準形式だけを実装してください。公開ファイル URL には `transfer_method: remote_url` と `url` を使用します。ローカルファイルは[ファイルをアップロード](/ja/api-reference/files/upload-file)でアップロードし、`transfer_method: local_file` と、返された `id` を指定する `upload_file_id` を使用します。生成されたその他の `anyOf` の組み合わせは、保存済みの旧形式参照との後方互換性のためだけに存在します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "アプリ定義変数の値です。想定される変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/query/description",
+      "source_sha256": "471e3964eb5e828809bb8ce8b7df96c8aba289839bd3521465e3cc501332c2d4",
+      "value": "ユーザー入力または質問の内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/response_mode/description",
+      "source_sha256": "c581b2c300c810f3aee9272bcd889e500a65443b16a9729c8538d3b4540237d1",
+      "value": "レスポンスモード。`streaming` は Server-Sent Events（SSE）を使用し、`blocking` は完了後に返します。新しい Agent アプリモードはストリーミングのみをサポートします。省略すると、Agent 以外はブロッキング、新しい Agent はストリーミングで実行されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/workflow_id/description",
+      "source_sha256": "73733c8ea4eb596b707394ec840174c0200e4c3c4ffb2c523f0f1e7af3c9abc3",
+      "value": "高度なチャットで実行する公開済みワークフローバージョン ID。省略すると、アプリの現在の公開済みワークフローを使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/title",
+      "source_sha256": "737ed654af2d15b7259a6742f94f2f965deeff0143b24f8c6394a335a43318e6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChildChunkListQuery/properties/keyword/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "検索キーワードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChildChunkListQuery/properties/limit/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChildChunkListQuery/properties/page/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/title",
+      "source_sha256": "b1c6a7020550b6caf74316c4f6f0d9a79bb59b5fe961a3d65331855b2e4fa238"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "マルチモーダル入力に使用するファイルです。新しいクライアントは 2 つの標準形式だけを実装してください。公開ファイル URL には `transfer_method: remote_url` と `url` を使用します。ローカルファイルは[ファイルをアップロード](/ja/api-reference/files/upload-file)でアップロードし、`transfer_method: local_file` と、返された `id` を指定する `upload_file_id` を使用します。生成されたその他の `anyOf` の組み合わせは、保存済みの旧形式参照との後方互換性のためだけに存在します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "アプリ定義変数の値です。想定される変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/query/description",
+      "source_sha256": "ce812efc2fab57a97815d53cc2e428893ce5a4e5b29c9f0289f5e19f4178d4c3",
+      "value": "ユーザー入力またはプロンプトの内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/response_mode/description",
+      "source_sha256": "b3d5908801262c0944f042ea2597fca96c2cfff286dfcf52f032c9c966ce3f5a",
+      "value": "レスポンスモード。`streaming` は Server-Sent Events（SSE）を使用し、`blocking` は完了後に返します。省略するとブロッキングモードで実行されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/title",
+      "source_sha256": "af0367558fbca9f02fe0c6614e89b0fbaddd2d5462f4aa34f224f2cdf7e90469"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationListQuery/properties/last_id/description",
+      "source_sha256": "f766603b3efb94aa18c59ff583b84741e8ba3fa64045be1bdd854b3aa1141eae",
+      "value": "現在のページの最後のレコード ID。次のページの取得に使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/properties/last_id/title",
+      "source_sha256": "6f0775443ca28929399d056640ab02a09c28ea42cb79273e233d978894adf007"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationListQuery/properties/limit/description",
+      "source_sha256": "490495d3368b0a533413bb0bd504495b22c896a5b7c65f579d7c267929e3c842",
+      "value": "返すレコード数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationListQuery/properties/sort_by/description",
+      "source_sha256": "acbcc63fe2fa86d10fc6cdad5dfa2d316fa34a626d175bfb2e9507b5e158428f",
+      "value": "並べ替えフィールド。降順にするには `-` 接頭辞を使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/properties/sort_by/title",
+      "source_sha256": "695dcf2c05fdac5102823497cf8cf570e1c99dfe97158227ffaff0f4e51de4d5"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/title",
+      "source_sha256": "3be276dca8054bfc8650a2ade49e121930f782c4e579f179616aa36c69da49a3"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/0/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/0",
+      "context_sha256": "7796d8ececea2ec336a2a0a0edd7c48487ce70b34b87c42f095c92c68f1fd88d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/0/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/0",
+      "context_sha256": "7796d8ececea2ec336a2a0a0edd7c48487ce70b34b87c42f095c92c68f1fd88d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/0/properties/name/description",
+      "source_sha256": "246b01fd801492655f586faef4387a5106f549fdd898de10259a0308868ea580",
+      "value": "会話名。`auto_generate` が `false` の場合は必須です。",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/0",
+      "context_sha256": "7796d8ececea2ec336a2a0a0edd7c48487ce70b34b87c42f095c92c68f1fd88d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/0/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/0",
+      "context_sha256": "7796d8ececea2ec336a2a0a0edd7c48487ce70b34b87c42f095c92c68f1fd88d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/name/description",
+      "value": "会話名。",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayload/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayload/properties/name/description",
+      "source_sha256": "246b01fd801492655f586faef4387a5106f549fdd898de10259a0308868ea580",
+      "value": "会話名。`auto_generate` が `false` の場合は必須です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/title",
+      "source_sha256": "5007bf01416d1203f9aeac8979d407c9432d6420dfba585d65249853164be8b6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariableUpdatePayload/properties/value/description",
+      "source_sha256": "c023a9fd7cdee70eae72c18bb8bd84cd7c51f6170d4b075f585b72d55ea046de",
+      "value": "変数の新しい値。変数の期待される型と一致する必要があります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayload/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayload/title",
+      "source_sha256": "ab9aedc458ad087c3e8f47e9d46c7180ff78e73b058595f23c06153749e8d9be"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/last_id/description",
+      "source_sha256": "f766603b3efb94aa18c59ff583b84741e8ba3fa64045be1bdd854b3aa1141eae",
+      "value": "現在のページの最後のレコード ID。次のページの取得に使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/last_id/title",
+      "source_sha256": "6f0775443ca28929399d056640ab02a09c28ea42cb79273e233d978894adf007"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/limit/description",
+      "source_sha256": "490495d3368b0a533413bb0bd504495b22c896a5b7c65f579d7c267929e3c842",
+      "value": "返すレコード数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/variable_name/description",
+      "source_sha256": "a05c046de37de969ae40fca0146dc032378314b8cb741bb0a7cc56d4cdb70fd3",
+      "value": "指定した名前で変数をフィルタリングします。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/variable_name/title",
+      "source_sha256": "78dbc71b7dd3b9881202bb123af942baa3ea39b55fcfdd3957757e099d1599d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/title",
+      "source_sha256": "d1e08414749216d358acfde1760dab99902f7d272b4334dc742b0c6e0f3fa9a1"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetListQuery/properties/include_all/description",
+      "source_sha256": "42ec0cfe0d70ab1439e6efd97eab8ed04b3723cf7eaa967a9ea50082c82f8ecc",
+      "value": "権限に関係なくすべてのナレッジベースを含めるかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/include_all/title",
+      "source_sha256": "0ed407edf20b9a0cd51edb26d336b83ab00e4b98009f3bd0c0b98c6c5aa670ee"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetListQuery/properties/keyword/description",
+      "source_sha256": "969b4fbf074465fa6786b80e50aa7c231966efcf3ffd4fb9907eac1eb2470a92",
+      "value": "名前でフィルタリングする検索キーワードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetListQuery/properties/limit/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetListQuery/properties/page/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetListQuery/properties/tag_ids/description",
+      "source_sha256": "ada725b7472603774b1855ed05b52c49914a723fea230dd88496f4f9e27efff4",
+      "value": "絞り込みに使用するタグ ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/tag_ids/title",
+      "source_sha256": "185b1bbb86d24865700f4807ef17e5b4cfb00f26b994b81ed2961a16a08296b8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/title",
+      "source_sha256": "fc0d9565af1ad1839448481672b9f23de466a6299631b453b5d8e7e2739696fa"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasourcePluginsQuery/properties/is_published/description",
+      "source_sha256": "5c48d3437a279f6bd9bde8071f0c9482a5fc24366e0d244247f80f4d668dc02d",
+      "value": "公開済みまたはドラフトのナレッジパイプラインからノードを取得するかどうか。`true` は公開済みバージョン、`false` はドラフトのノードを返します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginsQuery/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginsQuery/title",
+      "source_sha256": "63246588db3edc622fc9aeef4dc8cdfe80ccee0f8e90d4df88b85d9b5a09db16"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentGetQuery/properties/metadata/description",
+      "source_sha256": "4872f96fedffd9e413abf58ce36a21d9eda0ba203c4c38f9c553593c4a30d5ec",
+      "value": "`all` はメタデータを含むすべてのフィールドを返します。`only` は `id`、`doc_type`、`doc_metadata` のみを返します。`without` は `doc_metadata` を除くすべてのフィールドを返します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentGetQuery/properties/metadata/title",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentGetQuery/title",
+      "source_sha256": "5bf6699a8622e02e2a3b8e018716aafbf0954fdd617b00106f71e00082084999"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentListQuery/properties/keyword/description",
+      "source_sha256": "aba31e6369655c584b35d021ac80b7a64ff80eaba5de41afdeb1914b4493bf42",
+      "value": "ドキュメント名でフィルタリングするための検索キーワードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentListQuery/properties/limit/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentListQuery/properties/page/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentListQuery/properties/status/description",
+      "source_sha256": "50bce7bd6ac91e8f61540bc9cdbdb5ae9e6867325a9912e84bbabe8f4f09202f",
+      "value": "表示ステータスでフィルタリングします。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/title",
+      "source_sha256": "ed2db5c64b168833d59052e05d0a006c0c7f1f83ada31a1dbf4c7a06e48fceda"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EventStreamResponse/title",
+      "source_sha256": "cb598d0c9427cccc89d63f389617e8966efeffc6cf0b9bad1c5823624bf470d3"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/FeedbackListQuery/properties/limit/description",
+      "source_sha256": "961f01632b762573bfbd59b7cbb6205f0992f8b912f5686b5375b1536adedc7f",
+      "value": "1 ページあたりのレコード数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FeedbackListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/FeedbackListQuery/properties/page/description",
+      "source_sha256": "60c2f027f5bd9e882b5ea965c3bdfd7d624017802cdb80bd0b8b6000aa775c62",
+      "value": "ページネーションのページ番号。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FeedbackListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FeedbackListQuery/title",
+      "source_sha256": "2ee2ef5a0b8833947992d468c455c3ec9722d91f0512455ef418a2ca9fa97e89"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/FilePreviewQuery/properties/as_attachment/description",
+      "source_sha256": "f9c567f7630732e17ddcbf65657256aba6e339dfe6b252545230bd8b32ff53b3",
+      "value": "`true` の場合、ブラウザでプレビューせず、ファイルを添付ファイルとして強制的にダウンロードします。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FilePreviewQuery/properties/as_attachment/title",
+      "source_sha256": "4002a1980adbcfbe63aee5f634bd84eeacc78ae334a3020996076d5508bacecd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FilePreviewQuery/title",
+      "source_sha256": "34f058141cf139f35d0840e326719c0af503c33e745ab65d911e0449050fe2b2"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/properties/action/description",
+      "source_sha256": "3da3bf444ea4552df683d22e39bbba3d292b7270d42e322568b9dbf85cbf9d7f",
+      "value": "受信者が選択したアクションボタンの ID。フォームの `user_actions` リストにある `id` 値のいずれかと一致する必要があります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/properties/action/title",
+      "source_sha256": "5efcc1e437cbeada52653f133121f3ca259b84b74a51e15c277b4de93f11bd75"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/properties/inputs/description",
+      "source_sha256": "1f22c5be035a6620b87ddfb1582988875cfc11dec9117525dc371f0db59c5961",
+      "value": "出力変数名をキーとする送信済み人工入力値。段落または選択入力には文字列、ファイル入力にはファイルマッピング、ファイルリスト入力にはファイルマッピングのリストを使用します。ローカルファイルは `transfer_method=local_file` と `upload_file_id`、リモートファイルは `transfer_method=remote_url` と `url` または `remote_url` を使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/title",
+      "source_sha256": "38a626e4a4e1642a39e35116d44bec129a532a22191e06434ecc3c9b4c51c3d3"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageFeedbackPayload/properties/content/description",
+      "source_sha256": "f1b13f33ce2fae7757c4b30cad4a78f091f9ff5ed649c04f9d9851e7f7dad06b",
+      "value": "追加の詳細を提供する任意のテキストフィードバック。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageFeedbackPayload/properties/rating/description",
+      "source_sha256": "a22a86af4ca3b6b23b547b829f67d88997e274ed483d1ddd4d6fd916fadc8c44",
+      "value": "フィードバック評価。以前送信したフィードバックを取り消すには `null` に設定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayload/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayload/title",
+      "source_sha256": "dc826ad9804a26c2e92124a2d20c938b54f7e6abf59d8fbccb326f20ac4e7c70"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageListQuery/properties/conversation_id/description",
+      "source_sha256": "20bf5d8f6428fb73090cff7ba6229670b2eb9efb308644e7fe121ef46d0d3d87",
+      "value": "会話 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageListQuery/properties/first_id/description",
+      "source_sha256": "5e4c90d4e0c0319035c79eff301c7dca8a1d41219c8da46d6dd16b3a28410ab5",
+      "value": "現在のページの最初のチャットレコード ID。最新メッセージを取得する場合は省略します。次のページでは、現在のリストの最初のメッセージ ID を使って古いメッセージを取得します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/properties/first_id/title",
+      "source_sha256": "68654ca965f8b8a40a044427a6a4214508ab4b57019715ec0cc768900bf0c36a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageListQuery/properties/limit/description",
+      "source_sha256": "77e7ddf0c9aea543afaeb95894b8dcf30fae15ac7aaa7891b6cbde3456d8841d",
+      "value": "リクエストごとに返すチャット履歴メッセージの数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/title",
+      "source_sha256": "17997d5395df2c93391badf0ba144f4ca86426f5b37ae14fd35d9c873a56e906"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentListQuery/properties/keyword/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "検索キーワードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentListQuery/properties/limit/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentListQuery/properties/page/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentListQuery/properties/status/description",
+      "source_sha256": "8553c4a96f020a09cde5ec784da5824c9b02c954d7cae9faa4d0300b9835a2d8",
+      "value": "`completed`、`indexing`、`error` などのインデックス状態でチャンクを絞り込みます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/title",
+      "source_sha256": "0cd59385c6acbfa47454f1681728f3753d5b551e24e8ca993624fd336f64d154"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleResultResponse/properties/result/description",
+      "value": "操作結果。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultResponse/title",
+      "source_sha256": "412feb3d6da0cbf2901a8634d7612e513ffb59141b7369d0048187cfca1c7a73"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayload/properties/message_id/description",
+      "source_sha256": "47f5efd48161cf7478427652060c2fbe41c0ffd3adea29c80a7e92824fb6f704",
+      "value": "メッセージ ID。両方を指定した場合は `text` より優先されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayload/properties/streaming/description",
+      "source_sha256": "bbbeba9487a0113a787e0ed2b2a3e0d6ab588013080484518fdadd925438c956",
+      "value": "互換性のために予約されています。TTS レスポンスのストリーミングはプロバイダーの出力によって決まります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/streaming/title",
+      "source_sha256": "99c855ec96bb79eda46be7218b5ac2045b607b2135c1181034e6746519b88b06"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayload/properties/text/description",
+      "source_sha256": "efbe836ec14e32683d74f164f15caf0c25a45c490c6c4ac6fb2c7db6e5918db7",
+      "value": "変換する音声内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayload/properties/voice/description",
+      "source_sha256": "093f32f71464b6ee988240562bff4f647ec3d81381328089f3daaf171c1bd766",
+      "value": "テキスト読み上げに使用する音声です。利用可能な音声は、このアプリに設定された TTS プロバイダーによって異なります。省略すると、利用可能な場合はアプリに設定された音声を使用します。この値は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)の `text_to_speech.voice` で確認できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/voice/title",
+      "source_sha256": "75d5a120334e208c41bdff270efdb5ed48de029fa6a9399b5897166f2dc6baf2"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/title",
+      "source_sha256": "21460ec2d744ed638ddcc8912fa8e504c6ad781a6a7ad4206976f4aeb17aaab9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowBlockingResponse/description",
+      "source_sha256": "a616ccd4fc71f888b9aa8dd25540afa1deb4a3727760e49447263a524f64ef16"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowBlockingResponse/title",
+      "source_sha256": "8a25c0876465560ae896727bbc84bd3049455ecae245a7ca10fd82e274c2fda1"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/continue_on_pause/description",
+      "source_sha256": "313727deed2f4e1de30f13fd2077e5bc3cc9291cea56e5ed6b362be9869e5e9d",
+      "value": "`true` にすると、複数の `workflow_paused` イベントにまたがってストリームを開いたままにします。複数の人工入力ノードが連続するワークフローで便利です。デフォルトでは最初の一時停止後にストリームを閉じます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/continue_on_pause/title",
+      "source_sha256": "d6d9fa184ceedc0b96bf45750f3c618382d5333d440102854924100831a4a84f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/include_state_snapshot/description",
+      "source_sha256": "f3dfbabd8d5e07e7a7f9360e67b54ad86c2b85bb9804de7bef3e73048c1ae0d1",
+      "value": "`true` の場合、永続化された状態スナップショットからリプレイし、新しいイベントのストリーミング開始前に実行済みノードのステータスサマリーを含めます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/include_state_snapshot/title",
+      "source_sha256": "7fabce975428617138849051994fe0dc6669293e76360e5d9cee9d09c1a03547"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/user/description",
+      "source_sha256": "5ea2c1709b50a75b1ba6f8176a40072ac944e32363bc9d8d780ab1d5e90eab09",
+      "value": "最初に実行をトリガーしたエンドユーザー識別子。実行の作成者と一致する必要があります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/user/title",
+      "source_sha256": "f59d0ea2e8ec813b4add7a45f4e4fc4fecaa18239ba84fc70f8f2cead37130a8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/title",
+      "source_sha256": "ac939e3eecf5e3d6748a4d3ac0dab3ce62375741fd86a8792107bc7717712f0d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/created_at/description",
+      "value": "作成時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/elapsed_time/description",
+      "value": "合計経過時間（秒）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/error/description",
+      "value": "ワークフローが失敗した場合のエラーメッセージです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/finished_at/description",
+      "value": "終了時刻（Unix 秒タイムスタンプ）。未終了の場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/id/description",
+      "value": "ワークフロー実行 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/outputs/description",
+      "value": "ワークフローからの出力データです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/outputs/title",
+      "source_sha256": "d65ed4159859975e88dbd98c69421ec1e5cc195d03f8dfcec429a5d57839e838"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/status/description",
+      "value": "ワークフロー実行の最終ステータスです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_steps/description",
+      "value": "実行されたワークフローの合計ステップ数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_tokens/description",
+      "value": "全ノードで消費された合計トークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/workflow_id/description",
+      "value": "ワークフロー ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/title",
+      "source_sha256": "715157795d8b380fe94a30469f534ca7e40f109bd65d1ec378d791502db81bcf"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/description",
+      "value": "ワークフロー実行の完了後に返されるブロッキングレスポンスです。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/data/description",
+      "value": "ワークフロー完了時に返されるデータ。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/task_id/description",
+      "value": "進行中の実行のタスク ID です。[ワークフロータスクを停止](/ja/api-reference/workflow-runs/stop-workflow-task) と組み合わせて、実行中のワークフローをキャンセルします。実行中のみ有効です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/workflow_run_id/description",
+      "value": "このワークフロー実行記録の永続的な識別子です。[ワークフロー実行詳細を取得](/ja/api-reference/workflow-runs/get-workflow-run-detail) と組み合わせて、実行後に結果を取得します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/title",
+      "source_sha256": "a3ed654a469e4180e8e79784db67190c5dd4f590779e15c864e7db896d6a6946"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_at__after/description",
+      "source_sha256": "2252a93d9ef7f2626fdaa48085deb371ca9a9fe9b967e8a30083767955026040",
+      "value": "この ISO 8601 タイムスタンプ以降に作成されたログをフィルタリングします。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_at__after/title",
+      "source_sha256": "66af12cf87894c0818ccc99f5710b4e4886762fea4da609d42c02086aa622bbf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_at__before/description",
+      "source_sha256": "a8d98560ed90085c1cdec0bac363e759e5efb851380b07c81c4264adf23714a0",
+      "value": "この ISO 8601 タイムスタンプ以前に作成されたログをフィルタリングします。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_at__before/title",
+      "source_sha256": "d2911b94dc373196a26acd55709a42953d6611c21e3fec634b34111330a51130"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_account/description",
+      "source_sha256": "bcaada8c9cffa4545d1b0cd31daf2dae5469fa4a5dea4c4132f00b75fbab4f6b",
+      "value": "ワークスペースメンバーのメールアドレスで絞り込みます。歴史的なフィールド名とは異なり、ランタイムはこの値をアカウント ID ではなくメールアドレスとして解決します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_account/title",
+      "source_sha256": "bb80a09792cf6f229771c8acdbcc36f0cbeaeda2eb98ef66fcb06f913dc24acb"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_end_user_session_id/description",
+      "source_sha256": "ddb44f946885bab9411c2a482ce74067d2c19427bca4b958b093b20852d1dc2d",
+      "value": "エンドユーザーのセッション ID で絞り込みます。[エンドユーザー情報を取得](/ja/api-reference/end-users/get-end-user-info) の `session_id` から取得できます。Service API ユーザーでは通常、リクエストの `user` と同じ値です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_end_user_session_id/title",
+      "source_sha256": "d65d9417ceeb07b07990c78354dcc83959969aae9589193f460122424e608d36"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/keyword/description",
+      "source_sha256": "9897972c173a662b00c2dbfafd2b566ac8a4761ea2b45ec142a3e86eea8a903d",
+      "value": "ログ内を検索するキーワードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/limit/description",
+      "source_sha256": "b7269c3371993ac98a8701b8579faa800b2770dee55d626ceb1f74b35a4ba2c7",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/page/description",
+      "source_sha256": "60c2f027f5bd9e882b5ea965c3bdfd7d624017802cdb80bd0b8b6000aa775c62",
+      "value": "ページネーションのページ番号。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/status/description",
+      "source_sha256": "719b90aef82c13efc69025cc4eadf17de412eb1607f9997fdd1e752625e21a84",
+      "value": "実行ステータスでフィルタリングします。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/title",
+      "source_sha256": "1fc771938e6b956e7dbd44e362a07ecf4da3fb4c964abe9cde1371eff7a5f8a0"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/description",
+      "source_sha256": "90c9e7c5b68590bfea68a876fad8e9833c393fb91cab1e806f21e9323c3b804a",
+      "value": "ブロッキングワークフロー実行が一時停止した理由の公開情報です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/TYPE/description",
+      "value": "一時停止理由のタイプです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/TYPE/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/actions/description",
+      "value": "人間の入力フォームで利用できるアクションです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/actions/title",
+      "source_sha256": "aa6d82bdb3cc1d9a5e542ae2669fef27690019ab5d7b20f17d9f1331a6a942fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/approval_channels/description",
+      "value": "設定された承認チャネルです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/approval_channels/title",
+      "source_sha256": "e8dc5bb01a260360a49a9e3ee2b7e7ecc9e6b4f68aaf2bf205e3a4bcfc747d63"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/display_in_ui/description",
+      "value": "一時停止理由を UI に表示するかどうかを示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/display_in_ui/title",
+      "source_sha256": "8c71965fd96e6f8b785ae269402727f478472205a018ad31c70fd0860c046614"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/expiration_time/description",
+      "value": "人間の入力フォームの有効期限を示す Unix タイムスタンプです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_content/description",
+      "value": "人間の入力フォームに表示する内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_id/description",
+      "value": "人間の入力フォーム ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_id/title",
+      "source_sha256": "fafd71c45b122dd8a3264f51789d5b76c7b77ff8dc669263056f89c55464dd7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_token/description",
+      "value": "人間の入力フォーム API で使用するアクセストークンです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_token/title",
+      "source_sha256": "7a13fbb60d7b9386e1e508b9270fcf384926bf6ed214f4b6523f46e5946f2c67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/inputs/description",
+      "value": "人間の入力フォームの入力フィールドです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/message/description",
+      "value": "ワークフローが一時停止した理由を説明するメッセージです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/message/title",
+      "source_sha256": "be1af94c8c00110d748345ea5e25cfc3aca39055ab9101ab1d8d551928445819"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_id/description",
+      "value": "一時停止したワークフローノード ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_title/description",
+      "value": "一時停止したワークフローノードのタイトルです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/resolved_default_values/description",
+      "value": "フォーム入力で解決されたデフォルト値です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/title",
+      "source_sha256": "9b007e71d5352bde7ac68262e0a05063c7163b0c97899d94b2b620cec553363f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/created_at/description",
+      "value": "作成時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/elapsed_time/description",
+      "value": "合計経過時間（秒）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/error/description",
+      "value": "ワークフローが失敗した場合のエラーメッセージです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/finished_at/description",
+      "value": "終了時刻（Unix 秒タイムスタンプ）。未終了の場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/id/description",
+      "value": "ワークフロー実行 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/outputs/description",
+      "value": "ワークフローからの出力データです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/outputs/title",
+      "source_sha256": "d65ed4159859975e88dbd98c69421ec1e5cc195d03f8dfcec429a5d57839e838"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/paused_nodes/description",
+      "value": "入力待ちのワークフローノード ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/paused_nodes/title",
+      "source_sha256": "1be2bcf1f1cac22fee5004654f91685bb8d677de3e9c946a311420a413e25f98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/reasons/description",
+      "value": "人間の入力フォームの詳細を含む、ワークフローの一時停止理由です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/reasons/title",
+      "source_sha256": "c9f903172d68246eaeee2c130b732b3b5596a22100ff964b1a54aa9351f20b08"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/status/description",
+      "value": "ワークフロー実行ステータスは `paused` 固定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_steps/description",
+      "value": "実行されたワークフローの合計ステップ数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_tokens/description",
+      "value": "全ノードで消費された合計トークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/workflow_id/description",
+      "value": "ワークフロー ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/title",
+      "source_sha256": "c9be2fdf427b0563c3a8674597c4524748092125b87659a9a6b10fb2f93e85c7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/description",
+      "value": "ワークフロー実行が人間の入力を待機している場合に返されるブロッキングレスポンスです。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/data/description",
+      "value": "ワークフローが入力待ちで一時停止したときに返されるデータ。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/task_id/description",
+      "value": "進行中の実行のタスク ID です。[ワークフロータスクを停止](/ja/api-reference/workflow-runs/stop-workflow-task) と組み合わせて、実行中のワークフローをキャンセルします。実行中のみ有効です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/workflow_run_id/description",
+      "value": "このワークフロー実行記録の永続的な識別子です。[ワークフロー実行詳細を取得](/ja/api-reference/workflow-runs/get-workflow-run-detail) と組み合わせて、実行後に結果を取得します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/title",
+      "source_sha256": "dbfd757fad089c9351abf34e0ded1ad305716aa9cf964d9dc5dabecd6141e448"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/description",
+      "source_sha256": "2b389dd61c5418f868e8d3f5f8741a3cbfb1b9e4fb15604bdc8e72f0c2649974",
+      "value": "ワークフローのシステムファイル入力の一覧です。ワークフローでファイルアップロードが有効な場合に使用できます。ローカルファイルを添付するには、まず[ファイルをアップロード](/ja/api-reference/files/upload-file)し、返された `id` を `upload_file_id` に指定して、`transfer_method` を `local_file` に設定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/inputs/description",
+      "source_sha256": "048d45b6175968d587d71c3ac5f810521aafb994d9f016b592b5a23e353f186f",
+      "value": "ワークフロー入力変数のキーと値のペアです。ファイル型変数の値は、`type`、`transfer_method`、および `url` または `upload_file_id` を含むファイルオブジェクトの配列にします。アプリが要求する変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/response_mode/description",
+      "source_sha256": "a05eb85e740430b5fc70be8c963c4dacf30a2ca5059ffe72433c24101ed10462",
+      "value": "レスポンスモード。同期レスポンスには `blocking`、Server-Sent Events（SSE）には `streaming` を使用します。省略するとブロッキングモードで実行されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/title",
+      "source_sha256": "610156d74f8171372740a56b3a96632a903151f9cbfcc6f0ada83493fd50cf49"
+    },
+    {
+      "op": "replace",
+      "path": "/components/securitySchemes/Bearer/description",
+      "source_sha256": "fb8a8717afa69eabf097c32010ec4a793b39e05063fd831c5cf289a43b0b1cb9",
+      "value": "Service API キーを Authorization ヘッダーの Bearer トークンとして使用します。"
+    },
+    {
+      "op": "add",
+      "path": "/externalDocs",
+      "value": {
+        "description": "クイックスタートガイド",
+        "url": "/ja/api-reference/guides/get-started"
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/info/description",
+      "source_sha256": "f9f832328876efa29dc9214aea03bd3c0816deb597e87b5ab1548adb3ec57d9c",
+      "value": "Dify アプリケーションとナレッジベースのための REST API です。呼び出す前に、Dify でアプリを作成して公開するか、ナレッジベースを作成してください。リクエストは Dify の API アクセス画面に表示される Service API エンドポイント（パス末尾は `/v1`）へ送り、`Authorization: Bearer <キー>` で認証します。アプリ系エンドポイントでは、公開済みアプリを開き、左側のナビゲーションで **API アクセス** を選択してアプリ API キーを作成します。このキーはそのアプリだけに有効です。まず `GET /info` でモードを確認し、次に `GET /parameters` で `inputs` に必要なキーと型を取得します。ナレッジ系エンドポイントでは、**ナレッジ** > **Service API** でナレッジベース API キーを作成します。個別のナレッジベースで API アクセスを無効にしていない限り、キー作成者から見えるすべてのナレッジベースにアクセスできます。最初に `GET /datasets` を呼び出してください。`dataset_id`、`document_id`、`workflow_id` などのリソース ID は、各フィールド説明が示す作成または一覧取得レスポンスから取得します。最初の呼び出しの手順は[はじめに](/ja/api-reference/guides/get-started)を参照してください。\n\n**最初の認証済みリクエスト。** Dify Cloud の `api_base_url` は `api.dify.ai/v1` で、例は HTTPS を前提としています。セルフホスト版では API アクセス画面から Service API エンドポイント全体をコピーし、`{api_base_url}` に代入する際は `https://` または `http://` のスキームを除いてください。HTTP の場合は、例の接頭辞も `http://` に変更します。キーはバックエンドだけに保存します。アプリキーをテストするには：\n\n```bash\ncurl https://api.dify.ai/v1/info \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\nナレッジベースキーをテストするには：\n\n```bash\ncurl 'https://api.dify.ai/v1/datasets?page=1&limit=20' \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\n**Dify の用語。** チャットボットは基本的な会話アプリです。Chatflow は会話にビジュアルワークフローを追加します。Workflow は非会話型のビジュアル自動化です。旧 Agent と新しい Agent アプリでは、モデルがツールを選択します。アノテーション返信はユーザーの質問を保存済みの質問と回答のペアに照合し、保存済み回答を返します。ナレッジパイプラインはビジュアルな取り込みワークフローで、データソースノードがインデックス作成前にファイル、プロバイダーページ、ドライブ、Web サイトを読み込みます。`GET /info` が返す `mode` により使用するアプリエンドポイント群が決まり、各操作の冒頭にも対象範囲が記載されています。 `doc_form` はチャンク構造を選びます。`text_model` はフラットなチャンク、`hierarchical_model` は親子チャンク、`qa_model` は質問と回答のチャンクです。`indexing_technique` は埋め込みベースの `high_quality` インデックス、またはキーワードベースの `economy` インデックスを選びます。"
+    },
+    {
+      "op": "replace",
+      "path": "/info/title",
+      "source_sha256": "1318c329cc79d19aa64673e792c48efc513698cbfe14eb073d1dd04e4078ce41",
+      "value": "Dify サービス API"
+    },
+    {
+      "op": "add",
+      "path": "/servers/0/description",
+      "value": "Service API のベースパスです。例は HTTPS を前提としています。`{api_base_url}` はスキームを除いたデプロイ先ホストと `/v1` パスに置き換えてください（例：`api.dify.ai/v1`）。セルフホストのエンドポイントが HTTP の場合は、例の `https://` も `http://` に変更してください。",
+      "context_path": "/servers/0",
+      "context_sha256": "b2eba7fd15014a5006b8aab50754d9ebc6a0fef2888e7152982afdcc613dbedf"
+    },
+    {
+      "op": "replace",
+      "path": "/tags",
+      "source_sha256": "21a2a3bc7749afffc03e82ff6a69e38a43a86dabf578b46577c2d605501f9023",
+      "value": [
+        {
+          "name": "チャットメッセージ",
+          "description": "チャットメッセージとインタラクションに関連する操作です。"
+        },
+        {
+          "name": "ファイル操作",
+          "description": "ファイルのアップロードとプレビューの操作です。"
+        },
+        {
+          "name": "エンドユーザー",
+          "description": "エンドユーザー情報に関連する操作です。"
+        },
+        {
+          "name": "メッセージフィードバック",
+          "description": "ユーザーフィードバックの操作です。"
+        },
+        {
+          "name": "会話管理",
+          "description": "会話管理に関連する操作です。"
+        },
+        {
+          "name": "音声・テキスト変換",
+          "description": "テキスト読み上げと音声認識の操作です。"
+        },
+        {
+          "name": "アプリケーション設定",
+          "description": "アプリケーション設定と情報を取得する操作です。"
+        },
+        {
+          "name": "アノテーション管理",
+          "description": "ダイレクト返信用のアノテーション管理に関連する操作です。"
+        },
+        {
+          "name": "人間の入力",
+          "description": "人間の入力を要する一時停止中のワークフローの再開操作です。"
+        },
+        {
+          "name": "ワークフロー実行",
+          "description": "ワークフローの実行と管理のための操作です。"
+        },
+        {
+          "name": "完了メッセージ",
+          "description": "テキスト生成に関連する操作です。"
+        },
+        {
+          "name": "ナレッジベース",
+          "description": "ナレッジベースの作成、設定、取得を含むナレッジベース管理の操作です。"
+        },
+        {
+          "name": "ドキュメント",
+          "description": "ナレッジベース内のドキュメントの作成、更新、管理のための操作です。"
+        },
+        {
+          "name": "チャンク",
+          "description": "ドキュメントチャンクと子チャンクの管理のための操作です。"
+        },
+        {
+          "name": "メタデータ",
+          "description": "ナレッジベースのメタデータフィールドとドキュメントメタデータ値の管理のための操作です。"
+        },
+        {
+          "name": "タグ管理",
+          "description": "ナレッジベースタグとタグバインディングの管理のための操作です。"
+        },
+        {
+          "name": "モデル",
+          "description": "利用可能なモデルを取得するための操作です。"
+        },
+        {
+          "name": "ナレッジパイプライン",
+          "description": "データソースプラグインとパイプライン実行を含むナレッジパイプラインの管理と実行のための操作です。"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/api-pipeline/service_api_overlays/zh.json
+++ b/tools/api-pipeline/service_api_overlays/zh.json
@@ -1,0 +1,2050 @@
+{
+  "version": 1,
+  "language": "zh",
+  "description": "Reviewed locale overlay applied to Dify's generated Service API OpenAPI base. Replace/remove actions pin the upstream value with source_sha256.",
+  "actions": [
+    {
+      "op": "replace",
+      "path": "/components/responses/AppInvokeQuotaExceededError/description",
+      "source_sha256": "2428762a7b92a1c51b4693b34f7d458b5504b57568f1f174361a82c175ba50f0",
+      "value": "应用调用配额超限错误。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/Exception/description",
+      "source_sha256": "abaf89ae2e45284cb7f10d51a1e9c617333da6d4c3a1022b7ab2e4af37a6e6f8",
+      "value": "异常。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/HTTPException/description",
+      "source_sha256": "3b1dc5c7df507397267d7c45af18e125f26395e1ce27f44e4e1757fdb72fc166",
+      "value": "HTTP 异常。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/MaskError/description",
+      "source_sha256": "b8a66eadd4bd9b72f732516cb7a54a804cdf8835c8a2b5092769c924a4288f35",
+      "value": "掩码发生任何错误时返回。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/ParseError/description",
+      "source_sha256": "f94ad88a2ce87124a14622952328245be9d6d2164c0525ad28b6f89af6cce128",
+      "value": "无法解析掩码时返回。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/PluginRuntimeError/description",
+      "source_sha256": "54884de15922cd1e6a3c193e8cf2c3c840b431f2ecb93c7f2841d03d9afe29ea",
+      "value": "插件运行时错误。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/responses/ValueError/description",
+      "source_sha256": "aedbd4afd2977a291063bee1272366e7411eec87998693fac977fabbd76f1c00",
+      "value": "值错误。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationListQuery/properties/keyword/description",
+      "source_sha256": "5fd30b8249e33765d94bb777c6421570c4fb1faf94ab41cbac0d1e0b7f763233",
+      "value": "按问题或回答内容筛选标注的关键词。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationListQuery/properties/limit/description",
+      "source_sha256": "b7269c3371993ac98a8701b8579faa800b2770dee55d626ceb1f74b35a4ba2c7",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationListQuery/properties/page/description",
+      "source_sha256": "60c2f027f5bd9e882b5ea965c3bdfd7d624017802cdb80bd0b8b6000aa775c62",
+      "value": "分页页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationListQuery/title",
+      "source_sha256": "eb84fea86ba7ca8a051d796765be892d20a92ecd050e29212f7498902bab4536"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AudioBinaryResponse/title",
+      "source_sha256": "ef754dee1a457218bc6c216dbd5138062dae750a388d7af5791b480dbf56c417"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BinaryFileResponse/title",
+      "source_sha256": "40ee4d6aa1f0027872e6b1bea14f0389f51e33afdf6edbf84edc04f56b572787"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/auto_generate_name/description",
+      "source_sha256": "e5973e5a893cd7bdbc306bccb9e8dad1cc4cdd20f63d801ac823cd1d07119df8",
+      "value": "是否自动生成会话标题。若为 `false`，可调用重命名会话 API，并设置 `auto_generate: true` 来异步生成标题。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/auto_generate_name/title",
+      "source_sha256": "3ed483bca55763140ff1d72d40e67e287249200e1fa7c544a8cf98312bcff07d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/conversation_id/description",
+      "source_sha256": "27e05c95b7ec09544d57afd7b24bb352c65a4bce2ab5f86401b97d3c5d7a4511",
+      "value": "用于继续会话的会话 ID。省略此字段或传入空字符串可开始新会话，后续请求再传入返回的 `conversation_id`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/ChatRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "用于多模态输入的文件。新客户端只需实现两种规范形式：公共文件 URL 使用 `transfer_method: remote_url` 和 `url`；本地文件先通过[上传文件](/zh/api-reference/files/upload-file)上传，再使用 `transfer_method: local_file`，并将返回的 `id` 作为 `upload_file_id`。生成的其他 `anyOf` 组合仅用于兼容已存储的旧版引用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "应用自定义变量的值。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解预期的变量名称和类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/query/description",
+      "source_sha256": "471e3964eb5e828809bb8ce8b7df96c8aba289839bd3521465e3cc501332c2d4",
+      "value": "用户输入或问题内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/response_mode/description",
+      "source_sha256": "c581b2c300c810f3aee9272bcd889e500a65443b16a9729c8538d3b4540237d1",
+      "value": "响应模式。`streaming` 使用服务器发送事件（SSE）；`blocking` 在执行完成后返回。新版 Agent 应用仅支持流式模式。省略时，非 Agent 应用使用阻塞模式，新版 Agent 应用使用流式模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayload/properties/workflow_id/description",
+      "source_sha256": "73733c8ea4eb596b707394ec840174c0200e4c3c4ffb2c523f0f1e7af3c9abc3",
+      "value": "高级聊天要执行的已发布工作流版本 ID。省略时，使用应用当前已发布的工作流。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayload/title",
+      "source_sha256": "737ed654af2d15b7259a6742f94f2f965deeff0143b24f8c6394a335a43318e6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChildChunkListQuery/properties/keyword/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "搜索关键词。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChildChunkListQuery/properties/limit/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChildChunkListQuery/properties/page/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListQuery/title",
+      "source_sha256": "b1c6a7020550b6caf74316c4f6f0d9a79bb59b5fe961a3d65331855b2e4fa238"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/CompletionRequestPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "用于多模态输入的文件。新客户端只需实现两种规范形式：公共文件 URL 使用 `transfer_method: remote_url` 和 `url`；本地文件先通过[上传文件](/zh/api-reference/files/upload-file)上传，再使用 `transfer_method: local_file`，并将返回的 `id` 作为 `upload_file_id`。生成的其他 `anyOf` 组合仅用于兼容已存储的旧版引用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "应用自定义变量的值。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解预期的变量名称和类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/query/description",
+      "source_sha256": "ce812efc2fab57a97815d53cc2e428893ce5a4e5b29c9f0289f5e19f4178d4c3",
+      "value": "用户输入或提示词内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayload/properties/response_mode/description",
+      "source_sha256": "b3d5908801262c0944f042ea2597fca96c2cfff286dfcf52f032c9c966ce3f5a",
+      "value": "响应模式。`streaming` 使用服务器发送事件（SSE）；`blocking` 在执行完成后返回。省略时，请求使用阻塞模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayload/title",
+      "source_sha256": "af0367558fbca9f02fe0c6614e89b0fbaddd2d5462f4aa34f224f2cdf7e90469"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationListQuery/properties/last_id/description",
+      "source_sha256": "f766603b3efb94aa18c59ff583b84741e8ba3fa64045be1bdd854b3aa1141eae",
+      "value": "当前页面最后一条记录的 ID，用于获取下一页。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/properties/last_id/title",
+      "source_sha256": "6f0775443ca28929399d056640ab02a09c28ea42cb79273e233d978894adf007"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationListQuery/properties/limit/description",
+      "source_sha256": "490495d3368b0a533413bb0bd504495b22c896a5b7c65f579d7c267929e3c842",
+      "value": "返回的记录数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationListQuery/properties/sort_by/description",
+      "source_sha256": "acbcc63fe2fa86d10fc6cdad5dfa2d316fa34a626d175bfb2e9507b5e158428f",
+      "value": "排序字段。使用 `-` 前缀表示降序。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/properties/sort_by/title",
+      "source_sha256": "695dcf2c05fdac5102823497cf8cf570e1c99dfe97158227ffaff0f4e51de4d5"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationListQuery/title",
+      "source_sha256": "3be276dca8054bfc8650a2ade49e121930f782c4e579f179616aa36c69da49a3"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/0/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/0",
+      "context_sha256": "7796d8ececea2ec336a2a0a0edd7c48487ce70b34b87c42f095c92c68f1fd88d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/0/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/0",
+      "context_sha256": "7796d8ececea2ec336a2a0a0edd7c48487ce70b34b87c42f095c92c68f1fd88d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/0/properties/name/description",
+      "source_sha256": "246b01fd801492655f586faef4387a5106f549fdd898de10259a0308868ea580",
+      "value": "会话名称。当 `auto_generate` 为 `false` 时必填。",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/0",
+      "context_sha256": "7796d8ececea2ec336a2a0a0edd7c48487ce70b34b87c42f095c92c68f1fd88d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/0/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/0",
+      "context_sha256": "7796d8ececea2ec336a2a0a0edd7c48487ce70b34b87c42f095c92c68f1fd88d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/name/description",
+      "value": "会话名称。",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/anyOf/1/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayload/anyOf/1",
+      "context_sha256": "7ff925737d6db8fd76194447c9381be7054ea2dfd214cacfc05febdd21f3bfa7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayload/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayload/properties/name/description",
+      "source_sha256": "246b01fd801492655f586faef4387a5106f549fdd898de10259a0308868ea580",
+      "value": "会话名称。当 `auto_generate` 为 `false` 时必填。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayload/title",
+      "source_sha256": "5007bf01416d1203f9aeac8979d407c9432d6420dfba585d65249853164be8b6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariableUpdatePayload/properties/value/description",
+      "source_sha256": "c023a9fd7cdee70eae72c18bb8bd84cd7c51f6170d4b075f585b72d55ea046de",
+      "value": "变量的新值。必须与变量的预期类型匹配。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayload/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayload/title",
+      "source_sha256": "ab9aedc458ad087c3e8f47e9d46c7180ff78e73b058595f23c06153749e8d9be"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/last_id/description",
+      "source_sha256": "f766603b3efb94aa18c59ff583b84741e8ba3fa64045be1bdd854b3aa1141eae",
+      "value": "当前页面最后一条记录的 ID，用于获取下一页。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/last_id/title",
+      "source_sha256": "6f0775443ca28929399d056640ab02a09c28ea42cb79273e233d978894adf007"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/limit/description",
+      "source_sha256": "490495d3368b0a533413bb0bd504495b22c896a5b7c65f579d7c267929e3c842",
+      "value": "返回的记录数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/variable_name/description",
+      "source_sha256": "a05c046de37de969ae40fca0146dc032378314b8cb741bb0a7cc56d4cdb70fd3",
+      "value": "按指定名称筛选变量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/properties/variable_name/title",
+      "source_sha256": "78dbc71b7dd3b9881202bb123af942baa3ea39b55fcfdd3957757e099d1599d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariablesQuery/title",
+      "source_sha256": "d1e08414749216d358acfde1760dab99902f7d272b4334dc742b0c6e0f3fa9a1"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetListQuery/properties/include_all/description",
+      "source_sha256": "42ec0cfe0d70ab1439e6efd97eab8ed04b3723cf7eaa967a9ea50082c82f8ecc",
+      "value": "是否包含所有知识库，无论权限如何。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/include_all/title",
+      "source_sha256": "0ed407edf20b9a0cd51edb26d336b83ab00e4b98009f3bd0c0b98c6c5aa670ee"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetListQuery/properties/keyword/description",
+      "source_sha256": "969b4fbf074465fa6786b80e50aa7c231966efcf3ffd4fb9907eac1eb2470a92",
+      "value": "按名称筛选的搜索关键词。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetListQuery/properties/limit/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetListQuery/properties/page/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetListQuery/properties/tag_ids/description",
+      "source_sha256": "ada725b7472603774b1855ed05b52c49914a723fea230dd88496f4f9e27efff4",
+      "value": "用于筛选的标签 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/properties/tag_ids/title",
+      "source_sha256": "185b1bbb86d24865700f4807ef17e5b4cfb00f26b994b81ed2961a16a08296b8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListQuery/title",
+      "source_sha256": "fc0d9565af1ad1839448481672b9f23de466a6299631b453b5d8e7e2739696fa"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasourcePluginsQuery/properties/is_published/description",
+      "source_sha256": "5c48d3437a279f6bd9bde8071f0c9482a5fc24366e0d244247f80f4d668dc02d",
+      "value": "是否从已发布或草稿知识流水线中获取节点。`true` 返回已发布版本的节点，`false` 返回草稿版本的节点。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginsQuery/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginsQuery/title",
+      "source_sha256": "63246588db3edc622fc9aeef4dc8cdfe80ccee0f8e90d4df88b85d9b5a09db16"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentGetQuery/properties/metadata/description",
+      "source_sha256": "4872f96fedffd9e413abf58ce36a21d9eda0ba203c4c38f9c553593c4a30d5ec",
+      "value": "`all` 返回所有字段（包括元数据）。`only` 仅返回 `id`、`doc_type` 和 `doc_metadata`。`without` 返回除 `doc_metadata` 外的所有字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentGetQuery/properties/metadata/title",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentGetQuery/title",
+      "source_sha256": "5bf6699a8622e02e2a3b8e018716aafbf0954fdd617b00106f71e00082084999"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentListQuery/properties/keyword/description",
+      "source_sha256": "aba31e6369655c584b35d021ac80b7a64ff80eaba5de41afdeb1914b4493bf42",
+      "value": "按文档名称筛选的搜索关键词。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentListQuery/properties/limit/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentListQuery/properties/page/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentListQuery/properties/status/description",
+      "source_sha256": "50bce7bd6ac91e8f61540bc9cdbdb5ae9e6867325a9912e84bbabe8f4f09202f",
+      "value": "按显示状态筛选。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListQuery/title",
+      "source_sha256": "ed2db5c64b168833d59052e05d0a006c0c7f1f83ada31a1dbf4c7a06e48fceda"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EventStreamResponse/title",
+      "source_sha256": "cb598d0c9427cccc89d63f389617e8966efeffc6cf0b9bad1c5823624bf470d3"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/FeedbackListQuery/properties/limit/description",
+      "source_sha256": "961f01632b762573bfbd59b7cbb6205f0992f8b912f5686b5375b1536adedc7f",
+      "value": "每页记录数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FeedbackListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/FeedbackListQuery/properties/page/description",
+      "source_sha256": "60c2f027f5bd9e882b5ea965c3bdfd7d624017802cdb80bd0b8b6000aa775c62",
+      "value": "分页页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FeedbackListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FeedbackListQuery/title",
+      "source_sha256": "2ee2ef5a0b8833947992d468c455c3ec9722d91f0512455ef418a2ca9fa97e89"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/FilePreviewQuery/properties/as_attachment/description",
+      "source_sha256": "f9c567f7630732e17ddcbf65657256aba6e339dfe6b252545230bd8b32ff53b3",
+      "value": "若为 `true`，强制将文件作为附件下载，而不是在浏览器中预览。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FilePreviewQuery/properties/as_attachment/title",
+      "source_sha256": "4002a1980adbcfbe63aee5f634bd84eeacc78ae334a3020996076d5508bacecd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FilePreviewQuery/title",
+      "source_sha256": "34f058141cf139f35d0840e326719c0af503c33e745ab65d911e0449050fe2b2"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/properties/action/description",
+      "source_sha256": "3da3bf444ea4552df683d22e39bbba3d292b7270d42e322568b9dbf85cbf9d7f",
+      "value": "接收者所选操作按钮的 ID，必须与表单 `user_actions` 列表中的某个 `id` 值匹配。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/properties/action/title",
+      "source_sha256": "5efcc1e437cbeada52653f133121f3ca259b84b74a51e15c277b4de93f11bd75"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/properties/inputs/description",
+      "source_sha256": "1f22c5be035a6620b87ddfb1582988875cfc11dec9117525dc371f0db59c5961",
+      "value": "按输出变量名称组织的人工输入值。段落或选择输入使用字符串，文件输入使用文件映射，文件列表输入使用文件映射列表。本地文件映射使用 `transfer_method=local_file` 和 `upload_file_id`；远程文件映射使用 `transfer_method=remote_url` 和 `url` 或 `remote_url`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayload/title",
+      "source_sha256": "38a626e4a4e1642a39e35116d44bec129a532a22191e06434ecc3c9b4c51c3d3"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageFeedbackPayload/properties/content/description",
+      "source_sha256": "f1b13f33ce2fae7757c4b30cad4a78f091f9ff5ed649c04f9d9851e7f7dad06b",
+      "value": "提供额外详情的可选文字反馈。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageFeedbackPayload/properties/rating/description",
+      "source_sha256": "a22a86af4ca3b6b23b547b829f67d88997e274ed483d1ddd4d6fd916fadc8c44",
+      "value": "反馈评分。设为 `null` 可撤销之前提交的反馈。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayload/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayload/title",
+      "source_sha256": "dc826ad9804a26c2e92124a2d20c938b54f7e6abf59d8fbccb326f20ac4e7c70"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageListQuery/properties/conversation_id/description",
+      "source_sha256": "20bf5d8f6428fb73090cff7ba6229670b2eb9efb308644e7fe121ef46d0d3d87",
+      "value": "会话 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageListQuery/properties/first_id/description",
+      "source_sha256": "5e4c90d4e0c0319035c79eff301c7dca8a1d41219c8da46d6dd16b3a28410ab5",
+      "value": "当前页面第一条聊天记录的 ID。省略此值可获取最新消息；获取后续页面时，使用当前列表第一条消息的 ID 来获取更早的消息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/properties/first_id/title",
+      "source_sha256": "68654ca965f8b8a40a044427a6a4214508ab4b57019715ec0cc768900bf0c36a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageListQuery/properties/limit/description",
+      "source_sha256": "77e7ddf0c9aea543afaeb95894b8dcf30fae15ac7aaa7891b6cbde3456d8841d",
+      "value": "每次请求返回的聊天历史消息数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListQuery/title",
+      "source_sha256": "17997d5395df2c93391badf0ba144f4ca86426f5b37ae14fd35d9c873a56e906"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentListQuery/properties/keyword/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "搜索关键词。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentListQuery/properties/limit/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentListQuery/properties/page/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentListQuery/properties/status/description",
+      "source_sha256": "8553c4a96f020a09cde5ec784da5824c9b02c954d7cae9faa4d0300b9835a2d8",
+      "value": "按索引状态筛选分段，例如 `completed`、`indexing` 或 `error`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListQuery/title",
+      "source_sha256": "0cd59385c6acbfa47454f1681728f3753d5b551e24e8ca993624fd336f64d154"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleResultResponse/properties/result/description",
+      "value": "操作结果。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultResponse/title",
+      "source_sha256": "412feb3d6da0cbf2901a8634d7612e513ffb59141b7369d0048187cfca1c7a73"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayload/properties/message_id/description",
+      "source_sha256": "47f5efd48161cf7478427652060c2fbe41c0ffd3adea29c80a7e92824fb6f704",
+      "value": "消息 ID。同时提供时，其优先级高于 `text`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayload/properties/streaming/description",
+      "source_sha256": "bbbeba9487a0113a787e0ed2b2a3e0d6ab588013080484518fdadd925438c956",
+      "value": "为兼容性保留；TTS 响应是否流式传输由提供商输出决定。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/streaming/title",
+      "source_sha256": "99c855ec96bb79eda46be7218b5ac2045b607b2135c1181034e6746519b88b06"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayload/properties/text/description",
+      "source_sha256": "efbe836ec14e32683d74f164f15caf0c25a45c490c6c4ac6fb2c7db6e5918db7",
+      "value": "要转换的语音内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayload/properties/voice/description",
+      "source_sha256": "093f32f71464b6ee988240562bff4f647ec3d81381328089f3daaf171c1bd766",
+      "value": "文本转语音使用的声音。可用声音取决于此应用配置的 TTS 提供商。省略时会尽可能使用应用配置的声音；可通过[获取应用参数](/zh/api-reference/applications/get-app-parameters)返回的 `text_to_speech.voice` 查看该值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/properties/voice/title",
+      "source_sha256": "75d5a120334e208c41bdff270efdb5ed48de029fa6a9399b5897166f2dc6baf2"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayload/title",
+      "source_sha256": "21460ec2d744ed638ddcc8912fa8e504c6ad781a6a7ad4206976f4aeb17aaab9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowBlockingResponse/description",
+      "source_sha256": "a616ccd4fc71f888b9aa8dd25540afa1deb4a3727760e49447263a524f64ef16"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowBlockingResponse/title",
+      "source_sha256": "8a25c0876465560ae896727bbc84bd3049455ecae245a7ca10fd82e274c2fda1"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/continue_on_pause/description",
+      "source_sha256": "313727deed2f4e1de30f13fd2077e5bc3cc9291cea56e5ed6b362be9869e5e9d",
+      "value": "设置为 `true`，可在多个 `workflow_paused` 事件之间保持流连接，适用于工作流连续包含多个人工输入节点的情况。默认在首次暂停后关闭流。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/continue_on_pause/title",
+      "source_sha256": "d6d9fa184ceedc0b96bf45750f3c618382d5333d440102854924100831a4a84f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/include_state_snapshot/description",
+      "source_sha256": "f3dfbabd8d5e07e7a7f9360e67b54ad86c2b85bb9804de7bef3e73048c1ae0d1",
+      "value": "为 `true` 时，从持久化状态快照重放，在流式发送新事件前附带已执行节点的状态摘要。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/include_state_snapshot/title",
+      "source_sha256": "7fabce975428617138849051994fe0dc6669293e76360e5d9cee9d09c1a03547"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/user/description",
+      "source_sha256": "5ea2c1709b50a75b1ba6f8176a40072ac944e32363bc9d8d780ab1d5e90eab09",
+      "value": "最初触发运行的终端用户标识符，必须与该运行的创建者一致。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/properties/user/title",
+      "source_sha256": "f59d0ea2e8ec813b4add7a45f4e4fc4fecaa18239ba84fc70f8f2cead37130a8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowEventsQuery/title",
+      "source_sha256": "ac939e3eecf5e3d6748a4d3ac0dab3ce62375741fd86a8792107bc7717712f0d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/created_at/description",
+      "value": "创建时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/elapsed_time/description",
+      "value": "总耗时（秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/error/description",
+      "value": "工作流失败时的错误消息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/finished_at/description",
+      "value": "结束时间，Unix 秒级时间戳；未结束时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/id/description",
+      "value": "工作流运行 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/outputs/description",
+      "value": "工作流的输出数据。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/outputs/title",
+      "source_sha256": "d65ed4159859975e88dbd98c69421ec1e5cc195d03f8dfcec429a5d57839e838"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/status/description",
+      "value": "工作流执行的最终状态。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_steps/description",
+      "value": "已执行的工作流总步数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_tokens/description",
+      "value": "所有节点消耗的总令牌数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/workflow_id/description",
+      "value": "工作流 ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingDataResponse/title",
+      "source_sha256": "715157795d8b380fe94a30469f534ca7e40f109bd65d1ec378d791502db81bcf"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/description",
+      "value": "工作流执行完成后返回的阻塞响应。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/data/description",
+      "value": "工作流完成时返回的数据。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/task_id/description",
+      "value": "进行中的执行任务 ID。配合 [停止工作流任务](/zh/api-reference/workflow-runs/stop-workflow-task) 使用以取消运行中的工作流。仅在执行期间有效。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/workflow_run_id/description",
+      "value": "此工作流运行记录的持久化标识符。配合 [获取工作流运行详情](/zh/api-reference/workflow-runs/get-workflow-run-detail) 使用以在执行后获取结果。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowFinishedBlockingResponse/title",
+      "source_sha256": "a3ed654a469e4180e8e79784db67190c5dd4f590779e15c864e7db896d6a6946"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_at__after/description",
+      "source_sha256": "2252a93d9ef7f2626fdaa48085deb371ca9a9fe9b967e8a30083767955026040",
+      "value": "筛选在此 ISO 8601 时间戳之后创建的日志。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_at__after/title",
+      "source_sha256": "66af12cf87894c0818ccc99f5710b4e4886762fea4da609d42c02086aa622bbf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_at__before/description",
+      "source_sha256": "a8d98560ed90085c1cdec0bac363e759e5efb851380b07c81c4264adf23714a0",
+      "value": "筛选在此 ISO 8601 时间戳之前创建的日志。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_at__before/title",
+      "source_sha256": "d2911b94dc373196a26acd55709a42953d6611c21e3fec634b34111330a51130"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_account/description",
+      "source_sha256": "bcaada8c9cffa4545d1b0cd31daf2dae5469fa4a5dea4c4132f00b75fbab4f6b",
+      "value": "按工作区成员的邮箱地址筛选。尽管历史字段名如此，运行时会把该值解析为邮箱，而不是账户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_account/title",
+      "source_sha256": "bb80a09792cf6f229771c8acdbcc36f0cbeaeda2eb98ef66fcb06f913dc24acb"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_end_user_session_id/description",
+      "source_sha256": "ddb44f946885bab9411c2a482ce74067d2c19427bca4b958b093b20852d1dc2d",
+      "value": "按终端用户会话 ID 筛选。可从[获取终端用户信息](/zh/api-reference/end-users/get-end-user-info) 的 `session_id` 获取；对于 Service API 用户，该值通常与请求中的 `user` 相同。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/created_by_end_user_session_id/title",
+      "source_sha256": "d65d9417ceeb07b07990c78354dcc83959969aae9589193f460122424e608d36"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/keyword/description",
+      "source_sha256": "9897972c173a662b00c2dbfafd2b566ac8a4761ea2b45ec142a3e86eea8a903d",
+      "value": "在日志中搜索的关键词。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/keyword/title",
+      "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/limit/description",
+      "source_sha256": "b7269c3371993ac98a8701b8579faa800b2770dee55d626ceb1f74b35a4ba2c7",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/page/description",
+      "source_sha256": "60c2f027f5bd9e882b5ea965c3bdfd7d624017802cdb80bd0b8b6000aa775c62",
+      "value": "分页页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowLogQuery/properties/status/description",
+      "source_sha256": "719b90aef82c13efc69025cc4eadf17de412eb1607f9997fdd1e752625e21a84",
+      "value": "按执行状态筛选。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowLogQuery/title",
+      "source_sha256": "1fc771938e6b956e7dbd44e362a07ecf4da3fb4c964abe9cde1371eff7a5f8a0"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/description",
+      "source_sha256": "90c9e7c5b68590bfea68a876fad8e9833c393fb91cab1e806f21e9323c3b804a",
+      "value": "阻塞式工作流执行暂停原因的公开详情。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/TYPE/description",
+      "value": "暂停原因类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/TYPE/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/actions/description",
+      "value": "人工介入表单中可执行的操作。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/actions/title",
+      "source_sha256": "aa6d82bdb3cc1d9a5e542ae2669fef27690019ab5d7b20f17d9f1331a6a942fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/approval_channels/description",
+      "value": "已配置的审批渠道。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/approval_channels/title",
+      "source_sha256": "e8dc5bb01a260360a49a9e3ee2b7e7ecc9e6b4f68aaf2bf205e3a4bcfc747d63"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/display_in_ui/description",
+      "value": "是否在 UI 中显示该暂停原因。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/display_in_ui/title",
+      "source_sha256": "8c71965fd96e6f8b785ae269402727f478472205a018ad31c70fd0860c046614"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/expiration_time/description",
+      "value": "人工介入表单的过期时间（Unix 时间戳）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_content/description",
+      "value": "人工介入表单中显示的内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_id/description",
+      "value": "人工介入表单 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_id/title",
+      "source_sha256": "fafd71c45b122dd8a3264f51789d5b76c7b77ff8dc669263056f89c55464dd7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_token/description",
+      "value": "调用人工介入表单 API 时使用的访问令牌。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/form_token/title",
+      "source_sha256": "7a13fbb60d7b9386e1e508b9270fcf384926bf6ed214f4b6523f46e5946f2c67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/inputs/description",
+      "value": "人工介入表单的输入字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/message/description",
+      "value": "说明工作流暂停原因的消息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/message/title",
+      "source_sha256": "be1af94c8c00110d748345ea5e25cfc3aca39055ab9101ab1d8d551928445819"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_id/description",
+      "value": "暂停的工作流节点 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_title/description",
+      "value": "暂停的工作流节点标题。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/resolved_default_values/description",
+      "value": "表单输入解析后的默认值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPauseReasonResponse/title",
+      "source_sha256": "9b007e71d5352bde7ac68262e0a05063c7163b0c97899d94b2b620cec553363f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/created_at/description",
+      "value": "创建时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/elapsed_time/description",
+      "value": "总耗时（秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/error/description",
+      "value": "工作流失败时的错误消息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/finished_at/description",
+      "value": "结束时间，Unix 秒级时间戳；未结束时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/id/description",
+      "value": "工作流运行 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/outputs/description",
+      "value": "工作流的输出数据。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/outputs/title",
+      "source_sha256": "d65ed4159859975e88dbd98c69421ec1e5cc195d03f8dfcec429a5d57839e838"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/paused_nodes/description",
+      "value": "等待输入的工作流节点 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/paused_nodes/title",
+      "source_sha256": "1be2bcf1f1cac22fee5004654f91685bb8d677de3e9c946a311420a413e25f98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/reasons/description",
+      "value": "工作流暂停原因，包括人工介入表单详情。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/reasons/title",
+      "source_sha256": "c9f903172d68246eaeee2c130b732b3b5596a22100ff964b1a54aa9351f20b08"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/status/description",
+      "value": "工作流执行状态，固定为 `paused`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_steps/description",
+      "value": "已执行的工作流总步数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_tokens/description",
+      "value": "所有节点消耗的总令牌数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/workflow_id/description",
+      "value": "工作流 ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingDataResponse/title",
+      "source_sha256": "c9be2fdf427b0563c3a8674597c4524748092125b87659a9a6b10fb2f93e85c7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/description",
+      "value": "工作流执行等待人工输入时返回的阻塞响应。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/data/description",
+      "value": "工作流暂停等待输入时返回的数据。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/task_id/description",
+      "value": "进行中的执行任务 ID。配合 [停止工作流任务](/zh/api-reference/workflow-runs/stop-workflow-task) 使用以取消运行中的工作流。仅在执行期间有效。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/workflow_run_id/description",
+      "value": "此工作流运行记录的持久化标识符。配合 [获取工作流运行详情](/zh/api-reference/workflow-runs/get-workflow-run-detail) 使用以在执行后获取结果。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowPausedBlockingResponse/title",
+      "source_sha256": "dbfd757fad089c9351abf34e0ded1ad305716aa9cf964d9dc5dabecd6141e448"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/description",
+      "source_sha256": "2b389dd61c5418f868e8d3f5f8741a3cbfb1b9e4fb15604bdc8e72f0c2649974",
+      "value": "工作流系统文件输入列表。仅在工作流启用文件上传时可用。要附加本地文件，请先通过[上传文件](/zh/api-reference/files/upload-file)上传，然后将返回的 `id` 用作 `upload_file_id`，并将 `transfer_method` 设置为 `local_file`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/inputs/description",
+      "source_sha256": "048d45b6175968d587d71c3ac5f810521aafb994d9f016b592b5a23e353f186f",
+      "value": "工作流输入变量的键值对。文件类型变量的值应为文件对象数组，每个对象包含 `type`、`transfer_method`，以及 `url` 或 `upload_file_id`。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解应用所需的变量名称和类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayload/properties/response_mode/description",
+      "source_sha256": "a05eb85e740430b5fc70be8c963c4dacf30a2ca5059ffe72433c24101ed10462",
+      "value": "响应模式。同步响应使用 `blocking`，服务器发送事件（SSE）使用 `streaming`。省略时，请求使用阻塞模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayload/title",
+      "source_sha256": "610156d74f8171372740a56b3a96632a903151f9cbfcc6f0ada83493fd50cf49"
+    },
+    {
+      "op": "replace",
+      "path": "/components/securitySchemes/Bearer/description",
+      "source_sha256": "fb8a8717afa69eabf097c32010ec4a793b39e05063fd831c5cf289a43b0b1cb9",
+      "value": "在 Authorization 请求头中将 Service API 密钥用作 Bearer 令牌。"
+    },
+    {
+      "op": "add",
+      "path": "/externalDocs",
+      "value": {
+        "description": "快速开始指南",
+        "url": "/zh/api-reference/guides/get-started"
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/info/description",
+      "source_sha256": "f9f832328876efa29dc9214aea03bd3c0816deb597e87b5ab1548adb3ec57d9c",
+      "value": "用于 Dify 应用与知识库的 REST API。调用前，请先在 Dify 中创建并发布应用，或创建知识库。将请求发送到 Dify API 访问面板显示的 Service API 端点（路径以 `/v1` 结尾），并使用 `Authorization: Bearer <密钥>` 认证。应用类接口需打开已发布的应用，在左侧导航中选择 **API 访问**，然后创建应用 API 密钥；该密钥仅作用于此应用。先调用 `GET /info` 确认应用模式，再调用 `GET /parameters` 获取 `inputs` 所需的键和类型。知识库类接口需在 **知识库** > **Service API** 创建知识库 API 密钥；除非某个知识库关闭了 API 访问，否则该密钥可访问创建者可见的所有知识库。请先调用 `GET /datasets`。`dataset_id`、`document_id`、`workflow_id` 等资源 ID 来自各字段说明所指向的创建或列表接口响应。端到端首个请求参见[快速开始](/zh/api-reference/guides/get-started)。\n\n**首个认证请求。** Dify Cloud 的 `api_base_url` 为 `api.dify.ai/v1`，示例默认使用 HTTPS。自部署 Dify 请从 API 访问面板复制完整 Service API 端点；替换 `{api_base_url}` 时去掉 `https://` 或 `http://` 协议。如果部署使用 HTTP，还需将示例前缀改为 `http://`。请只在后端保存密钥。测试应用密钥：\n\n```bash\ncurl https://api.dify.ai/v1/info \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\n测试知识库密钥：\n\n```bash\ncurl 'https://api.dify.ai/v1/datasets?page=1&limit=20' \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\n**Dify 概念。** 聊天助手是基础对话应用；Chatflow 在对话中加入可视化工作流；Workflow 是非对话式可视化自动化；旧版 Agent 与新版 Agent 应用让模型自主选择工具。标注回复会把用户问题与已保存的问答对匹配，并返回已保存的答案。知识流水线是可视化数据摄取工作流，其数据源节点在索引前读取文件、供应商页面、云盘或网站。`GET /info` 返回的 `mode` 决定应使用哪个应用接口组；每个接口也会在开头标明适用范围。 `doc_form` 选择分段结构：`text_model` 为扁平分段，`hierarchical_model` 为父子分段，`qa_model` 为问答分段。`indexing_technique` 选择基于嵌入的 `high_quality` 索引或基于关键词的 `economy` 索引。"
+    },
+    {
+      "op": "replace",
+      "path": "/info/title",
+      "source_sha256": "1318c329cc79d19aa64673e792c48efc513698cbfe14eb073d1dd04e4078ce41",
+      "value": "Dify 服务 API"
+    },
+    {
+      "op": "add",
+      "path": "/servers/0/description",
+      "value": "Service API 的基础路径。示例默认使用 HTTPS：请将 `{api_base_url}` 替换为不含协议的部署主机和 `/v1` 路径（例如 `api.dify.ai/v1`）。如果自部署端点使用 HTTP，还需将示例中的 `https://` 前缀改为 `http://`。",
+      "context_path": "/servers/0",
+      "context_sha256": "b2eba7fd15014a5006b8aab50754d9ebc6a0fef2888e7152982afdcc613dbedf"
+    },
+    {
+      "op": "replace",
+      "path": "/tags",
+      "source_sha256": "21a2a3bc7749afffc03e82ff6a69e38a43a86dabf578b46577c2d605501f9023",
+      "value": [
+        {
+          "name": "对话消息",
+          "description": "与聊天消息和交互相关的操作。"
+        },
+        {
+          "name": "文件操作",
+          "description": "文件上传和预览操作。"
+        },
+        {
+          "name": "终端用户",
+          "description": "终端用户信息相关操作。"
+        },
+        {
+          "name": "消息反馈",
+          "description": "用户反馈操作。"
+        },
+        {
+          "name": "会话管理",
+          "description": "与管理会话相关的操作。"
+        },
+        {
+          "name": "语音与文字转换",
+          "description": "文字转语音和语音转文字操作。"
+        },
+        {
+          "name": "应用配置",
+          "description": "获取应用设置和信息的操作。"
+        },
+        {
+          "name": "标注管理",
+          "description": "与管理标注直接回复相关的操作。"
+        },
+        {
+          "name": "人工介入",
+          "description": "暂停等待人工输入的工作流恢复操作。"
+        },
+        {
+          "name": "工作流运行",
+          "description": "用于执行和管理工作流的操作。"
+        },
+        {
+          "name": "文本生成消息",
+          "description": "文本生成相关操作。"
+        },
+        {
+          "name": "知识库",
+          "description": "用于管理知识库的操作，包括创建、配置和检索。"
+        },
+        {
+          "name": "文档",
+          "description": "用于在知识库中创建、更新和管理文档的操作。"
+        },
+        {
+          "name": "分段",
+          "description": "用于管理分段和子分段的操作。"
+        },
+        {
+          "name": "元数据",
+          "description": "用于管理知识库元数据字段和文档元数据值的操作。"
+        },
+        {
+          "name": "标签",
+          "description": "用于管理知识库标签和标签绑定的操作。"
+        },
+        {
+          "name": "模型",
+          "description": "用于获取可用模型的操作。"
+        },
+        {
+          "name": "知识流水线",
+          "description": "用于管理和运行知识流水线的操作，包括数据源插件和流水线执行。"
+        }
+      ]
+    }
+  ]
+}

--- a/zh/api-reference/openapi_service.json
+++ b/zh/api-reference/openapi_service.json
@@ -1,25 +1,19 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.1.0",
   "info": {
+    "description": "用于 Dify 应用与知识库的 REST API。调用前，请先在 Dify 中创建并发布应用，或创建知识库。将请求发送到 Dify API 访问面板显示的 Service API 端点（路径以 `/v1` 结尾），并使用 `Authorization: Bearer <密钥>` 认证。应用类接口需打开已发布的应用，在左侧导航中选择 **API 访问**，然后创建应用 API 密钥；该密钥仅作用于此应用。先调用 `GET /info` 确认应用模式，再调用 `GET /parameters` 获取 `inputs` 所需的键和类型。知识库类接口需在 **知识库** > **Service API** 创建知识库 API 密钥；除非某个知识库关闭了 API 访问，否则该密钥可访问创建者可见的所有知识库。请先调用 `GET /datasets`。`dataset_id`、`document_id`、`workflow_id` 等资源 ID 来自各字段说明所指向的创建或列表接口响应。端到端首个请求参见[快速开始](/zh/api-reference/guides/get-started)。\n\n**首个认证请求。** Dify Cloud 的 `api_base_url` 为 `api.dify.ai/v1`，示例默认使用 HTTPS。自部署 Dify 请从 API 访问面板复制完整 Service API 端点；替换 `{api_base_url}` 时去掉 `https://` 或 `http://` 协议。如果部署使用 HTTP，还需将示例前缀改为 `http://`。请只在后端保存密钥。测试应用密钥：\n\n```bash\ncurl https://api.dify.ai/v1/info \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\n测试知识库密钥：\n\n```bash\ncurl 'https://api.dify.ai/v1/datasets?page=1&limit=20' \\\n  -H \"Authorization: Bearer $DIFY_API_KEY\"\n```\n\n**Dify 概念。** 聊天助手是基础对话应用；Chatflow 在对话中加入可视化工作流；Workflow 是非对话式可视化自动化；旧版 Agent 与新版 Agent 应用让模型自主选择工具。标注回复会把用户问题与已保存的问答对匹配，并返回已保存的答案。知识流水线是可视化数据摄取工作流，其数据源节点在索引前读取文件、供应商页面、云盘或网站。`GET /info` 返回的 `mode` 决定应使用哪个应用接口组；每个接口也会在开头标明适用范围。 `doc_form` 选择分段结构：`text_model` 为扁平分段，`hierarchical_model` 为父子分段，`qa_model` 为问答分段。`indexing_technique` 选择基于嵌入的 `high_quality` 索引或基于关键词的 `economy` 索引。",
     "title": "Dify 服务 API",
-    "description": "用于 Dify 应用与知识库的 REST API。应用类接口使用应用 API 密钥认证，知识库类接口使用知识库 API 密钥认证。",
-    "version": "1.0.0"
+    "version": "1.0"
   },
   "servers": [
     {
-      "url": "https://{api_base_url}",
-      "description": "Dify 服务 API 的基础 URL。自部署时，替换为你的 API 基础 URL。",
-      "variables": {
-        "api_base_url": {
-          "default": "api.dify.ai/v1",
-          "description": "API 基础 URL 的主机与路径，不含 `https://` 前缀。"
-        }
-      }
+      "url": "/v1",
+      "description": "Service API 的基础路径。示例默认使用 HTTPS：请将 `{api_base_url}` 替换为不含协议的部署主机和 `/v1` 路径（例如 `api.dify.ai/v1`）。如果自部署端点使用 HTTP，还需将示例中的 `https://` 前缀改为 `http://`。"
     }
   ],
   "security": [
     {
-      "ApiKeyAuth": []
+      "Bearer": []
     }
   ],
   "tags": [
@@ -13205,41 +13199,2269 @@
     }
   },
   "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "API_KEY",
-        "description": "每个请求都通过 API Key 认证：`Authorization: Bearer {API_KEY}`。应用接口使用应用 API Key，知识库接口使用知识库 API Key（[快速开始](/zh/api-reference/guides/get-started)）。\n\nAPI Key 应保存在服务端，切勿嵌入客户端代码。缺失或无效的 Key 会返回 HTTP `401`（`unauthorized`）。"
+    "responses": {
+      "AppInvokeQuotaExceededError": {
+        "description": "应用调用配额超限错误。"
+      },
+      "Exception": {
+        "description": "异常。"
+      },
+      "HTTPException": {
+        "description": "HTTP 异常。"
+      },
+      "MaskError": {
+        "description": "掩码发生任何错误时返回。"
+      },
+      "ParseError": {
+        "description": "无法解析掩码时返回。"
+      },
+      "PluginRuntimeError": {
+        "description": "插件运行时错误。"
+      },
+      "ValueError": {
+        "description": "值错误。"
       }
     },
-    "responses": {
-      "SuccessResult": {
-        "description": "操作成功。",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
+    "schemas": {
+      "AnnotationListQuery": {
+        "properties": {
+          "keyword": {
+            "default": "",
+            "description": "按问题或回答内容筛选标注的关键词。",
+            "type": "string"
+          },
+          "limit": {
+            "default": 20,
+            "description": "每页条目数。",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "分页页码。",
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "AppInfoResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "应用名称。"
+          },
+          "description": {
+            "type": "string",
+            "description": "应用描述。"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "应用标签。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "应用模式。`completion` 为文本生成应用，`chat` 为基础对话应用，`agent-chat` 为 Agent 应用，`advanced-chat` 为 Chatflow 应用，`workflow` 为 Workflow 应用，`agent` 为新 Agent 应用。"
+          },
+          "author_name": {
+            "type": "string",
+            "description": "应用作者名称。"
+          }
+        }
+      },
+      "AppMetaResponse": {
+        "type": "object",
+        "properties": {
+          "tool_icons": {
+            "type": "object",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "title": "Icon URL",
                   "type": "string",
-                  "description": "操作结果，固定为 `success`。"
+                  "format": "url",
+                  "description": "图标的 URL。"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolIconDetail"
                 }
+              ]
+            },
+            "description": "工具图标。键为工具名称。"
+          }
+        }
+      },
+      "AudioBinaryResponse": {
+        "format": "binary",
+        "type": "string"
+      },
+      "BinaryFileResponse": {
+        "format": "binary",
+        "type": "string"
+      },
+      "ChatRequestPayload": {
+        "properties": {
+          "auto_generate_name": {
+            "default": true,
+            "description": "是否自动生成会话标题。若为 `false`，可调用重命名会话 API，并设置 `auto_generate: true` 来异步生成标题。",
+            "type": "boolean"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于继续会话的会话 ID。省略此字段或传入空字符串可开始新会话，后续请求再传入返回的 `conversation_id`。"
+          },
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于多模态输入的文件。新客户端只需实现两种规范形式：公共文件 URL 使用 `transfer_method: remote_url` 和 `url`；本地文件先通过[上传文件](/zh/api-reference/files/upload-file)上传，再使用 `transfer_method: local_file`，并将返回的 `id` 作为 `upload_file_id`。生成的其他 `anyOf` 组合仅用于兼容已存储的旧版引用。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "应用自定义变量的值。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解预期的变量名称和类型。",
+            "type": "object"
+          },
+          "query": {
+            "description": "用户输入或问题内容。",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "响应模式。`streaming` 使用服务器发送事件（SSE）；`blocking` 在执行完成后返回。新版 Agent 应用仅支持流式模式。省略时，非 Agent 应用使用阻塞模式，新版 Agent 应用使用流式模式。"
+          },
+          "workflow_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "高级聊天要执行的已发布工作流版本 ID。省略时，使用应用当前已发布的工作流。"
+          }
+        },
+        "required": [
+          "inputs",
+          "query"
+        ],
+        "type": "object"
+      },
+      "ChildChunkListQuery": {
+        "properties": {
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "搜索关键词。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "每页的项目数量。服务器上限为 `100`。",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "要获取的页码。",
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "CompletionRequestPayload": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于多模态输入的文件。新客户端只需实现两种规范形式：公共文件 URL 使用 `transfer_method: remote_url` 和 `url`；本地文件先通过[上传文件](/zh/api-reference/files/upload-file)上传，再使用 `transfer_method: local_file`，并将返回的 `id` 作为 `upload_file_id`。生成的其他 `anyOf` 组合仅用于兼容已存储的旧版引用。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "应用自定义变量的值。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解预期的变量名称和类型。",
+            "type": "object"
+          },
+          "query": {
+            "default": "",
+            "description": "用户输入或提示词内容。",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "响应模式。`streaming` 使用服务器发送事件（SSE）；`blocking` 在执行完成后返回。省略时，请求使用阻塞模式。"
+          }
+        },
+        "required": [
+          "inputs"
+        ],
+        "type": "object"
+      },
+      "ConversationListQuery": {
+        "properties": {
+          "last_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "当前页面最后一条记录的 ID，用于获取下一页。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "返回的记录数。",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "sort_by": {
+            "default": "-updated_at",
+            "description": "排序字段。使用 `-` 前缀表示降序。",
+            "enum": [
+              "-created_at",
+              "-updated_at",
+              "created_at",
+              "updated_at"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ConversationRenamePayload": {
+        "anyOf": [
+          {
+            "properties": {
+              "auto_generate": {
+                "description": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。",
+                "enum": [
+                  true
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "会话名称。当 `auto_generate` 为 `false` 时必填。"
               }
             },
-            "examples": {
-              "success": {
-                "summary": "响应示例",
-                "value": {
-                  "result": "success"
+            "required": [
+              "auto_generate"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "auto_generate": {
+                "default": false,
+                "description": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。",
+                "enum": [
+                  false
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "pattern": ".*\\S.*",
+                "type": "string",
+                "description": "会话名称。"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "auto_generate": {
+            "default": false,
+            "description": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。",
+            "type": "boolean"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "会话名称。当 `auto_generate` 为 `false` 时必填。"
+          }
+        },
+        "type": "object"
+      },
+      "ConversationVariableUpdatePayload": {
+        "properties": {
+          "value": {
+            "description": "变量的新值。必须与变量的预期类型匹配。"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "ConversationVariablesQuery": {
+        "properties": {
+          "last_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "当前页面最后一条记录的 ID，用于获取下一页。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "返回的记录数。",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "variable_name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "按指定名称筛选变量。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetListQuery": {
+        "properties": {
+          "include_all": {
+            "default": false,
+            "description": "是否包含所有知识库，无论权限如何。",
+            "type": "boolean"
+          },
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "按名称筛选的搜索关键词。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "每页的项目数量。服务器上限为 `100`。",
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "要获取的页码。",
+            "type": "integer"
+          },
+          "tag_ids": {
+            "description": "用于筛选的标签 ID。",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "DatasourcePluginsQuery": {
+        "properties": {
+          "is_published": {
+            "default": true,
+            "description": "是否从已发布或草稿知识流水线中获取节点。`true` 返回已发布版本的节点，`false` 返回草稿版本的节点。",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentGetQuery": {
+        "properties": {
+          "metadata": {
+            "default": "all",
+            "description": "`all` 返回所有字段（包括元数据）。`only` 仅返回 `id`、`doc_type` 和 `doc_metadata`。`without` 返回除 `doc_metadata` 外的所有字段。",
+            "enum": [
+              "all",
+              "only",
+              "without"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentListQuery": {
+        "properties": {
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "按文档名称筛选的搜索关键词。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "每页的项目数量。服务器上限为 `100`。",
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "要获取的页码。",
+            "type": "integer"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "archived",
+                  "available",
+                  "disabled",
+                  "error",
+                  "indexing",
+                  "paused",
+                  "queuing"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "按显示状态筛选。"
+          }
+        },
+        "type": "object"
+      },
+      "EndUserDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "终端用户 ID。"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "租户 ID。"
+          },
+          "app_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "应用 ID。"
+          },
+          "type": {
+            "type": "string",
+            "description": "终端用户类型。Service API 用户固定为 `service-api`。"
+          },
+          "external_user_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "API 请求中提供的 `user` 标识符（例如 [发送对话消息](/zh/api-reference/chat-messages/send-chat-message) 中的 `user` 字段）。"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "description": "终端用户名称。"
+          },
+          "is_anonymous": {
+            "type": "boolean",
+            "description": "用户是否为匿名用户。当原始 API 请求中未提供 `user` 标识符时，值为 `true`。"
+          },
+          "session_id": {
+            "type": "string",
+            "description": "会话标识符。默认为 `external_user_id` 的值。"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "创建时间戳。"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "最后更新时间戳。"
+          }
+        }
+      },
+      "EventStreamResponse": {
+        "type": "string"
+      },
+      "FeedbackListQuery": {
+        "properties": {
+          "limit": {
+            "default": 20,
+            "description": "每页记录数。",
+            "maximum": 101,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "分页页码。",
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "FilePreviewQuery": {
+        "properties": {
+          "as_attachment": {
+            "default": false,
+            "description": "若为 `true`，强制将文件作为附件下载，而不是在浏览器中预览。",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "HumanInputContent": {
+        "type": "object",
+        "description": "人工介入节点的执行内容，包括表单定义和提交数据。",
+        "properties": {
+          "workflow_run_id": {
+            "type": "string",
+            "description": "该内容所属的工作流运行 ID。"
+          },
+          "submitted": {
+            "type": "boolean",
+            "description": "人工介入表单是否已提交。"
+          },
+          "type": {
+            "type": "string",
+            "description": "`human_input` 表示人工介入内容。"
+          },
+          "form_definition": {
+            "nullable": true,
+            "description": "人工介入节点的表单定义。当内容表示提交响应时为 `null`。",
+            "$ref": "#/components/schemas/HumanInputFormDefinition"
+          },
+          "form_submission_data": {
+            "nullable": true,
+            "description": "已提交的表单数据。表单尚未提交时为 `null`。",
+            "$ref": "#/components/schemas/HumanInputFormSubmissionData"
+          }
+        }
+      },
+      "HumanInputFormDefinition": {
+        "type": "object",
+        "description": "由人工介入节点渲染的人工介入表单定义。",
+        "properties": {
+          "form_id": {
+            "type": "string",
+            "description": "表单唯一标识符。"
+          },
+          "node_id": {
+            "type": "string",
+            "description": "生成该表单的人工介入节点 ID。"
+          },
+          "node_title": {
+            "type": "string",
+            "description": "人工介入节点的标题。"
+          },
+          "form_content": {
+            "type": "string",
+            "description": "与表单一起显示的 Markdown 或文本内容。"
+          },
+          "inputs": {
+            "type": "array",
+            "description": "表单中的输入字段。",
+            "items": {
+              "$ref": "#/components/schemas/FormInput"
+            }
+          },
+          "actions": {
+            "type": "array",
+            "description": "表单上可用的操作按钮。",
+            "items": {
+              "$ref": "#/components/schemas/UserAction"
+            }
+          },
+          "display_in_ui": {
+            "type": "boolean",
+            "description": "表单是否应在 UI 中显示。"
+          },
+          "form_token": {
+            "type": "string",
+            "nullable": true,
+            "description": "表单提交认证的令牌。"
+          },
+          "resolved_default_values": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "表单输入的已解析默认值，按输出变量名称索引。"
+          },
+          "expiration_time": {
+            "type": "integer",
+            "description": "表单过期的 Unix 时间戳。"
+          }
+        }
+      },
+      "HumanInputFormSubmissionData": {
+        "type": "object",
+        "description": "来自已提交的人工介入表单的数据。",
+        "properties": {
+          "node_id": {
+            "type": "string",
+            "description": "人工介入节点的 ID。"
+          },
+          "node_title": {
+            "type": "string",
+            "description": "人工介入节点的标题。"
+          },
+          "rendered_content": {
+            "type": "string",
+            "description": "表单提交的渲染内容。"
+          },
+          "action_id": {
+            "type": "string",
+            "description": "被点击的操作按钮的 ID。"
+          },
+          "action_text": {
+            "type": "string",
+            "description": "被点击的操作按钮的显示文本。"
+          }
+        }
+      },
+      "HumanInputFormSubmitPayload": {
+        "properties": {
+          "action": {
+            "description": "接收者所选操作按钮的 ID，必须与表单 `user_actions` 列表中的某个 `id` 值匹配。",
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "description": "按输出变量名称组织的人工输入值。段落或选择输入使用字符串，文件输入使用文件映射，文件列表输入使用文件映射列表。本地文件映射使用 `transfer_method=local_file` 和 `upload_file_id`；远程文件映射使用 `transfer_method=remote_url` 和 `url` 或 `remote_url`。",
+            "examples": [
+              {
+                "attachment": {
+                  "transfer_method": "local_file",
+                  "type": "document",
+                  "upload_file_id": "4e0d1b87-52f2-49f6-b8c6-95cd9c954b3e"
+                },
+                "attachments": [
+                  {
+                    "transfer_method": "local_file",
+                    "type": "document",
+                    "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee"
+                  },
+                  {
+                    "transfer_method": "remote_url",
+                    "type": "document",
+                    "url": "https://example.com/report.pdf"
+                  }
+                ],
+                "decision": "approve"
+              }
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "action",
+          "inputs"
+        ],
+        "type": "object"
+      },
+      "JSONObject": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "MessageFeedbackPayload": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "提供额外详情的可选文字反馈。"
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "enum": [
+                  "dislike",
+                  "like"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "反馈评分。设为 `null` 可撤销之前提交的反馈。"
+          }
+        },
+        "type": "object"
+      },
+      "MessageListQuery": {
+        "properties": {
+          "conversation_id": {
+            "description": "会话 ID。",
+            "type": "string"
+          },
+          "first_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "当前页面第一条聊天记录的 ID。省略此值可获取最新消息；获取后续页面时，使用当前列表第一条消息的 ID 来获取更早的消息。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "每次请求返回的聊天历史消息数量。",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "conversation_id"
+        ],
+        "type": "object"
+      },
+      "RetrievalModel": {
+        "type": "object",
+        "required": [
+          "search_method",
+          "reranking_enable",
+          "top_k",
+          "score_threshold_enabled"
+        ],
+        "properties": {
+          "search_method": {
+            "type": "string",
+            "description": "用于检索的搜索方法。",
+            "enum": [
+              "keyword_search",
+              "semantic_search",
+              "full_text_search",
+              "hybrid_search"
+            ]
+          },
+          "reranking_enable": {
+            "type": "boolean",
+            "description": "是否启用重排序。"
+          },
+          "reranking_model": {
+            "type": "object",
+            "description": "重排序模型配置。",
+            "properties": {
+              "reranking_provider_name": {
+                "type": "string",
+                "description": "重排序模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/cohere/cohere`）。`cohere` 这类简写会展开为 `langgenius/<name>/<name>`，仅对 langgenius 发布的插件有效。\n\n有效取值从 [获取可用模型](/zh/api-reference/models/get-available-models) 中 `model_type=rerank` 返回的 `provider` 字段获取。"
+              },
+              "reranking_model_name": {
+                "type": "string",
+                "description": "重排序模型名称。"
+              }
+            }
+          },
+          "reranking_mode": {
+            "type": "string",
+            "enum": [
+              "reranking_model",
+              "weighted_score"
+            ],
+            "nullable": true,
+            "description": "重排序模式。当 `reranking_enable` 为 `true` 时必填。"
+          },
+          "top_k": {
+            "type": "integer",
+            "description": "返回的最大结果数。"
+          },
+          "score_threshold_enabled": {
+            "type": "boolean",
+            "description": "是否启用分数阈值过滤。"
+          },
+          "score_threshold": {
+            "type": "number",
+            "nullable": true,
+            "description": "结果的最低相关性分数。仅在 `score_threshold_enabled` 为 `true` 时生效。"
+          },
+          "weights": {
+            "type": "object",
+            "nullable": true,
+            "description": "混合搜索的权重配置。",
+            "properties": {
+              "weight_type": {
+                "type": "string",
+                "description": "平衡语义搜索和关键词搜索权重的策略。",
+                "enum": [
+                  "semantic_first",
+                  "keyword_first",
+                  "customized"
+                ]
+              },
+              "vector_setting": {
+                "type": "object",
+                "description": "语义搜索权重设置。",
+                "properties": {
+                  "vector_weight": {
+                    "type": "number",
+                    "description": "分配给语义（向量）搜索结果的权重。"
+                  },
+                  "embedding_provider_name": {
+                    "type": "string",
+                    "description": "用于向量搜索的嵌入模型供应商。"
+                  },
+                  "embedding_model_name": {
+                    "type": "string",
+                    "description": "用于向量搜索的嵌入模型名称。"
+                  }
+                }
+              },
+              "keyword_setting": {
+                "type": "object",
+                "description": "关键词搜索权重设置。",
+                "properties": {
+                  "keyword_weight": {
+                    "type": "number",
+                    "description": "分配给关键词搜索结果的权重。"
+                  }
+                }
+              }
+            }
+          },
+          "metadata_filtering_conditions": {
+            "type": "object",
+            "nullable": true,
+            "description": "仅检索文档元数据匹配指定条件的分段。条件由服务端基于文档元数据字段评估。",
+            "properties": {
+              "logical_operator": {
+                "type": "string",
+                "enum": [
+                  "and",
+                  "or"
+                ],
+                "default": "and",
+                "nullable": true,
+                "description": "多个条件之间的组合方式。"
+              },
+              "conditions": {
+                "type": "array",
+                "nullable": true,
+                "description": "要评估的元数据条件列表。",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "comparison_operator"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "用于比较的元数据字段名称。"
+                    },
+                    "comparison_operator": {
+                      "type": "string",
+                      "description": "按元数据类型选择要应用的比较方式：\n\n- 字符串或数组类型元数据：`contains`、`not contains`、`start with`、`end with`、`is`、`is not`、`empty`、`not empty`、`in`、`not in`\n- 数值类型元数据：`=`、`≠`、`>`、`<`、`≥`、`≤`\n- 时间类型元数据：`before`、`after`",
+                      "enum": [
+                        "contains",
+                        "not contains",
+                        "start with",
+                        "end with",
+                        "is",
+                        "is not",
+                        "empty",
+                        "not empty",
+                        "in",
+                        "not in",
+                        "=",
+                        "≠",
+                        ">",
+                        "<",
+                        "≥",
+                        "≤",
+                        "before",
+                        "after"
+                      ]
+                    },
+                    "value": {
+                      "nullable": true,
+                      "description": "用于比较的值。类型取决于 `comparison_operator`：大多数字符串运算符使用字符串；`in` 和 `not in` 使用字符串数组；数值运算符使用数字；`empty` 和 `not empty` 时省略。",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
           }
         }
-      }
-    },
-    "schemas": {
+      },
+      "RetrieverResource": {
+        "type": "object",
+        "description": "检索资源的引用和归属信息。",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "检索资源的唯一 ID。"
+          },
+          "message_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "该资源所属消息的 ID。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "资源在列表中的位置。"
+          },
+          "dataset_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "知识库 ID。"
+          },
+          "dataset_name": {
+            "type": "string",
+            "description": "知识库名称。"
+          },
+          "document_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "文档 ID。"
+          },
+          "document_name": {
+            "type": "string",
+            "description": "文档名称。"
+          },
+          "data_source_type": {
+            "type": "string",
+            "description": "数据源类型。"
+          },
+          "segment_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "文档中特定块的 ID。"
+          },
+          "score": {
+            "type": "number",
+            "format": "float",
+            "description": "资源的相关性评分。"
+          },
+          "hit_count": {
+            "type": "integer",
+            "description": "该块被命中的次数。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "块的字数。"
+          },
+          "segment_position": {
+            "type": "integer",
+            "description": "块在文档中的位置。"
+          },
+          "index_node_hash": {
+            "type": "string",
+            "description": "索引节点的哈希值。"
+          },
+          "content": {
+            "type": "string",
+            "description": "资源的内容片段。"
+          },
+          "summary": {
+            "type": "string",
+            "nullable": true,
+            "description": "块内容的摘要。"
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "int64",
+            "description": "创建时间戳（Unix 纪元秒）。"
+          }
+        }
+      },
+      "SegmentListQuery": {
+        "properties": {
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "搜索关键词。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "每页的项目数量。服务器上限为 `100`。",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "要获取的页码。",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "status": {
+            "description": "按索引状态筛选分段，例如 `completed`、`indexing` 或 `error`。",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "SimpleResultResponse": {
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "操作结果。"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object"
+      },
+      "TextToAudioPayload": {
+        "properties": {
+          "message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "消息 ID。同时提供时，其优先级高于 `text`。"
+          },
+          "streaming": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "为兼容性保留；TTS 响应是否流式传输由提供商输出决定。"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "要转换的语音内容。"
+          },
+          "voice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文本转语音使用的声音。可用声音取决于此应用配置的 TTS 提供商。省略时会尽可能使用应用配置的声音；可通过[获取应用参数](/zh/api-reference/applications/get-app-parameters)返回的 `text_to_speech.voice` 查看该值。"
+          }
+        },
+        "type": "object"
+      },
+      "WorkflowBlockingResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/WorkflowFinishedBlockingResponse"
+          },
+          {
+            "$ref": "#/components/schemas/WorkflowPausedBlockingResponse"
+          }
+        ]
+      },
+      "WorkflowEventsQuery": {
+        "properties": {
+          "continue_on_pause": {
+            "default": false,
+            "description": "设置为 `true`，可在多个 `workflow_paused` 事件之间保持流连接，适用于工作流连续包含多个人工输入节点的情况。默认在首次暂停后关闭流。",
+            "type": "boolean"
+          },
+          "include_state_snapshot": {
+            "default": false,
+            "description": "为 `true` 时，从持久化状态快照重放，在流式发送新事件前附带已执行节点的状态摘要。",
+            "type": "boolean"
+          },
+          "user": {
+            "description": "最初触发运行的终端用户标识符，必须与该运行的创建者一致。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "type": "object"
+      },
+      "WorkflowFinishedBlockingDataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "创建时间，Unix 秒级时间戳。"
+          },
+          "elapsed_time": {
+            "format": "float",
+            "type": "number",
+            "description": "总耗时（秒）。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "工作流失败时的错误消息。"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "结束时间，Unix 秒级时间戳；未结束时为 `null`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "工作流运行 ID。"
+          },
+          "outputs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "工作流的输出数据。"
+          },
+          "status": {
+            "enum": [
+              "failed",
+              "partial-succeeded",
+              "stopped",
+              "succeeded"
+            ],
+            "type": "string",
+            "description": "工作流执行的最终状态。"
+          },
+          "total_steps": {
+            "type": "integer",
+            "description": "已执行的工作流总步数。"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "所有节点消耗的总令牌数。"
+          },
+          "workflow_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "工作流 ID."
+          }
+        },
+        "required": [
+          "created_at",
+          "elapsed_time",
+          "error",
+          "finished_at",
+          "id",
+          "outputs",
+          "status",
+          "total_steps",
+          "total_tokens",
+          "workflow_id"
+        ],
+        "type": "object"
+      },
+      "WorkflowFinishedBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WorkflowFinishedBlockingDataResponse",
+            "description": "工作流完成时返回的数据。"
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "进行中的执行任务 ID。配合 [停止工作流任务](/zh/api-reference/workflow-runs/stop-workflow-task) 使用以取消运行中的工作流。仅在执行期间有效。"
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "此工作流运行记录的持久化标识符。配合 [获取工作流运行详情](/zh/api-reference/workflow-runs/get-workflow-run-detail) 使用以在执行后获取结果。"
+          }
+        },
+        "required": [
+          "data",
+          "task_id",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "工作流执行完成后返回的阻塞响应。"
+      },
+      "WorkflowLogQuery": {
+        "properties": {
+          "created_at__after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "筛选在此 ISO 8601 时间戳之后创建的日志。",
+            "format": "date-time"
+          },
+          "created_at__before": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "筛选在此 ISO 8601 时间戳之前创建的日志。",
+            "format": "date-time"
+          },
+          "created_by_account": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "按工作区成员的邮箱地址筛选。尽管历史字段名如此，运行时会把该值解析为邮箱，而不是账户 ID。"
+          },
+          "created_by_end_user_session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "按终端用户会话 ID 筛选。可从[获取终端用户信息](/zh/api-reference/end-users/get-end-user-info) 的 `session_id` 获取；对于 Service API 用户，该值通常与请求中的 `user` 相同。"
+          },
+          "keyword": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "在日志中搜索的关键词。"
+          },
+          "limit": {
+            "default": 20,
+            "description": "每页条目数。",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "page": {
+            "default": 1,
+            "description": "分页页码。",
+            "maximum": 99999,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "failed",
+                  "stopped",
+                  "succeeded"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "按执行状态筛选。"
+          }
+        },
+        "type": "object"
+      },
+      "WorkflowPauseReasonResponse": {
+        "additionalProperties": true,
+        "description": "阻塞式工作流执行暂停原因的公开详情。",
+        "properties": {
+          "TYPE": {
+            "type": "string",
+            "description": "暂停原因类型。"
+          },
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "人工介入表单中可执行的操作。"
+          },
+          "approval_channels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "已配置的审批渠道。"
+          },
+          "display_in_ui": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "是否在 UI 中显示该暂停原因。"
+          },
+          "expiration_time": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人工介入表单的过期时间（Unix 时间戳）。"
+          },
+          "form_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人工介入表单中显示的内容。"
+          },
+          "form_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人工介入表单 ID。"
+          },
+          "form_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "调用人工介入表单 API 时使用的访问令牌。"
+          },
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "人工介入表单的输入字段。"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "说明工作流暂停原因的消息。"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "暂停的工作流节点 ID。"
+          },
+          "node_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "暂停的工作流节点标题。"
+          },
+          "resolved_default_values": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "表单输入解析后的默认值。"
+          }
+        },
+        "required": [
+          "TYPE"
+        ],
+        "type": "object"
+      },
+      "WorkflowPausedBlockingDataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "创建时间，Unix 秒级时间戳。"
+          },
+          "elapsed_time": {
+            "format": "float",
+            "type": "number",
+            "description": "总耗时（秒）。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "工作流失败时的错误消息。"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "结束时间，Unix 秒级时间戳；未结束时为 `null`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "工作流运行 ID。"
+          },
+          "outputs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "工作流的输出数据。"
+          },
+          "paused_nodes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "等待输入的工作流节点 ID。"
+          },
+          "reasons": {
+            "items": {
+              "$ref": "#/components/schemas/WorkflowPauseReasonResponse"
+            },
+            "type": "array",
+            "description": "工作流暂停原因，包括人工介入表单详情。"
+          },
+          "status": {
+            "const": "paused",
+            "type": "string",
+            "description": "工作流执行状态，固定为 `paused`。"
+          },
+          "total_steps": {
+            "type": "integer",
+            "description": "已执行的工作流总步数。"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "所有节点消耗的总令牌数。"
+          },
+          "workflow_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "工作流 ID."
+          }
+        },
+        "required": [
+          "created_at",
+          "elapsed_time",
+          "error",
+          "finished_at",
+          "id",
+          "outputs",
+          "paused_nodes",
+          "reasons",
+          "status",
+          "total_steps",
+          "total_tokens",
+          "workflow_id"
+        ],
+        "type": "object"
+      },
+      "WorkflowPausedBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WorkflowPausedBlockingDataResponse",
+            "description": "工作流暂停等待输入时返回的数据。"
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "进行中的执行任务 ID。配合 [停止工作流任务](/zh/api-reference/workflow-runs/stop-workflow-task) 使用以取消运行中的工作流。仅在执行期间有效。"
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "此工作流运行记录的持久化标识符。配合 [获取工作流运行详情](/zh/api-reference/workflow-runs/get-workflow-run-detail) 使用以在执行后获取结果。"
+          }
+        },
+        "required": [
+          "data",
+          "task_id",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "工作流执行等待人工输入时返回的阻塞响应。"
+      },
+      "WorkflowRunPayload": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "工作流系统文件输入列表。仅在工作流启用文件上传时可用。要附加本地文件，请先通过[上传文件](/zh/api-reference/files/upload-file)上传，然后将返回的 `id` 用作 `upload_file_id`，并将 `transfer_method` 设置为 `local_file`。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "工作流输入变量的键值对。文件类型变量的值应为文件对象数组，每个对象包含 `type`、`transfer_method`，以及 `url` 或 `upload_file_id`。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解应用所需的变量名称和类型。",
+            "type": "object"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "响应模式。同步响应使用 `blocking`，服务器发送事件（SSE）使用 `streaming`。省略时，请求使用阻塞模式。"
+          }
+        },
+        "required": [
+          "inputs"
+        ],
+        "type": "object"
+      },
       "ChatRequest": {
         "type": "object",
         "required": [
@@ -13806,88 +16028,6 @@
           }
         }
       },
-      "RetrieverResource": {
-        "type": "object",
-        "description": "检索资源的引用和归属信息。",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "检索资源的唯一 ID。"
-          },
-          "message_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "该资源所属消息的 ID。"
-          },
-          "position": {
-            "type": "integer",
-            "description": "资源在列表中的位置。"
-          },
-          "dataset_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "知识库 ID。"
-          },
-          "dataset_name": {
-            "type": "string",
-            "description": "知识库名称。"
-          },
-          "document_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "文档 ID。"
-          },
-          "document_name": {
-            "type": "string",
-            "description": "文档名称。"
-          },
-          "data_source_type": {
-            "type": "string",
-            "description": "数据源类型。"
-          },
-          "segment_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "文档中特定块的 ID。"
-          },
-          "score": {
-            "type": "number",
-            "format": "float",
-            "description": "资源的相关性评分。"
-          },
-          "hit_count": {
-            "type": "integer",
-            "description": "该块被命中的次数。"
-          },
-          "word_count": {
-            "type": "integer",
-            "description": "块的字数。"
-          },
-          "segment_position": {
-            "type": "integer",
-            "description": "块在文档中的位置。"
-          },
-          "index_node_hash": {
-            "type": "string",
-            "description": "索引节点的哈希值。"
-          },
-          "content": {
-            "type": "string",
-            "description": "资源的内容片段。"
-          },
-          "summary": {
-            "type": "string",
-            "nullable": true,
-            "description": "块内容的摘要。"
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "int64",
-            "description": "创建时间戳（Unix 纪元秒）。"
-          }
-        }
-      },
       "FileUploadResponse": {
         "type": "object",
         "properties": {
@@ -13966,59 +16106,6 @@
             "type": "string",
             "nullable": true,
             "description": "未使用，始终为 `null`。"
-          }
-        }
-      },
-      "EndUserDetail": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "终端用户 ID。"
-          },
-          "tenant_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "租户 ID。"
-          },
-          "app_id": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true,
-            "description": "应用 ID。"
-          },
-          "type": {
-            "type": "string",
-            "description": "终端用户类型。Service API 用户固定为 `service-api`。"
-          },
-          "external_user_id": {
-            "type": "string",
-            "nullable": true,
-            "description": "API 请求中提供的 `user` 标识符（例如 [发送对话消息](/zh/api-reference/chat-messages/send-chat-message) 中的 `user` 字段）。"
-          },
-          "name": {
-            "type": "string",
-            "nullable": true,
-            "description": "终端用户名称。"
-          },
-          "is_anonymous": {
-            "type": "boolean",
-            "description": "用户是否为匿名用户。当原始 API 请求中未提供 `user` 标识符时，值为 `true`。"
-          },
-          "session_id": {
-            "type": "string",
-            "description": "会话标识符。默认为 `external_user_id` 的值。"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "创建时间戳。"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "最后更新时间戳。"
           }
         }
       },
@@ -14584,34 +16671,6 @@
           }
         }
       },
-      "AppInfoResponse": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "应用名称。"
-          },
-          "description": {
-            "type": "string",
-            "description": "应用描述。"
-          },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "应用标签。"
-          },
-          "mode": {
-            "type": "string",
-            "description": "应用模式。`completion` 为文本生成应用，`chat` 为基础对话应用，`agent-chat` 为 Agent 应用，`advanced-chat` 为 Chatflow 应用，`workflow` 为 Workflow 应用，`agent` 为新 Agent 应用。"
-          },
-          "author_name": {
-            "type": "string",
-            "description": "应用作者名称。"
-          }
-        }
-      },
       "UserInputFormItem": {
         "type": "object",
         "oneOf": [
@@ -14720,28 +16779,6 @@
               "type": "string"
             },
             "description": "此表单控件的可选值列表。"
-          }
-        }
-      },
-      "AppMetaResponse": {
-        "type": "object",
-        "properties": {
-          "tool_icons": {
-            "type": "object",
-            "additionalProperties": {
-              "oneOf": [
-                {
-                  "title": "Icon URL",
-                  "type": "string",
-                  "format": "url",
-                  "description": "图标的 URL。"
-                },
-                {
-                  "$ref": "#/components/schemas/ToolIconDetail"
-                }
-              ]
-            },
-            "description": "工具图标。键为工具名称。"
           }
         }
       },
@@ -16693,114 +18730,6 @@
           }
         }
       },
-      "HumanInputContent": {
-        "type": "object",
-        "description": "人工介入节点的执行内容，包括表单定义和提交数据。",
-        "properties": {
-          "workflow_run_id": {
-            "type": "string",
-            "description": "该内容所属的工作流运行 ID。"
-          },
-          "submitted": {
-            "type": "boolean",
-            "description": "人工介入表单是否已提交。"
-          },
-          "type": {
-            "type": "string",
-            "description": "`human_input` 表示人工介入内容。"
-          },
-          "form_definition": {
-            "nullable": true,
-            "description": "人工介入节点的表单定义。当内容表示提交响应时为 `null`。",
-            "$ref": "#/components/schemas/HumanInputFormDefinition"
-          },
-          "form_submission_data": {
-            "nullable": true,
-            "description": "已提交的表单数据。表单尚未提交时为 `null`。",
-            "$ref": "#/components/schemas/HumanInputFormSubmissionData"
-          }
-        }
-      },
-      "HumanInputFormDefinition": {
-        "type": "object",
-        "description": "由人工介入节点渲染的人工介入表单定义。",
-        "properties": {
-          "form_id": {
-            "type": "string",
-            "description": "表单唯一标识符。"
-          },
-          "node_id": {
-            "type": "string",
-            "description": "生成该表单的人工介入节点 ID。"
-          },
-          "node_title": {
-            "type": "string",
-            "description": "人工介入节点的标题。"
-          },
-          "form_content": {
-            "type": "string",
-            "description": "与表单一起显示的 Markdown 或文本内容。"
-          },
-          "inputs": {
-            "type": "array",
-            "description": "表单中的输入字段。",
-            "items": {
-              "$ref": "#/components/schemas/FormInput"
-            }
-          },
-          "actions": {
-            "type": "array",
-            "description": "表单上可用的操作按钮。",
-            "items": {
-              "$ref": "#/components/schemas/UserAction"
-            }
-          },
-          "display_in_ui": {
-            "type": "boolean",
-            "description": "表单是否应在 UI 中显示。"
-          },
-          "form_token": {
-            "type": "string",
-            "nullable": true,
-            "description": "表单提交认证的令牌。"
-          },
-          "resolved_default_values": {
-            "type": "object",
-            "additionalProperties": true,
-            "description": "表单输入的已解析默认值，按输出变量名称索引。"
-          },
-          "expiration_time": {
-            "type": "integer",
-            "description": "表单过期的 Unix 时间戳。"
-          }
-        }
-      },
-      "HumanInputFormSubmissionData": {
-        "type": "object",
-        "description": "来自已提交的人工介入表单的数据。",
-        "properties": {
-          "node_id": {
-            "type": "string",
-            "description": "人工介入节点的 ID。"
-          },
-          "node_title": {
-            "type": "string",
-            "description": "人工介入节点的标题。"
-          },
-          "rendered_content": {
-            "type": "string",
-            "description": "表单提交的渲染内容。"
-          },
-          "action_id": {
-            "type": "string",
-            "description": "被点击的操作按钮的 ID。"
-          },
-          "action_text": {
-            "type": "string",
-            "description": "被点击的操作按钮的显示文本。"
-          }
-        }
-      },
       "FormInput": {
         "type": "object",
         "description": "表单输入字段定义。",
@@ -16993,24 +18922,6 @@
             }
           }
         ]
-      },
-      "WorkflowBlockingResponse": {
-        "type": "object",
-        "properties": {
-          "task_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "进行中的执行任务 ID。配合 [停止工作流任务](/zh/api-reference/workflow-runs/stop-workflow-task) 使用以取消运行中的工作流。仅在执行期间有效。"
-          },
-          "workflow_run_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "此工作流运行记录的持久化标识符。配合 [获取工作流运行详情](/zh/api-reference/workflow-runs/get-workflow-run-detail) 使用以在执行后获取结果。"
-          },
-          "data": {
-            "$ref": "#/components/schemas/WorkflowFinishedData"
-          }
-        }
       },
       "ChunkWorkflowEvent": {
         "type": "object",
@@ -19483,189 +21394,19 @@
             "description": "最后更新时间戳（Unix 纪元，单位为秒）。"
           }
         }
-      },
-      "RetrievalModel": {
-        "type": "object",
-        "required": [
-          "search_method",
-          "reranking_enable",
-          "top_k",
-          "score_threshold_enabled"
-        ],
-        "properties": {
-          "search_method": {
-            "type": "string",
-            "description": "用于检索的搜索方法。",
-            "enum": [
-              "keyword_search",
-              "semantic_search",
-              "full_text_search",
-              "hybrid_search"
-            ]
-          },
-          "reranking_enable": {
-            "type": "boolean",
-            "description": "是否启用重排序。"
-          },
-          "reranking_model": {
-            "type": "object",
-            "description": "重排序模型配置。",
-            "properties": {
-              "reranking_provider_name": {
-                "type": "string",
-                "description": "重排序模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/cohere/cohere`）。`cohere` 这类简写会展开为 `langgenius/<name>/<name>`，仅对 langgenius 发布的插件有效。\n\n有效取值从 [获取可用模型](/zh/api-reference/models/get-available-models) 中 `model_type=rerank` 返回的 `provider` 字段获取。"
-              },
-              "reranking_model_name": {
-                "type": "string",
-                "description": "重排序模型名称。"
-              }
-            }
-          },
-          "reranking_mode": {
-            "type": "string",
-            "enum": [
-              "reranking_model",
-              "weighted_score"
-            ],
-            "nullable": true,
-            "description": "重排序模式。当 `reranking_enable` 为 `true` 时必填。"
-          },
-          "top_k": {
-            "type": "integer",
-            "description": "返回的最大结果数。"
-          },
-          "score_threshold_enabled": {
-            "type": "boolean",
-            "description": "是否启用分数阈值过滤。"
-          },
-          "score_threshold": {
-            "type": "number",
-            "nullable": true,
-            "description": "结果的最低相关性分数。仅在 `score_threshold_enabled` 为 `true` 时生效。"
-          },
-          "weights": {
-            "type": "object",
-            "nullable": true,
-            "description": "混合搜索的权重配置。",
-            "properties": {
-              "weight_type": {
-                "type": "string",
-                "description": "平衡语义搜索和关键词搜索权重的策略。",
-                "enum": [
-                  "semantic_first",
-                  "keyword_first",
-                  "customized"
-                ]
-              },
-              "vector_setting": {
-                "type": "object",
-                "description": "语义搜索权重设置。",
-                "properties": {
-                  "vector_weight": {
-                    "type": "number",
-                    "description": "分配给语义（向量）搜索结果的权重。"
-                  },
-                  "embedding_provider_name": {
-                    "type": "string",
-                    "description": "用于向量搜索的嵌入模型供应商。"
-                  },
-                  "embedding_model_name": {
-                    "type": "string",
-                    "description": "用于向量搜索的嵌入模型名称。"
-                  }
-                }
-              },
-              "keyword_setting": {
-                "type": "object",
-                "description": "关键词搜索权重设置。",
-                "properties": {
-                  "keyword_weight": {
-                    "type": "number",
-                    "description": "分配给关键词搜索结果的权重。"
-                  }
-                }
-              }
-            }
-          },
-          "metadata_filtering_conditions": {
-            "type": "object",
-            "nullable": true,
-            "description": "仅检索文档元数据匹配指定条件的分段。条件由服务端基于文档元数据字段评估。",
-            "properties": {
-              "logical_operator": {
-                "type": "string",
-                "enum": [
-                  "and",
-                  "or"
-                ],
-                "default": "and",
-                "nullable": true,
-                "description": "多个条件之间的组合方式。"
-              },
-              "conditions": {
-                "type": "array",
-                "nullable": true,
-                "description": "要评估的元数据条件列表。",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "name",
-                    "comparison_operator"
-                  ],
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "用于比较的元数据字段名称。"
-                    },
-                    "comparison_operator": {
-                      "type": "string",
-                      "description": "按元数据类型选择要应用的比较方式：\n\n- 字符串或数组类型元数据：`contains`、`not contains`、`start with`、`end with`、`is`、`is not`、`empty`、`not empty`、`in`、`not in`\n- 数值类型元数据：`=`、`≠`、`>`、`<`、`≥`、`≤`\n- 时间类型元数据：`before`、`after`",
-                      "enum": [
-                        "contains",
-                        "not contains",
-                        "start with",
-                        "end with",
-                        "is",
-                        "is not",
-                        "empty",
-                        "not empty",
-                        "in",
-                        "not in",
-                        "=",
-                        "≠",
-                        ">",
-                        "<",
-                        "≥",
-                        "≤",
-                        "before",
-                        "after"
-                      ]
-                    },
-                    "value": {
-                      "nullable": true,
-                      "description": "用于比较的值。类型取决于 `comparison_operator`：大多数字符串运算符使用字符串；`in` 和 `not in` 使用字符串数组；数值运算符使用数字；`empty` 和 `not empty` 时省略。",
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        {
-                          "type": "number"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "bearerFormat": "API_KEY",
+        "description": "在 Authorization 请求头中将 Service API 密钥用作 Bearer 令牌。",
+        "scheme": "bearer",
+        "type": "http"
       }
     }
+  },
+  "externalDocs": {
+    "description": "快速开始指南",
+    "url": "/zh/api-reference/guides/get-started"
   }
 }


### PR DESCRIPTION
## Summary

- align top-level OpenAPI metadata and 33 schemas shared across application and knowledge operations
- add the corresponding reviewed English, Chinese, and Japanese overlay actions
- preserve the existing operation paths for later stack layers

## Validation

- three-locale structural parity — 0 issues
- JSON parsing passed for all six changed files