### PR TITLE
docs: align application api schemas

### DIFF
--- a/en/api-reference/openapi_service.json
+++ b/en/api-reference/openapi_service.json
@@ -13223,6 +13223,280 @@
       }
     },
     "schemas": {
+      "AgentThought": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Tool or model answer associated with this thought."
+          },
+          "chain_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Chain ID for this thought."
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation time as a Unix timestamp in seconds."
+          },
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "File IDs related to this thought."
+          },
+          "id": {
+            "type": "string",
+            "description": "Agent thought ID."
+          },
+          "message_id": {
+            "type": "string",
+            "description": "Unique message ID this thought belongs to."
+          },
+          "observation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Response from tool calls."
+          },
+          "position": {
+            "type": "integer",
+            "description": "Position of this thought."
+          },
+          "thought": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "What LLM is thinking."
+          },
+          "tool": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Tools called, split by `;`."
+          },
+          "tool_input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Input of tools in JSON format."
+          },
+          "tool_labels": {
+            "$ref": "#/components/schemas/JSONValue",
+            "description": "Labels for tools used."
+          }
+        },
+        "required": [
+          "files",
+          "id",
+          "message_id",
+          "position",
+          "tool_labels"
+        ],
+        "type": "object"
+      },
+      "Annotation": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Predefined answer returned when the annotation is matched."
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation timestamp (Unix epoch seconds)."
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Number of times this annotation has been matched and returned as a reply."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Unique annotation identifier."
+          },
+          "question": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Question text that triggers this annotation."
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "AnnotationCreatePayload": {
+        "properties": {
+          "answer": {
+            "description": "Annotation answer.",
+            "type": "string"
+          },
+          "question": {
+            "description": "Annotation question.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "answer",
+          "question"
+        ],
+        "type": "object"
+      },
+      "AnnotationJobStatusDetailResponse": {
+        "properties": {
+          "error_msg": {
+            "default": "",
+            "type": "string",
+            "description": "Error message describing why the job failed. Empty string when `job_status` is not `error`."
+          },
+          "job_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Job ID from the [Configure Annotation Reply](/en/api-reference/annotations/configure-annotation-reply) call."
+          },
+          "job_status": {
+            "type": "string",
+            "description": "Current job status. `waiting` for queued, `processing` for in progress, `completed` when finished, `error` if failed."
+          }
+        },
+        "required": [
+          "job_id",
+          "job_status"
+        ],
+        "type": "object"
+      },
+      "AnnotationJobStatusResponse": {
+        "properties": {
+          "job_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Asynchronous job ID. Use with [Get Annotation Reply Job Status](/en/api-reference/annotations/get-annotation-reply-job-status) to track progress."
+          },
+          "job_status": {
+            "type": "string",
+            "description": "Current job status: `waiting` (queued) or `processing` (in progress). `completed` and `error` are returned only by [Get Annotation Reply Job Status](/en/api-reference/annotations/get-annotation-reply-job-status)."
+          }
+        },
+        "required": [
+          "job_id",
+          "job_status"
+        ],
+        "type": "object"
+      },
+      "AnnotationList": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            },
+            "type": "array",
+            "description": "Annotations on the current page."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether more annotations are available."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Number of items per page."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number."
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of matching annotations."
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
       "AnnotationListQuery": {
         "properties": {
           "keyword": {
@@ -13245,63 +13519,1014 @@
         },
         "type": "object"
       },
-      "AppInfoResponse": {
-        "type": "object",
+      "AnnotationReplyActionPayload": {
         "properties": {
+          "embedding_model_name": {
+            "description": "Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`, for example `text-embedding-3-small`.",
+            "type": "string"
+          },
+          "embedding_provider_name": {
+            "description": "Use the `provider` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`, for example `openai`; do not use the display label.",
+            "type": "string"
+          },
+          "score_threshold": {
+            "description": "Minimum similarity score from 0 to 1 for an annotation match. Higher values require closer matches.",
+            "format": "float",
+            "type": "number"
+          }
+        },
+        "required": [
+          "embedding_model_name",
+          "embedding_provider_name",
+          "score_threshold"
+        ],
+        "type": "object"
+      },
+      "AppFeedbackListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AppFeedbackResponse"
+            },
+            "type": "array",
+            "description": "Feedback records on the current page."
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "AppFeedbackResponse": {
+        "properties": {
+          "app_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Application ID."
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional text feedback."
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Conversation ID."
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Creation time as an RFC 3339 date-time string."
+          },
+          "from_account_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Account ID who submitted the feedback. Present when `from_source` is `admin`."
+          },
+          "from_end_user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "End user ID who submitted the feedback. Present when `from_source` is `user`."
+          },
+          "from_source": {
+            "type": "string",
+            "description": "Feedback source. `user` for end-user feedback submitted via API, `admin` for feedback submitted from the console."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Feedback ID."
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Message ID."
+          },
+          "rating": {
+            "type": "string",
+            "description": "Feedback rating. `like` for positive, `dislike` for negative."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "Last update time as an RFC 3339 date-time string."
+          }
+        },
+        "required": [
+          "app_id",
+          "conversation_id",
+          "created_at",
+          "from_source",
+          "id",
+          "message_id",
+          "rating",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "AppInfoResponse": {
+        "properties": {
+          "author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Name of the application author."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Application description."
+          },
+          "mode": {
+            "type": "string",
+            "description": "Application mode. `completion` is a Text Generator; `chat` is a basic Chatbot; `agent-chat` is the legacy Agent app; `advanced-chat` is a Chatflow (a conversational workflow); `workflow` is a non-conversational Workflow app; `agent` is the newer Agent app. Operation descriptions state which modes they support."
+          },
           "name": {
             "type": "string",
             "description": "Application name."
           },
-          "description": {
-            "type": "string",
-            "description": "Application description."
-          },
           "tags": {
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "type": "array",
             "description": "Application tags."
-          },
-          "mode": {
-            "type": "string",
-            "description": "Application mode. `completion` for text generation apps, `chat` for basic chat apps, `agent-chat` for agent-based apps, `advanced-chat` for Chatflow apps, `workflow` for Workflow apps, `agent` for New Agent apps."
-          },
-          "author_name": {
-            "type": "string",
-            "description": "Name of the application author."
           }
-        }
+        },
+        "required": [
+          "author_name",
+          "description",
+          "mode",
+          "name",
+          "tags"
+        ],
+        "type": "object"
       },
       "AppMetaResponse": {
-        "type": "object",
         "properties": {
           "tool_icons": {
-            "type": "object",
             "additionalProperties": {
-              "oneOf": [
+              "anyOf": [
                 {
-                  "title": "Icon URL",
-                  "type": "string",
                   "format": "url",
+                  "type": "string",
                   "description": "URL of the icon."
                 },
                 {
-                  "$ref": "#/components/schemas/ToolIconDetail"
+                  "$ref": "#/components/schemas/ToolIcon"
                 }
               ]
             },
+            "type": "object",
             "description": "Tool icons. Keys are tool names."
           }
-        }
+        },
+        "type": "object"
       },
       "AudioBinaryResponse": {
         "format": "binary",
         "type": "string"
       },
+      "AudioTranscriptResponse": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Output text from speech recognition."
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
       "BinaryFileResponse": {
         "format": "binary",
         "type": "string"
+      },
+      "BlockingMetadataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "retriever_resources": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/BlockingRetrieverResourceResponse"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "List of retriever resources used."
+          },
+          "usage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BlockingUsageResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Model usage information."
+          }
+        },
+        "type": "object",
+        "description": "Metadata including usage and retriever resources."
+      },
+      "BlockingRetrieverResourceResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Content snippet from the resource."
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation timestamp (Unix epoch seconds)."
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Type of the data source."
+          },
+          "dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the knowledge base."
+          },
+          "dataset_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the knowledge base."
+          },
+          "document_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the document."
+          },
+          "document_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the document."
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Number of times this chunk was hit."
+          },
+          "id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unique ID of the retriever resource."
+          },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Hash of the index node."
+          },
+          "message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the message this resource belongs to."
+          },
+          "position": {
+            "type": "integer",
+            "description": "Position of the resource in the list."
+          },
+          "score": {
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Similarity score of the resource."
+          },
+          "segment_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the specific chunk within the document."
+          },
+          "segment_position": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Position of the chunk within the document."
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Summary of the chunk content."
+          },
+          "word_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Word count of the chunk."
+          }
+        },
+        "required": [
+          "position"
+        ],
+        "type": "object"
+      },
+      "BlockingUsageResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "completion_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total price for completion tokens."
+          },
+          "completion_price_unit": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Price unit for completion tokens."
+          },
+          "completion_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Number of tokens in the completion."
+          },
+          "completion_unit_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unit price per completion token."
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Currency for pricing."
+          },
+          "latency": {
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Latency in seconds."
+          },
+          "prompt_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total price for prompt tokens."
+          },
+          "prompt_price_unit": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Price unit for prompt tokens."
+          },
+          "prompt_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Number of tokens in the prompt."
+          },
+          "prompt_unit_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unit price per prompt token."
+          },
+          "total_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total price for all tokens."
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total number of tokens used."
+          }
+        },
+        "type": "object"
+      },
+      "ButtonStyle": {
+        "description": "Button styles for user actions.",
+        "enum": [
+          "accent",
+          "default",
+          "ghost",
+          "primary"
+        ],
+        "type": "string"
+      },
+      "ChatBlockingResponse": {
+        "discriminator": {
+          "mapping": {
+            "message": "#/components/schemas/ChatMessageBlockingResponse",
+            "workflow_paused": "#/components/schemas/ChatPausedBlockingResponse"
+          },
+          "propertyName": "event"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatMessageBlockingResponse"
+          },
+          {
+            "$ref": "#/components/schemas/ChatPausedBlockingResponse"
+          }
+        ]
+      },
+      "ChatMessageBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "Complete response content."
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Conversation ID."
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "Message creation timestamp (Unix epoch seconds)."
+          },
+          "event": {
+            "const": "message",
+            "type": "string",
+            "description": "Event type, fixed as `message`."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Unique ID of this response event."
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Unique message ID. Use this as the `message_id` parameter when calling feedback or suggested questions endpoints."
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "Metadata including usage and retriever resources."
+          },
+          "mode": {
+            "type": "string",
+            "description": "App mode. `chat` for Chatbot apps, `agent-chat` for Agent apps, `advanced-chat` for Chatflow apps."
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Task ID for request tracking and stop response API."
+          }
+        },
+        "required": [
+          "answer",
+          "conversation_id",
+          "created_at",
+          "event",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "task_id"
+        ],
+        "type": "object",
+        "description": "Event type, fixed as `message`."
+      },
+      "ChatPauseReasonResponse": {
+        "additionalProperties": true,
+        "description": "Public details explaining why a blocking Chatflow execution paused.",
+        "properties": {
+          "TYPE": {
+            "type": "string",
+            "description": "Pause reason type."
+          },
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "Actions available in the Human Input form."
+          },
+          "approval_channels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Configured approval channels."
+          },
+          "display_in_ui": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether the pause reason should be displayed in the UI."
+          },
+          "expiration_time": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unix timestamp when the Human Input form expires."
+          },
+          "form_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Content displayed with the Human Input form."
+          },
+          "form_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Human Input form ID."
+          },
+          "form_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Access token used with the Human Input Form API."
+          },
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "Input fields in the Human Input form."
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Message explaining why the workflow paused."
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the workflow node that paused."
+          },
+          "node_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Title of the workflow node that paused."
+          },
+          "resolved_default_values": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "Resolved default values for the form inputs."
+          }
+        },
+        "required": [
+          "TYPE"
+        ],
+        "type": "object"
+      },
+      "ChatPausedBlockingDataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "Complete response content."
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Conversation ID."
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "Message creation timestamp (Unix epoch seconds)."
+          },
+          "elapsed_time": {
+            "format": "float",
+            "type": "number",
+            "description": "Total time elapsed in seconds."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Unique ID of this response event."
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Unique message ID. Use this as the `message_id` parameter when calling feedback or suggested questions endpoints."
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "Metadata including usage and retriever resources."
+          },
+          "mode": {
+            "type": "string",
+            "description": "App mode. `chat` for Chatbot apps, `agent-chat` for Agent apps, `advanced-chat` for Chatflow apps."
+          },
+          "paused_nodes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "IDs of workflow nodes waiting for input."
+          },
+          "reasons": {
+            "items": {
+              "$ref": "#/components/schemas/ChatPauseReasonResponse"
+            },
+            "type": "array",
+            "description": "Reasons the workflow paused, including Human Input form details."
+          },
+          "status": {
+            "const": "paused",
+            "type": "string",
+            "description": "Workflow execution status, fixed as `paused`."
+          },
+          "total_steps": {
+            "type": "integer",
+            "description": "Total number of workflow steps executed."
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Total tokens consumed across all nodes."
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Persistent identifier for the paused workflow run."
+          }
+        },
+        "required": [
+          "answer",
+          "conversation_id",
+          "created_at",
+          "elapsed_time",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "paused_nodes",
+          "reasons",
+          "status",
+          "total_steps",
+          "total_tokens",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "Pause details for the Chatflow workflow run."
+      },
+      "ChatPausedBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "Complete response content."
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Conversation ID."
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "Message creation timestamp (Unix epoch seconds)."
+          },
+          "data": {
+            "$ref": "#/components/schemas/ChatPausedBlockingDataResponse",
+            "description": "Pause details for the Chatflow workflow run."
+          },
+          "event": {
+            "const": "workflow_paused",
+            "type": "string",
+            "description": "Event type, fixed as `workflow_paused` when the Chatflow is waiting for human input."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Unique ID of this response event."
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Unique message ID. Use this as the `message_id` parameter when calling feedback or suggested questions endpoints."
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "Metadata including usage and retriever resources."
+          },
+          "mode": {
+            "type": "string",
+            "description": "App mode. `chat` for Chatbot apps, `agent-chat` for Agent apps, `advanced-chat` for Chatflow apps."
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Task ID for request tracking and stop response API."
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Persistent identifier for the paused workflow run."
+          }
+        },
+        "required": [
+          "answer",
+          "conversation_id",
+          "created_at",
+          "data",
+          "event",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "task_id",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "Blocking response returned when a Chatflow is waiting for human input."
       },
       "ChatRequestPayload": {
         "properties": {
@@ -13551,6 +14776,259 @@
         ],
         "type": "object"
       },
+      "ChatRequestPayloadWithUser": {
+        "properties": {
+          "auto_generate_name": {
+            "default": true,
+            "description": "Auto-generate the conversation title. If `false`, use the Rename Conversation API with `auto_generate: true` to generate the title asynchronously.",
+            "type": "boolean"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Conversation ID to continue a conversation. Omit this field or pass an empty string to start a new conversation, then pass the returned `conversation_id` in subsequent requests."
+          },
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Files for multimodal input. New clients should implement two canonical forms only: use `transfer_method: remote_url` with `url` for a public file URL, or upload through [Upload File](/en/api-reference/files/upload-file) and use `transfer_method: local_file` with the returned `id` as `upload_file_id`. Other generated `anyOf` combinations exist only for backward compatibility with stored legacy references."
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "Values for app-defined variables. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover expected variable names and types.",
+            "type": "object"
+          },
+          "query": {
+            "description": "User input or question content.",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Response mode. `streaming` uses Server-Sent Events; `blocking` returns after completion. New Agent app mode supports streaming only. When omitted, non-Agent apps run in blocking mode and new Agent apps stream."
+          },
+          "user": {
+            "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+            "type": "string"
+          },
+          "workflow_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Published workflow version ID to execute for advanced chat. If omitted, the app's current published workflow is used."
+          }
+        },
+        "required": [
+          "inputs",
+          "query",
+          "user"
+        ],
+        "type": "object"
+      },
       "ChildChunkListQuery": {
         "properties": {
           "keyword": {
@@ -13578,6 +15056,58 @@
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "CompletionBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "Complete response content."
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "Message creation timestamp (Unix epoch seconds)."
+          },
+          "event": {
+            "type": "string",
+            "description": "Event type, fixed as `message`."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Unique ID of this response event."
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Unique message ID. Use it as `message_id` when submitting feedback. Suggested-question generation is not available for Text Generator apps."
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "Metadata including usage and retriever resources."
+          },
+          "mode": {
+            "type": "string",
+            "description": "App mode, fixed as `completion`."
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Task ID for request tracking and the [Stop Completion Message Generation](/en/api-reference/completion-messages/stop-completion-message-generation) API."
+          }
+        },
+        "required": [
+          "answer",
+          "created_at",
+          "event",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "task_id"
+        ],
         "type": "object"
       },
       "CompletionRequestPayload": {
@@ -13799,6 +15329,255 @@
         ],
         "type": "object"
       },
+      "CompletionRequestPayloadWithUser": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Files for multimodal input. New clients should implement two canonical forms only: use `transfer_method: remote_url` with `url` for a public file URL, or upload through [Upload File](/en/api-reference/files/upload-file) and use `transfer_method: local_file` with the returned `id` as `upload_file_id`. Other generated `anyOf` combinations exist only for backward compatibility with stored legacy references."
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "Values for app-defined variables. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover expected variable names and types.",
+            "type": "object"
+          },
+          "query": {
+            "default": "",
+            "description": "User input or prompt content.",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Response mode. `streaming` uses Server-Sent Events; `blocking` returns after completion. When omitted, the request runs in blocking mode."
+          },
+          "user": {
+            "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputs",
+          "user"
+        ],
+        "type": "object"
+      },
+      "ConversationInfiniteScrollPagination": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SimpleConversation"
+            },
+            "type": "array",
+            "description": "Conversations in this page of results."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether older conversations are available."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Number of items per page."
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit"
+        ],
+        "type": "object"
+      },
       "ConversationListQuery": {
         "properties": {
           "last_id": {
@@ -13906,8 +15685,205 @@
         },
         "type": "object"
       },
+      "ConversationRenamePayloadWithUser": {
+        "anyOf": [
+          {
+            "properties": {
+              "auto_generate": {
+                "description": "Automatically generate the conversation name. When `true`, the `name` field is ignored.",
+                "enum": [
+                  true
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Conversation name. Required when `auto_generate` is `false`."
+              },
+              "user": {
+                "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "auto_generate"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "auto_generate": {
+                "default": false,
+                "description": "Automatically generate the conversation name. When `true`, the `name` field is ignored.",
+                "enum": [
+                  false
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "pattern": ".*\\S.*",
+                "type": "string",
+                "description": "New conversation name. Required unless `auto_generate` is `true`."
+              },
+              "user": {
+                "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "auto_generate": {
+            "default": false,
+            "description": "Automatically generate the conversation name. When `true`, the `name` field is ignored.",
+            "type": "boolean"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Conversation name. Required when `auto_generate` is `false`."
+          },
+          "user": {
+            "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ConversationVariableInfiniteScrollPaginationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationVariableResponse"
+            },
+            "type": "array",
+            "description": "Conversation variables in this page of results."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether more conversation variables are available."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Number of items per page."
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit"
+        ],
+        "type": "object"
+      },
+      "ConversationVariableResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation time as a Unix timestamp in seconds."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Variable description."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Variable ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Variable name."
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Last update time as a Unix timestamp in seconds."
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Variable value (can be a JSON string for complex types)."
+          },
+          "value_type": {
+            "type": "string",
+            "description": "Variable value type. Possible values: `string`, `number`, `object`, `secret`, `file`, `boolean`, `array[any]`, `array[string]`, `array[number]`, `array[object]`, `array[file]`, `array[boolean]`."
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "value_type"
+        ],
+        "type": "object"
+      },
       "ConversationVariableUpdatePayload": {
         "properties": {
+          "value": {
+            "description": "The new value for the variable. Must match the variable's expected type."
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "ConversationVariableUpdatePayloadWithUser": {
+        "properties": {
+          "user": {
+            "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+            "type": "string"
+          },
           "value": {
             "description": "The new value for the variable. Must match the variable's expected type."
           }
@@ -14068,59 +16044,95 @@
         "type": "object"
       },
       "EndUserDetail": {
-        "type": "object",
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "End user ID."
-          },
-          "tenant_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Tenant ID."
-          },
           "app_id": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true,
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "Application ID."
           },
-          "type": {
+          "created_at": {
+            "format": "date-time",
             "type": "string",
-            "description": "End user type. Always `service-api` for Service API users."
+            "description": "Creation timestamp."
           },
           "external_user_id": {
-            "type": "string",
-            "nullable": true,
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "The `user` identifier provided in API requests (e.g., the `user` field in [Send Chat Message](/en/api-reference/chat-messages/send-chat-message))."
           },
-          "name": {
+          "id": {
+            "format": "uuid",
             "type": "string",
-            "nullable": true,
-            "description": "End user name."
+            "description": "End user ID."
           },
           "is_anonymous": {
             "type": "boolean",
             "description": "Whether the user is anonymous. `true` when no `user` identifier was provided in the original API request."
           },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "End user name."
+          },
           "session_id": {
             "type": "string",
             "description": "Session identifier. Defaults to the `external_user_id` value."
           },
-          "created_at": {
+          "tenant_id": {
+            "format": "uuid",
             "type": "string",
-            "format": "date-time",
-            "description": "Creation timestamp."
+            "description": "Tenant ID."
+          },
+          "type": {
+            "type": "string",
+            "description": "End user type. Always `service-api` for Service API users."
           },
           "updated_at": {
-            "type": "string",
             "format": "date-time",
+            "type": "string",
             "description": "Last update timestamp."
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "id",
+          "is_anonymous",
+          "session_id",
+          "tenant_id",
+          "type",
+          "updated_at"
+        ],
+        "type": "object"
       },
       "EventStreamResponse": {
+        "type": "string"
+      },
+      "ExecutionContentType": {
+        "enum": [
+          "human_input"
+        ],
         "type": "string"
       },
       "FeedbackListQuery": {
@@ -14141,6 +16153,90 @@
         },
         "type": "object"
       },
+      "FileInputConfig": {
+        "properties": {
+          "allowed_file_extensions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Allowed file extensions when `allowed_file_types` includes `custom`. Include the leading `.` in each extension, for example `.md`. Present for `file` and `file-list` inputs."
+          },
+          "allowed_file_types": {
+            "items": {
+              "$ref": "#/components/schemas/FileType"
+            },
+            "type": "array",
+            "description": "File categories the recipient may upload. Present for `file` and `file-list` inputs. Values: `image`, `document`, `audio`, `video`, `custom`."
+          },
+          "allowed_file_upload_methods": {
+            "items": {
+              "$ref": "#/components/schemas/FileTransferMethod"
+            },
+            "type": "array",
+            "description": "Upload methods the recipient may use. Values: `local_file`, `remote_url`. Present for `file` and `file-list` inputs."
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "Variable name used to reference this input's submitted value inside the workflow. Corresponds to the key in the submission `inputs` object."
+          },
+          "type": {
+            "const": "file",
+            "default": "file",
+            "type": "string",
+            "description": "Form input control type. Available values: `paragraph` (multi-line text input), `select` (single-choice from a list), `file` (single file upload), and `file-list` (multiple file uploads)."
+          }
+        },
+        "required": [
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
+      "FileListInputConfig": {
+        "properties": {
+          "allowed_file_extensions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Allowed file extensions when `allowed_file_types` includes `custom`. Include the leading `.` in each extension, for example `.md`. Present for `file` and `file-list` inputs."
+          },
+          "allowed_file_types": {
+            "items": {
+              "$ref": "#/components/schemas/FileType"
+            },
+            "type": "array",
+            "description": "File categories the recipient may upload. Present for `file` and `file-list` inputs. Values: `image`, `document`, `audio`, `video`, `custom`."
+          },
+          "allowed_file_upload_methods": {
+            "items": {
+              "$ref": "#/components/schemas/FileTransferMethod"
+            },
+            "type": "array",
+            "description": "Upload methods the recipient may use. Values: `local_file`, `remote_url`. Present for `file` and `file-list` inputs."
+          },
+          "number_limits": {
+            "default": 0,
+            "minimum": 0,
+            "type": "integer",
+            "description": "Maximum number of files the recipient may upload. Present only for `file-list` inputs."
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "Variable name used to reference this input's submitted value inside the workflow. Corresponds to the key in the submission `inputs` object."
+          },
+          "type": {
+            "const": "file-list",
+            "default": "file-list",
+            "type": "string",
+            "description": "Form input control type. Available values: `paragraph` (multi-line text input), `select` (single-choice from a list), `file` (single file upload), and `file-list` (multiple file uploads)."
+          }
+        },
+        "required": [
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
       "FilePreviewQuery": {
         "properties": {
           "as_attachment": {
@@ -14151,41 +16247,313 @@
         },
         "type": "object"
       },
-      "HumanInputContent": {
-        "type": "object",
-        "description": "Execution content from a Human Input node, including form definition and submission data.",
+      "FileResponse": {
         "properties": {
-          "workflow_run_id": {
+          "conversation_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the associated conversation."
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Upload timestamp (Unix epoch seconds)."
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "End-user ID of the uploader. Look up details with [Get End User Info](/en/api-reference/end-users/get-end-user-info)."
+          },
+          "extension": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "File extension."
+          },
+          "file_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unused; always `null`."
+          },
+          "id": {
+            "format": "uuid",
             "type": "string",
-            "description": "ID of the workflow run this content belongs to."
+            "description": "Unique file ID."
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "MIME type of the file."
+          },
+          "name": {
+            "type": "string",
+            "description": "File name."
+          },
+          "original_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Original URL of the file."
+          },
+          "preview_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Preview URL for the file."
+          },
+          "reference": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque file reference used internally when attaching files in agent and tool contexts. Always `null` for files uploaded through this endpoint."
+          },
+          "size": {
+            "type": "integer",
+            "description": "File size in bytes."
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Signed URL for downloading the file."
+          },
+          "tenant_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the associated tenant."
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unused; always `null`."
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "size"
+        ],
+        "type": "object"
+      },
+      "FileTransferMethod": {
+        "enum": [
+          "datasource_file",
+          "local_file",
+          "remote_url",
+          "tool_file"
+        ],
+        "type": "string"
+      },
+      "FileType": {
+        "enum": [
+          "audio",
+          "custom",
+          "document",
+          "image",
+          "video"
+        ],
+        "type": "string"
+      },
+      "FormInputConfig": {
+        "discriminator": {
+          "mapping": {
+            "file": "#/components/schemas/FileInputConfig",
+            "file-list": "#/components/schemas/FileListInputConfig",
+            "paragraph": "#/components/schemas/ParagraphInputConfig",
+            "select": "#/components/schemas/SelectInputConfig"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ParagraphInputConfig"
+          },
+          {
+            "$ref": "#/components/schemas/SelectInputConfig"
+          },
+          {
+            "$ref": "#/components/schemas/FileInputConfig"
+          },
+          {
+            "$ref": "#/components/schemas/FileListInputConfig"
+          }
+        ]
+      },
+      "HumanInputContent": {
+        "properties": {
+          "form_definition": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HumanInputFormDefinition"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Form definition from the Human Input node. `null` when the content represents a submission response."
+          },
+          "form_submission_data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HumanInputFormSubmissionData"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Submitted form data. `null` when the form has not been submitted yet."
           },
           "submitted": {
             "type": "boolean",
             "description": "Whether the human input form has been submitted."
           },
           "type": {
-            "type": "string",
+            "$ref": "#/components/schemas/ExecutionContentType",
+            "default": "human_input",
             "description": "`human_input` for human input content."
           },
-          "form_definition": {
-            "nullable": true,
-            "description": "Form definition from the Human Input node. `null` when the content represents a submission response.",
-            "$ref": "#/components/schemas/HumanInputFormDefinition"
-          },
-          "form_submission_data": {
-            "nullable": true,
-            "description": "Submitted form data. `null` when the form has not been submitted yet.",
-            "$ref": "#/components/schemas/HumanInputFormSubmissionData"
+          "workflow_run_id": {
+            "type": "string",
+            "description": "ID of the workflow run this content belongs to."
           }
-        }
+        },
+        "required": [
+          "submitted",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "Execution content from a Human Input node, including form definition and submission data."
       },
       "HumanInputFormDefinition": {
-        "type": "object",
-        "description": "Definition of a human input form rendered by a Human Input node.",
         "properties": {
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/UserActionConfig"
+            },
+            "type": "array",
+            "description": "Action buttons available on the form."
+          },
+          "display_in_ui": {
+            "default": false,
+            "type": "boolean",
+            "description": "Whether the form should be displayed in the UI."
+          },
+          "expiration_time": {
+            "type": "integer",
+            "description": "Unix timestamp when the form expires."
+          },
+          "form_content": {
+            "type": "string",
+            "description": "Markdown or text content displayed with the form."
+          },
           "form_id": {
             "type": "string",
             "description": "Unique form identifier."
+          },
+          "form_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Token for form submission authentication."
+          },
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/FormInputConfig"
+            },
+            "type": "array",
+            "description": "Input fields in the form."
           },
           "node_id": {
             "type": "string",
@@ -14195,48 +16563,81 @@
             "type": "string",
             "description": "Title of the Human Input node."
           },
+          "resolved_default_values": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "Resolved default values for form inputs, keyed by output variable name."
+          }
+        },
+        "required": [
+          "expiration_time",
+          "form_content",
+          "form_id",
+          "node_id",
+          "node_title"
+        ],
+        "type": "object",
+        "description": "Definition of a human input form rendered by a Human Input node."
+      },
+      "HumanInputFormDefinitionResponse": {
+        "properties": {
+          "expiration_time": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unix timestamp (seconds) after which this form can no longer be submitted."
+          },
           "form_content": {
             "type": "string",
-            "description": "Markdown or text content displayed with the form."
+            "description": "Pre-rendered form body with workflow variables substituted."
           },
           "inputs": {
-            "type": "array",
-            "description": "Input fields in the form.",
             "items": {
-              "$ref": "#/components/schemas/FormInput"
-            }
-          },
-          "actions": {
+              "$ref": "#/components/schemas/FormInputConfig"
+            },
             "type": "array",
-            "description": "Action buttons available on the form.",
-            "items": {
-              "$ref": "#/components/schemas/UserAction"
-            }
-          },
-          "display_in_ui": {
-            "type": "boolean",
-            "description": "Whether the form should be displayed in the UI."
-          },
-          "form_token": {
-            "type": "string",
-            "nullable": true,
-            "description": "Token for form submission authentication."
+            "description": "Form input field definitions."
           },
           "resolved_default_values": {
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
-            "additionalProperties": true,
-            "description": "Resolved default values for form inputs, keyed by output variable name."
+            "description": "Pre-rendered values to display in the form. Keyed by input `output_variable_name`. Populated for `paragraph` inputs whose default resolves from a workflow variable; empty for inputs with no resolvable default. Display these values; do not re-resolve `default` on the client. All values are stringified."
           },
-          "expiration_time": {
-            "type": "integer",
-            "description": "Unix timestamp when the form expires."
+          "user_actions": {
+            "items": {
+              "$ref": "#/components/schemas/UserActionConfig"
+            },
+            "type": "array",
+            "description": "Available submission actions."
           }
-        }
+        },
+        "required": [
+          "form_content",
+          "inputs",
+          "resolved_default_values",
+          "user_actions"
+        ],
+        "type": "object"
       },
       "HumanInputFormSubmissionData": {
-        "type": "object",
-        "description": "Data from a submitted human input form.",
         "properties": {
+          "action_id": {
+            "type": "string",
+            "description": "ID of the action button that was clicked."
+          },
+          "action_text": {
+            "type": "string",
+            "description": "Display text of the action button that was clicked."
+          },
           "node_id": {
             "type": "string",
             "description": "ID of the Human Input node."
@@ -14249,15 +16650,31 @@
             "type": "string",
             "description": "Rendered content of the form submission."
           },
-          "action_id": {
-            "type": "string",
-            "description": "ID of the action button that was clicked."
-          },
-          "action_text": {
-            "type": "string",
-            "description": "Display text of the action button that was clicked."
+          "submitted_data": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Values the recipient submitted, keyed by each form input's `output_variable_name`."
           }
-        }
+        },
+        "required": [
+          "action_id",
+          "action_text",
+          "node_id",
+          "node_title",
+          "rendered_content"
+        ],
+        "type": "object",
+        "description": "Data from a submitted human input form."
       },
       "HumanInputFormSubmitPayload": {
         "properties": {
@@ -14301,10 +16718,87 @@
         ],
         "type": "object"
       },
+      "HumanInputFormSubmitPayloadWithUser": {
+        "properties": {
+          "action": {
+            "description": "ID of the action button the recipient selected. Must match one of the `id` values from the form's `user_actions` list.",
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "description": "Submitted human input values keyed by output variable name. Use a string for paragraph or select input values, a file mapping for file inputs, and a list of file mappings for file-list inputs. Local file mappings use `transfer_method=local_file` with `upload_file_id`; remote file mappings use `transfer_method=remote_url` with `url` or `remote_url`.",
+            "examples": [
+              {
+                "attachment": {
+                  "transfer_method": "local_file",
+                  "type": "document",
+                  "upload_file_id": "4e0d1b87-52f2-49f6-b8c6-95cd9c954b3e"
+                },
+                "attachments": [
+                  {
+                    "transfer_method": "local_file",
+                    "type": "document",
+                    "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee"
+                  },
+                  {
+                    "transfer_method": "remote_url",
+                    "type": "document",
+                    "url": "https://example.com/report.pdf"
+                  }
+                ],
+                "decision": "approve"
+              }
+            ],
+            "type": "object"
+          },
+          "user": {
+            "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action",
+          "inputs",
+          "user"
+        ],
+        "type": "object"
+      },
+      "HumanInputFormSubmitResponse": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "IndexInfoResponse": {
+        "properties": {
+          "api_version": {
+            "type": "string",
+            "description": "Service API version."
+          },
+          "server_version": {
+            "type": "string",
+            "description": "Dify server version."
+          },
+          "welcome": {
+            "type": "string",
+            "description": "Service welcome message."
+          }
+        },
+        "required": [
+          "api_version",
+          "server_version",
+          "welcome"
+        ],
+        "type": "object"
+      },
       "JSONObject": {
         "additionalProperties": true,
         "type": "object"
       },
+      "JSONValue": {},
+      "JSONValueType": {},
+      "JsonValue": {},
       "MessageFeedbackPayload": {
         "properties": {
           "content": {
@@ -14338,6 +16832,332 @@
         },
         "type": "object"
       },
+      "MessageFeedbackPayloadWithUser": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional text feedback providing additional detail."
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "enum": [
+                  "dislike",
+                  "like"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Feedback rating. Set to `null` to revoke previously submitted feedback."
+          },
+          "user": {
+            "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "type": "object"
+      },
+      "MessageFile": {
+        "properties": {
+          "belongs_to": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Who this file belongs to. `user` for user-uploaded files, `assistant` for assistant-generated files."
+          },
+          "filename": {
+            "type": "string",
+            "description": "Original filename."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Message file ID."
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "MIME type of the file."
+          },
+          "size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "File size in bytes."
+          },
+          "transfer_method": {
+            "type": "string",
+            "description": "Transfer method used. `remote_url` for URL-based files, `local_file` for uploaded files, `tool_file` for tool-generated files."
+          },
+          "type": {
+            "type": "string",
+            "description": "File type, e.g., `image`."
+          },
+          "upload_file_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Upload file ID if transferred via `local_file`."
+          },
+          "url": {
+            "anyOf": [
+              {
+                "format": "url",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Preview URL for the file."
+          }
+        },
+        "required": [
+          "filename",
+          "id",
+          "transfer_method",
+          "type"
+        ],
+        "type": "object"
+      },
+      "MessageInfiniteScrollPagination": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/MessageListItem"
+            },
+            "type": "array",
+            "description": "Messages in this page of results."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether older messages are available."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Number of items per page."
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit"
+        ],
+        "type": "object"
+      },
+      "MessageListItem": {
+        "properties": {
+          "agent_thoughts": {
+            "items": {
+              "$ref": "#/components/schemas/AgentThought"
+            },
+            "type": "array",
+            "description": "Agent thoughts for this message."
+          },
+          "answer": {
+            "type": "string",
+            "description": "Assistant answer text."
+          },
+          "answer_tokens": {
+            "default": 0,
+            "type": "integer",
+            "description": "Number of tokens in the generated answer."
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Conversation ID."
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation timestamp (Unix epoch seconds)."
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Currency for `total_price` (for example, `USD`), or `null` when pricing is unavailable."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Error message if `status` is `error`."
+          },
+          "extra_contents": {
+            "items": {
+              "$ref": "#/components/schemas/HumanInputContent"
+            },
+            "type": "array",
+            "description": "Additional execution content associated with this message, such as human input form data from Human Input nodes in Chatflow workflows."
+          },
+          "feedback": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleFeedback"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "User feedback for this message."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Message ID."
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JSONValueType"
+            },
+            "type": "object",
+            "description": "Input variables for this message."
+          },
+          "message_files": {
+            "items": {
+              "$ref": "#/components/schemas/MessageFile"
+            },
+            "type": "array",
+            "description": "Files attached to this message."
+          },
+          "message_tokens": {
+            "default": 0,
+            "type": "integer",
+            "description": "Number of tokens in the input message."
+          },
+          "parent_message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Parent message ID for threaded conversations."
+          },
+          "provider_response_latency": {
+            "default": 0,
+            "format": "float",
+            "type": "number",
+            "description": "Model provider response latency in seconds."
+          },
+          "query": {
+            "type": "string",
+            "description": "User query text."
+          },
+          "retriever_resources": {
+            "items": {
+              "$ref": "#/components/schemas/RetrieverResource"
+            },
+            "type": "array",
+            "description": "Retriever resources used for this message."
+          },
+          "status": {
+            "type": "string",
+            "description": "Message status. `normal` for successful messages, `error` when generation failed."
+          },
+          "total_price": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total price for the tokens used, or `null` when pricing is unavailable."
+          },
+          "total_tokens": {
+            "readOnly": true,
+            "type": "integer",
+            "description": "Total tokens used, the sum of `message_tokens` and `answer_tokens`."
+          }
+        },
+        "required": [
+          "agent_thoughts",
+          "answer",
+          "conversation_id",
+          "extra_contents",
+          "id",
+          "inputs",
+          "message_files",
+          "query",
+          "retriever_resources",
+          "status",
+          "total_tokens"
+        ],
+        "type": "object"
+      },
       "MessageListQuery": {
         "properties": {
           "conversation_id": {
@@ -14366,6 +17186,1479 @@
         },
         "required": [
           "conversation_id"
+        ],
+        "type": "object"
+      },
+      "OptionalServiceApiUserPayload": {
+        "properties": {
+          "user": {
+            "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ParagraphInputConfig": {
+        "description": "Form input definition.",
+        "properties": {
+          "default": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringSource"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Raw default-value configuration for `paragraph` inputs. The client should not resolve this directly; use `resolved_default_values` to display defaults. absent for other input types or when no default is configured."
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "Variable name used to reference this input's submitted value inside the workflow. Corresponds to the key in the submission `inputs` object."
+          },
+          "type": {
+            "const": "paragraph",
+            "default": "paragraph",
+            "type": "string",
+            "description": "Form input control type. Available values: `paragraph` (multi-line text input), `select` (single-choice from a list), `file` (single file upload), and `file-list` (multiple file uploads)."
+          }
+        },
+        "required": [
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
+      "Parameters": {
+        "properties": {
+          "annotation_reply": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether this feature is enabled."
+              }
+            },
+            "type": "object",
+            "description": "Annotation reply feature configuration."
+          },
+          "file_upload": {
+            "properties": {
+              "allowed_file_extensions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "Custom file extensions accepted by the application."
+              },
+              "allowed_file_types": {
+                "items": {
+                  "enum": [
+                    "audio",
+                    "custom",
+                    "document",
+                    "image",
+                    "video"
+                  ],
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "File types accepted by the application."
+              },
+              "allowed_file_upload_methods": {
+                "items": {
+                  "enum": [
+                    "local_file",
+                    "remote_url"
+                  ],
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "File transfer methods accepted by the application."
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether file upload is enabled."
+              },
+              "image": {
+                "properties": {
+                  "detail": {
+                    "type": "string",
+                    "description": "Image detail level for vision models."
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "Whether image upload is enabled."
+                  },
+                  "number_limits": {
+                    "type": "integer",
+                    "description": "Maximum number of images that can be uploaded."
+                  },
+                  "transfer_methods": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "description": "Allowed transfer methods for image upload. `remote_url` for file URL, `local_file` for uploaded file."
+                  }
+                },
+                "type": "object",
+                "description": "Image upload settings."
+              },
+              "number_limits": {
+                "type": "integer",
+                "description": "Maximum number of files that can be uploaded."
+              }
+            },
+            "type": "object",
+            "description": "File upload configuration."
+          },
+          "more_like_this": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether this feature is enabled."
+              }
+            },
+            "type": "object",
+            "description": "More-like-this feature configuration."
+          },
+          "opening_statement": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opening statement text."
+          },
+          "retriever_resource": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether this feature is enabled."
+              }
+            },
+            "type": "object",
+            "description": "Knowledge retrieval citation resource configuration."
+          },
+          "sensitive_word_avoidance": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether this feature is enabled."
+              }
+            },
+            "type": "object",
+            "description": "Content moderation feature configuration."
+          },
+          "speech_to_text": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether this feature is enabled."
+              }
+            },
+            "type": "object",
+            "description": "Speech-to-text feature configuration."
+          },
+          "suggested_questions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "List of suggested questions."
+          },
+          "suggested_questions_after_answer": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether this feature is enabled."
+              }
+            },
+            "type": "object",
+            "description": "Configuration for suggested questions after an answer."
+          },
+          "system_parameters": {
+            "$ref": "#/components/schemas/SystemParameters",
+            "description": "System-level parameter limits."
+          },
+          "text_to_speech": {
+            "properties": {
+              "autoPlay": {
+                "type": "string",
+                "description": "Auto-play setting. `enabled` to auto-play audio, `disabled` to require manual play."
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether this feature is enabled."
+              },
+              "language": {
+                "type": "string",
+                "description": "Language for TTS."
+              },
+              "voice": {
+                "type": "string",
+                "description": "Voice identifier for TTS."
+              }
+            },
+            "type": "object",
+            "description": "Text-to-speech feature configuration."
+          },
+          "user_input_form": {
+            "items": {
+              "oneOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "text-input": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file extensions when this input accepts files."
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file categories when this input accepts files."
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed upload methods when this input accepts files."
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "Additional input configuration."
+                        },
+                        "default": {
+                          "description": "Default value. Its JSON type depends on the form type."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Optional input description."
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "Whether the input is hidden from the public form."
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON Schema used to validate JSON object input."
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "Display label for the input."
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Maximum input length when the input type supports a length limit."
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "List of selectable values for this form control."
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether the input is required."
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape."
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "Variable name used by the application."
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "Text input configuration."
+                    }
+                  },
+                  "required": [
+                    "text-input"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "select": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file extensions when this input accepts files."
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file categories when this input accepts files."
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed upload methods when this input accepts files."
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "Additional input configuration."
+                        },
+                        "default": {
+                          "description": "Default value. Its JSON type depends on the form type."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Optional input description."
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "Whether the input is hidden from the public form."
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON Schema used to validate JSON object input."
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "Display label for the input."
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Maximum input length when the input type supports a length limit."
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "List of selectable values for this form control."
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether the input is required."
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape."
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "Variable name used by the application."
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "Select input configuration."
+                    }
+                  },
+                  "required": [
+                    "select"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "paragraph": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file extensions when this input accepts files."
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file categories when this input accepts files."
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed upload methods when this input accepts files."
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "Additional input configuration."
+                        },
+                        "default": {
+                          "description": "Default value. Its JSON type depends on the form type."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Optional input description."
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "Whether the input is hidden from the public form."
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON Schema used to validate JSON object input."
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "Display label for the input."
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Maximum input length when the input type supports a length limit."
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "List of selectable values for this form control."
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether the input is required."
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape."
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "Variable name used by the application."
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "Paragraph input configuration."
+                    }
+                  },
+                  "required": [
+                    "paragraph"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "number": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file extensions when this input accepts files."
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file categories when this input accepts files."
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed upload methods when this input accepts files."
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "Additional input configuration."
+                        },
+                        "default": {
+                          "description": "Default value. Its JSON type depends on the form type."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Optional input description."
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "Whether the input is hidden from the public form."
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON Schema used to validate JSON object input."
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "Display label for the input."
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Maximum input length when the input type supports a length limit."
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "List of selectable values for this form control."
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether the input is required."
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape."
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "Variable name used by the application."
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "Number input configuration."
+                    }
+                  },
+                  "required": [
+                    "number"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "external_data_tool": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file extensions when this input accepts files."
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file categories when this input accepts files."
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed upload methods when this input accepts files."
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "Additional input configuration."
+                        },
+                        "default": {
+                          "description": "Default value. Its JSON type depends on the form type."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Optional input description."
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "Whether the input is hidden from the public form."
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON Schema used to validate JSON object input."
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "Display label for the input."
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Maximum input length when the input type supports a length limit."
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "List of selectable values for this form control."
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether the input is required."
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape."
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "Variable name used by the application."
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "External data tool input configuration."
+                    }
+                  },
+                  "required": [
+                    "external_data_tool"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "file": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file extensions when this input accepts files."
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file categories when this input accepts files."
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed upload methods when this input accepts files."
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "Additional input configuration."
+                        },
+                        "default": {
+                          "description": "Default value. Its JSON type depends on the form type."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Optional input description."
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "Whether the input is hidden from the public form."
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON Schema used to validate JSON object input."
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "Display label for the input."
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Maximum input length when the input type supports a length limit."
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "List of selectable values for this form control."
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether the input is required."
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape."
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "Variable name used by the application."
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "File-form control configuration returned by the application. It describes the label, variable name, whether input is required, accepted file categories and extensions, and supported transfer methods; it is not an uploaded multipart file."
+                    }
+                  },
+                  "required": [
+                    "file"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "file-list": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file extensions when this input accepts files."
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file categories when this input accepts files."
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed upload methods when this input accepts files."
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "Additional input configuration."
+                        },
+                        "default": {
+                          "description": "Default value. Its JSON type depends on the form type."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Optional input description."
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "Whether the input is hidden from the public form."
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON Schema used to validate JSON object input."
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "Display label for the input."
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Maximum input length when the input type supports a length limit."
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "List of selectable values for this form control."
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether the input is required."
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape."
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "Variable name used by the application."
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "File-list input configuration."
+                    }
+                  },
+                  "required": [
+                    "file-list"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "checkbox": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file extensions when this input accepts files."
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file categories when this input accepts files."
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed upload methods when this input accepts files."
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "Additional input configuration."
+                        },
+                        "default": {
+                          "description": "Default value. Its JSON type depends on the form type."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Optional input description."
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "Whether the input is hidden from the public form."
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON Schema used to validate JSON object input."
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "Display label for the input."
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Maximum input length when the input type supports a length limit."
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "List of selectable values for this form control."
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether the input is required."
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape."
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "Variable name used by the application."
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "Checkbox input configuration."
+                    }
+                  },
+                  "required": [
+                    "checkbox"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "json_object": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file extensions when this input accepts files."
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed file categories when this input accepts files."
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Allowed upload methods when this input accepts files."
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "Additional input configuration."
+                        },
+                        "default": {
+                          "description": "Default value. Its JSON type depends on the form type."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Optional input description."
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "Whether the input is hidden from the public form."
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON Schema used to validate JSON object input."
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "Display label for the input."
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Maximum input length when the input type supports a length limit."
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "List of selectable values for this form control."
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether the input is required."
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape."
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "Variable name used by the application."
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "JSON object input configuration."
+                    }
+                  },
+                  "required": [
+                    "json_object"
+                  ],
+                  "type": "object"
+                }
+              ],
+              "type": "object"
+            },
+            "type": "array",
+            "description": "User input form configuration."
+          }
+        },
+        "required": [
+          "annotation_reply",
+          "file_upload",
+          "more_like_this",
+          "retriever_resource",
+          "sensitive_word_avoidance",
+          "speech_to_text",
+          "suggested_questions",
+          "suggested_questions_after_answer",
+          "system_parameters",
+          "text_to_speech",
+          "user_input_form"
+        ],
+        "type": "object"
+      },
+      "RequiredServiceApiUserPayload": {
+        "properties": {
+          "user": {
+            "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "type": "object"
+      },
+      "ResultResponse": {
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "Operation result."
+          }
+        },
+        "required": [
+          "result"
         ],
         "type": "object"
       },
@@ -14552,86 +18845,200 @@
         }
       },
       "RetrieverResource": {
-        "type": "object",
-        "description": "Citation and attribution information for a retriever resource.",
         "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Content snippet from the resource."
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation timestamp (Unix epoch seconds)."
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Type of the data source."
+          },
+          "dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the knowledge base."
+          },
+          "dataset_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the knowledge base."
+          },
+          "document_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the document."
+          },
+          "document_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the document."
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Number of times this chunk was hit."
+          },
           "id": {
-            "type": "string",
             "format": "uuid",
+            "type": "string",
             "description": "Unique ID of the retriever resource."
           },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Hash of the index node."
+          },
           "message_id": {
-            "type": "string",
             "format": "uuid",
+            "type": "string",
             "description": "ID of the message this resource belongs to."
           },
           "position": {
             "type": "integer",
             "description": "Position of the resource in the list."
           },
-          "dataset_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ID of the knowledge base."
-          },
-          "dataset_name": {
-            "type": "string",
-            "description": "Name of the knowledge base."
-          },
-          "document_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ID of the document."
-          },
-          "document_name": {
-            "type": "string",
-            "description": "Name of the document."
-          },
-          "data_source_type": {
-            "type": "string",
-            "description": "Type of the data source."
-          },
-          "segment_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ID of the specific chunk within the document."
-          },
           "score": {
-            "type": "number",
-            "format": "float",
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "Similarity score of the resource."
           },
-          "hit_count": {
-            "type": "integer",
-            "description": "Number of times this chunk was hit."
-          },
-          "word_count": {
-            "type": "integer",
-            "description": "Word count of the chunk."
+          "segment_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the specific chunk within the document."
           },
           "segment_position": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "Position of the chunk within the document."
           },
-          "index_node_hash": {
-            "type": "string",
-            "description": "Hash of the index node."
-          },
-          "content": {
-            "type": "string",
-            "description": "Content snippet from the resource."
-          },
           "summary": {
-            "type": "string",
-            "nullable": true,
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "Summary of the chunk content."
           },
-          "created_at": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Creation timestamp (Unix epoch seconds)."
+          "word_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Word count of the chunk."
           }
-        }
+        },
+        "required": [
+          "position"
+        ],
+        "type": "object",
+        "description": "Citation and attribution information for a retriever resource."
       },
       "SegmentListQuery": {
         "properties": {
@@ -14669,6 +19076,171 @@
         },
         "type": "object"
       },
+      "SelectInputConfig": {
+        "properties": {
+          "option_source": {
+            "$ref": "#/components/schemas/StringListSource",
+            "description": "Source of options for `select` inputs. Present only when `type` is `select`."
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "Variable name used to reference this input's submitted value inside the workflow. Corresponds to the key in the submission `inputs` object."
+          },
+          "type": {
+            "const": "select",
+            "default": "select",
+            "type": "string",
+            "description": "Form input control type. Available values: `paragraph` (multi-line text input), `select` (single-choice from a list), `file` (single file upload), and `file-list` (multiple file uploads)."
+          }
+        },
+        "required": [
+          "option_source",
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
+      "SimpleAccountResponse": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Account email address."
+          },
+          "id": {
+            "type": "string",
+            "description": "Account ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Account display name."
+          }
+        },
+        "required": [
+          "email",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "SimpleConversation": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation time as a Unix timestamp in seconds."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Conversation ID."
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JSONValue"
+            },
+            "type": "object",
+            "description": "Input variables for the conversation."
+          },
+          "introduction": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Conversation introduction."
+          },
+          "name": {
+            "type": "string",
+            "description": "Conversation name."
+          },
+          "status": {
+            "type": "string",
+            "description": "Conversation status. `normal` for active conversations."
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Last update time as a Unix timestamp in seconds."
+          }
+        },
+        "required": [
+          "id",
+          "inputs",
+          "name",
+          "status"
+        ],
+        "type": "object"
+      },
+      "SimpleEndUser": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "End user ID."
+          },
+          "is_anonymous": {
+            "type": "boolean",
+            "description": "Whether the end user is anonymous."
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Session identifier."
+          },
+          "type": {
+            "type": "string",
+            "description": "End user type."
+          }
+        },
+        "required": [
+          "id",
+          "is_anonymous",
+          "type"
+        ],
+        "type": "object"
+      },
+      "SimpleFeedback": {
+        "properties": {
+          "rating": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Feedback rating. `like` for positive, `dislike` for negative."
+          }
+        },
+        "type": "object"
+      },
       "SimpleResultResponse": {
         "properties": {
           "result": {
@@ -14678,6 +19250,263 @@
         },
         "required": [
           "result"
+        ],
+        "type": "object"
+      },
+      "SimpleResultStringListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "List of suggested questions."
+          },
+          "result": {
+            "type": "string",
+            "description": "Result status."
+          }
+        },
+        "required": [
+          "data",
+          "result"
+        ],
+        "type": "object"
+      },
+      "Site": {
+        "properties": {
+          "chat_color_theme": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Chat color theme."
+          },
+          "chat_color_theme_inverted": {
+            "type": "boolean",
+            "description": "Whether the chat color theme is inverted."
+          },
+          "copyright": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Copyright text."
+          },
+          "custom_disclaimer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Custom disclaimer text."
+          },
+          "default_language": {
+            "type": "string",
+            "description": "Default language code."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Web app description."
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Icon content (emoji or image ID)."
+          },
+          "icon_background": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Icon background color."
+          },
+          "icon_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Type of icon used. `emoji` for emoji icons, `image` for uploaded image icons."
+          },
+          "icon_url": {
+            "anyOf": [
+              {
+                "format": "url",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "readOnly": true,
+            "description": "URL of the icon image."
+          },
+          "input_placeholder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Placeholder text shown in the web app message input box. `null` when not configured."
+          },
+          "privacy_policy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Privacy policy URL."
+          },
+          "show_workflow_steps": {
+            "type": "boolean",
+            "description": "Whether to show workflow steps."
+          },
+          "title": {
+            "type": "string",
+            "description": "Web app title."
+          },
+          "use_icon_as_answer_icon": {
+            "type": "boolean",
+            "description": "Whether to use the app icon as the answer icon."
+          }
+        },
+        "required": [
+          "chat_color_theme_inverted",
+          "default_language",
+          "icon_url",
+          "show_workflow_steps",
+          "title",
+          "use_icon_as_answer_icon"
+        ],
+        "type": "object"
+      },
+      "StringListSource": {
+        "properties": {
+          "selector": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Variable reference path when `type` is `variable`."
+          },
+          "type": {
+            "$ref": "#/components/schemas/ValueSourceType",
+            "description": "Origin of the options. `constant` means `value` lists the options literally; `variable` means `selector` points to an `array[string]` workflow variable that provides them."
+          },
+          "value": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Literal option list when `type` is `constant`."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "StringSource": {
+        "description": "Default configuration for form inputs.",
+        "properties": {
+          "selector": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Variable reference path (for example, `[\"node_id\", \"var_name\"]`) when `type` is `variable`. Must contain at least two elements."
+          },
+          "type": {
+            "$ref": "#/components/schemas/ValueSourceType",
+            "description": "Source of the default. `constant` means `value` is used as a literal string; `variable` means `selector` points to a workflow variable."
+          },
+          "value": {
+            "default": "",
+            "type": "string",
+            "description": "Literal default value when `type` is `constant`. Always a string."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "SystemParameters": {
+        "properties": {
+          "audio_file_size_limit": {
+            "type": "integer",
+            "description": "Maximum audio file size in MB."
+          },
+          "file_size_limit": {
+            "type": "integer",
+            "description": "Maximum general file size in MB."
+          },
+          "image_file_size_limit": {
+            "type": "integer",
+            "description": "Maximum image file size in MB."
+          },
+          "video_file_size_limit": {
+            "type": "integer",
+            "description": "Maximum video file size in MB."
+          },
+          "workflow_file_upload_limit": {
+            "type": "integer",
+            "description": "Maximum number of files per workflow execution."
+          }
+        },
+        "required": [
+          "audio_file_size_limit",
+          "file_size_limit",
+          "image_file_size_limit",
+          "video_file_size_limit",
+          "workflow_file_upload_limit"
         ],
         "type": "object"
       },
@@ -14733,6 +19562,265 @@
             "description": "Voice to use for text-to-speech. Available voices depend on the TTS provider configured for this app. Omit to use the app's configured voice when available; that value is exposed by [Get App Parameters](/en/api-reference/applications/get-app-parameters) as `text_to_speech.voice`."
           }
         },
+        "type": "object"
+      },
+      "TextToAudioPayloadWithUser": {
+        "properties": {
+          "message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Message ID. Takes priority over `text` when both are provided."
+          },
+          "streaming": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Reserved for compatibility; TTS response streaming is determined by the provider output."
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Speech content to convert."
+          },
+          "user": {
+            "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+            "type": "string"
+          },
+          "voice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Voice to use for text-to-speech. Available voices depend on the TTS provider configured for this app. Omit to use the app's configured voice when available; that value is exposed by [Get App Parameters](/en/api-reference/applications/get-app-parameters) as `text_to_speech.voice`."
+          }
+        },
+        "type": "object"
+      },
+      "ToolIcon": {
+        "properties": {
+          "background": {
+            "type": "string",
+            "description": "Background color in hex format."
+          },
+          "content": {
+            "type": "string",
+            "description": "Emoji content."
+          }
+        },
+        "required": [
+          "background",
+          "content"
+        ],
+        "type": "object"
+      },
+      "UserActionConfig": {
+        "description": "User action configuration.",
+        "properties": {
+          "button_style": {
+            "$ref": "#/components/schemas/ButtonStyle",
+            "default": "default",
+            "description": "Visual style of the button. Available values: `primary`, `default`, `accent`, `ghost`."
+          },
+          "id": {
+            "maxLength": 20,
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+            "type": "string",
+            "description": "Identifier of the action button. Pass as `action` on [Submit Human Input Form](/en/api-reference/human-input/submit-human-input-form) when the recipient selects this button."
+          },
+          "title": {
+            "maxLength": 100,
+            "type": "string",
+            "description": "Action button label."
+          }
+        },
+        "required": [
+          "id",
+          "title"
+        ],
+        "type": "object"
+      },
+      "ValueSourceType": {
+        "description": "ValueSourceType records whether the value comes from a static setting\nin form definition, or a variable while the workflow is running.",
+        "enum": [
+          "constant",
+          "variable"
+        ],
+        "type": "string"
+      },
+      "WorkflowAppLogPaginationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WorkflowAppLogPartialResponse"
+            },
+            "type": "array",
+            "description": "Workflow log records on the current page."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether more workflow log records are available."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Number of items per page."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number."
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of matching workflow log records."
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "WorkflowAppLogPartialResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation time as a Unix timestamp in seconds."
+          },
+          "created_by_account": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleAccountResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Account details if created by an admin user."
+          },
+          "created_by_end_user": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleEndUser"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "End user that created the workflow run."
+          },
+          "created_by_role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Role of the creator (e.g., `end_user`, `account`)."
+          },
+          "created_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Source of the workflow run (e.g., `service-api`)."
+          },
+          "details": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Additional details for the log entry."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Log entry ID."
+          },
+          "workflow_run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowRunForLogResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Workflow run details for this log entry."
+          }
+        },
+        "required": [
+          "id"
+        ],
         "type": "object"
       },
       "WorkflowBlockingResponse": {
@@ -15248,6 +20336,145 @@
         "type": "object",
         "description": "Blocking response returned when a workflow execution is waiting for human input."
       },
+      "WorkflowRunForLogResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation time as a Unix timestamp in seconds."
+          },
+          "elapsed_time": {
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total time elapsed in seconds."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Error message if the workflow failed."
+          },
+          "exceptions_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Number of exceptions that occurred during execution."
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Finish time as a Unix timestamp in seconds; `null` if not finished."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Workflow run ID."
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Workflow execution status. `running` for in-progress executions, `succeeded` when completed successfully, `failed` when execution encountered an error, `stopped` when manually halted, `partial-succeeded` when some nodes succeeded but others failed, `paused` when awaiting human input."
+          },
+          "total_steps": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total number of workflow steps executed."
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total tokens consumed."
+          },
+          "triggered_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Source that triggered the workflow run. `app-run` for runs started from the app or API, `webhook` for runs started by a webhook trigger, `schedule` for runs started by a schedule trigger, `plugin` for runs started by an integration trigger."
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Workflow version identifier."
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
       "WorkflowRunPayload": {
         "properties": {
           "files": {
@@ -15459,6 +20686,361 @@
         },
         "required": [
           "inputs"
+        ],
+        "type": "object"
+      },
+      "WorkflowRunPayloadWithUser": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method: `remote_url` for a file URL or persisted uploaded-file reference, `local_file` for an uploaded file.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method: `remote_url` for a file URL or persisted uploaded-file reference, `local_file` for an uploaded file.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method: `remote_url` for a file URL or persisted uploaded-file reference, `local_file` for an uploaded file.",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "Legacy alias of `url` when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "Transfer method: `remote_url` for a file URL or persisted uploaded-file reference, `local_file` for an uploaded file.",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "File type.",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "File URL when `transfer_method` is `remote_url`.",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "File list for workflow system file inputs. Available when file upload is enabled for the workflow. To attach a local file, first upload it via [Upload File](/en/api-reference/files/upload-file) and use the returned `id` as `upload_file_id` with `transfer_method: local_file`."
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "Key-value pairs for workflow input variables. Values for file-type variables should be arrays of file objects with `type`, `transfer_method`, and either `url` or `upload_file_id`. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover the variable names and types expected by your app.",
+            "type": "object"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Response mode. Use `blocking` for synchronous responses or `streaming` for Server-Sent Events. When omitted, the request runs in blocking mode."
+          },
+          "user": {
+            "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputs",
+          "user"
+        ],
+        "type": "object"
+      },
+      "WorkflowRunResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation time as a Unix timestamp in seconds."
+          },
+          "elapsed_time": {
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total time elapsed in seconds."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Error message if the workflow failed."
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Finish time as a Unix timestamp in seconds; `null` if not finished."
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Workflow run ID."
+          },
+          "inputs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Inputs supplied to the workflow run. The JSON value can be an object, array, primitive, or `null`; it is already decoded according to the response schema and does not require an additional JSON parse."
+          },
+          "outputs": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "Output data from the workflow. An empty object until outputs are available."
+          },
+          "status": {
+            "type": "string",
+            "description": "Workflow execution status. `running` for in-progress executions, `succeeded` when completed successfully, `failed` when execution encountered an error, `stopped` when manually halted, `partial-succeeded` when some nodes succeeded but others failed, `paused` when awaiting human input."
+          },
+          "total_steps": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total number of workflow steps executed."
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total tokens consumed."
+          },
+          "workflow_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "Workflow definition ID used for this run."
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "workflow_id"
         ],
         "type": "object"
       },

--- a/ja/api-reference/openapi_service.json
+++ b/ja/api-reference/openapi_service.json
@@ -13223,6 +13223,280 @@
       }
     },
     "schemas": {
+      "AgentThought": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "この思考に関連するツールまたはモデルの回答。"
+          },
+          "chain_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "この思考のチェーン ID です。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成時刻（Unix 秒タイムスタンプ）。"
+          },
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "この思考に関連するファイル ID です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "エージェント思考 ID です。"
+          },
+          "message_id": {
+            "type": "string",
+            "description": "この思考が属する一意のメッセージ ID です。"
+          },
+          "observation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ツール呼び出しからのレスポンスです。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "この思考の位置です。"
+          },
+          "thought": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM が思考している内容です。"
+          },
+          "tool": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "呼び出されたツール（`;` で区切り）です。"
+          },
+          "tool_input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ツールの入力（JSON 形式）です。"
+          },
+          "tool_labels": {
+            "$ref": "#/components/schemas/JSONValue",
+            "description": "使用されたツールのラベルです。"
+          }
+        },
+        "required": [
+          "files",
+          "id",
+          "message_id",
+          "position",
+          "tool_labels"
+        ],
+        "type": "object"
+      },
+      "Annotation": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "アノテーションがマッチした際に返される定義済みの回答です。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成タイムスタンプ（Unix エポック秒）。"
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このアノテーションがマッチして返信として返された回数です。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "アノテーションの一意識別子です。"
+          },
+          "question": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このアノテーションをトリガーする質問テキストです。"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "AnnotationCreatePayload": {
+        "properties": {
+          "answer": {
+            "description": "アノテーションの回答。",
+            "type": "string"
+          },
+          "question": {
+            "description": "アノテーションの質問。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "answer",
+          "question"
+        ],
+        "type": "object"
+      },
+      "AnnotationJobStatusDetailResponse": {
+        "properties": {
+          "error_msg": {
+            "default": "",
+            "type": "string",
+            "description": "ジョブが失敗した理由を説明するエラーメッセージです。`job_status` が `error` でない場合は空文字列です。"
+          },
+          "job_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "[アノテーション返信を設定](/ja/api-reference/annotations/configure-annotation-reply) 呼び出しから取得したジョブ ID です。"
+          },
+          "job_status": {
+            "type": "string",
+            "description": "現在のジョブステータスです。`waiting` はキュー待ち、`processing` は処理中、`completed` は完了、`error` は失敗を示します。"
+          }
+        },
+        "required": [
+          "job_id",
+          "job_status"
+        ],
+        "type": "object"
+      },
+      "AnnotationJobStatusResponse": {
+        "properties": {
+          "job_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "非同期ジョブ ID です。[アノテーション返信の初期設定タスクステータスを取得](/ja/api-reference/annotations/get-annotation-reply-job-status) と組み合わせて進捗を追跡します。"
+          },
+          "job_status": {
+            "type": "string",
+            "description": "現在のジョブステータスです。このエンドポイントが返すのは `waiting`（キュー待ち）または `processing`（処理中）のみです。`completed` と `error` は [アノテーション返信の初期設定タスクステータスを取得](/ja/api-reference/annotations/get-annotation-reply-job-status) からのみ返されます。"
+          }
+        },
+        "required": [
+          "job_id",
+          "job_status"
+        ],
+        "type": "object"
+      },
+      "AnnotationList": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            },
+            "type": "array",
+            "description": "現在のページのアノテーション一覧。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "さらにアノテーションがあるかどうか。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "1 ページあたりの件数です。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "現在のページ番号です。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "一致するアノテーションの総数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
       "AnnotationListQuery": {
         "properties": {
           "keyword": {
@@ -13245,63 +13519,1014 @@
         },
         "type": "object"
       },
-      "AppInfoResponse": {
-        "type": "object",
+      "AnnotationReplyActionPayload": {
         "properties": {
+          "embedding_model_name": {
+            "description": "[利用可能なモデルを取得](/ja/api-reference/models/get-available-models) に `model_type=text-embedding` を指定したレスポンスの `model` フィールドを使用します（例：`text-embedding-3-small`）。",
+            "type": "string"
+          },
+          "embedding_provider_name": {
+            "description": "[利用可能なモデルを取得](/ja/api-reference/models/get-available-models) に `model_type=text-embedding` を指定したレスポンスの `provider` フィールドを使用します（例：`openai`）。表示名は使用しないでください。",
+            "type": "string"
+          },
+          "score_threshold": {
+            "description": "アノテーション一致とみなす最小類似度スコア（0〜1）。値が高いほど厳密な一致が必要です。",
+            "format": "float",
+            "type": "number"
+          }
+        },
+        "required": [
+          "embedding_model_name",
+          "embedding_provider_name",
+          "score_threshold"
+        ],
+        "type": "object"
+      },
+      "AppFeedbackListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AppFeedbackResponse"
+            },
+            "type": "array",
+            "description": "現在のページのフィードバックレコード。"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "AppFeedbackResponse": {
+        "properties": {
+          "app_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "アプリケーション ID。"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "任意のテキストフィードバック。"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会話 ID。"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "作成時刻（RFC 3339 日時文字列）。"
+          },
+          "from_account_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "フィードバックを送信したアカウント ID。`from_source` が `admin` の場合に存在します。"
+          },
+          "from_end_user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "フィードバックを送信したエンドユーザー ID。`from_source` が `user` の場合に存在します。"
+          },
+          "from_source": {
+            "type": "string",
+            "description": "フィードバックのソース。API 経由でエンドユーザーが送信したフィードバックの場合は `user`、コンソールから送信されたフィードバックの場合は `admin`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "フィードバック ID。"
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "メッセージ ID。"
+          },
+          "rating": {
+            "type": "string",
+            "description": "フィードバック評価。肯定的な場合は `like`、否定的な場合は `dislike`。"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "最終更新時刻（RFC 3339 日時文字列）。"
+          }
+        },
+        "required": [
+          "app_id",
+          "conversation_id",
+          "created_at",
+          "from_source",
+          "id",
+          "message_id",
+          "rating",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "AppInfoResponse": {
+        "properties": {
+          "author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "アプリケーション作成者の名前。"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "アプリケーションの説明。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "アプリケーションモード。`completion` はテキストジェネレーター、`chat` は基本チャットボット、`agent-chat` は旧 Agent アプリ、`advanced-chat` は Chatflow（会話型ワークフロー）、`workflow` は非会話型 Workflow アプリ、`agent` は新しい Agent アプリです。各操作の説明に対応モードを記載しています。"
+          },
           "name": {
             "type": "string",
             "description": "アプリケーション名。"
           },
-          "description": {
-            "type": "string",
-            "description": "アプリケーションの説明。"
-          },
           "tags": {
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "type": "array",
             "description": "アプリケーションタグ。"
-          },
-          "mode": {
-            "type": "string",
-            "description": "アプリケーションモード。`completion` はテキスト生成アプリ、`chat` は基本チャットアプリ、`agent-chat` はエージェントベースのアプリ、`advanced-chat` は Chatflow アプリ、`workflow` は Workflow アプリです、`agent` は新しい Agent アプリです。"
-          },
-          "author_name": {
-            "type": "string",
-            "description": "アプリケーション作成者の名前。"
           }
-        }
+        },
+        "required": [
+          "author_name",
+          "description",
+          "mode",
+          "name",
+          "tags"
+        ],
+        "type": "object"
       },
       "AppMetaResponse": {
-        "type": "object",
         "properties": {
           "tool_icons": {
-            "type": "object",
             "additionalProperties": {
-              "oneOf": [
+              "anyOf": [
                 {
-                  "title": "Icon URL",
-                  "type": "string",
                   "format": "url",
+                  "type": "string",
                   "description": "アイコンの URL。"
                 },
                 {
-                  "$ref": "#/components/schemas/ToolIconDetail"
+                  "$ref": "#/components/schemas/ToolIcon"
                 }
               ]
             },
+            "type": "object",
             "description": "ツールアイコン。キーはツール名です。"
           }
-        }
+        },
+        "type": "object"
       },
       "AudioBinaryResponse": {
         "format": "binary",
         "type": "string"
       },
+      "AudioTranscriptResponse": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "音声認識からの出力テキスト。"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
       "BinaryFileResponse": {
         "format": "binary",
         "type": "string"
+      },
+      "BlockingMetadataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "retriever_resources": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/BlockingRetrieverResourceResponse"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "使用された検索リソースのリスト。"
+          },
+          "usage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BlockingUsageResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "モデルの使用情報です。"
+          }
+        },
+        "type": "object",
+        "description": "使用量と検索リソースを含むメタデータ。"
+      },
+      "BlockingRetrieverResourceResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "リソースからのコンテンツスニペット。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成タイムスタンプ（Unix エポック秒）。"
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "データソースのタイプ。"
+          },
+          "dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ナレッジベース ID。"
+          },
+          "dataset_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ナレッジベース名。"
+          },
+          "document_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント ID。"
+          },
+          "document_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント名。"
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このチャンクがヒットした回数。"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "検索リソースの一意の ID。"
+          },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "インデックスノードのハッシュ。"
+          },
+          "message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このリソースが属するメッセージの ID。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "リスト内のリソースの位置。"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "リソースの関連性スコア。"
+          },
+          "segment_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント内の特定のチャンクの ID。"
+          },
+          "segment_position": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント内のチャンクの位置。"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンクコンテンツの要約。"
+          },
+          "word_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンクの単語数。"
+          }
+        },
+        "required": [
+          "position"
+        ],
+        "type": "object"
+      },
+      "BlockingUsageResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "completion_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "補完トークンの合計価格。"
+          },
+          "completion_price_unit": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "補完トークンの価格単位。"
+          },
+          "completion_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "補完のトークン数。"
+          },
+          "completion_unit_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "補完トークンあたりの単価。"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "課金通貨。"
+          },
+          "latency": {
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "レイテンシ（秒）。"
+          },
+          "prompt_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "プロンプトトークンの合計価格。"
+          },
+          "prompt_price_unit": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "プロンプトトークンの価格単位。"
+          },
+          "prompt_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "プロンプト内のトークン数。"
+          },
+          "prompt_unit_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "プロンプトトークンあたりの単価。"
+          },
+          "total_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "すべてのトークンの合計価格。"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "使用されたトークンの合計数。"
+          }
+        },
+        "type": "object"
+      },
+      "ButtonStyle": {
+        "description": "ユーザーアクションのボタンスタイル。",
+        "enum": [
+          "accent",
+          "default",
+          "ghost",
+          "primary"
+        ],
+        "type": "string"
+      },
+      "ChatBlockingResponse": {
+        "discriminator": {
+          "mapping": {
+            "message": "#/components/schemas/ChatMessageBlockingResponse",
+            "workflow_paused": "#/components/schemas/ChatPausedBlockingResponse"
+          },
+          "propertyName": "event"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatMessageBlockingResponse"
+          },
+          {
+            "$ref": "#/components/schemas/ChatPausedBlockingResponse"
+          }
+        ]
+      },
+      "ChatMessageBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "完全なレスポンスコンテンツ。"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会話 ID。"
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "メッセージ作成タイムスタンプ（Unix エポック秒）。"
+          },
+          "event": {
+            "const": "message",
+            "type": "string",
+            "description": "イベントタイプ。`message` に固定されています。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "このレスポンスイベントの一意 ID です。"
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "一意のメッセージ ID です。フィードバックや推奨質問のエンドポイントを呼び出す際に `message_id` パラメータとして使用します。"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "使用量と検索リソースを含むメタデータ。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "アプリモード。`chat` はチャットボットアプリ、`agent-chat` は Agent アプリ、`advanced-chat` は Chatflow アプリです。"
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "リクエスト追跡およびレスポンス停止 API 用のタスク ID です。"
+          }
+        },
+        "required": [
+          "answer",
+          "conversation_id",
+          "created_at",
+          "event",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "task_id"
+        ],
+        "type": "object",
+        "description": "イベントタイプ。`message` に固定されています。"
+      },
+      "ChatPauseReasonResponse": {
+        "additionalProperties": true,
+        "description": "ブロッキング Chatflow 実行が一時停止した理由の公開情報です。",
+        "properties": {
+          "TYPE": {
+            "type": "string",
+            "description": "一時停止理由のタイプです。"
+          },
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "人間の入力フォームで利用できるアクションです。"
+          },
+          "approval_channels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "設定された承認チャネルです。"
+          },
+          "display_in_ui": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "一時停止理由を UI に表示するかどうかを示します。"
+          },
+          "expiration_time": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人間の入力フォームの有効期限を示す Unix タイムスタンプです。"
+          },
+          "form_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人間の入力フォームに表示する内容です。"
+          },
+          "form_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人間の入力フォーム ID です。"
+          },
+          "form_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人間の入力フォーム API で使用するアクセストークンです。"
+          },
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "人間の入力フォームの入力フィールドです。"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフローが一時停止した理由を説明するメッセージです。"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "一時停止したワークフローノード ID です。"
+          },
+          "node_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "一時停止したワークフローノードのタイトルです。"
+          },
+          "resolved_default_values": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "フォーム入力で解決されたデフォルト値です。"
+          }
+        },
+        "required": [
+          "TYPE"
+        ],
+        "type": "object"
+      },
+      "ChatPausedBlockingDataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "完全なレスポンスコンテンツ。"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会話 ID。"
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "メッセージ作成タイムスタンプ（Unix エポック秒）。"
+          },
+          "elapsed_time": {
+            "format": "float",
+            "type": "number",
+            "description": "合計実行時間（秒）です。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "このレスポンスイベントの一意 ID です。"
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "一意のメッセージ ID です。フィードバックや推奨質問のエンドポイントを呼び出す際に `message_id` パラメータとして使用します。"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "使用量と検索リソースを含むメタデータ。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "アプリモード。`chat` はチャットボットアプリ、`agent-chat` は Agent アプリ、`advanced-chat` は Chatflow アプリです。"
+          },
+          "paused_nodes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "入力待ちのワークフローノード ID です。"
+          },
+          "reasons": {
+            "items": {
+              "$ref": "#/components/schemas/ChatPauseReasonResponse"
+            },
+            "type": "array",
+            "description": "人間の入力フォームの詳細を含む、ワークフローの一時停止理由です。"
+          },
+          "status": {
+            "const": "paused",
+            "type": "string",
+            "description": "ワークフロー実行ステータスは `paused` 固定です。"
+          },
+          "total_steps": {
+            "type": "integer",
+            "description": "実行されたワークフローステップの合計数です。"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "すべてのノードで消費された Token の合計数です。"
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "一時停止したワークフロー実行の永続 ID です。"
+          }
+        },
+        "required": [
+          "answer",
+          "conversation_id",
+          "created_at",
+          "elapsed_time",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "paused_nodes",
+          "reasons",
+          "status",
+          "total_steps",
+          "total_tokens",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "Chatflow ワークフロー実行の一時停止詳細です。"
+      },
+      "ChatPausedBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "完全なレスポンスコンテンツ。"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会話 ID。"
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "メッセージ作成タイムスタンプ（Unix エポック秒）。"
+          },
+          "data": {
+            "$ref": "#/components/schemas/ChatPausedBlockingDataResponse",
+            "description": "Chatflow ワークフロー実行の一時停止詳細です。"
+          },
+          "event": {
+            "const": "workflow_paused",
+            "type": "string",
+            "description": "Chatflow が人間の入力を待機している場合、イベントタイプは `workflow_paused` 固定です。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "このレスポンスイベントの一意 ID です。"
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "一意のメッセージ ID です。フィードバックや推奨質問のエンドポイントを呼び出す際に `message_id` パラメータとして使用します。"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "使用量と検索リソースを含むメタデータ。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "アプリモード。`chat` はチャットボットアプリ、`agent-chat` は Agent アプリ、`advanced-chat` は Chatflow アプリです。"
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "リクエスト追跡およびレスポンス停止 API 用のタスク ID です。"
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "一時停止したワークフロー実行の永続 ID です。"
+          }
+        },
+        "required": [
+          "answer",
+          "conversation_id",
+          "created_at",
+          "data",
+          "event",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "task_id",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "Chatflow が人間の入力を待機している場合に返されるブロッキングレスポンスです。"
       },
       "ChatRequestPayload": {
         "properties": {
@@ -13551,6 +14776,259 @@
         ],
         "type": "object"
       },
+      "ChatRequestPayloadWithUser": {
+        "properties": {
+          "auto_generate_name": {
+            "default": true,
+            "description": "会話タイトルを自動生成するかどうか。`false` の場合は、会話名変更 API で `auto_generate: true` を指定してタイトルを非同期生成できます。",
+            "type": "boolean"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "会話を継続するための会話 ID。このフィールドを省略するか空文字列を渡すと新しい会話が開始されます。以降のリクエストでは返された `conversation_id` を渡します。"
+          },
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "マルチモーダル入力に使用するファイルです。新しいクライアントは 2 つの標準形式だけを実装してください。公開ファイル URL には `transfer_method: remote_url` と `url` を使用します。ローカルファイルは[ファイルをアップロード](/ja/api-reference/files/upload-file)でアップロードし、`transfer_method: local_file` と、返された `id` を指定する `upload_file_id` を使用します。生成されたその他の `anyOf` の組み合わせは、保存済みの旧形式参照との後方互換性のためだけに存在します。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "アプリ定義変数の値です。想定される変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。",
+            "type": "object"
+          },
+          "query": {
+            "description": "ユーザー入力または質問の内容。",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "レスポンスモード。`streaming` は Server-Sent Events（SSE）を使用し、`blocking` は完了後に返します。新しい Agent アプリモードはストリーミングのみをサポートします。省略すると、Agent 以外はブロッキング、新しい Agent はストリーミングで実行されます。"
+          },
+          "user": {
+            "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+            "type": "string"
+          },
+          "workflow_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "高度なチャットで実行する公開済みワークフローバージョン ID。省略すると、アプリの現在の公開済みワークフローを使用します。"
+          }
+        },
+        "required": [
+          "inputs",
+          "query",
+          "user"
+        ],
+        "type": "object"
+      },
       "ChildChunkListQuery": {
         "properties": {
           "keyword": {
@@ -13578,6 +15056,58 @@
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "CompletionBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "完全なレスポンスコンテンツ。"
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "メッセージ作成タイムスタンプ（Unix エポック秒）。"
+          },
+          "event": {
+            "type": "string",
+            "description": "イベントタイプ。`message` に固定されています。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "このレスポンスイベントの一意 ID です。"
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "一意のメッセージ ID。フィードバック送信時に `message_id` として使用します。テキストジェネレーターでは質問候補の生成を利用できません。"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "使用量と検索リソースを含むメタデータ。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "アプリモード、`completion` 固定です。"
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "リクエスト追跡および [生成を停止](/ja/api-reference/completion-messages/stop-completion-message-generation) API 用のタスク ID です。"
+          }
+        },
+        "required": [
+          "answer",
+          "created_at",
+          "event",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "task_id"
+        ],
         "type": "object"
       },
       "CompletionRequestPayload": {
@@ -13799,6 +15329,255 @@
         ],
         "type": "object"
       },
+      "CompletionRequestPayloadWithUser": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "マルチモーダル入力に使用するファイルです。新しいクライアントは 2 つの標準形式だけを実装してください。公開ファイル URL には `transfer_method: remote_url` と `url` を使用します。ローカルファイルは[ファイルをアップロード](/ja/api-reference/files/upload-file)でアップロードし、`transfer_method: local_file` と、返された `id` を指定する `upload_file_id` を使用します。生成されたその他の `anyOf` の組み合わせは、保存済みの旧形式参照との後方互換性のためだけに存在します。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "アプリ定義変数の値です。想定される変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。",
+            "type": "object"
+          },
+          "query": {
+            "default": "",
+            "description": "ユーザー入力またはプロンプトの内容。",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "レスポンスモード。`streaming` は Server-Sent Events（SSE）を使用し、`blocking` は完了後に返します。省略するとブロッキングモードで実行されます。"
+          },
+          "user": {
+            "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputs",
+          "user"
+        ],
+        "type": "object"
+      },
+      "ConversationInfiniteScrollPagination": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SimpleConversation"
+            },
+            "type": "array",
+            "description": "このページの会話一覧。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "さらに古い会話があるかどうか。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "1 ページあたりの件数です。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit"
+        ],
+        "type": "object"
+      },
       "ConversationListQuery": {
         "properties": {
           "last_id": {
@@ -13906,8 +15685,205 @@
         },
         "type": "object"
       },
+      "ConversationRenamePayloadWithUser": {
+        "anyOf": [
+          {
+            "properties": {
+              "auto_generate": {
+                "description": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。",
+                "enum": [
+                  true
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "会話名。`auto_generate` が `false` の場合は必須です。"
+              },
+              "user": {
+                "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+                "type": "string"
+              }
+            },
+            "required": [
+              "auto_generate"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "auto_generate": {
+                "default": false,
+                "description": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。",
+                "enum": [
+                  false
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "pattern": ".*\\S.*",
+                "type": "string",
+                "description": "新しい会話名です。`auto_generate` が `true` でない限り必須です。"
+              },
+              "user": {
+                "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "auto_generate": {
+            "default": false,
+            "description": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。",
+            "type": "boolean"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "会話名。`auto_generate` が `false` の場合は必須です。"
+          },
+          "user": {
+            "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ConversationVariableInfiniteScrollPaginationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationVariableResponse"
+            },
+            "type": "array",
+            "description": "このページの会話変数一覧。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "さらに会話変数があるかどうか。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "1 ページあたりの件数です。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit"
+        ],
+        "type": "object"
+      },
+      "ConversationVariableResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成時刻（Unix 秒タイムスタンプ）。"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "変数の説明です。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "変数 ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "変数名です。"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "最終更新時刻（Unix 秒タイムスタンプ）。"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "変数値（複雑な型の場合は JSON 文字列）。"
+          },
+          "value_type": {
+            "type": "string",
+            "description": "変数の値の型です。指定可能な値：`string`、`number`、`object`、`secret`、`file`、`boolean`、`array[any]`、`array[string]`、`array[number]`、`array[object]`、`array[file]`、`array[boolean]`。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "value_type"
+        ],
+        "type": "object"
+      },
       "ConversationVariableUpdatePayload": {
         "properties": {
+          "value": {
+            "description": "変数の新しい値。変数の期待される型と一致する必要があります。"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "ConversationVariableUpdatePayloadWithUser": {
+        "properties": {
+          "user": {
+            "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+            "type": "string"
+          },
           "value": {
             "description": "変数の新しい値。変数の期待される型と一致する必要があります。"
           }
@@ -14068,59 +16044,95 @@
         "type": "object"
       },
       "EndUserDetail": {
-        "type": "object",
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "エンドユーザー ID。"
-          },
-          "tenant_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "テナント ID。"
-          },
           "app_id": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true,
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "アプリケーション ID。"
           },
-          "type": {
+          "created_at": {
+            "format": "date-time",
             "type": "string",
-            "description": "エンドユーザーのタイプ。Service API ユーザーの場合は常に `service-api` です。"
+            "description": "作成タイムスタンプ。"
           },
           "external_user_id": {
-            "type": "string",
-            "nullable": true,
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "API リクエストで提供された `user` 識別子です（例：[チャットメッセージを送信](/ja/api-reference/chat-messages/send-chat-message) の `user` フィールド）。"
           },
-          "name": {
+          "id": {
+            "format": "uuid",
             "type": "string",
-            "nullable": true,
-            "description": "エンドユーザー名。"
+            "description": "エンドユーザー ID。"
           },
           "is_anonymous": {
             "type": "boolean",
             "description": "ユーザーが匿名かどうかを示します。元の API リクエストで `user` 識別子が提供されなかった場合、`true` になります。"
           },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "エンドユーザー名。"
+          },
           "session_id": {
             "type": "string",
             "description": "セッション識別子。デフォルトは `external_user_id` の値です。"
           },
-          "created_at": {
+          "tenant_id": {
+            "format": "uuid",
             "type": "string",
-            "format": "date-time",
-            "description": "作成タイムスタンプ。"
+            "description": "テナント ID。"
+          },
+          "type": {
+            "type": "string",
+            "description": "エンドユーザーのタイプ。Service API ユーザーの場合は常に `service-api` です。"
           },
           "updated_at": {
-            "type": "string",
             "format": "date-time",
+            "type": "string",
             "description": "最終更新タイムスタンプ。"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "id",
+          "is_anonymous",
+          "session_id",
+          "tenant_id",
+          "type",
+          "updated_at"
+        ],
+        "type": "object"
       },
       "EventStreamResponse": {
+        "type": "string"
+      },
+      "ExecutionContentType": {
+        "enum": [
+          "human_input"
+        ],
         "type": "string"
       },
       "FeedbackListQuery": {
@@ -14141,6 +16153,90 @@
         },
         "type": "object"
       },
+      "FileInputConfig": {
+        "properties": {
+          "allowed_file_extensions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "`allowed_file_types` に `custom` が含まれる場合に許可されるファイル拡張子。各拡張子には先頭の `.` を含めてください。たとえば `.md` です。`file` および `file-list` 入力に含まれます。"
+          },
+          "allowed_file_types": {
+            "items": {
+              "$ref": "#/components/schemas/FileType"
+            },
+            "type": "array",
+            "description": "受信者がアップロード可能なファイルカテゴリ。 `file` および `file-list` 入力に含まれます。値： `image`、 `document`、 `audio`、 `video`、 `custom`。"
+          },
+          "allowed_file_upload_methods": {
+            "items": {
+              "$ref": "#/components/schemas/FileTransferMethod"
+            },
+            "type": "array",
+            "description": "受信者が使用できるアップロード方法。値： `local_file`、 `remote_url`。 `file` および `file-list` 入力に含まれます。"
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "ワークフロー内でこの入力の送信値を参照する際の変数名。送信リクエストの `inputs` オブジェクトのキーに対応します。"
+          },
+          "type": {
+            "const": "file",
+            "default": "file",
+            "type": "string",
+            "description": "フォーム入力コントロールの種類。利用可能な値： `paragraph` （複数行テキスト入力）、 `select` （リストからの単一選択）、 `file` （単一ファイルアップロード）、 `file-list` （複数ファイルアップロード）。"
+          }
+        },
+        "required": [
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
+      "FileListInputConfig": {
+        "properties": {
+          "allowed_file_extensions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "`allowed_file_types` に `custom` が含まれる場合に許可されるファイル拡張子。各拡張子には先頭の `.` を含めてください。たとえば `.md` です。`file` および `file-list` 入力に含まれます。"
+          },
+          "allowed_file_types": {
+            "items": {
+              "$ref": "#/components/schemas/FileType"
+            },
+            "type": "array",
+            "description": "受信者がアップロード可能なファイルカテゴリ。 `file` および `file-list` 入力に含まれます。値： `image`、 `document`、 `audio`、 `video`、 `custom`。"
+          },
+          "allowed_file_upload_methods": {
+            "items": {
+              "$ref": "#/components/schemas/FileTransferMethod"
+            },
+            "type": "array",
+            "description": "受信者が使用できるアップロード方法。値： `local_file`、 `remote_url`。 `file` および `file-list` 入力に含まれます。"
+          },
+          "number_limits": {
+            "default": 0,
+            "minimum": 0,
+            "type": "integer",
+            "description": "受信者がアップロードできるファイルの最大数。 `file-list` 入力のみに含まれます。"
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "ワークフロー内でこの入力の送信値を参照する際の変数名。送信リクエストの `inputs` オブジェクトのキーに対応します。"
+          },
+          "type": {
+            "const": "file-list",
+            "default": "file-list",
+            "type": "string",
+            "description": "フォーム入力コントロールの種類。利用可能な値： `paragraph` （複数行テキスト入力）、 `select` （リストからの単一選択）、 `file` （単一ファイルアップロード）、 `file-list` （複数ファイルアップロード）。"
+          }
+        },
+        "required": [
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
       "FilePreviewQuery": {
         "properties": {
           "as_attachment": {
@@ -14151,41 +16247,313 @@
         },
         "type": "object"
       },
-      "HumanInputContent": {
-        "type": "object",
-        "description": "人間の入力ノードからの実行コンテンツです。フォーム定義と送信データを含みます。",
+      "FileResponse": {
         "properties": {
-          "workflow_run_id": {
+          "conversation_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "関連付けられた会話の ID。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "アップロードタイムスタンプ（Unix エポック秒）。"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "アップロードしたエンドユーザーの ID。[エンドユーザー取得](/ja/api-reference/end-users/get-end-user-info) で詳細を確認できます。"
+          },
+          "extension": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ファイル拡張子。"
+          },
+          "file_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "未使用です。常に `null` になります。"
+          },
+          "id": {
+            "format": "uuid",
             "type": "string",
-            "description": "このコンテンツが属するワークフロー実行の ID です。"
+            "description": "一意のファイル ID。"
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ファイルの MIME タイプ。"
+          },
+          "name": {
+            "type": "string",
+            "description": "ファイル名。"
+          },
+          "original_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ファイルの元の URL。"
+          },
+          "preview_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ファイルのプレビュー URL。"
+          },
+          "reference": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Agent やツールのコンテキストでファイルを添付する際に内部的に使用される不透明なファイル参照です。このエンドポイントでアップロードされたファイルでは常に `null` です。"
+          },
+          "size": {
+            "type": "integer",
+            "description": "ファイルサイズ（バイト）。"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ファイルの署名付きダウンロード URL です。"
+          },
+          "tenant_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "関連付けられたテナントの ID。"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "未使用です。常に `null` になります。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "size"
+        ],
+        "type": "object"
+      },
+      "FileTransferMethod": {
+        "enum": [
+          "datasource_file",
+          "local_file",
+          "remote_url",
+          "tool_file"
+        ],
+        "type": "string"
+      },
+      "FileType": {
+        "enum": [
+          "audio",
+          "custom",
+          "document",
+          "image",
+          "video"
+        ],
+        "type": "string"
+      },
+      "FormInputConfig": {
+        "discriminator": {
+          "mapping": {
+            "file": "#/components/schemas/FileInputConfig",
+            "file-list": "#/components/schemas/FileListInputConfig",
+            "paragraph": "#/components/schemas/ParagraphInputConfig",
+            "select": "#/components/schemas/SelectInputConfig"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ParagraphInputConfig"
+          },
+          {
+            "$ref": "#/components/schemas/SelectInputConfig"
+          },
+          {
+            "$ref": "#/components/schemas/FileInputConfig"
+          },
+          {
+            "$ref": "#/components/schemas/FileListInputConfig"
+          }
+        ]
+      },
+      "HumanInputContent": {
+        "properties": {
+          "form_definition": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HumanInputFormDefinition"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人間の入力ノードからのフォーム定義です。コンテンツが送信レスポンスを表す場合は `null` です。"
+          },
+          "form_submission_data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HumanInputFormSubmissionData"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "送信されたフォームデータです。フォームがまだ送信されていない場合は `null` です。"
           },
           "submitted": {
             "type": "boolean",
             "description": "人間の入力フォームが送信されたかどうかです。"
           },
           "type": {
-            "type": "string",
+            "$ref": "#/components/schemas/ExecutionContentType",
+            "default": "human_input",
             "description": "`human_input` は人間の入力コンテンツを示します。"
           },
-          "form_definition": {
-            "nullable": true,
-            "description": "人間の入力ノードからのフォーム定義です。コンテンツが送信レスポンスを表す場合は `null` です。",
-            "$ref": "#/components/schemas/HumanInputFormDefinition"
-          },
-          "form_submission_data": {
-            "nullable": true,
-            "description": "送信されたフォームデータです。フォームがまだ送信されていない場合は `null` です。",
-            "$ref": "#/components/schemas/HumanInputFormSubmissionData"
+          "workflow_run_id": {
+            "type": "string",
+            "description": "このコンテンツが属するワークフロー実行の ID です。"
           }
-        }
+        },
+        "required": [
+          "submitted",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "人間の入力ノードからの実行コンテンツです。フォーム定義と送信データを含みます。"
       },
       "HumanInputFormDefinition": {
-        "type": "object",
-        "description": "人間の入力ノードによってレンダリングされる人間の入力フォームの定義です。",
         "properties": {
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/UserActionConfig"
+            },
+            "type": "array",
+            "description": "フォームで利用可能なアクションボタンです。"
+          },
+          "display_in_ui": {
+            "default": false,
+            "type": "boolean",
+            "description": "フォームを UI に表示するかどうかです。"
+          },
+          "expiration_time": {
+            "type": "integer",
+            "description": "フォームが期限切れになる Unix タイムスタンプです。"
+          },
+          "form_content": {
+            "type": "string",
+            "description": "フォームと共に表示される Markdown またはテキストコンテンツです。"
+          },
           "form_id": {
             "type": "string",
             "description": "フォームの一意識別子です。"
+          },
+          "form_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "フォーム送信認証用のトークンです。"
+          },
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/FormInputConfig"
+            },
+            "type": "array",
+            "description": "フォーム内の入力フィールドです。"
           },
           "node_id": {
             "type": "string",
@@ -14195,48 +16563,81 @@
             "type": "string",
             "description": "人間の入力ノードのタイトルです。"
           },
+          "resolved_default_values": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "出力変数名をキーとする、フォーム入力の解決済みデフォルト値です。"
+          }
+        },
+        "required": [
+          "expiration_time",
+          "form_content",
+          "form_id",
+          "node_id",
+          "node_title"
+        ],
+        "type": "object",
+        "description": "人間の入力ノードによってレンダリングされる人間の入力フォームの定義です。"
+      },
+      "HumanInputFormDefinitionResponse": {
+        "properties": {
+          "expiration_time": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unix タイムスタンプ（秒）。この時刻以降、フォームは送信できなくなります。"
+          },
           "form_content": {
             "type": "string",
-            "description": "フォームと共に表示される Markdown またはテキストコンテンツです。"
+            "description": "ワークフロー変数を埋め込んだ、事前レンダリング済みのフォーム本文。"
           },
           "inputs": {
-            "type": "array",
-            "description": "フォーム内の入力フィールドです。",
             "items": {
-              "$ref": "#/components/schemas/FormInput"
-            }
-          },
-          "actions": {
+              "$ref": "#/components/schemas/FormInputConfig"
+            },
             "type": "array",
-            "description": "フォームで利用可能なアクションボタンです。",
-            "items": {
-              "$ref": "#/components/schemas/UserAction"
-            }
-          },
-          "display_in_ui": {
-            "type": "boolean",
-            "description": "フォームを UI に表示するかどうかです。"
-          },
-          "form_token": {
-            "type": "string",
-            "nullable": true,
-            "description": "フォーム送信認証用のトークンです。"
+            "description": "フォーム入力フィールドの定義。"
           },
           "resolved_default_values": {
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
-            "additionalProperties": true,
-            "description": "出力変数名をキーとする、フォーム入力の解決済みデフォルト値です。"
+            "description": "フォームに表示するための事前計算済みデフォルト値。入力の `output_variable_name` をキーとします。デフォルト値がワークフロー変数から解決可能な `paragraph` 入力にのみ設定されます。解決可能なデフォルトがない入力では空になります。クライアントはこれらの値をそのまま表示してください。 `default` をクライアント側で再解決する必要はありません。すべての値は文字列化されています。"
           },
-          "expiration_time": {
-            "type": "integer",
-            "description": "フォームが期限切れになる Unix タイムスタンプです。"
+          "user_actions": {
+            "items": {
+              "$ref": "#/components/schemas/UserActionConfig"
+            },
+            "type": "array",
+            "description": "利用可能な送信アクション。"
           }
-        }
+        },
+        "required": [
+          "form_content",
+          "inputs",
+          "resolved_default_values",
+          "user_actions"
+        ],
+        "type": "object"
       },
       "HumanInputFormSubmissionData": {
-        "type": "object",
-        "description": "送信された人間の入力フォームからのデータです。",
         "properties": {
+          "action_id": {
+            "type": "string",
+            "description": "クリックされたアクションボタンの ID です。"
+          },
+          "action_text": {
+            "type": "string",
+            "description": "クリックされたアクションボタンの表示テキストです。"
+          },
           "node_id": {
             "type": "string",
             "description": "人間の入力ノードの ID です。"
@@ -14249,15 +16650,31 @@
             "type": "string",
             "description": "フォーム送信のレンダリングされた内容です。"
           },
-          "action_id": {
-            "type": "string",
-            "description": "クリックされたアクションボタンの ID です。"
-          },
-          "action_text": {
-            "type": "string",
-            "description": "クリックされたアクションボタンの表示テキストです。"
+          "submitted_data": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "受信者が送信したフォームの値。各入力項目の `output_variable_name` をキーとします。"
           }
-        }
+        },
+        "required": [
+          "action_id",
+          "action_text",
+          "node_id",
+          "node_title",
+          "rendered_content"
+        ],
+        "type": "object",
+        "description": "送信された人間の入力フォームからのデータです。"
       },
       "HumanInputFormSubmitPayload": {
         "properties": {
@@ -14301,10 +16718,87 @@
         ],
         "type": "object"
       },
+      "HumanInputFormSubmitPayloadWithUser": {
+        "properties": {
+          "action": {
+            "description": "受信者が選択したアクションボタンの ID。フォームの `user_actions` リストにある `id` 値のいずれかと一致する必要があります。",
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "description": "出力変数名をキーとする送信済み人工入力値。段落または選択入力には文字列、ファイル入力にはファイルマッピング、ファイルリスト入力にはファイルマッピングのリストを使用します。ローカルファイルは `transfer_method=local_file` と `upload_file_id`、リモートファイルは `transfer_method=remote_url` と `url` または `remote_url` を使用します。",
+            "examples": [
+              {
+                "attachment": {
+                  "transfer_method": "local_file",
+                  "type": "document",
+                  "upload_file_id": "4e0d1b87-52f2-49f6-b8c6-95cd9c954b3e"
+                },
+                "attachments": [
+                  {
+                    "transfer_method": "local_file",
+                    "type": "document",
+                    "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee"
+                  },
+                  {
+                    "transfer_method": "remote_url",
+                    "type": "document",
+                    "url": "https://example.com/report.pdf"
+                  }
+                ],
+                "decision": "approve"
+              }
+            ],
+            "type": "object"
+          },
+          "user": {
+            "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action",
+          "inputs",
+          "user"
+        ],
+        "type": "object"
+      },
+      "HumanInputFormSubmitResponse": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "IndexInfoResponse": {
+        "properties": {
+          "api_version": {
+            "type": "string",
+            "description": "Service API のバージョン。"
+          },
+          "server_version": {
+            "type": "string",
+            "description": "Dify サーバーのバージョン。"
+          },
+          "welcome": {
+            "type": "string",
+            "description": "サービスのウェルカムメッセージ。"
+          }
+        },
+        "required": [
+          "api_version",
+          "server_version",
+          "welcome"
+        ],
+        "type": "object"
+      },
       "JSONObject": {
         "additionalProperties": true,
         "type": "object"
       },
+      "JSONValue": {},
+      "JSONValueType": {},
+      "JsonValue": {},
       "MessageFeedbackPayload": {
         "properties": {
           "content": {
@@ -14338,6 +16832,332 @@
         },
         "type": "object"
       },
+      "MessageFeedbackPayloadWithUser": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "追加の詳細を提供する任意のテキストフィードバック。"
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "enum": [
+                  "dislike",
+                  "like"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "フィードバック評価。以前送信したフィードバックを取り消すには `null` に設定します。"
+          },
+          "user": {
+            "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "type": "object"
+      },
+      "MessageFile": {
+        "properties": {
+          "belongs_to": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このファイルの所有者です。ユーザーがアップロードしたファイルの場合は `user`、アシスタントが生成したファイルの場合は `assistant` です。"
+          },
+          "filename": {
+            "type": "string",
+            "description": "元のファイル名です。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "メッセージファイル ID。"
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ファイルの MIME タイプ。"
+          },
+          "size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ファイルサイズ（バイト）。"
+          },
+          "transfer_method": {
+            "type": "string",
+            "description": "使用された転送方法です。`remote_url` は URL ベースのファイル、`local_file` はアップロード済みファイル、`tool_file` はツール生成ファイルを示します。"
+          },
+          "type": {
+            "type": "string",
+            "description": "ファイルの種類（例：`image`）です。"
+          },
+          "upload_file_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`local_file` で転送された場合のアップロードファイル ID です。"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "format": "url",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ファイルのプレビュー URL。"
+          }
+        },
+        "required": [
+          "filename",
+          "id",
+          "transfer_method",
+          "type"
+        ],
+        "type": "object"
+      },
+      "MessageInfiniteScrollPagination": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/MessageListItem"
+            },
+            "type": "array",
+            "description": "このページのメッセージ一覧。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "さらに古いメッセージがあるかどうか。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "1 ページあたりの件数です。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit"
+        ],
+        "type": "object"
+      },
+      "MessageListItem": {
+        "properties": {
+          "agent_thoughts": {
+            "items": {
+              "$ref": "#/components/schemas/AgentThought"
+            },
+            "type": "array",
+            "description": "このメッセージのエージェント思考です。"
+          },
+          "answer": {
+            "type": "string",
+            "description": "アシスタントの回答テキストです。"
+          },
+          "answer_tokens": {
+            "default": 0,
+            "type": "integer",
+            "description": "生成された回答のトークン数です。"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会話 ID。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成タイムスタンプ（Unix エポック秒）。"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`total_price` の通貨（例：`USD`）です。価格情報が利用できない場合は `null` です。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`status` が `error` の場合のエラーメッセージです。"
+          },
+          "extra_contents": {
+            "items": {
+              "$ref": "#/components/schemas/HumanInputContent"
+            },
+            "type": "array",
+            "description": "このメッセージに関連する追加の実行コンテンツです。chatflow ワークフローの人間の入力ノードからのフォームデータなどが含まれます。"
+          },
+          "feedback": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleFeedback"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このメッセージのユーザーフィードバックです。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "メッセージ ID。"
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JSONValueType"
+            },
+            "type": "object",
+            "description": "このメッセージの入力変数です。"
+          },
+          "message_files": {
+            "items": {
+              "$ref": "#/components/schemas/MessageFile"
+            },
+            "type": "array",
+            "description": "このメッセージに添付されたファイルです。"
+          },
+          "message_tokens": {
+            "default": 0,
+            "type": "integer",
+            "description": "入力メッセージのトークン数です。"
+          },
+          "parent_message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "スレッド会話の親メッセージ ID です。"
+          },
+          "provider_response_latency": {
+            "default": 0,
+            "format": "float",
+            "type": "number",
+            "description": "モデルプロバイダーの応答レイテンシ（秒）です。"
+          },
+          "query": {
+            "type": "string",
+            "description": "ユーザークエリテキストです。"
+          },
+          "retriever_resources": {
+            "items": {
+              "$ref": "#/components/schemas/RetrieverResource"
+            },
+            "type": "array",
+            "description": "このメッセージに使用された検索リソースです。"
+          },
+          "status": {
+            "type": "string",
+            "description": "メッセージステータスです。成功したメッセージの場合は `normal`、生成に失敗した場合は `error` です。"
+          },
+          "total_price": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "使用されたトークンの合計金額です。価格情報が利用できない場合は `null` です。"
+          },
+          "total_tokens": {
+            "readOnly": true,
+            "type": "integer",
+            "description": "使用されたトークンの合計。`message_tokens` と `answer_tokens` の合計です。"
+          }
+        },
+        "required": [
+          "agent_thoughts",
+          "answer",
+          "conversation_id",
+          "extra_contents",
+          "id",
+          "inputs",
+          "message_files",
+          "query",
+          "retriever_resources",
+          "status",
+          "total_tokens"
+        ],
+        "type": "object"
+      },
       "MessageListQuery": {
         "properties": {
           "conversation_id": {
@@ -14366,6 +17186,1479 @@
         },
         "required": [
           "conversation_id"
+        ],
+        "type": "object"
+      },
+      "OptionalServiceApiUserPayload": {
+        "properties": {
+          "user": {
+            "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ParagraphInputConfig": {
+        "description": "フォーム入力の定義。",
+        "properties": {
+          "default": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringSource"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`paragraph` 入力の生のデフォルト値設定。クライアントはこのフィールドを直接解決すべきではありません。デフォルトの表示には `resolved_default_values` を使用してください。その他の入力タイプ、またはデフォルト値が未設定の場合、このキーは含まれません。"
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "ワークフロー内でこの入力の送信値を参照する際の変数名。送信リクエストの `inputs` オブジェクトのキーに対応します。"
+          },
+          "type": {
+            "const": "paragraph",
+            "default": "paragraph",
+            "type": "string",
+            "description": "フォーム入力コントロールの種類。利用可能な値： `paragraph` （複数行テキスト入力）、 `select` （リストからの単一選択）、 `file` （単一ファイルアップロード）、 `file-list` （複数ファイルアップロード）。"
+          }
+        },
+        "required": [
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
+      "Parameters": {
+        "properties": {
+          "annotation_reply": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "この機能が有効かどうか。"
+              }
+            },
+            "type": "object",
+            "description": "アノテーション返信機能の設定です。"
+          },
+          "file_upload": {
+            "properties": {
+              "allowed_file_extensions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "アプリケーションが受け付けるカスタムファイル拡張子です。"
+              },
+              "allowed_file_types": {
+                "items": {
+                  "enum": [
+                    "audio",
+                    "custom",
+                    "document",
+                    "image",
+                    "video"
+                  ],
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "アプリケーションが受け付けるファイルタイプです。"
+              },
+              "allowed_file_upload_methods": {
+                "items": {
+                  "enum": [
+                    "local_file",
+                    "remote_url"
+                  ],
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "アプリケーションが受け付けるファイル転送方法です。"
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "ファイルアップロードが有効かどうか。"
+              },
+              "image": {
+                "properties": {
+                  "detail": {
+                    "type": "string",
+                    "description": "ビジョンモデルの画像詳細レベルです。"
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "画像アップロードが有効かどうか。"
+                  },
+                  "number_limits": {
+                    "type": "integer",
+                    "description": "アップロード可能な画像の最大数です。"
+                  },
+                  "transfer_methods": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "description": "画像アップロードで許可される転送方法です。`remote_url` はファイル URL 経由、`local_file` はアップロード済みファイルを示します。"
+                  }
+                },
+                "type": "object",
+                "description": "画像アップロード設定。"
+              },
+              "number_limits": {
+                "type": "integer",
+                "description": "アップロード可能なファイルの最大数です。"
+              }
+            },
+            "type": "object",
+            "description": "ファイルアップロードの設定。"
+          },
+          "more_like_this": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "この機能が有効かどうか。"
+              }
+            },
+            "type": "object",
+            "description": "類似コンテンツ機能の設定です。"
+          },
+          "opening_statement": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "オープニングステートメントのテキストです。"
+          },
+          "retriever_resource": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "この機能が有効かどうか。"
+              }
+            },
+            "type": "object",
+            "description": "ナレッジ検索の引用リソース設定です。"
+          },
+          "sensitive_word_avoidance": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "この機能が有効かどうか。"
+              }
+            },
+            "type": "object",
+            "description": "コンテンツモデレーション機能の設定です。"
+          },
+          "speech_to_text": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "この機能が有効かどうか。"
+              }
+            },
+            "type": "object",
+            "description": "音声テキスト変換機能の設定です。"
+          },
+          "suggested_questions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "提案された質問のリストです。"
+          },
+          "suggested_questions_after_answer": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "この機能が有効かどうか。"
+              }
+            },
+            "type": "object",
+            "description": "回答後の提案質問の設定です。"
+          },
+          "system_parameters": {
+            "$ref": "#/components/schemas/SystemParameters",
+            "description": "システムレベルのパラメータ制限です。"
+          },
+          "text_to_speech": {
+            "properties": {
+              "autoPlay": {
+                "type": "string",
+                "description": "自動再生設定です。音声を自動再生するには `enabled`、手動再生を要求するには `disabled` を指定します。"
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "この機能が有効かどうか。"
+              },
+              "language": {
+                "type": "string",
+                "description": "TTS 言語。"
+              },
+              "voice": {
+                "type": "string",
+                "description": "TTS 音声識別子。"
+              }
+            },
+            "type": "object",
+            "description": "テキスト音声変換機能の設定です。"
+          },
+          "user_input_form": {
+            "items": {
+              "oneOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "text-input": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可される拡張子。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるアップロード方法。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "追加の入力設定。"
+                        },
+                        "default": {
+                          "description": "デフォルト値です。JSON の型はフォームタイプによって異なります。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "入力項目の任意の説明です。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "公開フォームで入力項目を非表示にするかどうかです。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON オブジェクト入力の検証に使用する JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "入力項目の表示ラベルです。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "入力タイプが長さ制限をサポートする場合の最大入力長。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "このフォームコントロールの選択可能な値のリスト。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "入力が必須かどうかです。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "アプリケーションで使用される変数名です。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "テキスト入力設定。"
+                    }
+                  },
+                  "required": [
+                    "text-input"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "select": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可される拡張子。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるアップロード方法。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "追加の入力設定。"
+                        },
+                        "default": {
+                          "description": "デフォルト値です。JSON の型はフォームタイプによって異なります。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "入力項目の任意の説明です。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "公開フォームで入力項目を非表示にするかどうかです。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON オブジェクト入力の検証に使用する JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "入力項目の表示ラベルです。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "入力タイプが長さ制限をサポートする場合の最大入力長。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "このフォームコントロールの選択可能な値のリスト。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "入力が必須かどうかです。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "アプリケーションで使用される変数名です。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "選択入力設定。"
+                    }
+                  },
+                  "required": [
+                    "select"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "paragraph": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可される拡張子。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるアップロード方法。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "追加の入力設定。"
+                        },
+                        "default": {
+                          "description": "デフォルト値です。JSON の型はフォームタイプによって異なります。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "入力項目の任意の説明です。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "公開フォームで入力項目を非表示にするかどうかです。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON オブジェクト入力の検証に使用する JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "入力項目の表示ラベルです。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "入力タイプが長さ制限をサポートする場合の最大入力長。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "このフォームコントロールの選択可能な値のリスト。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "入力が必須かどうかです。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "アプリケーションで使用される変数名です。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "段落入力設定。"
+                    }
+                  },
+                  "required": [
+                    "paragraph"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "number": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可される拡張子。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるアップロード方法。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "追加の入力設定。"
+                        },
+                        "default": {
+                          "description": "デフォルト値です。JSON の型はフォームタイプによって異なります。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "入力項目の任意の説明です。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "公開フォームで入力項目を非表示にするかどうかです。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON オブジェクト入力の検証に使用する JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "入力項目の表示ラベルです。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "入力タイプが長さ制限をサポートする場合の最大入力長。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "このフォームコントロールの選択可能な値のリスト。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "入力が必須かどうかです。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "アプリケーションで使用される変数名です。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "数値入力設定。"
+                    }
+                  },
+                  "required": [
+                    "number"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "external_data_tool": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可される拡張子。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるアップロード方法。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "追加の入力設定。"
+                        },
+                        "default": {
+                          "description": "デフォルト値です。JSON の型はフォームタイプによって異なります。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "入力項目の任意の説明です。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "公開フォームで入力項目を非表示にするかどうかです。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON オブジェクト入力の検証に使用する JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "入力項目の表示ラベルです。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "入力タイプが長さ制限をサポートする場合の最大入力長。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "このフォームコントロールの選択可能な値のリスト。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "入力が必須かどうかです。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "アプリケーションで使用される変数名です。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "外部データツール入力設定。"
+                    }
+                  },
+                  "required": [
+                    "external_data_tool"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "file": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可される拡張子。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるアップロード方法。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "追加の入力設定。"
+                        },
+                        "default": {
+                          "description": "デフォルト値です。JSON の型はフォームタイプによって異なります。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "入力項目の任意の説明です。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "公開フォームで入力項目を非表示にするかどうかです。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON オブジェクト入力の検証に使用する JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "入力項目の表示ラベルです。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "入力タイプが長さ制限をサポートする場合の最大入力長。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "このフォームコントロールの選択可能な値のリスト。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "入力が必須かどうかです。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "アプリケーションで使用される変数名です。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "アプリケーションが返すファイルフォームコントロールの設定です。ラベル、変数名、必須かどうか、許可するファイルカテゴリと拡張子、対応する転送方法を表します。アップロード済みの multipart ファイルではありません。"
+                    }
+                  },
+                  "required": [
+                    "file"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "file-list": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可される拡張子。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるアップロード方法。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "追加の入力設定。"
+                        },
+                        "default": {
+                          "description": "デフォルト値です。JSON の型はフォームタイプによって異なります。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "入力項目の任意の説明です。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "公開フォームで入力項目を非表示にするかどうかです。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON オブジェクト入力の検証に使用する JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "入力項目の表示ラベルです。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "入力タイプが長さ制限をサポートする場合の最大入力長。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "このフォームコントロールの選択可能な値のリスト。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "入力が必須かどうかです。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "アプリケーションで使用される変数名です。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "ファイルリスト入力設定。"
+                    }
+                  },
+                  "required": [
+                    "file-list"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "checkbox": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可される拡張子。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるアップロード方法。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "追加の入力設定。"
+                        },
+                        "default": {
+                          "description": "デフォルト値です。JSON の型はフォームタイプによって異なります。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "入力項目の任意の説明です。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "公開フォームで入力項目を非表示にするかどうかです。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON オブジェクト入力の検証に使用する JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "入力項目の表示ラベルです。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "入力タイプが長さ制限をサポートする場合の最大入力長。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "このフォームコントロールの選択可能な値のリスト。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "入力が必須かどうかです。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "アプリケーションで使用される変数名です。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "チェックボックス入力設定。"
+                    }
+                  },
+                  "required": [
+                    "checkbox"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "json_object": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可される拡張子。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "この入力がファイルを受け付ける場合に許可されるアップロード方法。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "追加の入力設定。"
+                        },
+                        "default": {
+                          "description": "デフォルト値です。JSON の型はフォームタイプによって異なります。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "入力項目の任意の説明です。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "公開フォームで入力項目を非表示にするかどうかです。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "JSON オブジェクト入力の検証に使用する JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "入力項目の表示ラベルです。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "入力タイプが長さ制限をサポートする場合の最大入力長。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "このフォームコントロールの選択可能な値のリスト。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "入力が必須かどうかです。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "アプリケーションで使用される変数名です。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "JSON オブジェクト入力設定。"
+                    }
+                  },
+                  "required": [
+                    "json_object"
+                  ],
+                  "type": "object"
+                }
+              ],
+              "type": "object"
+            },
+            "type": "array",
+            "description": "ユーザー入力フォームの設定です。"
+          }
+        },
+        "required": [
+          "annotation_reply",
+          "file_upload",
+          "more_like_this",
+          "retriever_resource",
+          "sensitive_word_avoidance",
+          "speech_to_text",
+          "suggested_questions",
+          "suggested_questions_after_answer",
+          "system_parameters",
+          "text_to_speech",
+          "user_input_form"
+        ],
+        "type": "object"
+      },
+      "RequiredServiceApiUserPayload": {
+        "properties": {
+          "user": {
+            "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "type": "object"
+      },
+      "ResultResponse": {
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "操作結果。"
+          }
+        },
+        "required": [
+          "result"
         ],
         "type": "object"
       },
@@ -14552,86 +18845,200 @@
         }
       },
       "RetrieverResource": {
-        "type": "object",
-        "description": "検索リソースの引用および帰属情報です。",
         "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "リソースからのコンテンツスニペット。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成タイムスタンプ（Unix エポック秒）。"
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "データソースのタイプ。"
+          },
+          "dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ナレッジベース ID。"
+          },
+          "dataset_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ナレッジベース名。"
+          },
+          "document_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント ID。"
+          },
+          "document_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント名。"
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このチャンクがヒットした回数。"
+          },
           "id": {
-            "type": "string",
             "format": "uuid",
+            "type": "string",
             "description": "検索リソースの一意の ID。"
           },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "インデックスノードのハッシュ。"
+          },
           "message_id": {
-            "type": "string",
             "format": "uuid",
+            "type": "string",
             "description": "このリソースが属するメッセージの ID。"
           },
           "position": {
             "type": "integer",
             "description": "リスト内のリソースの位置。"
           },
-          "dataset_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ナレッジベース ID。"
-          },
-          "dataset_name": {
-            "type": "string",
-            "description": "ナレッジベース名。"
-          },
-          "document_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ドキュメント ID。"
-          },
-          "document_name": {
-            "type": "string",
-            "description": "ドキュメント名。"
-          },
-          "data_source_type": {
-            "type": "string",
-            "description": "データソースのタイプ。"
-          },
-          "segment_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ドキュメント内の特定のチャンクの ID。"
-          },
           "score": {
-            "type": "number",
-            "format": "float",
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "リソースの関連性スコア。"
           },
-          "hit_count": {
-            "type": "integer",
-            "description": "このチャンクがヒットした回数。"
-          },
-          "word_count": {
-            "type": "integer",
-            "description": "チャンクの単語数。"
+          "segment_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント内の特定のチャンクの ID。"
           },
           "segment_position": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "ドキュメント内のチャンクの位置。"
           },
-          "index_node_hash": {
-            "type": "string",
-            "description": "インデックスノードのハッシュ。"
-          },
-          "content": {
-            "type": "string",
-            "description": "リソースからのコンテンツスニペット。"
-          },
           "summary": {
-            "type": "string",
-            "nullable": true,
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "チャンクコンテンツの要約。"
           },
-          "created_at": {
-            "type": "integer",
-            "format": "int64",
-            "description": "作成タイムスタンプ（Unix エポック秒）。"
+          "word_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンクの単語数。"
           }
-        }
+        },
+        "required": [
+          "position"
+        ],
+        "type": "object",
+        "description": "検索リソースの引用および帰属情報です。"
       },
       "SegmentListQuery": {
         "properties": {
@@ -14669,6 +19076,171 @@
         },
         "type": "object"
       },
+      "SelectInputConfig": {
+        "properties": {
+          "option_source": {
+            "$ref": "#/components/schemas/StringListSource",
+            "description": "`select` 入力の選択肢のソース。 `type` が `select` の場合のみ含まれます。"
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "ワークフロー内でこの入力の送信値を参照する際の変数名。送信リクエストの `inputs` オブジェクトのキーに対応します。"
+          },
+          "type": {
+            "const": "select",
+            "default": "select",
+            "type": "string",
+            "description": "フォーム入力コントロールの種類。利用可能な値： `paragraph` （複数行テキスト入力）、 `select` （リストからの単一選択）、 `file` （単一ファイルアップロード）、 `file-list` （複数ファイルアップロード）。"
+          }
+        },
+        "required": [
+          "option_source",
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
+      "SimpleAccountResponse": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "アカウントメールアドレス。"
+          },
+          "id": {
+            "type": "string",
+            "description": "アカウント ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "アカウント表示名。"
+          }
+        },
+        "required": [
+          "email",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "SimpleConversation": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成時刻（Unix 秒タイムスタンプ）。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会話 ID。"
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JSONValue"
+            },
+            "type": "object",
+            "description": "会話の入力変数です。"
+          },
+          "introduction": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "会話の紹介文です。"
+          },
+          "name": {
+            "type": "string",
+            "description": "会話名です。"
+          },
+          "status": {
+            "type": "string",
+            "description": "会話ステータスです。アクティブな会話の場合は `normal` です。"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "最終更新時刻（Unix 秒タイムスタンプ）。"
+          }
+        },
+        "required": [
+          "id",
+          "inputs",
+          "name",
+          "status"
+        ],
+        "type": "object"
+      },
+      "SimpleEndUser": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "エンドユーザー ID。"
+          },
+          "is_anonymous": {
+            "type": "boolean",
+            "description": "エンドユーザーが匿名かどうかです。"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "セッション識別子です。"
+          },
+          "type": {
+            "type": "string",
+            "description": "エンドユーザーの種類です。"
+          }
+        },
+        "required": [
+          "id",
+          "is_anonymous",
+          "type"
+        ],
+        "type": "object"
+      },
+      "SimpleFeedback": {
+        "properties": {
+          "rating": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "フィードバック評価。肯定的な場合は `like`、否定的な場合は `dislike`。"
+          }
+        },
+        "type": "object"
+      },
       "SimpleResultResponse": {
         "properties": {
           "result": {
@@ -14678,6 +19250,263 @@
         },
         "required": [
           "result"
+        ],
+        "type": "object"
+      },
+      "SimpleResultStringListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "提案された質問のリストです。"
+          },
+          "result": {
+            "type": "string",
+            "description": "結果ステータス。"
+          }
+        },
+        "required": [
+          "data",
+          "result"
+        ],
+        "type": "object"
+      },
+      "Site": {
+        "properties": {
+          "chat_color_theme": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャットカラーテーマ。"
+          },
+          "chat_color_theme_inverted": {
+            "type": "boolean",
+            "description": "チャットカラーテーマが反転しているかどうか。"
+          },
+          "copyright": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "著作権テキスト。"
+          },
+          "custom_disclaimer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "カスタム免責事項テキスト。"
+          },
+          "default_language": {
+            "type": "string",
+            "description": "デフォルト言語コード。"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Web アプリの説明。"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "アイコンのコンテンツ（絵文字または画像 ID）。"
+          },
+          "icon_background": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "アイコンの背景色。"
+          },
+          "icon_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "使用されるアイコンのタイプ。`emoji` は絵文字アイコン、`image` はアップロードされた画像アイコンです。"
+          },
+          "icon_url": {
+            "anyOf": [
+              {
+                "format": "url",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "readOnly": true,
+            "description": "アイコン画像の URL。"
+          },
+          "input_placeholder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Web アプリのメッセージ入力ボックスに表示されるプレースホルダーテキストです。設定されていない場合は `null` です。"
+          },
+          "privacy_policy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "プライバシーポリシー URL。"
+          },
+          "show_workflow_steps": {
+            "type": "boolean",
+            "description": "ワークフローステップを表示するかどうか。"
+          },
+          "title": {
+            "type": "string",
+            "description": "Web アプリタイトル。"
+          },
+          "use_icon_as_answer_icon": {
+            "type": "boolean",
+            "description": "アプリアイコンを回答アイコンとして使用するかどうか。"
+          }
+        },
+        "required": [
+          "chat_color_theme_inverted",
+          "default_language",
+          "icon_url",
+          "show_workflow_steps",
+          "title",
+          "use_icon_as_answer_icon"
+        ],
+        "type": "object"
+      },
+      "StringListSource": {
+        "properties": {
+          "selector": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "`type` が `variable` の場合の変数参照パス。"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ValueSourceType",
+            "description": "選択肢のソース。 `constant` は `value` に選択肢を直接列挙することを示します。 `variable` は `selector` が選択肢を提供する `array[string]` 型のワークフロー変数を指すことを示します。"
+          },
+          "value": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "`type` が `constant` の場合のリテラルな選択肢リスト。"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "StringSource": {
+        "description": "フォーム入力のデフォルト設定。",
+        "properties": {
+          "selector": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "`type` が `variable` の場合の変数参照パス（例： `[\"node_id\", \"var_name\"]`）。少なくとも 2 つの要素を含む必要があります。"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ValueSourceType",
+            "description": "デフォルト値のソース。 `constant` は `value` をリテラル文字列として使用することを示します。 `variable` は `selector` がワークフロー変数を指すことを示します。"
+          },
+          "value": {
+            "default": "",
+            "type": "string",
+            "description": "`type` が `constant` の場合のリテラルなデフォルト値。常に文字列です。"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "SystemParameters": {
+        "properties": {
+          "audio_file_size_limit": {
+            "type": "integer",
+            "description": "最大音声ファイルサイズ（MB）。"
+          },
+          "file_size_limit": {
+            "type": "integer",
+            "description": "一般ファイルの最大サイズ（MB）です。"
+          },
+          "image_file_size_limit": {
+            "type": "integer",
+            "description": "最大画像ファイルサイズ（MB）。"
+          },
+          "video_file_size_limit": {
+            "type": "integer",
+            "description": "最大動画ファイルサイズ（MB）。"
+          },
+          "workflow_file_upload_limit": {
+            "type": "integer",
+            "description": "ワークフロー実行ごとの最大ファイル数です。"
+          }
+        },
+        "required": [
+          "audio_file_size_limit",
+          "file_size_limit",
+          "image_file_size_limit",
+          "video_file_size_limit",
+          "workflow_file_upload_limit"
         ],
         "type": "object"
       },
@@ -14733,6 +19562,265 @@
             "description": "テキスト読み上げに使用する音声です。利用可能な音声は、このアプリに設定された TTS プロバイダーによって異なります。省略すると、利用可能な場合はアプリに設定された音声を使用します。この値は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)の `text_to_speech.voice` で確認できます。"
           }
         },
+        "type": "object"
+      },
+      "TextToAudioPayloadWithUser": {
+        "properties": {
+          "message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "メッセージ ID。両方を指定した場合は `text` より優先されます。"
+          },
+          "streaming": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "互換性のために予約されています。TTS レスポンスのストリーミングはプロバイダーの出力によって決まります。"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "変換する音声内容。"
+          },
+          "user": {
+            "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+            "type": "string"
+          },
+          "voice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "テキスト読み上げに使用する音声です。利用可能な音声は、このアプリに設定された TTS プロバイダーによって異なります。省略すると、利用可能な場合はアプリに設定された音声を使用します。この値は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)の `text_to_speech.voice` で確認できます。"
+          }
+        },
+        "type": "object"
+      },
+      "ToolIcon": {
+        "properties": {
+          "background": {
+            "type": "string",
+            "description": "16進数形式の背景色。"
+          },
+          "content": {
+            "type": "string",
+            "description": "Emoji コンテンツ。"
+          }
+        },
+        "required": [
+          "background",
+          "content"
+        ],
+        "type": "object"
+      },
+      "UserActionConfig": {
+        "description": "ユーザーアクション設定。",
+        "properties": {
+          "button_style": {
+            "$ref": "#/components/schemas/ButtonStyle",
+            "default": "default",
+            "description": "ボタンの視覚スタイル。利用可能な値： `primary`、 `default`、 `accent`、 `ghost`。"
+          },
+          "id": {
+            "maxLength": 20,
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+            "type": "string",
+            "description": "アクションボタンの識別子。受信者がこのボタンを選択したときに、[人間の入力フォームを送信](/ja/api-reference/human-input/submit-human-input-form) エンドポイントの `action` として渡します。"
+          },
+          "title": {
+            "maxLength": 100,
+            "type": "string",
+            "description": "アクションボタンのラベル。"
+          }
+        },
+        "required": [
+          "id",
+          "title"
+        ],
+        "type": "object"
+      },
+      "ValueSourceType": {
+        "description": "`ValueSourceType` は、値がフォーム定義の静的設定から取得されたか、ワークフロー実行中の変数から取得されたかを記録します。",
+        "enum": [
+          "constant",
+          "variable"
+        ],
+        "type": "string"
+      },
+      "WorkflowAppLogPaginationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WorkflowAppLogPartialResponse"
+            },
+            "type": "array",
+            "description": "現在のページのワークフローログレコード。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "さらにワークフローログレコードがあるかどうか。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "1 ページあたりの件数です。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "現在のページ番号です。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "一致するワークフローログレコードの総数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "WorkflowAppLogPartialResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成時刻（Unix 秒タイムスタンプ）。"
+          },
+          "created_by_account": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleAccountResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "管理者ユーザーが作成した場合のアカウント詳細です。"
+          },
+          "created_by_end_user": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleEndUser"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフロー実行を作成したエンドユーザー。"
+          },
+          "created_by_role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成者のロール（例：`end_user`、`account`）です。"
+          },
+          "created_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフロー実行のソース（例：`service-api`）です。"
+          },
+          "details": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ログエントリの追加詳細です。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "ログエントリ ID です。"
+          },
+          "workflow_run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowRunForLogResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このログエントリのワークフロー実行詳細。"
+          }
+        },
+        "required": [
+          "id"
+        ],
         "type": "object"
       },
       "WorkflowBlockingResponse": {
@@ -15248,6 +20336,145 @@
         "type": "object",
         "description": "ワークフロー実行が人間の入力を待機している場合に返されるブロッキングレスポンスです。"
       },
+      "WorkflowRunForLogResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成時刻（Unix 秒タイムスタンプ）。"
+          },
+          "elapsed_time": {
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "合計経過時間（秒）です。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフローが失敗した場合のエラーメッセージです。"
+          },
+          "exceptions_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "実行中に発生した例外の数です。"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "終了時刻（Unix 秒タイムスタンプ）。未終了の場合は `null`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "ワークフロー実行 ID です。"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフローの実行ステータスです。`running` は実行中、`succeeded` は正常完了、`failed` は実行エラー、`stopped` は手動停止、`partial-succeeded` は一部のノードが成功し他が失敗、`paused` は人間の入力待ちを示します。"
+          },
+          "total_steps": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "実行されたワークフローの合計ステップ数です。"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "消費された合計トークン数です。"
+          },
+          "triggered_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフロー実行をトリガーしたソースです。`app-run` はアプリまたは API からの実行、`webhook` は Webhook トリガーによる実行、`schedule` はスケジュールトリガーによる実行、`plugin` はインテグレーショントリガーによる実行を示します。"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフローバージョン識別子です。"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
       "WorkflowRunPayload": {
         "properties": {
           "files": {
@@ -15459,6 +20686,361 @@
         },
         "required": [
           "inputs"
+        ],
+        "type": "object"
+      },
+      "WorkflowRunPayloadWithUser": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ファイルタイプ。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフローのシステムファイル入力の一覧です。ワークフローでファイルアップロードが有効な場合に使用できます。ローカルファイルを添付するには、まず[ファイルをアップロード](/ja/api-reference/files/upload-file)し、返された `id` を `upload_file_id` に指定して、`transfer_method` を `local_file` に設定します。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "ワークフロー入力変数のキーと値のペアです。ファイル型変数の値は、`type`、`transfer_method`、および `url` または `upload_file_id` を含むファイルオブジェクトの配列にします。アプリが要求する変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。",
+            "type": "object"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "レスポンスモード。同期レスポンスには `blocking`、Server-Sent Events（SSE）には `streaming` を使用します。省略するとブロッキングモードで実行されます。"
+          },
+          "user": {
+            "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputs",
+          "user"
+        ],
+        "type": "object"
+      },
+      "WorkflowRunResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成時刻（Unix 秒タイムスタンプ）。"
+          },
+          "elapsed_time": {
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "合計経過時間（秒）です。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフローが失敗した場合のエラーメッセージです。"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "終了時刻（Unix 秒タイムスタンプ）。未終了の場合は `null`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "ワークフロー実行 ID です。"
+          },
+          "inputs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ワークフロー実行に渡された入力です。JSON 値はオブジェクト、配列、プリミティブ、または `null` です。レスポンス schema に従ってすでにデコードされているため、追加の JSON 解析は不要です。"
+          },
+          "outputs": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "ワークフローからの出力データです。出力がまだない場合は空のオブジェクトです。"
+          },
+          "status": {
+            "type": "string",
+            "description": "ワークフローの実行ステータスです。`running` は実行中、`succeeded` は正常完了、`failed` は実行エラー、`stopped` は手動停止、`partial-succeeded` は一部のノードが成功し他が失敗、`paused` は人間の入力待ちを示します。"
+          },
+          "total_steps": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "実行されたワークフローの合計ステップ数です。"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "消費された合計トークン数です。"
+          },
+          "workflow_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "この実行で使用したワークフロー定義 ID。"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "workflow_id"
         ],
         "type": "object"
       },

--- a/tools/api-pipeline/service_api_overlays/en.json
+++ b/tools/api-pipeline/service_api_overlays/en.json
@@ -4,6 +4,311 @@
   "description": "Reviewed locale overlay applied to Dify's generated Service API OpenAPI base. Replace/remove actions pin the upstream value with source_sha256.",
   "actions": [
     {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/answer/description",
+      "value": "Tool or model answer associated with this thought."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/chain_id/description",
+      "value": "Chain ID for this thought."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/chain_id/title",
+      "source_sha256": "295f6a392c61fdbbb6ef9abb1b4b8147059908a23e28a9e94d796e20422a86fd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/created_at/description",
+      "value": "Creation time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/files/description",
+      "value": "File IDs related to this thought."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/id/description",
+      "value": "Agent thought ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/message_id/description",
+      "value": "Unique message ID this thought belongs to."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/observation/description",
+      "value": "Response from tool calls."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/observation/title",
+      "source_sha256": "c4a6f6ba9024a0dbab79416f13405fe844b0c7bf192602e88e513be9a52d79d8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/position/description",
+      "value": "Position of this thought."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/thought/description",
+      "value": "What LLM is thinking."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/thought/title",
+      "source_sha256": "02bf582eb1a75c8e50c3bdcd83f2a7709b766e8a2665ab35eea31f9da2ac047e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/tool/description",
+      "value": "Tools called, split by `;`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/tool/title",
+      "source_sha256": "077dcaba577a59acd143ab78b5a82a1aecf5e12e5df0fc8a7bebfae7b492a894"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/tool_input/description",
+      "value": "Input of tools in JSON format."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/tool_input/title",
+      "source_sha256": "e6c0015853f82e8c5fa6ea7ac0d578344f50eee52392b5ca2cd4aeeca9b6d01d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/tool_labels/description",
+      "value": "Labels for tools used."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/title",
+      "source_sha256": "2e64047dcc72e66d47b39c7f80a94f47e35b0fc7ff3afa3e5b2c945840a567d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/answer/description",
+      "value": "Predefined answer returned when the annotation is matched."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/created_at/description",
+      "value": "Creation timestamp (Unix epoch seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/hit_count/description",
+      "value": "Number of times this annotation has been matched and returned as a reply."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/id/description",
+      "value": "Unique annotation identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/question/description",
+      "value": "Question text that triggers this annotation."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/question/title",
+      "source_sha256": "b9af1957d9fdeaa7a00f9959b1d3d7a0b86e7668490814638482312eddff520e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/title",
+      "source_sha256": "1d156a865fcd9720975862e919faa36a4b7ea8f663d0755308e270e8501d8126"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationCreatePayload/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationCreatePayload/properties/question/title",
+      "source_sha256": "b9af1957d9fdeaa7a00f9959b1d3d7a0b86e7668490814638482312eddff520e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationCreatePayload/title",
+      "source_sha256": "413a6ae76b1d2bfe14c473638acdad02036b866edfe5a1457bc47b09ed2d0a7b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/error_msg/description",
+      "value": "Error message describing why the job failed. Empty string when `job_status` is not `error`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/error_msg/title",
+      "source_sha256": "67b237015aff3ff7c6bd9b6b3efd48804f142eb82797cf06fe5a8ad1fa7b9f6a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_id/description",
+      "value": "Job ID from the [Configure Annotation Reply](/en/api-reference/annotations/configure-annotation-reply) call."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_id/title",
+      "source_sha256": "0e9ad890b0e8639f3521d2e36b860c41a72abef7b2752efd1288cb7aaf51f61a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_status/description",
+      "value": "Current job status. `waiting` for queued, `processing` for in progress, `completed` when finished, `error` if failed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_status/title",
+      "source_sha256": "9a40e8f9b1ac49b7bf83d3f139b4200b18138cf7ae61765baeac6f0f6fe3a8e9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/title",
+      "source_sha256": "a1cfc801d1b6e994cf2bc8080150df8f25096803221200581a99bca5ef2196ec"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_id/description",
+      "value": "Asynchronous job ID. Use with [Get Annotation Reply Job Status](/en/api-reference/annotations/get-annotation-reply-job-status) to track progress."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_id/title",
+      "source_sha256": "0e9ad890b0e8639f3521d2e36b860c41a72abef7b2752efd1288cb7aaf51f61a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_status/description",
+      "value": "Current job status: `waiting` (queued) or `processing` (in progress). `completed` and `error` are returned only by [Get Annotation Reply Job Status](/en/api-reference/annotations/get-annotation-reply-job-status)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_status/title",
+      "source_sha256": "9a40e8f9b1ac49b7bf83d3f139b4200b18138cf7ae61765baeac6f0f6fe3a8e9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusResponse/title",
+      "source_sha256": "35a266556dc525b5163ab1c4a9532dd08c70ba24bbc049ac94ea1a2680f7542e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/data/description",
+      "value": "Annotations on the current page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/has_more/description",
+      "value": "Whether more annotations are available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/limit/description",
+      "value": "Number of items per page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/page/description",
+      "value": "Current page number."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/total/description",
+      "value": "Total number of matching annotations."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/title",
+      "source_sha256": "2d0d76736240133bea40a30d2182193901623f5a9d376f31a75e0e437ea89554"
+    },
+    {
       "op": "remove",
       "path": "/components/schemas/AnnotationListQuery/properties/keyword/title",
       "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
@@ -24,14 +329,1105 @@
       "source_sha256": "eb84fea86ba7ca8a051d796765be892d20a92ecd050e29212f7498902bab4536"
     },
     {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_model_name/description",
+      "source_sha256": "c97df7b88c3b777272905064d453ebc60cc5f76c3d1cdabf236e29a079952ba2",
+      "value": "Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`, for example `text-embedding-3-small`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_model_name/title",
+      "source_sha256": "4d79d966137d5bf514424da3770d0535ef6289a20ce67d7d5be6038198ccd6bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_provider_name/description",
+      "source_sha256": "7708e9e2750cbc449cb13498e296c0079bfa6dbd04969ed0e586b855d76ff8eb",
+      "value": "Use the `provider` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`, for example `openai`; do not use the display label."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_provider_name/title",
+      "source_sha256": "4e0310d84c92f0465d3c1184754fbd60864f0d6925435fa6eff884947966e073"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/score_threshold/description",
+      "source_sha256": "78137b1381fc7cbe544de27fe6fe7ab2d01dbd702e4001e00b643290214b86c1",
+      "value": "Minimum similarity score from 0 to 1 for an annotation match. Higher values require closer matches."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/title",
+      "source_sha256": "b64b023cf7b9b8c2d5885e5766acb46dfdcdc788e3999ab6dbfad1ddeb03741f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackListResponse/properties/data/description",
+      "value": "Feedback records on the current page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackListResponse/title",
+      "source_sha256": "e4c6386ce897eb0ca2e13e996a1088fbcf09fe754f8d83417256df2bb95ce897"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/app_id/description",
+      "value": "Application ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/app_id/title",
+      "source_sha256": "9bb6aa4fb1320b37040e3c92ca381635520a01dab3a13c05e5058b135db6de04"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/content/description",
+      "value": "Optional text feedback."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/conversation_id/description",
+      "value": "Conversation ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/created_at/description",
+      "value": "Creation time as an RFC 3339 date-time string."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_account_id/description",
+      "value": "Account ID who submitted the feedback. Present when `from_source` is `admin`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_account_id/title",
+      "source_sha256": "cf6be2adfe52b9a1e32690eb1459bb3b20be1cf8fc055f7f7156102c5e59503b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_end_user_id/description",
+      "value": "End user ID who submitted the feedback. Present when `from_source` is `user`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_end_user_id/title",
+      "source_sha256": "6da19052c4804db16313c62d79be1a72ef4475a68ddc28566b4770664cdd7e32"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_source/description",
+      "value": "Feedback source. `user` for end-user feedback submitted via API, `admin` for feedback submitted from the console."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_source/title",
+      "source_sha256": "9a626efdfa6afdf31c0c0116f75a7858cb12aeca76c605c7fad2a276d2d2547d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/id/description",
+      "value": "Feedback ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/message_id/description",
+      "value": "Message ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/rating/description",
+      "value": "Feedback rating. `like` for positive, `dislike` for negative."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/updated_at/description",
+      "value": "Last update time as an RFC 3339 date-time string."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/title",
+      "source_sha256": "e32e96636947952e56902bb4f92cee12934f772ba0e4c6bebf793ab3c2064dc2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/author_name/description",
+      "value": "Name of the application author."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/author_name/title",
+      "source_sha256": "184bab624ca3534f57b76d065cf11c51a641c53cceed8e6b5f7909a253e49313"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/description/description",
+      "value": "Application description."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/mode/description",
+      "value": "Application mode. `completion` is a Text Generator; `chat` is a basic Chatbot; `agent-chat` is the legacy Agent app; `advanced-chat` is a Chatflow (a conversational workflow); `workflow` is a non-conversational Workflow app; `agent` is the newer Agent app. Operation descriptions state which modes they support."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/name/description",
+      "value": "Application name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/tags/description",
+      "value": "Application tags."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/tags/title",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/title",
+      "source_sha256": "d5b9c094d6791f9b503a3c097df4bc53a1e28c0b129cd294641a8d900d74a8b0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppMetaResponse/properties/tool_icons/additionalProperties/anyOf/0/description",
+      "value": "URL of the icon.",
+      "context_path": "/components/schemas/AppMetaResponse/properties/tool_icons/additionalProperties/anyOf/0",
+      "context_sha256": "7cda4ff9a25f90d276ecdd759f6660841ebf4aef042e04abe3635927522db28b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppMetaResponse/properties/tool_icons/description",
+      "value": "Tool icons. Keys are tool names."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppMetaResponse/properties/tool_icons/title",
+      "source_sha256": "a8cf9cfba30dbe3b343ffd1308aec61813daf50b8a95956dbc1f4a035c0a1ea9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppMetaResponse/title",
+      "source_sha256": "b50a0719720ed8b5183b9db8f973221fff3081a4e29db2d876bf65cc74cc7ea5"
+    },
+    {
       "op": "remove",
       "path": "/components/schemas/AudioBinaryResponse/title",
       "source_sha256": "ef754dee1a457218bc6c216dbd5138062dae750a388d7af5791b480dbf56c417"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/AudioTranscriptResponse/properties/text/description",
+      "value": "Output text from speech recognition."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AudioTranscriptResponse/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AudioTranscriptResponse/title",
+      "source_sha256": "41e01a98ed9542dd3ad194f18ddb4af06fe1d0beb98f35acac5dc3d18cbcd158"
+    },
+    {
       "op": "remove",
       "path": "/components/schemas/BinaryFileResponse/title",
       "source_sha256": "40ee4d6aa1f0027872e6b1bea14f0389f51e33afdf6edbf84edc04f56b572787"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingMetadataResponse/description",
+      "value": "Metadata including usage and retriever resources."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingMetadataResponse/properties/retriever_resources/description",
+      "value": "List of retriever resources used."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingMetadataResponse/properties/retriever_resources/title",
+      "source_sha256": "0cad6b9867870a47877812c4336c83401368174ab4b1b3d3de4636bb6b1e42b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingMetadataResponse/properties/usage/description",
+      "value": "Model usage information."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingMetadataResponse/title",
+      "source_sha256": "7fe0af522608ffffa14de6ad92786cbfaac522effc05308872c5a57e3f796820"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/content/description",
+      "value": "Content snippet from the resource."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/created_at/description",
+      "value": "Creation timestamp (Unix epoch seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/data_source_type/description",
+      "value": "Type of the data source."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_id/description",
+      "value": "ID of the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_id/title",
+      "source_sha256": "afd32ed627cd32334bfc447d13eeaef88fe7365a20bbe496d1b65e238ab4a97e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_name/description",
+      "value": "Name of the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_name/title",
+      "source_sha256": "c3f0ca5a47fcaf871602dc501da109161cf99c427aa29ab8b20ab03813246be5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_id/description",
+      "value": "ID of the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_name/description",
+      "value": "Name of the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_name/title",
+      "source_sha256": "afa98fb25c89955f16c5857a64ca57eeab8ad2fdfc7eaba13a79ddac268a3624"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/hit_count/description",
+      "value": "Number of times this chunk was hit."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/id/description",
+      "value": "Unique ID of the retriever resource."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/index_node_hash/description",
+      "value": "Hash of the index node."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/message_id/description",
+      "value": "ID of the message this resource belongs to."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/position/description",
+      "value": "Position of the resource in the list."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/score/description",
+      "value": "Similarity score of the resource."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_id/description",
+      "value": "ID of the specific chunk within the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_id/title",
+      "source_sha256": "7290170777560d41462deb95fa0c1a27884f2e487befa6820e24cf1acedb6131"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_position/description",
+      "value": "Position of the chunk within the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_position/title",
+      "source_sha256": "0bb9927f845754cf77570f81fd42d7660562e2b888a96d5ffbe8bfd2a1353d23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/summary/description",
+      "value": "Summary of the chunk content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/word_count/description",
+      "value": "Word count of the chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/title",
+      "source_sha256": "562f01953930e507e89d83f36436ed273caf2e0d7710f93757efdf32d5767ade"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price/description",
+      "value": "Total price for completion tokens."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price/title",
+      "source_sha256": "29d9f1eee907e3c79c50ce304a90fb9e166f0b6923150c2168fea6f305f8ac6d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price_unit/description",
+      "value": "Price unit for completion tokens."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price_unit/title",
+      "source_sha256": "7b51570d42e18985f1af94caada87243925486380581e2b09744ddb5c9329055"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_tokens/description",
+      "value": "Number of tokens in the completion."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_tokens/title",
+      "source_sha256": "fba7b76f7b0ed47936475461d4f609cfee6f2de15766d690821b86c3545f4f92"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_unit_price/description",
+      "value": "Unit price per completion token."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_unit_price/title",
+      "source_sha256": "8361013d73ca8fb1331aedf884946e7bc243afdb8fff3fbbccacd1227f6e7f35"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/currency/description",
+      "value": "Currency for pricing."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/currency/title",
+      "source_sha256": "dc3eb42975d1c1fd78c9d592adde6dbe02d004e08e7cd0dfd3951c84900b875e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/latency/description",
+      "value": "Latency in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/latency/title",
+      "source_sha256": "3265005a867197e7e231cd75b93d66feb7416493c730b6fb5cb643ce6a91e069"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price/description",
+      "value": "Total price for prompt tokens."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price/title",
+      "source_sha256": "6896cdeb14e5bfe7e9318f7da7e125e7938a304bb6ef3596e98142bdf229ca7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price_unit/description",
+      "value": "Price unit for prompt tokens."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price_unit/title",
+      "source_sha256": "83edd2617fd5182b95235c3150c4c6da8764c1ee436568aeaa20f177a5ecc709"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_tokens/description",
+      "value": "Number of tokens in the prompt."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_tokens/title",
+      "source_sha256": "00b76256407926bda0ce2732b9782cb51da7cb0df679f87c21321ee1cfc36788"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_unit_price/description",
+      "value": "Unit price per prompt token."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_unit_price/title",
+      "source_sha256": "9340411003259c99bfef4879cd17201753522ff030ed12bfa326b087eb9fe872"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_price/description",
+      "value": "Total price for all tokens."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_price/title",
+      "source_sha256": "3576c59289ecc321e2cfdba5f8a98bfe257996dc1fbc54b4ea53fe287e7987e2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_tokens/description",
+      "value": "Total number of tokens used."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/title",
+      "source_sha256": "39a4eb04a7c3190dc2b3ac19dcc6ed01d33411dcc9daaecfcc089ca5c9589c18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ButtonStyle/title",
+      "source_sha256": "0e4f7e534381b07844aae6f722fe74e489ba76de6af52373084a21916c6abef7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatBlockingResponse/description",
+      "source_sha256": "6855f2011b3097c7af89ef5d153387cf65e59df1ed9f3cb2ed30f99595532b5a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatBlockingResponse/title",
+      "source_sha256": "ae94d0636dd14bc30ed94d2e44c244ed20cbdea93abc003e90b6fb96612aaa38"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/description",
+      "value": "Event type, fixed as `message`."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/answer/description",
+      "value": "Complete response content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/conversation_id/description",
+      "value": "Conversation ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/created_at/description",
+      "value": "Message creation timestamp (Unix epoch seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/event/description",
+      "value": "Event type, fixed as `message`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/event/title",
+      "source_sha256": "426621e6a36074101f2af3e84f1bcc0a3df129e85946330dbece4d333264f5dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/id/description",
+      "value": "Unique ID of this response event."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/message_id/description",
+      "value": "Unique message ID. Use this as the `message_id` parameter when calling feedback or suggested questions endpoints."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/metadata/description",
+      "value": "Metadata including usage and retriever resources."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/mode/description",
+      "value": "App mode. `chat` for Chatbot apps, `agent-chat` for Agent apps, `advanced-chat` for Chatflow apps."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/task_id/description",
+      "value": "Task ID for request tracking and stop response API."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/title",
+      "source_sha256": "621cbd41e3abe7a913f3d24026a9e4a9772b928f3fabb276dfa8790ad6b53330"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatPauseReasonResponse/description",
+      "source_sha256": "1417d50eba847462718505449c0df336db0d597c4b1d553ab05db5aaf44983f5",
+      "value": "Public details explaining why a blocking Chatflow execution paused."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/TYPE/description",
+      "value": "Pause reason type."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/TYPE/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/actions/description",
+      "value": "Actions available in the Human Input form."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/actions/title",
+      "source_sha256": "aa6d82bdb3cc1d9a5e542ae2669fef27690019ab5d7b20f17d9f1331a6a942fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/approval_channels/description",
+      "value": "Configured approval channels."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/approval_channels/title",
+      "source_sha256": "e8dc5bb01a260360a49a9e3ee2b7e7ecc9e6b4f68aaf2bf205e3a4bcfc747d63"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/display_in_ui/description",
+      "value": "Whether the pause reason should be displayed in the UI."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/display_in_ui/title",
+      "source_sha256": "8c71965fd96e6f8b785ae269402727f478472205a018ad31c70fd0860c046614"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/expiration_time/description",
+      "value": "Unix timestamp when the Human Input form expires."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_content/description",
+      "value": "Content displayed with the Human Input form."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_id/description",
+      "value": "Human Input form ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_id/title",
+      "source_sha256": "fafd71c45b122dd8a3264f51789d5b76c7b77ff8dc669263056f89c55464dd7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_token/description",
+      "value": "Access token used with the Human Input Form API."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_token/title",
+      "source_sha256": "7a13fbb60d7b9386e1e508b9270fcf384926bf6ed214f4b6523f46e5946f2c67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/inputs/description",
+      "value": "Input fields in the Human Input form."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/message/description",
+      "value": "Message explaining why the workflow paused."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/message/title",
+      "source_sha256": "be1af94c8c00110d748345ea5e25cfc3aca39055ab9101ab1d8d551928445819"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_id/description",
+      "value": "ID of the workflow node that paused."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_title/description",
+      "value": "Title of the workflow node that paused."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/resolved_default_values/description",
+      "value": "Resolved default values for the form inputs."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/title",
+      "source_sha256": "6bd7d1ff1401cbea01fb89343104f99acc66302933d2c9d54b62ee9c1b97cf6a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/description",
+      "value": "Pause details for the Chatflow workflow run."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/answer/description",
+      "value": "Complete response content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/conversation_id/description",
+      "value": "Conversation ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/created_at/description",
+      "value": "Message creation timestamp (Unix epoch seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/elapsed_time/description",
+      "value": "Total time elapsed in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/id/description",
+      "value": "Unique ID of this response event."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/message_id/description",
+      "value": "Unique message ID. Use this as the `message_id` parameter when calling feedback or suggested questions endpoints."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/metadata/description",
+      "value": "Metadata including usage and retriever resources."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/mode/description",
+      "value": "App mode. `chat` for Chatbot apps, `agent-chat` for Agent apps, `advanced-chat` for Chatflow apps."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/paused_nodes/description",
+      "value": "IDs of workflow nodes waiting for input."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/paused_nodes/title",
+      "source_sha256": "1be2bcf1f1cac22fee5004654f91685bb8d677de3e9c946a311420a413e25f98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/reasons/description",
+      "value": "Reasons the workflow paused, including Human Input form details."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/reasons/title",
+      "source_sha256": "c9f903172d68246eaeee2c130b732b3b5596a22100ff964b1a54aa9351f20b08"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/status/description",
+      "value": "Workflow execution status, fixed as `paused`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_steps/description",
+      "value": "Total number of workflow steps executed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_tokens/description",
+      "value": "Total tokens consumed across all nodes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/workflow_run_id/description",
+      "value": "Persistent identifier for the paused workflow run."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/title",
+      "source_sha256": "cd61aef73a52645cfb71fe9879437e410b1afca2dac696a60f25998ad657099d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/description",
+      "value": "Blocking response returned when a Chatflow is waiting for human input."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/answer/description",
+      "value": "Complete response content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/conversation_id/description",
+      "value": "Conversation ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/created_at/description",
+      "value": "Message creation timestamp (Unix epoch seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/data/description",
+      "value": "Pause details for the Chatflow workflow run."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/event/description",
+      "value": "Event type, fixed as `workflow_paused` when the Chatflow is waiting for human input."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/event/title",
+      "source_sha256": "426621e6a36074101f2af3e84f1bcc0a3df129e85946330dbece4d333264f5dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/id/description",
+      "value": "Unique ID of this response event."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/message_id/description",
+      "value": "Unique message ID. Use this as the `message_id` parameter when calling feedback or suggested questions endpoints."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/metadata/description",
+      "value": "Metadata including usage and retriever resources."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/mode/description",
+      "value": "App mode. `chat` for Chatbot apps, `agent-chat` for Agent apps, `advanced-chat` for Chatflow apps."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/task_id/description",
+      "value": "Task ID for request tracking and stop response API."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/workflow_run_id/description",
+      "value": "Persistent identifier for the paused workflow run."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/title",
+      "source_sha256": "d5bf66fb39bbc16156f497f3a3126daab95b1f0125b5be3ba9e53d967b5ca843"
     },
     {
       "op": "remove",
@@ -151,6 +1547,122 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/auto_generate_name/title",
+      "source_sha256": "3ed483bca55763140ff1d72d40e67e287249200e1fa7c544a8cf98312bcff07d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "Files for multimodal input. New clients should implement two canonical forms only: use `transfer_method: remote_url` with `url` for a public file URL, or upload through [Upload File](/en/api-reference/files/upload-file) and use `transfer_method: local_file` with the returned `id` as `upload_file_id`. Other generated `anyOf` combinations exist only for backward compatibility with stored legacy references."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "Values for app-defined variables. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover expected variable names and types."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/title",
+      "source_sha256": "737ed654af2d15b7259a6742f94f2f965deeff0143b24f8c6394a335a43318e6"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/ChildChunkListQuery/properties/keyword/title",
       "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
     },
@@ -168,6 +1680,86 @@
       "op": "remove",
       "path": "/components/schemas/ChildChunkListQuery/title",
       "source_sha256": "b1c6a7020550b6caf74316c4f6f0d9a79bb59b5fe961a3d65331855b2e4fa238"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/answer/description",
+      "value": "Complete response content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/created_at/description",
+      "value": "Message creation timestamp (Unix epoch seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/event/description",
+      "value": "Event type, fixed as `message`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/event/title",
+      "source_sha256": "426621e6a36074101f2af3e84f1bcc0a3df129e85946330dbece4d333264f5dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/id/description",
+      "value": "Unique ID of this response event."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/message_id/description",
+      "value": "Unique message ID. Use it as `message_id` when submitting feedback. Suggested-question generation is not available for Text Generator apps."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/metadata/description",
+      "value": "Metadata including usage and retriever resources."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/mode/description",
+      "value": "App mode, fixed as `completion`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/task_id/description",
+      "value": "Task ID for request tracking and the [Stop Completion Message Generation](/en/api-reference/completion-messages/stop-completion-message-generation) API."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/title",
+      "source_sha256": "ee47e2a5e80d35feab4cf22bdf5ddc102cd7a070d83df22ca8e2b1fc9e22302b"
     },
     {
       "op": "replace",
@@ -271,6 +1863,142 @@
       "source_sha256": "af0367558fbca9f02fe0c6614e89b0fbaddd2d5462f4aa34f224f2cdf7e90469"
     },
     {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "Transfer method. New requests use `remote_url` with `url`, or `local_file` with `upload_file_id`. The additional generated combinations are backward-compatible legacy forms.",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "Files for multimodal input. New clients should implement two canonical forms only: use `transfer_method: remote_url` with `url` for a public file URL, or upload through [Upload File](/en/api-reference/files/upload-file) and use `transfer_method: local_file` with the returned `id` as `upload_file_id`. Other generated `anyOf` combinations exist only for backward compatibility with stored legacy references."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "Values for app-defined variables. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover expected variable names and types."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/title",
+      "source_sha256": "af0367558fbca9f02fe0c6614e89b0fbaddd2d5462f4aa34f224f2cdf7e90469"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/data/description",
+      "value": "Conversations in this page of results."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/has_more/description",
+      "value": "Whether older conversations are available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/limit/description",
+      "value": "Number of items per page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/title",
+      "source_sha256": "8d2c26d65f5574e6f0a965a27176479d828da87cfa8522634b679257d805d213"
+    },
+    {
       "op": "remove",
       "path": "/components/schemas/ConversationListQuery/properties/last_id/title",
       "source_sha256": "6f0775443ca28929399d056640ab02a09c28ea42cb79273e233d978894adf007"
@@ -342,12 +2070,182 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/name/description",
+      "value": "New conversation name. Required unless `auto_generate` is `true`.",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/title",
+      "source_sha256": "5007bf01416d1203f9aeac8979d407c9432d6420dfba585d65249853164be8b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/data/description",
+      "value": "Conversation variables in this page of results."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/has_more/description",
+      "value": "Whether more conversation variables are available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/limit/description",
+      "value": "Number of items per page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/title",
+      "source_sha256": "40398eaf223ae268d6ca662c0553a3b63efc0726833ecbdce3ec3e188c44a994"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/created_at/description",
+      "value": "Creation time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/description/description",
+      "value": "Variable description."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/id/description",
+      "value": "Variable ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/name/description",
+      "value": "Variable name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/updated_at/description",
+      "value": "Last update time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value/description",
+      "value": "Variable value (can be a JSON string for complex types)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value_type/description",
+      "value": "Variable value type. Possible values: `string`, `number`, `object`, `secret`, `file`, `boolean`, `array[any]`, `array[string]`, `array[number]`, `array[object]`, `array[file]`, `array[boolean]`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value_type/title",
+      "source_sha256": "1990c83514aae4414c3c0cdfe9926c617cf3a92057cf60c43cecfe243bf75d44"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/title",
+      "source_sha256": "8b07df8ff6c7bff5a6a4267191363393127c16f84cb667540cd56afdcbfce36e"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/ConversationVariableUpdatePayload/properties/value/title",
       "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
     },
     {
       "op": "remove",
       "path": "/components/schemas/ConversationVariableUpdatePayload/title",
+      "source_sha256": "ab9aedc458ad087c3e8f47e9d46c7180ff78e73b058595f23c06153749e8d9be"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayloadWithUser/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayloadWithUser/title",
       "source_sha256": "ab9aedc458ad087c3e8f47e9d46c7180ff78e73b058595f23c06153749e8d9be"
     },
     {
@@ -447,8 +2345,123 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/EndUserDetail/description",
+      "source_sha256": "aa3c373c92f25d2f94b8e188c71129841d23355dfed0285bf4e926738925d270"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/app_id/description",
+      "value": "Application ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/app_id/title",
+      "source_sha256": "9bb6aa4fb1320b37040e3c92ca381635520a01dab3a13c05e5058b135db6de04"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/created_at/description",
+      "value": "Creation timestamp."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/external_user_id/description",
+      "value": "The `user` identifier provided in API requests (e.g., the `user` field in [Send Chat Message](/en/api-reference/chat-messages/send-chat-message))."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/external_user_id/title",
+      "source_sha256": "73e63201b85107943bdd55a6e70905be50c4051b74922599d44bb3fe6a233f72"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/id/description",
+      "value": "End user ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/is_anonymous/description",
+      "value": "Whether the user is anonymous. `true` when no `user` identifier was provided in the original API request."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/is_anonymous/title",
+      "source_sha256": "042cb8fffd7f6edb56ac128deed67f447ceb287cd716f3056d4ee0d5cee10114"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/name/description",
+      "value": "End user name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/session_id/description",
+      "value": "Session identifier. Defaults to the `external_user_id` value."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/session_id/title",
+      "source_sha256": "eb75473dc0fd06e0d9e515069eb952720ae3d0b7edfe76d2e7a922d225818a47"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/tenant_id/description",
+      "value": "Tenant ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/tenant_id/title",
+      "source_sha256": "ae18aae49d3ccc237cd61077f9e1235aa293a131da760623f83eab7b5e51d944"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/type/description",
+      "value": "End user type. Always `service-api` for Service API users."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/updated_at/description",
+      "value": "Last update timestamp."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/title",
+      "source_sha256": "e280f5d56814b84006ebaa503204543732987703d54509b41ea6279aae618405"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/EventStreamResponse/title",
       "source_sha256": "cb598d0c9427cccc89d63f389617e8966efeffc6cf0b9bad1c5823624bf470d3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ExecutionContentType/title",
+      "source_sha256": "3b2b49df41fa1f57efbdf69684f4846436696825906cc5908b47a6d9dcb38165"
     },
     {
       "op": "remove",
@@ -466,6 +2479,126 @@
       "source_sha256": "2ee2ef5a0b8833947992d468c455c3ec9722d91f0512455ef418a2ca9fa97e89"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when `allowed_file_types` includes `custom`. Include the leading `.` in each extension, for example `.md`. Present for `file` and `file-list` inputs."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_extensions/title",
+      "source_sha256": "a9fbd8515a7570cbf8527621d2dfef68843739b7f642385e7614124dbf62c207"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_types/description",
+      "value": "File categories the recipient may upload. Present for `file` and `file-list` inputs. Values: `image`, `document`, `audio`, `video`, `custom`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_types/title",
+      "source_sha256": "dc39dad025bd4f01f3683f0b4275c0cfc39242bcd63c9df3a018450cb31a54b1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_upload_methods/description",
+      "value": "Upload methods the recipient may use. Values: `local_file`, `remote_url`. Present for `file` and `file-list` inputs."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_upload_methods/title",
+      "source_sha256": "27ec3b14f4b815bd97063c77366bd8925f2475e48b86322fc51ffee8a68010f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/output_variable_name/description",
+      "value": "Variable name used to reference this input's submitted value inside the workflow. Corresponds to the key in the submission `inputs` object."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/type/description",
+      "value": "Form input control type. Available values: `paragraph` (multi-line text input), `select` (single-choice from a list), `file` (single file upload), and `file-list` (multiple file uploads)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/title",
+      "source_sha256": "c16f00d355344aabe5c8f9d3ee46f954b3955758cbe7e98128580690751590f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when `allowed_file_types` includes `custom`. Include the leading `.` in each extension, for example `.md`. Present for `file` and `file-list` inputs."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_extensions/title",
+      "source_sha256": "a9fbd8515a7570cbf8527621d2dfef68843739b7f642385e7614124dbf62c207"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_types/description",
+      "value": "File categories the recipient may upload. Present for `file` and `file-list` inputs. Values: `image`, `document`, `audio`, `video`, `custom`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_types/title",
+      "source_sha256": "dc39dad025bd4f01f3683f0b4275c0cfc39242bcd63c9df3a018450cb31a54b1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_upload_methods/description",
+      "value": "Upload methods the recipient may use. Values: `local_file`, `remote_url`. Present for `file` and `file-list` inputs."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_upload_methods/title",
+      "source_sha256": "27ec3b14f4b815bd97063c77366bd8925f2475e48b86322fc51ffee8a68010f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/number_limits/description",
+      "value": "Maximum number of files the recipient may upload. Present only for `file-list` inputs."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/number_limits/title",
+      "source_sha256": "cffcf3dbc6eeea7d5b96f1a6c3695f1060321b5ddd099aa47ac900873301da17"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/output_variable_name/description",
+      "value": "Variable name used to reference this input's submitted value inside the workflow. Corresponds to the key in the submission `inputs` object."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/type/description",
+      "value": "Form input control type. Available values: `paragraph` (multi-line text input), `select` (single-choice from a list), `file` (single file upload), and `file-list` (multiple file uploads)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/title",
+      "source_sha256": "f523cc0240880eba6ee6fafc4c09c042bca376e0ac425c0bab976088289c0527"
+    },
+    {
       "op": "remove",
       "path": "/components/schemas/FilePreviewQuery/properties/as_attachment/title",
       "source_sha256": "4002a1980adbcfbe63aee5f634bd84eeacc78ae334a3020996076d5508bacecd"
@@ -474,6 +2607,451 @@
       "op": "remove",
       "path": "/components/schemas/FilePreviewQuery/title",
       "source_sha256": "34f058141cf139f35d0840e326719c0af503c33e745ab65d911e0449050fe2b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/conversation_id/description",
+      "value": "ID of the associated conversation."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/created_at/description",
+      "value": "Upload timestamp (Unix epoch seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/created_by/description",
+      "value": "End-user ID of the uploader. Look up details with [Get End User Info](/en/api-reference/end-users/get-end-user-info)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/extension/description",
+      "value": "File extension."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/file_key/description",
+      "value": "Unused; always `null`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/file_key/title",
+      "source_sha256": "e40ccb27af6fbb5ca42abd5c75fab69254329e65482470315875be7ab053799d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/id/description",
+      "value": "Unique file ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/mime_type/description",
+      "value": "MIME type of the file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/name/description",
+      "value": "File name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/original_url/description",
+      "value": "Original URL of the file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/original_url/title",
+      "source_sha256": "c4888fa31ede45075f22f445e420c81308f0e7926289179c73243e106dce12f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/preview_url/description",
+      "value": "Preview URL for the file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/preview_url/title",
+      "source_sha256": "5032783bebaa4d692996f8a238e903dff18dcde3b433a8a12f5ce10b8723d5c1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/reference/description",
+      "value": "Opaque file reference used internally when attaching files in agent and tool contexts. Always `null` for files uploaded through this endpoint."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/reference/title",
+      "source_sha256": "62bf2677b9ec30fcd1213616c78b6ede91fcf2778e6e1e06139f7a0ee9a2f22b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/size/description",
+      "value": "File size in bytes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/source_url/description",
+      "value": "Signed URL for downloading the file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/source_url/title",
+      "source_sha256": "3d48f2577f877973dd0a3ab85975e367b5a9ab1964eb533d2cb3dd317134d453"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/tenant_id/description",
+      "value": "ID of the associated tenant."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/tenant_id/title",
+      "source_sha256": "ae18aae49d3ccc237cd61077f9e1235aa293a131da760623f83eab7b5e51d944"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/user_id/description",
+      "value": "Unused; always `null`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/user_id/title",
+      "source_sha256": "61a98a9e2d63198ff47128e3e2b20573e9cd81c7bfaac7b52679c167124b4618"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/title",
+      "source_sha256": "e1fde1b159c838025a2bd05b8a08f570c7b8a335d4c17984cc000fdccc597bac"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileTransferMethod/title",
+      "source_sha256": "89ade223b5ca2b5b6c7b8c9b94144a779e59d931884fd19c951ea02efcd0900b"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileType/title",
+      "source_sha256": "1146fdf89b9afd90dd54e7a8a49cc084960dbe6ab3cb3c9ddb13494be2676ed7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/description",
+      "value": "Execution content from a Human Input node, including form definition and submission data."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/form_definition/description",
+      "value": "Form definition from the Human Input node. `null` when the content represents a submission response."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/form_submission_data/description",
+      "value": "Submitted form data. `null` when the form has not been submitted yet."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/submitted/description",
+      "value": "Whether the human input form has been submitted."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputContent/properties/submitted/title",
+      "source_sha256": "c6c415f99181251a358bb051196877f12f5d92f48454d2b3f0975426b3d77197"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/type/description",
+      "value": "`human_input` for human input content."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/workflow_run_id/description",
+      "value": "ID of the workflow run this content belongs to."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputContent/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputContent/title",
+      "source_sha256": "8be8a12c2e3e7a84b72adcf514810d1fa1ec486ad223eb6eedfe4fcbb840c83d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/description",
+      "value": "Definition of a human input form rendered by a Human Input node."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/actions/description",
+      "value": "Action buttons available on the form."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/actions/title",
+      "source_sha256": "aa6d82bdb3cc1d9a5e542ae2669fef27690019ab5d7b20f17d9f1331a6a942fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/display_in_ui/description",
+      "value": "Whether the form should be displayed in the UI."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/display_in_ui/title",
+      "source_sha256": "8c71965fd96e6f8b785ae269402727f478472205a018ad31c70fd0860c046614"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/expiration_time/description",
+      "value": "Unix timestamp when the form expires."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_content/description",
+      "value": "Markdown or text content displayed with the form."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_id/description",
+      "value": "Unique form identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_id/title",
+      "source_sha256": "fafd71c45b122dd8a3264f51789d5b76c7b77ff8dc669263056f89c55464dd7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_token/description",
+      "value": "Token for form submission authentication."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_token/title",
+      "source_sha256": "7a13fbb60d7b9386e1e508b9270fcf384926bf6ed214f4b6523f46e5946f2c67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/inputs/description",
+      "value": "Input fields in the form."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_id/description",
+      "value": "ID of the Human Input node that generated this form."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_title/description",
+      "value": "Title of the Human Input node."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/resolved_default_values/description",
+      "value": "Resolved default values for form inputs, keyed by output variable name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/title",
+      "source_sha256": "fca56dea40adeb7da6dc4dc9897a9d70e622d8794384f3f0a9a1bde76efebab6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/expiration_time/description",
+      "value": "Unix timestamp (seconds) after which this form can no longer be submitted."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/form_content/description",
+      "value": "Pre-rendered form body with workflow variables substituted."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/inputs/description",
+      "value": "Form input field definitions."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/resolved_default_values/description",
+      "value": "Pre-rendered values to display in the form. Keyed by input `output_variable_name`. Populated for `paragraph` inputs whose default resolves from a workflow variable; empty for inputs with no resolvable default. Display these values; do not re-resolve `default` on the client. All values are stringified."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/user_actions/description",
+      "value": "Available submission actions."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/user_actions/title",
+      "source_sha256": "1a4ed49eb5af3941bf9d0e30899e2a9c0be82d2089efadc9ac3c422e06580f1e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/title",
+      "source_sha256": "efe9278e93efddf0770298b0baa1af36c79f83167e15fe64c7e9ddcaa07917a0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/description",
+      "value": "Data from a submitted human input form."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_id/description",
+      "value": "ID of the action button that was clicked."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_id/title",
+      "source_sha256": "7e4688059b07745f9eac7661edcd135651dd97f393de9fd273c1fe29cd654215"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_text/description",
+      "value": "Display text of the action button that was clicked."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_text/title",
+      "source_sha256": "6d4c58126485bf41fe4903c696afd5f42aa118b96787a3bf97382b3e088c33cf"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_id/description",
+      "value": "ID of the Human Input node."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_title/description",
+      "value": "Title of the Human Input node."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/rendered_content/description",
+      "value": "Rendered content of the form submission."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/rendered_content/title",
+      "source_sha256": "7a73e1acdc736489774de1b928d6e98015e2ec121a590938f8954eef240d6044"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/submitted_data/description",
+      "value": "Values the recipient submitted, keyed by each form input's `output_variable_name`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/submitted_data/title",
+      "source_sha256": "a3f562e953210d2b0de95dcc91dbe78484cf58cfde9918a87c2cf39a3e8aecf1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/title",
+      "source_sha256": "8949c480137e5d219cf4f5313442efea2336e23601e1837935795cf3936c0e3a"
     },
     {
       "op": "remove",
@@ -492,6 +3070,61 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/action/title",
+      "source_sha256": "5efcc1e437cbeada52653f133121f3ca259b84b74a51e15c277b4de93f11bd75"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/title",
+      "source_sha256": "38a626e4a4e1642a39e35116d44bec129a532a22191e06434ecc3c9b4c51c3d3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitResponse/title",
+      "source_sha256": "aa2f56fbcc6b021221b64c92e880abaccf77304d4960f15e77f766fae9e7c1e1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/IndexInfoResponse/properties/api_version/description",
+      "value": "Service API version."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/properties/api_version/title",
+      "source_sha256": "ae9fbe000bcc107626c6a7562db6d9dbfdf0fc84bf08e7e3a160b90d59be00cd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/IndexInfoResponse/properties/server_version/description",
+      "value": "Dify server version."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/properties/server_version/title",
+      "source_sha256": "474479a19ac772ca7e9bdb8d22a2c24622e90170553d6fbe287d9cec70165ced"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/IndexInfoResponse/properties/welcome/description",
+      "value": "Service welcome message."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/properties/welcome/title",
+      "source_sha256": "1fa79baa5f6a65d49bbee9e12d6e320e542885ad389f26f8b744a14608e68cbb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/title",
+      "source_sha256": "39bae08b9ff59cac2e8753bfc4a2e27ee7493eb5d4f6402c2f1c354436048e6e"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/MessageFeedbackPayload/properties/content/title",
       "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
     },
@@ -504,6 +3137,351 @@
       "op": "remove",
       "path": "/components/schemas/MessageFeedbackPayload/title",
       "source_sha256": "dc826ad9804a26c2e92124a2d20c938b54f7e6abf59d8fbccb326f20ac4e7c70"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/title",
+      "source_sha256": "dc826ad9804a26c2e92124a2d20c938b54f7e6abf59d8fbccb326f20ac4e7c70"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/belongs_to/description",
+      "value": "Who this file belongs to. `user` for user-uploaded files, `assistant` for assistant-generated files."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/belongs_to/title",
+      "source_sha256": "9c4f84210a02189552fb0d669344eff0190bf70baef043015aef34ed8c0ac152"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/filename/description",
+      "value": "Original filename."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/filename/title",
+      "source_sha256": "fa233e390655e8ee27cb179523ba2c9fe37aae77a8f531ee59cd9af15377806d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/id/description",
+      "value": "Message file ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/mime_type/description",
+      "value": "MIME type of the file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/size/description",
+      "value": "File size in bytes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/transfer_method/description",
+      "value": "Transfer method used. `remote_url` for URL-based files, `local_file` for uploaded files, `tool_file` for tool-generated files."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/transfer_method/title",
+      "source_sha256": "b44be7211a456d1bd0ae715137a36e970b9f722bee23006b86ecab3bfc9d49d7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/type/description",
+      "value": "File type, e.g., `image`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/upload_file_id/description",
+      "value": "Upload file ID if transferred via `local_file`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/upload_file_id/title",
+      "source_sha256": "f29fbbf25b1c3154216e20e3583a05c7ed965a056bcd8f30a5c5ed91a33678d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/url/description",
+      "value": "Preview URL for the file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/url/title",
+      "source_sha256": "0146bf069164386d9cbddfbb77eed14df29c3fbf0326244f5676fc1c06a30963"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/title",
+      "source_sha256": "60f8396dde335458941fb0c59e5e4e7cbf2e36309e02c32c0b98f69ca3e444a3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/data/description",
+      "value": "Messages in this page of results."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/has_more/description",
+      "value": "Whether older messages are available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/limit/description",
+      "value": "Number of items per page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/title",
+      "source_sha256": "e74af12050ecc369553e1acd525a8588c859d754655ae355c3a25b4306393107"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/agent_thoughts/description",
+      "value": "Agent thoughts for this message."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/agent_thoughts/title",
+      "source_sha256": "2184f8609c9c4feeeb57c0b2cf05c2fde85cdf9cf74b0ce38155990fd5e63d18"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/answer/description",
+      "value": "Assistant answer text."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/answer_tokens/description",
+      "value": "Number of tokens in the generated answer."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/answer_tokens/title",
+      "source_sha256": "1b572d1e3ea69bf0ee0a51abcffa0431b7b84eb28ed5913becebec76d5046063"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/conversation_id/description",
+      "value": "Conversation ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/created_at/description",
+      "value": "Creation timestamp (Unix epoch seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/currency/description",
+      "value": "Currency for `total_price` (for example, `USD`), or `null` when pricing is unavailable."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/currency/title",
+      "source_sha256": "dc3eb42975d1c1fd78c9d592adde6dbe02d004e08e7cd0dfd3951c84900b875e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/error/description",
+      "value": "Error message if `status` is `error`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/extra_contents/description",
+      "value": "Additional execution content associated with this message, such as human input form data from Human Input nodes in Chatflow workflows."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/extra_contents/title",
+      "source_sha256": "ddc4b3e9e40fc66023e5a3b362c7383a7ff50cd282944c3e04fcdfe0fb040bf6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/feedback/description",
+      "value": "User feedback for this message."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/id/description",
+      "value": "Message ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/inputs/description",
+      "value": "Input variables for this message."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/message_files/description",
+      "value": "Files attached to this message."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/message_files/title",
+      "source_sha256": "019a4253ead76b257c4cd8c39037108752829deb2cab847c8c8784d81c88dc47"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/message_tokens/description",
+      "value": "Number of tokens in the input message."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/message_tokens/title",
+      "source_sha256": "dc40a100e53d859ae80ed9200353283259695db35d73ab038a376d75bc54ba8b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/parent_message_id/description",
+      "value": "Parent message ID for threaded conversations."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/parent_message_id/title",
+      "source_sha256": "9a5f1265a74baedbf683b3f039d7f0b6a0c19d2068c1b990b19b23bc6990c17e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/provider_response_latency/description",
+      "value": "Model provider response latency in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/provider_response_latency/title",
+      "source_sha256": "9db4fbca93f3cc70bbd13f2ad2095fc676b4252db5422e7079e92dd3fef05d1a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/query/description",
+      "value": "User query text."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/retriever_resources/description",
+      "value": "Retriever resources used for this message."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/retriever_resources/title",
+      "source_sha256": "0cad6b9867870a47877812c4336c83401368174ab4b1b3d3de4636bb6b1e42b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/status/description",
+      "value": "Message status. `normal` for successful messages, `error` when generation failed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/total_price/description",
+      "value": "Total price for the tokens used, or `null` when pricing is unavailable."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/total_price/title",
+      "source_sha256": "3576c59289ecc321e2cfdba5f8a98bfe257996dc1fbc54b4ea53fe287e7987e2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/total_tokens/description",
+      "value": "Total tokens used, the sum of `message_tokens` and `answer_tokens`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/title",
+      "source_sha256": "0fcf1f5699aeec1e3e5bbd380e3499c1378e4bd8f3acb4a9cb644541571ce995"
     },
     {
       "op": "remove",
@@ -524,6 +3502,1366 @@
       "op": "remove",
       "path": "/components/schemas/MessageListQuery/title",
       "source_sha256": "17997d5395df2c93391badf0ba144f4ca86426f5b37ae14fd35d9c873a56e906"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/OptionalServiceApiUserPayload/title",
+      "source_sha256": "a1269019db4ddc7c919d3b0447ea781251fcad5e3c189d0d8214785fae80891d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ParagraphInputConfig/properties/default/description",
+      "value": "Raw default-value configuration for `paragraph` inputs. The client should not resolve this directly; use `resolved_default_values` to display defaults. absent for other input types or when no default is configured."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ParagraphInputConfig/properties/output_variable_name/description",
+      "value": "Variable name used to reference this input's submitted value inside the workflow. Corresponds to the key in the submission `inputs` object."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ParagraphInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ParagraphInputConfig/properties/type/description",
+      "value": "Form input control type. Available values: `paragraph` (multi-line text input), `select` (single-choice from a list), `file` (single file upload), and `file-list` (multiple file uploads)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ParagraphInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ParagraphInputConfig/title",
+      "source_sha256": "f9a2dc09b2ae099fc58a4f362ed79a143bbccf3f8c122c3c7477a007c73776f1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/annotation_reply/description",
+      "value": "Annotation reply feature configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/annotation_reply/properties/enabled/description",
+      "value": "Whether this feature is enabled."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/description",
+      "value": "File upload configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/allowed_file_extensions/description",
+      "value": "Custom file extensions accepted by the application."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/allowed_file_types/description",
+      "value": "File types accepted by the application."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/allowed_file_upload_methods/description",
+      "value": "File transfer methods accepted by the application."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/enabled/description",
+      "value": "Whether file upload is enabled."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/description",
+      "value": "Image upload settings."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/detail/description",
+      "value": "Image detail level for vision models."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/enabled/description",
+      "value": "Whether image upload is enabled."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/number_limits/description",
+      "value": "Maximum number of images that can be uploaded."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/transfer_methods/description",
+      "value": "Allowed transfer methods for image upload. `remote_url` for file URL, `local_file` for uploaded file."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/number_limits/description",
+      "value": "Maximum number of files that can be uploaded."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/more_like_this/description",
+      "value": "More-like-this feature configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/more_like_this/properties/enabled/description",
+      "value": "Whether this feature is enabled."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/opening_statement/description",
+      "value": "Opening statement text."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/properties/opening_statement/title",
+      "source_sha256": "e555de2768123fb1fa943d99a2fb5549af0702ba1f3969de47bb55e9904ab890"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/retriever_resource/description",
+      "value": "Knowledge retrieval citation resource configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/retriever_resource/properties/enabled/description",
+      "value": "Whether this feature is enabled."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/sensitive_word_avoidance/description",
+      "value": "Content moderation feature configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/sensitive_word_avoidance/properties/enabled/description",
+      "value": "Whether this feature is enabled."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/speech_to_text/description",
+      "value": "Speech-to-text feature configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/speech_to_text/properties/enabled/description",
+      "value": "Whether this feature is enabled."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/suggested_questions/description",
+      "value": "List of suggested questions."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/properties/suggested_questions/title",
+      "source_sha256": "1033a0922394dc3617fd9d04bcbcdc9bdb42377312d236a2f54e8fd8ad417d6b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/suggested_questions_after_answer/description",
+      "value": "Configuration for suggested questions after an answer."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/suggested_questions_after_answer/properties/enabled/description",
+      "value": "Whether this feature is enabled."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/system_parameters/description",
+      "value": "System-level parameter limits."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/description",
+      "value": "Text-to-speech feature configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/autoPlay/description",
+      "value": "Auto-play setting. `enabled` to auto-play audio, `disabled` to require manual play."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/enabled/description",
+      "value": "Whether this feature is enabled."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/language/description",
+      "value": "Language for TTS."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/voice/description",
+      "value": "Voice identifier for TTS."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/description",
+      "value": "User input form configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/description",
+      "value": "Text input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/allowed_file_types/description",
+      "value": "Allowed file categories when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/allowed_file_upload_methods/description",
+      "value": "Allowed upload methods when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/config/description",
+      "value": "Additional input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/default/description",
+      "value": "Default value. Its JSON type depends on the form type.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/description/description",
+      "value": "Optional input description.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/hide/description",
+      "value": "Whether the input is hidden from the public form.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/json_schema/description",
+      "value": "JSON Schema used to validate JSON object input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/label/description",
+      "value": "Display label for the input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/max_length/description",
+      "value": "Maximum input length when the input type supports a length limit.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/options/description",
+      "value": "List of selectable values for this form control.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/required/description",
+      "value": "Whether the input is required.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/type/description",
+      "value": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/variable/description",
+      "value": "Variable name used by the application.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/description",
+      "value": "Select input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/allowed_file_types/description",
+      "value": "Allowed file categories when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/allowed_file_upload_methods/description",
+      "value": "Allowed upload methods when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/config/description",
+      "value": "Additional input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/default/description",
+      "value": "Default value. Its JSON type depends on the form type.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/description/description",
+      "value": "Optional input description.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/hide/description",
+      "value": "Whether the input is hidden from the public form.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/json_schema/description",
+      "value": "JSON Schema used to validate JSON object input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/label/description",
+      "value": "Display label for the input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/max_length/description",
+      "value": "Maximum input length when the input type supports a length limit.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/options/description",
+      "value": "List of selectable values for this form control.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/required/description",
+      "value": "Whether the input is required.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/type/description",
+      "value": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/variable/description",
+      "value": "Variable name used by the application.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/description",
+      "value": "Paragraph input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/allowed_file_types/description",
+      "value": "Allowed file categories when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/allowed_file_upload_methods/description",
+      "value": "Allowed upload methods when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/config/description",
+      "value": "Additional input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/default/description",
+      "value": "Default value. Its JSON type depends on the form type.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/description/description",
+      "value": "Optional input description.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/hide/description",
+      "value": "Whether the input is hidden from the public form.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/json_schema/description",
+      "value": "JSON Schema used to validate JSON object input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/label/description",
+      "value": "Display label for the input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/max_length/description",
+      "value": "Maximum input length when the input type supports a length limit.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/options/description",
+      "value": "List of selectable values for this form control.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/required/description",
+      "value": "Whether the input is required.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/type/description",
+      "value": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/variable/description",
+      "value": "Variable name used by the application.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/description",
+      "value": "Number input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/allowed_file_types/description",
+      "value": "Allowed file categories when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/allowed_file_upload_methods/description",
+      "value": "Allowed upload methods when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/config/description",
+      "value": "Additional input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/default/description",
+      "value": "Default value. Its JSON type depends on the form type.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/description/description",
+      "value": "Optional input description.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/hide/description",
+      "value": "Whether the input is hidden from the public form.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/json_schema/description",
+      "value": "JSON Schema used to validate JSON object input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/label/description",
+      "value": "Display label for the input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/max_length/description",
+      "value": "Maximum input length when the input type supports a length limit.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/options/description",
+      "value": "List of selectable values for this form control.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/required/description",
+      "value": "Whether the input is required.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/type/description",
+      "value": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/variable/description",
+      "value": "Variable name used by the application.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/description",
+      "value": "External data tool input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/allowed_file_types/description",
+      "value": "Allowed file categories when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/allowed_file_upload_methods/description",
+      "value": "Allowed upload methods when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/config/description",
+      "value": "Additional input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/default/description",
+      "value": "Default value. Its JSON type depends on the form type.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/description/description",
+      "value": "Optional input description.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/hide/description",
+      "value": "Whether the input is hidden from the public form.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/json_schema/description",
+      "value": "JSON Schema used to validate JSON object input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/label/description",
+      "value": "Display label for the input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/max_length/description",
+      "value": "Maximum input length when the input type supports a length limit.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/options/description",
+      "value": "List of selectable values for this form control.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/required/description",
+      "value": "Whether the input is required.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/type/description",
+      "value": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/variable/description",
+      "value": "Variable name used by the application.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/description",
+      "value": "File-form control configuration returned by the application. It describes the label, variable name, whether input is required, accepted file categories and extensions, and supported transfer methods; it is not an uploaded multipart file.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/allowed_file_types/description",
+      "value": "Allowed file categories when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/allowed_file_upload_methods/description",
+      "value": "Allowed upload methods when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/config/description",
+      "value": "Additional input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/default/description",
+      "value": "Default value. Its JSON type depends on the form type.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/description/description",
+      "value": "Optional input description.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/hide/description",
+      "value": "Whether the input is hidden from the public form.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/json_schema/description",
+      "value": "JSON Schema used to validate JSON object input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/label/description",
+      "value": "Display label for the input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/max_length/description",
+      "value": "Maximum input length when the input type supports a length limit.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/options/description",
+      "value": "List of selectable values for this form control.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/required/description",
+      "value": "Whether the input is required.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/type/description",
+      "value": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/variable/description",
+      "value": "Variable name used by the application.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/description",
+      "value": "File-list input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/allowed_file_types/description",
+      "value": "Allowed file categories when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/allowed_file_upload_methods/description",
+      "value": "Allowed upload methods when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/config/description",
+      "value": "Additional input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/default/description",
+      "value": "Default value. Its JSON type depends on the form type.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/description/description",
+      "value": "Optional input description.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/hide/description",
+      "value": "Whether the input is hidden from the public form.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/json_schema/description",
+      "value": "JSON Schema used to validate JSON object input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/label/description",
+      "value": "Display label for the input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/max_length/description",
+      "value": "Maximum input length when the input type supports a length limit.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/options/description",
+      "value": "List of selectable values for this form control.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/required/description",
+      "value": "Whether the input is required.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/type/description",
+      "value": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/variable/description",
+      "value": "Variable name used by the application.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/description",
+      "value": "Checkbox input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/allowed_file_types/description",
+      "value": "Allowed file categories when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/allowed_file_upload_methods/description",
+      "value": "Allowed upload methods when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/config/description",
+      "value": "Additional input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/default/description",
+      "value": "Default value. Its JSON type depends on the form type.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/description/description",
+      "value": "Optional input description.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/hide/description",
+      "value": "Whether the input is hidden from the public form.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/json_schema/description",
+      "value": "JSON Schema used to validate JSON object input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/label/description",
+      "value": "Display label for the input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/max_length/description",
+      "value": "Maximum input length when the input type supports a length limit.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/options/description",
+      "value": "List of selectable values for this form control.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/required/description",
+      "value": "Whether the input is required.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/type/description",
+      "value": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/variable/description",
+      "value": "Variable name used by the application.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/description",
+      "value": "JSON object input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/allowed_file_extensions/description",
+      "value": "Allowed file extensions when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/allowed_file_types/description",
+      "value": "Allowed file categories when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/allowed_file_upload_methods/description",
+      "value": "Allowed upload methods when this input accepts files.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/config/description",
+      "value": "Additional input configuration.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/default/description",
+      "value": "Default value. Its JSON type depends on the form type.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/description/description",
+      "value": "Optional input description.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/hide/description",
+      "value": "Whether the input is hidden from the public form.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/json_schema/description",
+      "value": "JSON Schema used to validate JSON object input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/label/description",
+      "value": "Display label for the input.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/max_length/description",
+      "value": "Maximum input length when the input type supports a length limit.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/options/description",
+      "value": "List of selectable values for this form control.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/required/description",
+      "value": "Whether the input is required.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/type/description",
+      "value": "Redundant form-type value in the response. When present, it matches the surrounding form key; use the outer key to choose the control shape.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/variable/description",
+      "value": "Variable name used by the application.",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/properties/user_input_form/title",
+      "source_sha256": "4f7c88fdb1fe5aaacc59e28f6ab6fe531304cea4523e39a724d8a4d43a768ca1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/title",
+      "source_sha256": "373b929318436fe3d709c2edd9dcb1f01d7a1b015ae52113396d8adb8f50d07f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RequiredServiceApiUserPayload/title",
+      "source_sha256": "a1269019db4ddc7c919d3b0447ea781251fcad5e3c189d0d8214785fae80891d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ResultResponse/properties/result/description",
+      "value": "Operation result."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ResultResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ResultResponse/title",
+      "source_sha256": "01088850b9c319d53d821afeaed65bffdaeb842f51b877c8b03a85f6877dc8da"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/description",
+      "value": "Citation and attribution information for a retriever resource."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/content/description",
+      "value": "Content snippet from the resource."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/created_at/description",
+      "value": "Creation timestamp (Unix epoch seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/data_source_type/description",
+      "value": "Type of the data source."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_id/description",
+      "value": "ID of the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_id/title",
+      "source_sha256": "afd32ed627cd32334bfc447d13eeaef88fe7365a20bbe496d1b65e238ab4a97e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_name/description",
+      "value": "Name of the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_name/title",
+      "source_sha256": "c3f0ca5a47fcaf871602dc501da109161cf99c427aa29ab8b20ab03813246be5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/document_id/description",
+      "value": "ID of the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/document_name/description",
+      "value": "Name of the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/document_name/title",
+      "source_sha256": "afa98fb25c89955f16c5857a64ca57eeab8ad2fdfc7eaba13a79ddac268a3624"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/hit_count/description",
+      "value": "Number of times this chunk was hit."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/id/description",
+      "value": "Unique ID of the retriever resource."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/index_node_hash/description",
+      "value": "Hash of the index node."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/message_id/description",
+      "value": "ID of the message this resource belongs to."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/position/description",
+      "value": "Position of the resource in the list."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/score/description",
+      "value": "Similarity score of the resource."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/segment_id/description",
+      "value": "ID of the specific chunk within the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/segment_id/title",
+      "source_sha256": "7290170777560d41462deb95fa0c1a27884f2e487befa6820e24cf1acedb6131"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/segment_position/description",
+      "value": "Position of the chunk within the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/segment_position/title",
+      "source_sha256": "0bb9927f845754cf77570f81fd42d7660562e2b888a96d5ffbe8bfd2a1353d23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/summary/description",
+      "value": "Summary of the chunk content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/word_count/description",
+      "value": "Word count of the chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/title",
+      "source_sha256": "8de104f17ff021d40479f94786508b6a09f0cd2fdaa9e3eee9cff2efd7cc02f9"
     },
     {
       "op": "remove",
@@ -552,6 +4890,206 @@
     },
     {
       "op": "add",
+      "path": "/components/schemas/SelectInputConfig/properties/option_source/description",
+      "value": "Source of options for `select` inputs. Present only when `type` is `select`."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SelectInputConfig/properties/output_variable_name/description",
+      "value": "Variable name used to reference this input's submitted value inside the workflow. Corresponds to the key in the submission `inputs` object."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SelectInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SelectInputConfig/properties/type/description",
+      "value": "Form input control type. Available values: `paragraph` (multi-line text input), `select` (single-choice from a list), `file` (single file upload), and `file-list` (multiple file uploads)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SelectInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SelectInputConfig/title",
+      "source_sha256": "66e1ade121cd346fdaa6d2736f8281eaadb98ac2a2982ddf88a9c526c6f06896"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleAccountResponse/properties/email/description",
+      "value": "Account email address."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/properties/email/title",
+      "source_sha256": "0b57e967ff55ce5d934b1ac35a1e4a404e69444be35dba221b8a345b161d4ec6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleAccountResponse/properties/id/description",
+      "value": "Account ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleAccountResponse/properties/name/description",
+      "value": "Account display name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/title",
+      "source_sha256": "074038de7e175ff8c2c27288070f216316be12924a10cbd2cb4b46e65b9597fc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/created_at/description",
+      "value": "Creation time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/id/description",
+      "value": "Conversation ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/inputs/description",
+      "value": "Input variables for the conversation."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/introduction/description",
+      "value": "Conversation introduction."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/introduction/title",
+      "source_sha256": "3d8ebba814c39a18678feb6015bc971c5603aaf487b51f141fd911ac77481409"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/name/description",
+      "value": "Conversation name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/status/description",
+      "value": "Conversation status. `normal` for active conversations."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/updated_at/description",
+      "value": "Last update time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/title",
+      "source_sha256": "5aad3cc59041619d3a39704700a243adea52d63f141cf1802f5d8d20bee1e015"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/id/description",
+      "value": "End user ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/is_anonymous/description",
+      "value": "Whether the end user is anonymous."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/is_anonymous/title",
+      "source_sha256": "042cb8fffd7f6edb56ac128deed67f447ceb287cd716f3056d4ee0d5cee10114"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/session_id/description",
+      "value": "Session identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/session_id/title",
+      "source_sha256": "eb75473dc0fd06e0d9e515069eb952720ae3d0b7edfe76d2e7a922d225818a47"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/type/description",
+      "value": "End user type."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/title",
+      "source_sha256": "84f1217c362fa4b0b1ea92b19043514bd209a298151ac1671404067828738398"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleFeedback/properties/rating/description",
+      "value": "Feedback rating. `like` for positive, `dislike` for negative."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleFeedback/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleFeedback/title",
+      "source_sha256": "e44c1483d3675a29e09484fe6e7392ba98494d7e638966ad3dfaf382debb0c4e"
+    },
+    {
+      "op": "add",
       "path": "/components/schemas/SimpleResultResponse/properties/result/description",
       "value": "Operation result."
     },
@@ -564,6 +5102,301 @@
       "op": "remove",
       "path": "/components/schemas/SimpleResultResponse/title",
       "source_sha256": "412feb3d6da0cbf2901a8634d7612e513ffb59141b7369d0048187cfca1c7a73"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/data/description",
+      "value": "List of suggested questions."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/result/description",
+      "value": "Result status."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultStringListResponse/title",
+      "source_sha256": "a2760999e2320b93524528206e20f1a332ca5f97fe86255b94a71f940a73a6df"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/chat_color_theme/description",
+      "value": "Chat color theme."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/chat_color_theme/title",
+      "source_sha256": "41ced5ae48a2a6e7bd660a8b5e94294e3c8e96e034f46bae09e0b8b552de4d72"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/chat_color_theme_inverted/description",
+      "value": "Whether the chat color theme is inverted."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/chat_color_theme_inverted/title",
+      "source_sha256": "2872ca62bcb754d2f8d716df0d771a2970c96ab3b1b9d5d0e1052fcfce9a0a76"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/copyright/description",
+      "value": "Copyright text."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/copyright/title",
+      "source_sha256": "47ccad55c912b7daeec42e936d198cee6dbe394ab811d4d3b3937b5fb3597f03"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/custom_disclaimer/description",
+      "value": "Custom disclaimer text."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/custom_disclaimer/title",
+      "source_sha256": "7d49493fafa647a9b42d3afda0937aa5fcf13486bfa359ade5cedf99a8320d67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/default_language/description",
+      "value": "Default language code."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/default_language/title",
+      "source_sha256": "571d638d9ee456f58df3dc2d950a6ae524563eb69128509ae7bb19adf67ffd23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/description/description",
+      "value": "Web app description."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon/description",
+      "value": "Icon content (emoji or image ID)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon/title",
+      "source_sha256": "a4c7282e026e9c0eb1fc174c7d813fb7e1fc644829b38d12c28db5f9b9514330"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon_background/description",
+      "value": "Icon background color."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon_background/title",
+      "source_sha256": "15067379b68b825a8c24c73dca876adf650c51636467e4209270fac5b87c6dda"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon_type/description",
+      "value": "Type of icon used. `emoji` for emoji icons, `image` for uploaded image icons."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon_type/title",
+      "source_sha256": "285323907b457c9b9afe39555fbc8def3298246940561fc8587bfb6e657e3170"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon_url/description",
+      "value": "URL of the icon image."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon_url/title",
+      "source_sha256": "2002ea73f523b651e2e6f4c79f87fcd5231a172d575ec276ef2bbcee3d338405"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/input_placeholder/description",
+      "value": "Placeholder text shown in the web app message input box. `null` when not configured."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/input_placeholder/title",
+      "source_sha256": "0b023e2beb71ec1aac71e42ede317609d11892d3eae9bb7bf5177eabb7f59eb0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/privacy_policy/description",
+      "value": "Privacy policy URL."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/privacy_policy/title",
+      "source_sha256": "0afb547bbe92b2430806c1c57aedf2081ba43740a6ff896b1b7595fa12514a74"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/show_workflow_steps/description",
+      "value": "Whether to show workflow steps."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/show_workflow_steps/title",
+      "source_sha256": "531c481f887f460d3971490ccf48093486d7e61e2c39258ea736553a70ee42f4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/title/description",
+      "value": "Web app title."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/title/title",
+      "source_sha256": "4be9d4f1daabdb03afb07253382b19d77501261a6106d734746734605436aa77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/use_icon_as_answer_icon/description",
+      "value": "Whether to use the app icon as the answer icon."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/use_icon_as_answer_icon/title",
+      "source_sha256": "4a4c7e5ebdfefcddb3ae4e26e41d919118a63cd8fcbd3a72f66a54866f3c85f0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/title",
+      "source_sha256": "91f90818d42a984e64dccf6f8b2bf80fba7cd3948ecd51daa40aa2b27624baec"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringListSource/properties/selector/description",
+      "value": "Variable reference path when `type` is `variable`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringListSource/properties/selector/title",
+      "source_sha256": "c542de810cd37268c31367eddb90015a9ed2c3ab5c55bc664e19ac59527ca14d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringListSource/properties/type/description",
+      "value": "Origin of the options. `constant` means `value` lists the options literally; `variable` means `selector` points to an `array[string]` workflow variable that provides them."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringListSource/properties/value/description",
+      "value": "Literal option list when `type` is `constant`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringListSource/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringListSource/title",
+      "source_sha256": "8b070b8435acce4ef835c16fb7a002405384b6950aa38d44f5889179ac10f7a1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringSource/properties/selector/description",
+      "value": "Variable reference path (for example, `[\"node_id\", \"var_name\"]`) when `type` is `variable`. Must contain at least two elements."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringSource/properties/selector/title",
+      "source_sha256": "c542de810cd37268c31367eddb90015a9ed2c3ab5c55bc664e19ac59527ca14d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringSource/properties/type/description",
+      "value": "Source of the default. `constant` means `value` is used as a literal string; `variable` means `selector` points to a workflow variable."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringSource/properties/value/description",
+      "value": "Literal default value when `type` is `constant`. Always a string."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringSource/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringSource/title",
+      "source_sha256": "bf9bd9920a45c7d6f459cbf55c4060f98add35f38e77e9f6ba732c85737fb219"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/audio_file_size_limit/description",
+      "value": "Maximum audio file size in MB."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/audio_file_size_limit/title",
+      "source_sha256": "ad2d08a17949c0e6e8f4a1021c9d11806e21507b453f895e5933ce4b83d83b17"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/file_size_limit/description",
+      "value": "Maximum general file size in MB."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/file_size_limit/title",
+      "source_sha256": "5dbcce634cd4848d0b5480c1ddf4884bf1a4170090f844c08b88648b08ad2574"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/image_file_size_limit/description",
+      "value": "Maximum image file size in MB."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/image_file_size_limit/title",
+      "source_sha256": "a1bfda249e18ed4d84c7682eb63a00f762f8c0bbfc7ce8c816b6f1746d25a751"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/video_file_size_limit/description",
+      "value": "Maximum video file size in MB."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/video_file_size_limit/title",
+      "source_sha256": "3d23d0e91fcffafd34c8b833160bdb31bb78589e47b0b77ad8d8409a0e251792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/workflow_file_upload_limit/description",
+      "value": "Maximum number of files per workflow execution."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/workflow_file_upload_limit/title",
+      "source_sha256": "4a0348537154080e395851404929faff73f15cc25337d34f5ff8f7ca3f6a90fb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/title",
+      "source_sha256": "124b91697511ce88de874095c8edaf4bbf7c369aaaed03a7bf2bff88fe04e270"
     },
     {
       "op": "remove",
@@ -595,6 +5428,222 @@
       "op": "remove",
       "path": "/components/schemas/TextToAudioPayload/title",
       "source_sha256": "21460ec2d744ed638ddcc8912fa8e504c6ad781a6a7ad4206976f4aeb17aaab9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/streaming/title",
+      "source_sha256": "99c855ec96bb79eda46be7218b5ac2045b607b2135c1181034e6746519b88b06"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/voice/description",
+      "source_sha256": "093f32f71464b6ee988240562bff4f647ec3d81381328089f3daaf171c1bd766",
+      "value": "Voice to use for text-to-speech. Available voices depend on the TTS provider configured for this app. Omit to use the app's configured voice when available; that value is exposed by [Get App Parameters](/en/api-reference/applications/get-app-parameters) as `text_to_speech.voice`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/voice/title",
+      "source_sha256": "75d5a120334e208c41bdff270efdb5ed48de029fa6a9399b5897166f2dc6baf2"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/title",
+      "source_sha256": "21460ec2d744ed638ddcc8912fa8e504c6ad781a6a7ad4206976f4aeb17aaab9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ToolIcon/properties/background/description",
+      "value": "Background color in hex format."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ToolIcon/properties/background/title",
+      "source_sha256": "7d67b6c9f37716ad92890af3917606fbdc14a776e1a03b9e40c58171ca128af4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ToolIcon/properties/content/description",
+      "value": "Emoji content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ToolIcon/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ToolIcon/title",
+      "source_sha256": "25ff44cb5514b1148a3243ce18e6135333123c6a437c924be3bd88f8be03028f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/UserActionConfig/properties/button_style/description",
+      "value": "Visual style of the button. Available values: `primary`, `default`, `accent`, `ghost`."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/UserActionConfig/properties/id/description",
+      "value": "Identifier of the action button. Pass as `action` on [Submit Human Input Form](/en/api-reference/human-input/submit-human-input-form) when the recipient selects this button."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UserActionConfig/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/UserActionConfig/properties/title/description",
+      "value": "Action button label."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UserActionConfig/properties/title/title",
+      "source_sha256": "4be9d4f1daabdb03afb07253382b19d77501261a6106d734746734605436aa77"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UserActionConfig/title",
+      "source_sha256": "8cc1df1dc023895b6b786fd37c77c50adbe3df59295854f93b10148de97ea429"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ValueSourceType/title",
+      "source_sha256": "b27082732c38a38ed5997a127490a1121fdd96ed9079027df4ac09ff3e557856"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/data/description",
+      "value": "Workflow log records on the current page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/has_more/description",
+      "value": "Whether more workflow log records are available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/limit/description",
+      "value": "Number of items per page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/page/description",
+      "value": "Current page number."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/total/description",
+      "value": "Total number of matching workflow log records."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/title",
+      "source_sha256": "6c3caf31a556cc72f384dea999bacd03aaaee6e71d7d8354ee9a34aa8f91e4ae"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_at/description",
+      "value": "Creation time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_account/description",
+      "value": "Account details if created by an admin user."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_end_user/description",
+      "value": "End user that created the workflow run."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_role/description",
+      "value": "Role of the creator (e.g., `end_user`, `account`)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_role/title",
+      "source_sha256": "e9f5487fc14e6afc3a6b15262084175591249b08d500c3d3de5c3b17d7f65a74"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_from/description",
+      "value": "Source of the workflow run (e.g., `service-api`)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_from/title",
+      "source_sha256": "ac7605d36b5da31a00bcf6692a557183ddce029a6ca4c5fb5cc911c9e9fd1495"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/details/description",
+      "value": "Additional details for the log entry."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/details/title",
+      "source_sha256": "ebc7bf40f12e237ea22047135a6283ad553d28145e437123173175174e8a40c0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/id/description",
+      "value": "Log entry ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/workflow_run/description",
+      "value": "Workflow run details for this log entry."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/title",
+      "source_sha256": "87d57c23bd12acd83d7db989a402f37910d6d9d1e8035e483782f75ab988defc"
     },
     {
       "op": "remove",
@@ -1125,6 +6174,121 @@
       "source_sha256": "dbfd757fad089c9351abf34e0ded1ad305716aa9cf964d9dc5dabecd6141e448"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/created_at/description",
+      "value": "Creation time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/elapsed_time/description",
+      "value": "Total time elapsed in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/error/description",
+      "value": "Error message if the workflow failed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/exceptions_count/description",
+      "value": "Number of exceptions that occurred during execution."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/exceptions_count/title",
+      "source_sha256": "94e4767e69ec132353328419cbe108ea7d347436868ffbdfb66ed053976c364f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/finished_at/description",
+      "value": "Finish time as a Unix timestamp in seconds; `null` if not finished."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/id/description",
+      "value": "Workflow run ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/status/description",
+      "value": "Workflow execution status. `running` for in-progress executions, `succeeded` when completed successfully, `failed` when execution encountered an error, `stopped` when manually halted, `partial-succeeded` when some nodes succeeded but others failed, `paused` when awaiting human input."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_steps/description",
+      "value": "Total number of workflow steps executed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_tokens/description",
+      "value": "Total tokens consumed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/triggered_from/description",
+      "value": "Source that triggered the workflow run. `app-run` for runs started from the app or API, `webhook` for runs started by a webhook trigger, `schedule` for runs started by a schedule trigger, `plugin` for runs started by an integration trigger."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/triggered_from/title",
+      "source_sha256": "ed0a91c6e5551150e5188bca26e06188f8a9cff5b3b66868e436008ced2d2a0b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/version/description",
+      "value": "Workflow version identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/version/title",
+      "source_sha256": "6a0ad2bedc57dba081cb41b98d36276eb4ebe6e16bf6523b185216d5b6dc0b0a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/title",
+      "source_sha256": "047103a06c1f0961fca15bedbd7e2e217512505bf65e5c4b52994216ae29a0b3"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
       "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
@@ -1187,6 +6351,185 @@
       "op": "remove",
       "path": "/components/schemas/WorkflowRunPayload/title",
       "source_sha256": "610156d74f8171372740a56b3a96632a903151f9cbfcc6f0ada83493fd50cf49"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "Uploaded file ID obtained from the [Upload File](/en/api-reference/files/upload-file) API. Required for `local_file`; also accepted with `remote_url` for compatibility with persisted file references.",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/description",
+      "source_sha256": "2b389dd61c5418f868e8d3f5f8741a3cbfb1b9e4fb15604bdc8e72f0c2649974",
+      "value": "File list for workflow system file inputs. Available when file upload is enabled for the workflow. To attach a local file, first upload it via [Upload File](/en/api-reference/files/upload-file) and use the returned `id` as `upload_file_id` with `transfer_method: local_file`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/inputs/description",
+      "source_sha256": "048d45b6175968d587d71c3ac5f810521aafb994d9f016b592b5a23e353f186f",
+      "value": "Key-value pairs for workflow input variables. Values for file-type variables should be arrays of file objects with `type`, `transfer_method`, and either `url` or `upload_file_id`. Refer to the `user_input_form` field in the [Get App Parameters](/en/api-reference/applications/get-app-parameters) response to discover the variable names and types expected by your app."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/title",
+      "source_sha256": "610156d74f8171372740a56b3a96632a903151f9cbfcc6f0ada83493fd50cf49"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/created_at/description",
+      "value": "Creation time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/elapsed_time/description",
+      "value": "Total time elapsed in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/error/description",
+      "value": "Error message if the workflow failed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/finished_at/description",
+      "value": "Finish time as a Unix timestamp in seconds; `null` if not finished."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/id/description",
+      "value": "Workflow run ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/inputs/description",
+      "value": "Inputs supplied to the workflow run. The JSON value can be an object, array, primitive, or `null`; it is already decoded according to the response schema and does not require an additional JSON parse."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/outputs/description",
+      "value": "Output data from the workflow. An empty object until outputs are available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/outputs/title",
+      "source_sha256": "d65ed4159859975e88dbd98c69421ec1e5cc195d03f8dfcec429a5d57839e838"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/status/description",
+      "value": "Workflow execution status. `running` for in-progress executions, `succeeded` when completed successfully, `failed` when execution encountered an error, `stopped` when manually halted, `partial-succeeded` when some nodes succeeded but others failed, `paused` when awaiting human input."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_steps/description",
+      "value": "Total number of workflow steps executed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_tokens/description",
+      "value": "Total tokens consumed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/workflow_id/description",
+      "value": "Workflow definition ID used for this run."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/title",
+      "source_sha256": "32535d42024ce5ae678a114565b28cb2d20517bf30a926b010c497834d0c94ba"
     },
     {
       "op": "add",

--- a/tools/api-pipeline/service_api_overlays/ja.json
+++ b/tools/api-pipeline/service_api_overlays/ja.json
@@ -46,6 +46,323 @@
       "value": "値エラー。"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/answer/description",
+      "value": "この思考に関連するツールまたはモデルの回答。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/chain_id/description",
+      "value": "この思考のチェーン ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/chain_id/title",
+      "source_sha256": "295f6a392c61fdbbb6ef9abb1b4b8147059908a23e28a9e94d796e20422a86fd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/created_at/description",
+      "value": "作成時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/files/description",
+      "value": "この思考に関連するファイル ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/id/description",
+      "value": "エージェント思考 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/message_id/description",
+      "value": "この思考が属する一意のメッセージ ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/observation/description",
+      "value": "ツール呼び出しからのレスポンスです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/observation/title",
+      "source_sha256": "c4a6f6ba9024a0dbab79416f13405fe844b0c7bf192602e88e513be9a52d79d8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/position/description",
+      "value": "この思考の位置です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/thought/description",
+      "value": "LLM が思考している内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/thought/title",
+      "source_sha256": "02bf582eb1a75c8e50c3bdcd83f2a7709b766e8a2665ab35eea31f9da2ac047e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/tool/description",
+      "value": "呼び出されたツール（`;` で区切り）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/tool/title",
+      "source_sha256": "077dcaba577a59acd143ab78b5a82a1aecf5e12e5df0fc8a7bebfae7b492a894"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/tool_input/description",
+      "value": "ツールの入力（JSON 形式）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/tool_input/title",
+      "source_sha256": "e6c0015853f82e8c5fa6ea7ac0d578344f50eee52392b5ca2cd4aeeca9b6d01d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/tool_labels/description",
+      "value": "使用されたツールのラベルです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/title",
+      "source_sha256": "2e64047dcc72e66d47b39c7f80a94f47e35b0fc7ff3afa3e5b2c945840a567d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/answer/description",
+      "value": "アノテーションがマッチした際に返される定義済みの回答です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/created_at/description",
+      "value": "作成タイムスタンプ（Unix エポック秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/hit_count/description",
+      "value": "このアノテーションがマッチして返信として返された回数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/id/description",
+      "value": "アノテーションの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/question/description",
+      "value": "このアノテーションをトリガーする質問テキストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/question/title",
+      "source_sha256": "b9af1957d9fdeaa7a00f9959b1d3d7a0b86e7668490814638482312eddff520e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/title",
+      "source_sha256": "1d156a865fcd9720975862e919faa36a4b7ea8f663d0755308e270e8501d8126"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationCreatePayload/properties/answer/description",
+      "source_sha256": "6de2ba7c6fafc16674eaa715351462f3f48378ac96c6abe2849def2cff32a83c",
+      "value": "アノテーションの回答。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationCreatePayload/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationCreatePayload/properties/question/description",
+      "source_sha256": "6594a0e78509693283abe64f502b3569b96e53dd1caa5e2abd93bf26265b3158",
+      "value": "アノテーションの質問。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationCreatePayload/properties/question/title",
+      "source_sha256": "b9af1957d9fdeaa7a00f9959b1d3d7a0b86e7668490814638482312eddff520e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationCreatePayload/title",
+      "source_sha256": "413a6ae76b1d2bfe14c473638acdad02036b866edfe5a1457bc47b09ed2d0a7b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/error_msg/description",
+      "value": "ジョブが失敗した理由を説明するエラーメッセージです。`job_status` が `error` でない場合は空文字列です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/error_msg/title",
+      "source_sha256": "67b237015aff3ff7c6bd9b6b3efd48804f142eb82797cf06fe5a8ad1fa7b9f6a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_id/description",
+      "value": "[アノテーション返信を設定](/ja/api-reference/annotations/configure-annotation-reply) 呼び出しから取得したジョブ ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_id/title",
+      "source_sha256": "0e9ad890b0e8639f3521d2e36b860c41a72abef7b2752efd1288cb7aaf51f61a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_status/description",
+      "value": "現在のジョブステータスです。`waiting` はキュー待ち、`processing` は処理中、`completed` は完了、`error` は失敗を示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_status/title",
+      "source_sha256": "9a40e8f9b1ac49b7bf83d3f139b4200b18138cf7ae61765baeac6f0f6fe3a8e9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/title",
+      "source_sha256": "a1cfc801d1b6e994cf2bc8080150df8f25096803221200581a99bca5ef2196ec"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_id/description",
+      "value": "非同期ジョブ ID です。[アノテーション返信の初期設定タスクステータスを取得](/ja/api-reference/annotations/get-annotation-reply-job-status) と組み合わせて進捗を追跡します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_id/title",
+      "source_sha256": "0e9ad890b0e8639f3521d2e36b860c41a72abef7b2752efd1288cb7aaf51f61a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_status/description",
+      "value": "現在のジョブステータスです。このエンドポイントが返すのは `waiting`（キュー待ち）または `processing`（処理中）のみです。`completed` と `error` は [アノテーション返信の初期設定タスクステータスを取得](/ja/api-reference/annotations/get-annotation-reply-job-status) からのみ返されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_status/title",
+      "source_sha256": "9a40e8f9b1ac49b7bf83d3f139b4200b18138cf7ae61765baeac6f0f6fe3a8e9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusResponse/title",
+      "source_sha256": "35a266556dc525b5163ab1c4a9532dd08c70ba24bbc049ac94ea1a2680f7542e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/data/description",
+      "value": "現在のページのアノテーション一覧。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/has_more/description",
+      "value": "さらにアノテーションがあるかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/limit/description",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/page/description",
+      "value": "現在のページ番号です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/total/description",
+      "value": "一致するアノテーションの総数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/title",
+      "source_sha256": "2d0d76736240133bea40a30d2182193901623f5a9d376f31a75e0e437ea89554"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/AnnotationListQuery/properties/keyword/description",
       "source_sha256": "5fd30b8249e33765d94bb777c6421570c4fb1faf94ab41cbac0d1e0b7f763233",
@@ -84,14 +401,1111 @@
       "source_sha256": "eb84fea86ba7ca8a051d796765be892d20a92ecd050e29212f7498902bab4536"
     },
     {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_model_name/description",
+      "source_sha256": "c97df7b88c3b777272905064d453ebc60cc5f76c3d1cdabf236e29a079952ba2",
+      "value": "[利用可能なモデルを取得](/ja/api-reference/models/get-available-models) に `model_type=text-embedding` を指定したレスポンスの `model` フィールドを使用します（例：`text-embedding-3-small`）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_model_name/title",
+      "source_sha256": "4d79d966137d5bf514424da3770d0535ef6289a20ce67d7d5be6038198ccd6bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_provider_name/description",
+      "source_sha256": "7708e9e2750cbc449cb13498e296c0079bfa6dbd04969ed0e586b855d76ff8eb",
+      "value": "[利用可能なモデルを取得](/ja/api-reference/models/get-available-models) に `model_type=text-embedding` を指定したレスポンスの `provider` フィールドを使用します（例：`openai`）。表示名は使用しないでください。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_provider_name/title",
+      "source_sha256": "4e0310d84c92f0465d3c1184754fbd60864f0d6925435fa6eff884947966e073"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/score_threshold/description",
+      "source_sha256": "78137b1381fc7cbe544de27fe6fe7ab2d01dbd702e4001e00b643290214b86c1",
+      "value": "アノテーション一致とみなす最小類似度スコア（0〜1）。値が高いほど厳密な一致が必要です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/title",
+      "source_sha256": "b64b023cf7b9b8c2d5885e5766acb46dfdcdc788e3999ab6dbfad1ddeb03741f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackListResponse/properties/data/description",
+      "value": "現在のページのフィードバックレコード。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackListResponse/title",
+      "source_sha256": "e4c6386ce897eb0ca2e13e996a1088fbcf09fe754f8d83417256df2bb95ce897"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/app_id/description",
+      "value": "アプリケーション ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/app_id/title",
+      "source_sha256": "9bb6aa4fb1320b37040e3c92ca381635520a01dab3a13c05e5058b135db6de04"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/content/description",
+      "value": "任意のテキストフィードバック。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/conversation_id/description",
+      "value": "会話 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/created_at/description",
+      "value": "作成時刻（RFC 3339 日時文字列）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_account_id/description",
+      "value": "フィードバックを送信したアカウント ID。`from_source` が `admin` の場合に存在します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_account_id/title",
+      "source_sha256": "cf6be2adfe52b9a1e32690eb1459bb3b20be1cf8fc055f7f7156102c5e59503b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_end_user_id/description",
+      "value": "フィードバックを送信したエンドユーザー ID。`from_source` が `user` の場合に存在します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_end_user_id/title",
+      "source_sha256": "6da19052c4804db16313c62d79be1a72ef4475a68ddc28566b4770664cdd7e32"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_source/description",
+      "value": "フィードバックのソース。API 経由でエンドユーザーが送信したフィードバックの場合は `user`、コンソールから送信されたフィードバックの場合は `admin`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_source/title",
+      "source_sha256": "9a626efdfa6afdf31c0c0116f75a7858cb12aeca76c605c7fad2a276d2d2547d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/id/description",
+      "value": "フィードバック ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/message_id/description",
+      "value": "メッセージ ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/rating/description",
+      "value": "フィードバック評価。肯定的な場合は `like`、否定的な場合は `dislike`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/updated_at/description",
+      "value": "最終更新時刻（RFC 3339 日時文字列）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/title",
+      "source_sha256": "e32e96636947952e56902bb4f92cee12934f772ba0e4c6bebf793ab3c2064dc2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/author_name/description",
+      "value": "アプリケーション作成者の名前。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/author_name/title",
+      "source_sha256": "184bab624ca3534f57b76d065cf11c51a641c53cceed8e6b5f7909a253e49313"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/description/description",
+      "value": "アプリケーションの説明。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/mode/description",
+      "value": "アプリケーションモード。`completion` はテキストジェネレーター、`chat` は基本チャットボット、`agent-chat` は旧 Agent アプリ、`advanced-chat` は Chatflow（会話型ワークフロー）、`workflow` は非会話型 Workflow アプリ、`agent` は新しい Agent アプリです。各操作の説明に対応モードを記載しています。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/name/description",
+      "value": "アプリケーション名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/tags/description",
+      "value": "アプリケーションタグ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/tags/title",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/title",
+      "source_sha256": "d5b9c094d6791f9b503a3c097df4bc53a1e28c0b129cd294641a8d900d74a8b0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppMetaResponse/properties/tool_icons/additionalProperties/anyOf/0/description",
+      "value": "アイコンの URL。",
+      "context_path": "/components/schemas/AppMetaResponse/properties/tool_icons/additionalProperties/anyOf/0",
+      "context_sha256": "7cda4ff9a25f90d276ecdd759f6660841ebf4aef042e04abe3635927522db28b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppMetaResponse/properties/tool_icons/description",
+      "value": "ツールアイコン。キーはツール名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppMetaResponse/properties/tool_icons/title",
+      "source_sha256": "a8cf9cfba30dbe3b343ffd1308aec61813daf50b8a95956dbc1f4a035c0a1ea9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppMetaResponse/title",
+      "source_sha256": "b50a0719720ed8b5183b9db8f973221fff3081a4e29db2d876bf65cc74cc7ea5"
+    },
+    {
       "op": "remove",
       "path": "/components/schemas/AudioBinaryResponse/title",
       "source_sha256": "ef754dee1a457218bc6c216dbd5138062dae750a388d7af5791b480dbf56c417"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/AudioTranscriptResponse/properties/text/description",
+      "value": "音声認識からの出力テキスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AudioTranscriptResponse/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AudioTranscriptResponse/title",
+      "source_sha256": "41e01a98ed9542dd3ad194f18ddb4af06fe1d0beb98f35acac5dc3d18cbcd158"
+    },
+    {
       "op": "remove",
       "path": "/components/schemas/BinaryFileResponse/title",
       "source_sha256": "40ee4d6aa1f0027872e6b1bea14f0389f51e33afdf6edbf84edc04f56b572787"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingMetadataResponse/description",
+      "value": "使用量と検索リソースを含むメタデータ。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingMetadataResponse/properties/retriever_resources/description",
+      "value": "使用された検索リソースのリスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingMetadataResponse/properties/retriever_resources/title",
+      "source_sha256": "0cad6b9867870a47877812c4336c83401368174ab4b1b3d3de4636bb6b1e42b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingMetadataResponse/properties/usage/description",
+      "value": "モデルの使用情報です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingMetadataResponse/title",
+      "source_sha256": "7fe0af522608ffffa14de6ad92786cbfaac522effc05308872c5a57e3f796820"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/content/description",
+      "value": "リソースからのコンテンツスニペット。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/created_at/description",
+      "value": "作成タイムスタンプ（Unix エポック秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/data_source_type/description",
+      "value": "データソースのタイプ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_id/description",
+      "value": "ナレッジベース ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_id/title",
+      "source_sha256": "afd32ed627cd32334bfc447d13eeaef88fe7365a20bbe496d1b65e238ab4a97e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_name/description",
+      "value": "ナレッジベース名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_name/title",
+      "source_sha256": "c3f0ca5a47fcaf871602dc501da109161cf99c427aa29ab8b20ab03813246be5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_id/description",
+      "value": "ドキュメント ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_name/description",
+      "value": "ドキュメント名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_name/title",
+      "source_sha256": "afa98fb25c89955f16c5857a64ca57eeab8ad2fdfc7eaba13a79ddac268a3624"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/hit_count/description",
+      "value": "このチャンクがヒットした回数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/id/description",
+      "value": "検索リソースの一意の ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/index_node_hash/description",
+      "value": "インデックスノードのハッシュ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/message_id/description",
+      "value": "このリソースが属するメッセージの ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/position/description",
+      "value": "リスト内のリソースの位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/score/description",
+      "value": "リソースの関連性スコア。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_id/description",
+      "value": "ドキュメント内の特定のチャンクの ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_id/title",
+      "source_sha256": "7290170777560d41462deb95fa0c1a27884f2e487befa6820e24cf1acedb6131"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_position/description",
+      "value": "ドキュメント内のチャンクの位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_position/title",
+      "source_sha256": "0bb9927f845754cf77570f81fd42d7660562e2b888a96d5ffbe8bfd2a1353d23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/summary/description",
+      "value": "チャンクコンテンツの要約。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/word_count/description",
+      "value": "チャンクの単語数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/title",
+      "source_sha256": "562f01953930e507e89d83f36436ed273caf2e0d7710f93757efdf32d5767ade"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price/description",
+      "value": "補完トークンの合計価格。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price/title",
+      "source_sha256": "29d9f1eee907e3c79c50ce304a90fb9e166f0b6923150c2168fea6f305f8ac6d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price_unit/description",
+      "value": "補完トークンの価格単位。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price_unit/title",
+      "source_sha256": "7b51570d42e18985f1af94caada87243925486380581e2b09744ddb5c9329055"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_tokens/description",
+      "value": "補完のトークン数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_tokens/title",
+      "source_sha256": "fba7b76f7b0ed47936475461d4f609cfee6f2de15766d690821b86c3545f4f92"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_unit_price/description",
+      "value": "補完トークンあたりの単価。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_unit_price/title",
+      "source_sha256": "8361013d73ca8fb1331aedf884946e7bc243afdb8fff3fbbccacd1227f6e7f35"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/currency/description",
+      "value": "課金通貨。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/currency/title",
+      "source_sha256": "dc3eb42975d1c1fd78c9d592adde6dbe02d004e08e7cd0dfd3951c84900b875e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/latency/description",
+      "value": "レイテンシ（秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/latency/title",
+      "source_sha256": "3265005a867197e7e231cd75b93d66feb7416493c730b6fb5cb643ce6a91e069"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price/description",
+      "value": "プロンプトトークンの合計価格。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price/title",
+      "source_sha256": "6896cdeb14e5bfe7e9318f7da7e125e7938a304bb6ef3596e98142bdf229ca7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price_unit/description",
+      "value": "プロンプトトークンの価格単位。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price_unit/title",
+      "source_sha256": "83edd2617fd5182b95235c3150c4c6da8764c1ee436568aeaa20f177a5ecc709"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_tokens/description",
+      "value": "プロンプト内のトークン数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_tokens/title",
+      "source_sha256": "00b76256407926bda0ce2732b9782cb51da7cb0df679f87c21321ee1cfc36788"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_unit_price/description",
+      "value": "プロンプトトークンあたりの単価。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_unit_price/title",
+      "source_sha256": "9340411003259c99bfef4879cd17201753522ff030ed12bfa326b087eb9fe872"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_price/description",
+      "value": "すべてのトークンの合計価格。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_price/title",
+      "source_sha256": "3576c59289ecc321e2cfdba5f8a98bfe257996dc1fbc54b4ea53fe287e7987e2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_tokens/description",
+      "value": "使用されたトークンの合計数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/title",
+      "source_sha256": "39a4eb04a7c3190dc2b3ac19dcc6ed01d33411dcc9daaecfcc089ca5c9589c18"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ButtonStyle/description",
+      "source_sha256": "026b21982c1217d0f6864e5b4247161bf98a7dc43fef34b381ddf865a1e19e0b",
+      "value": "ユーザーアクションのボタンスタイル。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ButtonStyle/title",
+      "source_sha256": "0e4f7e534381b07844aae6f722fe74e489ba76de6af52373084a21916c6abef7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatBlockingResponse/description",
+      "source_sha256": "6855f2011b3097c7af89ef5d153387cf65e59df1ed9f3cb2ed30f99595532b5a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatBlockingResponse/title",
+      "source_sha256": "ae94d0636dd14bc30ed94d2e44c244ed20cbdea93abc003e90b6fb96612aaa38"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/description",
+      "value": "イベントタイプ。`message` に固定されています。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/answer/description",
+      "value": "完全なレスポンスコンテンツ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/conversation_id/description",
+      "value": "会話 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/created_at/description",
+      "value": "メッセージ作成タイムスタンプ（Unix エポック秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/event/description",
+      "value": "イベントタイプ。`message` に固定されています。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/event/title",
+      "source_sha256": "426621e6a36074101f2af3e84f1bcc0a3df129e85946330dbece4d333264f5dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/id/description",
+      "value": "このレスポンスイベントの一意 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/message_id/description",
+      "value": "一意のメッセージ ID です。フィードバックや推奨質問のエンドポイントを呼び出す際に `message_id` パラメータとして使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/metadata/description",
+      "value": "使用量と検索リソースを含むメタデータ。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/mode/description",
+      "value": "アプリモード。`chat` はチャットボットアプリ、`agent-chat` は Agent アプリ、`advanced-chat` は Chatflow アプリです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/task_id/description",
+      "value": "リクエスト追跡およびレスポンス停止 API 用のタスク ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/title",
+      "source_sha256": "621cbd41e3abe7a913f3d24026a9e4a9772b928f3fabb276dfa8790ad6b53330"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatPauseReasonResponse/description",
+      "source_sha256": "1417d50eba847462718505449c0df336db0d597c4b1d553ab05db5aaf44983f5",
+      "value": "ブロッキング Chatflow 実行が一時停止した理由の公開情報です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/TYPE/description",
+      "value": "一時停止理由のタイプです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/TYPE/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/actions/description",
+      "value": "人間の入力フォームで利用できるアクションです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/actions/title",
+      "source_sha256": "aa6d82bdb3cc1d9a5e542ae2669fef27690019ab5d7b20f17d9f1331a6a942fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/approval_channels/description",
+      "value": "設定された承認チャネルです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/approval_channels/title",
+      "source_sha256": "e8dc5bb01a260360a49a9e3ee2b7e7ecc9e6b4f68aaf2bf205e3a4bcfc747d63"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/display_in_ui/description",
+      "value": "一時停止理由を UI に表示するかどうかを示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/display_in_ui/title",
+      "source_sha256": "8c71965fd96e6f8b785ae269402727f478472205a018ad31c70fd0860c046614"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/expiration_time/description",
+      "value": "人間の入力フォームの有効期限を示す Unix タイムスタンプです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_content/description",
+      "value": "人間の入力フォームに表示する内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_id/description",
+      "value": "人間の入力フォーム ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_id/title",
+      "source_sha256": "fafd71c45b122dd8a3264f51789d5b76c7b77ff8dc669263056f89c55464dd7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_token/description",
+      "value": "人間の入力フォーム API で使用するアクセストークンです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_token/title",
+      "source_sha256": "7a13fbb60d7b9386e1e508b9270fcf384926bf6ed214f4b6523f46e5946f2c67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/inputs/description",
+      "value": "人間の入力フォームの入力フィールドです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/message/description",
+      "value": "ワークフローが一時停止した理由を説明するメッセージです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/message/title",
+      "source_sha256": "be1af94c8c00110d748345ea5e25cfc3aca39055ab9101ab1d8d551928445819"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_id/description",
+      "value": "一時停止したワークフローノード ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_title/description",
+      "value": "一時停止したワークフローノードのタイトルです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/resolved_default_values/description",
+      "value": "フォーム入力で解決されたデフォルト値です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/title",
+      "source_sha256": "6bd7d1ff1401cbea01fb89343104f99acc66302933d2c9d54b62ee9c1b97cf6a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/description",
+      "value": "Chatflow ワークフロー実行の一時停止詳細です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/answer/description",
+      "value": "完全なレスポンスコンテンツ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/conversation_id/description",
+      "value": "会話 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/created_at/description",
+      "value": "メッセージ作成タイムスタンプ（Unix エポック秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/elapsed_time/description",
+      "value": "合計実行時間（秒）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/id/description",
+      "value": "このレスポンスイベントの一意 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/message_id/description",
+      "value": "一意のメッセージ ID です。フィードバックや推奨質問のエンドポイントを呼び出す際に `message_id` パラメータとして使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/metadata/description",
+      "value": "使用量と検索リソースを含むメタデータ。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/mode/description",
+      "value": "アプリモード。`chat` はチャットボットアプリ、`agent-chat` は Agent アプリ、`advanced-chat` は Chatflow アプリです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/paused_nodes/description",
+      "value": "入力待ちのワークフローノード ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/paused_nodes/title",
+      "source_sha256": "1be2bcf1f1cac22fee5004654f91685bb8d677de3e9c946a311420a413e25f98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/reasons/description",
+      "value": "人間の入力フォームの詳細を含む、ワークフローの一時停止理由です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/reasons/title",
+      "source_sha256": "c9f903172d68246eaeee2c130b732b3b5596a22100ff964b1a54aa9351f20b08"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/status/description",
+      "value": "ワークフロー実行ステータスは `paused` 固定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_steps/description",
+      "value": "実行されたワークフローステップの合計数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_tokens/description",
+      "value": "すべてのノードで消費された Token の合計数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/workflow_run_id/description",
+      "value": "一時停止したワークフロー実行の永続 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/title",
+      "source_sha256": "cd61aef73a52645cfb71fe9879437e410b1afca2dac696a60f25998ad657099d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/description",
+      "value": "Chatflow が人間の入力を待機している場合に返されるブロッキングレスポンスです。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/answer/description",
+      "value": "完全なレスポンスコンテンツ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/conversation_id/description",
+      "value": "会話 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/created_at/description",
+      "value": "メッセージ作成タイムスタンプ（Unix エポック秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/data/description",
+      "value": "Chatflow ワークフロー実行の一時停止詳細です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/event/description",
+      "value": "Chatflow が人間の入力を待機している場合、イベントタイプは `workflow_paused` 固定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/event/title",
+      "source_sha256": "426621e6a36074101f2af3e84f1bcc0a3df129e85946330dbece4d333264f5dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/id/description",
+      "value": "このレスポンスイベントの一意 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/message_id/description",
+      "value": "一意のメッセージ ID です。フィードバックや推奨質問のエンドポイントを呼び出す際に `message_id` パラメータとして使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/metadata/description",
+      "value": "使用量と検索リソースを含むメタデータ。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/mode/description",
+      "value": "アプリモード。`chat` はチャットボットアプリ、`agent-chat` は Agent アプリ、`advanced-chat` は Chatflow アプリです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/task_id/description",
+      "value": "リクエスト追跡およびレスポンス停止 API 用のタスク ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/workflow_run_id/description",
+      "value": "一時停止したワークフロー実行の永続 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/title",
+      "source_sha256": "d5bf66fb39bbc16156f497f3a3126daab95b1f0125b5be3ba9e53d967b5ca843"
     },
     {
       "op": "replace",
@@ -337,6 +1751,254 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/auto_generate_name/description",
+      "source_sha256": "e5973e5a893cd7bdbc306bccb9e8dad1cc4cdd20f63d801ac823cd1d07119df8",
+      "value": "会話タイトルを自動生成するかどうか。`false` の場合は、会話名変更 API で `auto_generate: true` を指定してタイトルを非同期生成できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/auto_generate_name/title",
+      "source_sha256": "3ed483bca55763140ff1d72d40e67e287249200e1fa7c544a8cf98312bcff07d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/conversation_id/description",
+      "source_sha256": "27e05c95b7ec09544d57afd7b24bb352c65a4bce2ab5f86401b97d3c5d7a4511",
+      "value": "会話を継続するための会話 ID。このフィールドを省略するか空文字列を渡すと新しい会話が開始されます。以降のリクエストでは返された `conversation_id` を渡します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "マルチモーダル入力に使用するファイルです。新しいクライアントは 2 つの標準形式だけを実装してください。公開ファイル URL には `transfer_method: remote_url` と `url` を使用します。ローカルファイルは[ファイルをアップロード](/ja/api-reference/files/upload-file)でアップロードし、`transfer_method: local_file` と、返された `id` を指定する `upload_file_id` を使用します。生成されたその他の `anyOf` の組み合わせは、保存済みの旧形式参照との後方互換性のためだけに存在します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "アプリ定義変数の値です。想定される変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/query/description",
+      "source_sha256": "471e3964eb5e828809bb8ce8b7df96c8aba289839bd3521465e3cc501332c2d4",
+      "value": "ユーザー入力または質問の内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/response_mode/description",
+      "source_sha256": "c581b2c300c810f3aee9272bcd889e500a65443b16a9729c8538d3b4540237d1",
+      "value": "レスポンスモード。`streaming` は Server-Sent Events（SSE）を使用し、`blocking` は完了後に返します。新しい Agent アプリモードはストリーミングのみをサポートします。省略すると、Agent 以外はブロッキング、新しい Agent はストリーミングで実行されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/workflow_id/description",
+      "source_sha256": "73733c8ea4eb596b707394ec840174c0200e4c3c4ffb2c523f0f1e7af3c9abc3",
+      "value": "高度なチャットで実行する公開済みワークフローバージョン ID。省略すると、アプリの現在の公開済みワークフローを使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/title",
+      "source_sha256": "737ed654af2d15b7259a6742f94f2f965deeff0143b24f8c6394a335a43318e6"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/ChildChunkListQuery/properties/keyword/description",
       "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
       "value": "検索キーワードです。"
@@ -372,6 +2034,86 @@
       "op": "remove",
       "path": "/components/schemas/ChildChunkListQuery/title",
       "source_sha256": "b1c6a7020550b6caf74316c4f6f0d9a79bb59b5fe961a3d65331855b2e4fa238"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/answer/description",
+      "value": "完全なレスポンスコンテンツ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/created_at/description",
+      "value": "メッセージ作成タイムスタンプ（Unix エポック秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/event/description",
+      "value": "イベントタイプ。`message` に固定されています。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/event/title",
+      "source_sha256": "426621e6a36074101f2af3e84f1bcc0a3df129e85946330dbece4d333264f5dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/id/description",
+      "value": "このレスポンスイベントの一意 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/message_id/description",
+      "value": "一意のメッセージ ID。フィードバック送信時に `message_id` として使用します。テキストジェネレーターでは質問候補の生成を利用できません。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/metadata/description",
+      "value": "使用量と検索リソースを含むメタデータ。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/mode/description",
+      "value": "アプリモード、`completion` 固定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/task_id/description",
+      "value": "リクエスト追跡および [生成を停止](/ja/api-reference/completion-messages/stop-completion-message-generation) API 用のタスク ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/title",
+      "source_sha256": "ee47e2a5e80d35feab4cf22bdf5ddc102cd7a070d83df22ca8e2b1fc9e22302b"
     },
     {
       "op": "replace",
@@ -584,6 +2326,256 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法です。新しいリクエストでは `remote_url` と `url`、または `local_file` と `upload_file_id` を組み合わせます。生成されたその他の組み合わせは後方互換用の旧形式です。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "マルチモーダル入力に使用するファイルです。新しいクライアントは 2 つの標準形式だけを実装してください。公開ファイル URL には `transfer_method: remote_url` と `url` を使用します。ローカルファイルは[ファイルをアップロード](/ja/api-reference/files/upload-file)でアップロードし、`transfer_method: local_file` と、返された `id` を指定する `upload_file_id` を使用します。生成されたその他の `anyOf` の組み合わせは、保存済みの旧形式参照との後方互換性のためだけに存在します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "アプリ定義変数の値です。想定される変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/query/description",
+      "source_sha256": "ce812efc2fab57a97815d53cc2e428893ce5a4e5b29c9f0289f5e19f4178d4c3",
+      "value": "ユーザー入力またはプロンプトの内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/response_mode/description",
+      "source_sha256": "b3d5908801262c0944f042ea2597fca96c2cfff286dfcf52f032c9c966ce3f5a",
+      "value": "レスポンスモード。`streaming` は Server-Sent Events（SSE）を使用し、`blocking` は完了後に返します。省略するとブロッキングモードで実行されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/title",
+      "source_sha256": "af0367558fbca9f02fe0c6614e89b0fbaddd2d5462f4aa34f224f2cdf7e90469"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/data/description",
+      "value": "このページの会話一覧。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/has_more/description",
+      "value": "さらに古い会話があるかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/limit/description",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/title",
+      "source_sha256": "8d2c26d65f5574e6f0a965a27176479d828da87cfa8522634b679257d805d213"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/ConversationListQuery/properties/last_id/description",
       "source_sha256": "f766603b3efb94aa18c59ff583b84741e8ba3fa64045be1bdd854b3aa1141eae",
       "value": "現在のページの最後のレコード ID。次のページの取得に使用します。"
@@ -708,6 +2700,224 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/name/description",
+      "source_sha256": "246b01fd801492655f586faef4387a5106f549fdd898de10259a0308868ea580",
+      "value": "会話名。`auto_generate` が `false` の場合は必須です。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/name/description",
+      "value": "新しい会話名です。`auto_generate` が `true` でない限り必須です。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "会話名を自動生成します。`true` の場合、`name` フィールドは無視されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/name/description",
+      "source_sha256": "246b01fd801492655f586faef4387a5106f549fdd898de10259a0308868ea580",
+      "value": "会話名。`auto_generate` が `false` の場合は必須です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/title",
+      "source_sha256": "5007bf01416d1203f9aeac8979d407c9432d6420dfba585d65249853164be8b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/data/description",
+      "value": "このページの会話変数一覧。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/has_more/description",
+      "value": "さらに会話変数があるかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/limit/description",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/title",
+      "source_sha256": "40398eaf223ae268d6ca662c0553a3b63efc0726833ecbdce3ec3e188c44a994"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/created_at/description",
+      "value": "作成時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/description/description",
+      "value": "変数の説明です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/id/description",
+      "value": "変数 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/name/description",
+      "value": "変数名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/updated_at/description",
+      "value": "最終更新時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value/description",
+      "value": "変数値（複雑な型の場合は JSON 文字列）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value_type/description",
+      "value": "変数の値の型です。指定可能な値：`string`、`number`、`object`、`secret`、`file`、`boolean`、`array[any]`、`array[string]`、`array[number]`、`array[object]`、`array[file]`、`array[boolean]`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value_type/title",
+      "source_sha256": "1990c83514aae4414c3c0cdfe9926c617cf3a92057cf60c43cecfe243bf75d44"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/title",
+      "source_sha256": "8b07df8ff6c7bff5a6a4267191363393127c16f84cb667540cd56afdcbfce36e"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/ConversationVariableUpdatePayload/properties/value/description",
       "source_sha256": "c023a9fd7cdee70eae72c18bb8bd84cd7c51f6170d4b075f585b72d55ea046de",
       "value": "変数の新しい値。変数の期待される型と一致する必要があります。"
@@ -720,6 +2930,28 @@
     {
       "op": "remove",
       "path": "/components/schemas/ConversationVariableUpdatePayload/title",
+      "source_sha256": "ab9aedc458ad087c3e8f47e9d46c7180ff78e73b058595f23c06153749e8d9be"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariableUpdatePayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariableUpdatePayloadWithUser/properties/value/description",
+      "source_sha256": "c023a9fd7cdee70eae72c18bb8bd84cd7c51f6170d4b075f585b72d55ea046de",
+      "value": "変数の新しい値。変数の期待される型と一致する必要があります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayloadWithUser/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayloadWithUser/title",
       "source_sha256": "ab9aedc458ad087c3e8f47e9d46c7180ff78e73b058595f23c06153749e8d9be"
     },
     {
@@ -903,8 +3135,123 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/EndUserDetail/description",
+      "source_sha256": "aa3c373c92f25d2f94b8e188c71129841d23355dfed0285bf4e926738925d270"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/app_id/description",
+      "value": "アプリケーション ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/app_id/title",
+      "source_sha256": "9bb6aa4fb1320b37040e3c92ca381635520a01dab3a13c05e5058b135db6de04"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/created_at/description",
+      "value": "作成タイムスタンプ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/external_user_id/description",
+      "value": "API リクエストで提供された `user` 識別子です（例：[チャットメッセージを送信](/ja/api-reference/chat-messages/send-chat-message) の `user` フィールド）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/external_user_id/title",
+      "source_sha256": "73e63201b85107943bdd55a6e70905be50c4051b74922599d44bb3fe6a233f72"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/id/description",
+      "value": "エンドユーザー ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/is_anonymous/description",
+      "value": "ユーザーが匿名かどうかを示します。元の API リクエストで `user` 識別子が提供されなかった場合、`true` になります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/is_anonymous/title",
+      "source_sha256": "042cb8fffd7f6edb56ac128deed67f447ceb287cd716f3056d4ee0d5cee10114"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/name/description",
+      "value": "エンドユーザー名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/session_id/description",
+      "value": "セッション識別子。デフォルトは `external_user_id` の値です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/session_id/title",
+      "source_sha256": "eb75473dc0fd06e0d9e515069eb952720ae3d0b7edfe76d2e7a922d225818a47"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/tenant_id/description",
+      "value": "テナント ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/tenant_id/title",
+      "source_sha256": "ae18aae49d3ccc237cd61077f9e1235aa293a131da760623f83eab7b5e51d944"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/type/description",
+      "value": "エンドユーザーのタイプ。Service API ユーザーの場合は常に `service-api` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/updated_at/description",
+      "value": "最終更新タイムスタンプ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/title",
+      "source_sha256": "e280f5d56814b84006ebaa503204543732987703d54509b41ea6279aae618405"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/EventStreamResponse/title",
       "source_sha256": "cb598d0c9427cccc89d63f389617e8966efeffc6cf0b9bad1c5823624bf470d3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ExecutionContentType/title",
+      "source_sha256": "3b2b49df41fa1f57efbdf69684f4846436696825906cc5908b47a6d9dcb38165"
     },
     {
       "op": "replace",
@@ -934,6 +3281,126 @@
       "source_sha256": "2ee2ef5a0b8833947992d468c455c3ec9722d91f0512455ef418a2ca9fa97e89"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_extensions/description",
+      "value": "`allowed_file_types` に `custom` が含まれる場合に許可されるファイル拡張子。各拡張子には先頭の `.` を含めてください。たとえば `.md` です。`file` および `file-list` 入力に含まれます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_extensions/title",
+      "source_sha256": "a9fbd8515a7570cbf8527621d2dfef68843739b7f642385e7614124dbf62c207"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_types/description",
+      "value": "受信者がアップロード可能なファイルカテゴリ。 `file` および `file-list` 入力に含まれます。値： `image`、 `document`、 `audio`、 `video`、 `custom`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_types/title",
+      "source_sha256": "dc39dad025bd4f01f3683f0b4275c0cfc39242bcd63c9df3a018450cb31a54b1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_upload_methods/description",
+      "value": "受信者が使用できるアップロード方法。値： `local_file`、 `remote_url`。 `file` および `file-list` 入力に含まれます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_upload_methods/title",
+      "source_sha256": "27ec3b14f4b815bd97063c77366bd8925f2475e48b86322fc51ffee8a68010f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/output_variable_name/description",
+      "value": "ワークフロー内でこの入力の送信値を参照する際の変数名。送信リクエストの `inputs` オブジェクトのキーに対応します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/type/description",
+      "value": "フォーム入力コントロールの種類。利用可能な値： `paragraph` （複数行テキスト入力）、 `select` （リストからの単一選択）、 `file` （単一ファイルアップロード）、 `file-list` （複数ファイルアップロード）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/title",
+      "source_sha256": "c16f00d355344aabe5c8f9d3ee46f954b3955758cbe7e98128580690751590f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_extensions/description",
+      "value": "`allowed_file_types` に `custom` が含まれる場合に許可されるファイル拡張子。各拡張子には先頭の `.` を含めてください。たとえば `.md` です。`file` および `file-list` 入力に含まれます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_extensions/title",
+      "source_sha256": "a9fbd8515a7570cbf8527621d2dfef68843739b7f642385e7614124dbf62c207"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_types/description",
+      "value": "受信者がアップロード可能なファイルカテゴリ。 `file` および `file-list` 入力に含まれます。値： `image`、 `document`、 `audio`、 `video`、 `custom`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_types/title",
+      "source_sha256": "dc39dad025bd4f01f3683f0b4275c0cfc39242bcd63c9df3a018450cb31a54b1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_upload_methods/description",
+      "value": "受信者が使用できるアップロード方法。値： `local_file`、 `remote_url`。 `file` および `file-list` 入力に含まれます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_upload_methods/title",
+      "source_sha256": "27ec3b14f4b815bd97063c77366bd8925f2475e48b86322fc51ffee8a68010f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/number_limits/description",
+      "value": "受信者がアップロードできるファイルの最大数。 `file-list` 入力のみに含まれます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/number_limits/title",
+      "source_sha256": "cffcf3dbc6eeea7d5b96f1a6c3695f1060321b5ddd099aa47ac900873301da17"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/output_variable_name/description",
+      "value": "ワークフロー内でこの入力の送信値を参照する際の変数名。送信リクエストの `inputs` オブジェクトのキーに対応します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/type/description",
+      "value": "フォーム入力コントロールの種類。利用可能な値： `paragraph` （複数行テキスト入力）、 `select` （リストからの単一選択）、 `file` （単一ファイルアップロード）、 `file-list` （複数ファイルアップロード）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/title",
+      "source_sha256": "f523cc0240880eba6ee6fafc4c09c042bca376e0ac425c0bab976088289c0527"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/FilePreviewQuery/properties/as_attachment/description",
       "source_sha256": "f9c567f7630732e17ddcbf65657256aba6e339dfe6b252545230bd8b32ff53b3",
@@ -948,6 +3415,451 @@
       "op": "remove",
       "path": "/components/schemas/FilePreviewQuery/title",
       "source_sha256": "34f058141cf139f35d0840e326719c0af503c33e745ab65d911e0449050fe2b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/conversation_id/description",
+      "value": "関連付けられた会話の ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/created_at/description",
+      "value": "アップロードタイムスタンプ（Unix エポック秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/created_by/description",
+      "value": "アップロードしたエンドユーザーの ID。[エンドユーザー取得](/ja/api-reference/end-users/get-end-user-info) で詳細を確認できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/extension/description",
+      "value": "ファイル拡張子。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/file_key/description",
+      "value": "未使用です。常に `null` になります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/file_key/title",
+      "source_sha256": "e40ccb27af6fbb5ca42abd5c75fab69254329e65482470315875be7ab053799d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/id/description",
+      "value": "一意のファイル ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/mime_type/description",
+      "value": "ファイルの MIME タイプ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/name/description",
+      "value": "ファイル名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/original_url/description",
+      "value": "ファイルの元の URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/original_url/title",
+      "source_sha256": "c4888fa31ede45075f22f445e420c81308f0e7926289179c73243e106dce12f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/preview_url/description",
+      "value": "ファイルのプレビュー URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/preview_url/title",
+      "source_sha256": "5032783bebaa4d692996f8a238e903dff18dcde3b433a8a12f5ce10b8723d5c1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/reference/description",
+      "value": "Agent やツールのコンテキストでファイルを添付する際に内部的に使用される不透明なファイル参照です。このエンドポイントでアップロードされたファイルでは常に `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/reference/title",
+      "source_sha256": "62bf2677b9ec30fcd1213616c78b6ede91fcf2778e6e1e06139f7a0ee9a2f22b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/size/description",
+      "value": "ファイルサイズ（バイト）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/source_url/description",
+      "value": "ファイルの署名付きダウンロード URL です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/source_url/title",
+      "source_sha256": "3d48f2577f877973dd0a3ab85975e367b5a9ab1964eb533d2cb3dd317134d453"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/tenant_id/description",
+      "value": "関連付けられたテナントの ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/tenant_id/title",
+      "source_sha256": "ae18aae49d3ccc237cd61077f9e1235aa293a131da760623f83eab7b5e51d944"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/user_id/description",
+      "value": "未使用です。常に `null` になります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/user_id/title",
+      "source_sha256": "61a98a9e2d63198ff47128e3e2b20573e9cd81c7bfaac7b52679c167124b4618"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/title",
+      "source_sha256": "e1fde1b159c838025a2bd05b8a08f570c7b8a335d4c17984cc000fdccc597bac"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileTransferMethod/title",
+      "source_sha256": "89ade223b5ca2b5b6c7b8c9b94144a779e59d931884fd19c951ea02efcd0900b"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileType/title",
+      "source_sha256": "1146fdf89b9afd90dd54e7a8a49cc084960dbe6ab3cb3c9ddb13494be2676ed7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/description",
+      "value": "人間の入力ノードからの実行コンテンツです。フォーム定義と送信データを含みます。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/form_definition/description",
+      "value": "人間の入力ノードからのフォーム定義です。コンテンツが送信レスポンスを表す場合は `null` です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/form_submission_data/description",
+      "value": "送信されたフォームデータです。フォームがまだ送信されていない場合は `null` です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/submitted/description",
+      "value": "人間の入力フォームが送信されたかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputContent/properties/submitted/title",
+      "source_sha256": "c6c415f99181251a358bb051196877f12f5d92f48454d2b3f0975426b3d77197"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/type/description",
+      "value": "`human_input` は人間の入力コンテンツを示します。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/workflow_run_id/description",
+      "value": "このコンテンツが属するワークフロー実行の ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputContent/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputContent/title",
+      "source_sha256": "8be8a12c2e3e7a84b72adcf514810d1fa1ec486ad223eb6eedfe4fcbb840c83d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/description",
+      "value": "人間の入力ノードによってレンダリングされる人間の入力フォームの定義です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/actions/description",
+      "value": "フォームで利用可能なアクションボタンです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/actions/title",
+      "source_sha256": "aa6d82bdb3cc1d9a5e542ae2669fef27690019ab5d7b20f17d9f1331a6a942fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/display_in_ui/description",
+      "value": "フォームを UI に表示するかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/display_in_ui/title",
+      "source_sha256": "8c71965fd96e6f8b785ae269402727f478472205a018ad31c70fd0860c046614"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/expiration_time/description",
+      "value": "フォームが期限切れになる Unix タイムスタンプです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_content/description",
+      "value": "フォームと共に表示される Markdown またはテキストコンテンツです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_id/description",
+      "value": "フォームの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_id/title",
+      "source_sha256": "fafd71c45b122dd8a3264f51789d5b76c7b77ff8dc669263056f89c55464dd7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_token/description",
+      "value": "フォーム送信認証用のトークンです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_token/title",
+      "source_sha256": "7a13fbb60d7b9386e1e508b9270fcf384926bf6ed214f4b6523f46e5946f2c67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/inputs/description",
+      "value": "フォーム内の入力フィールドです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_id/description",
+      "value": "このフォームを生成した人間の入力ノードの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_title/description",
+      "value": "人間の入力ノードのタイトルです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/resolved_default_values/description",
+      "value": "出力変数名をキーとする、フォーム入力の解決済みデフォルト値です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/title",
+      "source_sha256": "fca56dea40adeb7da6dc4dc9897a9d70e622d8794384f3f0a9a1bde76efebab6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/expiration_time/description",
+      "value": "Unix タイムスタンプ（秒）。この時刻以降、フォームは送信できなくなります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/form_content/description",
+      "value": "ワークフロー変数を埋め込んだ、事前レンダリング済みのフォーム本文。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/inputs/description",
+      "value": "フォーム入力フィールドの定義。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/resolved_default_values/description",
+      "value": "フォームに表示するための事前計算済みデフォルト値。入力の `output_variable_name` をキーとします。デフォルト値がワークフロー変数から解決可能な `paragraph` 入力にのみ設定されます。解決可能なデフォルトがない入力では空になります。クライアントはこれらの値をそのまま表示してください。 `default` をクライアント側で再解決する必要はありません。すべての値は文字列化されています。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/user_actions/description",
+      "value": "利用可能な送信アクション。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/user_actions/title",
+      "source_sha256": "1a4ed49eb5af3941bf9d0e30899e2a9c0be82d2089efadc9ac3c422e06580f1e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/title",
+      "source_sha256": "efe9278e93efddf0770298b0baa1af36c79f83167e15fe64c7e9ddcaa07917a0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/description",
+      "value": "送信された人間の入力フォームからのデータです。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_id/description",
+      "value": "クリックされたアクションボタンの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_id/title",
+      "source_sha256": "7e4688059b07745f9eac7661edcd135651dd97f393de9fd273c1fe29cd654215"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_text/description",
+      "value": "クリックされたアクションボタンの表示テキストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_text/title",
+      "source_sha256": "6d4c58126485bf41fe4903c696afd5f42aa118b96787a3bf97382b3e088c33cf"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_id/description",
+      "value": "人間の入力ノードの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_title/description",
+      "value": "人間の入力ノードのタイトルです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/rendered_content/description",
+      "value": "フォーム送信のレンダリングされた内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/rendered_content/title",
+      "source_sha256": "7a73e1acdc736489774de1b928d6e98015e2ec121a590938f8954eef240d6044"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/submitted_data/description",
+      "value": "受信者が送信したフォームの値。各入力項目の `output_variable_name` をキーとします。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/submitted_data/title",
+      "source_sha256": "a3f562e953210d2b0de95dcc91dbe78484cf58cfde9918a87c2cf39a3e8aecf1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/title",
+      "source_sha256": "8949c480137e5d219cf4f5313442efea2336e23601e1837935795cf3936c0e3a"
     },
     {
       "op": "replace",
@@ -978,6 +3890,79 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/action/description",
+      "source_sha256": "3da3bf444ea4552df683d22e39bbba3d292b7270d42e322568b9dbf85cbf9d7f",
+      "value": "受信者が選択したアクションボタンの ID。フォームの `user_actions` リストにある `id` 値のいずれかと一致する必要があります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/action/title",
+      "source_sha256": "5efcc1e437cbeada52653f133121f3ca259b84b74a51e15c277b4de93f11bd75"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/inputs/description",
+      "source_sha256": "1f22c5be035a6620b87ddfb1582988875cfc11dec9117525dc371f0db59c5961",
+      "value": "出力変数名をキーとする送信済み人工入力値。段落または選択入力には文字列、ファイル入力にはファイルマッピング、ファイルリスト入力にはファイルマッピングのリストを使用します。ローカルファイルは `transfer_method=local_file` と `upload_file_id`、リモートファイルは `transfer_method=remote_url` と `url` または `remote_url` を使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/title",
+      "source_sha256": "38a626e4a4e1642a39e35116d44bec129a532a22191e06434ecc3c9b4c51c3d3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitResponse/title",
+      "source_sha256": "aa2f56fbcc6b021221b64c92e880abaccf77304d4960f15e77f766fae9e7c1e1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/IndexInfoResponse/properties/api_version/description",
+      "value": "Service API のバージョン。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/properties/api_version/title",
+      "source_sha256": "ae9fbe000bcc107626c6a7562db6d9dbfdf0fc84bf08e7e3a160b90d59be00cd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/IndexInfoResponse/properties/server_version/description",
+      "value": "Dify サーバーのバージョン。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/properties/server_version/title",
+      "source_sha256": "474479a19ac772ca7e9bdb8d22a2c24622e90170553d6fbe287d9cec70165ced"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/IndexInfoResponse/properties/welcome/description",
+      "value": "サービスのウェルカムメッセージ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/properties/welcome/title",
+      "source_sha256": "1fa79baa5f6a65d49bbee9e12d6e320e542885ad389f26f8b744a14608e68cbb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/title",
+      "source_sha256": "39bae08b9ff59cac2e8753bfc4a2e27ee7493eb5d4f6402c2f1c354436048e6e"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/MessageFeedbackPayload/properties/content/description",
       "source_sha256": "f1b13f33ce2fae7757c4b30cad4a78f091f9ff5ed649c04f9d9851e7f7dad06b",
       "value": "追加の詳細を提供する任意のテキストフィードバック。"
@@ -1002,6 +3987,369 @@
       "op": "remove",
       "path": "/components/schemas/MessageFeedbackPayload/title",
       "source_sha256": "dc826ad9804a26c2e92124a2d20c938b54f7e6abf59d8fbccb326f20ac4e7c70"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/content/description",
+      "source_sha256": "f1b13f33ce2fae7757c4b30cad4a78f091f9ff5ed649c04f9d9851e7f7dad06b",
+      "value": "追加の詳細を提供する任意のテキストフィードバック。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/rating/description",
+      "source_sha256": "a22a86af4ca3b6b23b547b829f67d88997e274ed483d1ddd4d6fd916fadc8c44",
+      "value": "フィードバック評価。以前送信したフィードバックを取り消すには `null` に設定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/title",
+      "source_sha256": "dc826ad9804a26c2e92124a2d20c938b54f7e6abf59d8fbccb326f20ac4e7c70"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/belongs_to/description",
+      "value": "このファイルの所有者です。ユーザーがアップロードしたファイルの場合は `user`、アシスタントが生成したファイルの場合は `assistant` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/belongs_to/title",
+      "source_sha256": "9c4f84210a02189552fb0d669344eff0190bf70baef043015aef34ed8c0ac152"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/filename/description",
+      "value": "元のファイル名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/filename/title",
+      "source_sha256": "fa233e390655e8ee27cb179523ba2c9fe37aae77a8f531ee59cd9af15377806d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/id/description",
+      "value": "メッセージファイル ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/mime_type/description",
+      "value": "ファイルの MIME タイプ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/size/description",
+      "value": "ファイルサイズ（バイト）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/transfer_method/description",
+      "value": "使用された転送方法です。`remote_url` は URL ベースのファイル、`local_file` はアップロード済みファイル、`tool_file` はツール生成ファイルを示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/transfer_method/title",
+      "source_sha256": "b44be7211a456d1bd0ae715137a36e970b9f722bee23006b86ecab3bfc9d49d7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/type/description",
+      "value": "ファイルの種類（例：`image`）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/upload_file_id/description",
+      "value": "`local_file` で転送された場合のアップロードファイル ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/upload_file_id/title",
+      "source_sha256": "f29fbbf25b1c3154216e20e3583a05c7ed965a056bcd8f30a5c5ed91a33678d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/url/description",
+      "value": "ファイルのプレビュー URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/url/title",
+      "source_sha256": "0146bf069164386d9cbddfbb77eed14df29c3fbf0326244f5676fc1c06a30963"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/title",
+      "source_sha256": "60f8396dde335458941fb0c59e5e4e7cbf2e36309e02c32c0b98f69ca3e444a3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/data/description",
+      "value": "このページのメッセージ一覧。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/has_more/description",
+      "value": "さらに古いメッセージがあるかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/limit/description",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/title",
+      "source_sha256": "e74af12050ecc369553e1acd525a8588c859d754655ae355c3a25b4306393107"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/agent_thoughts/description",
+      "value": "このメッセージのエージェント思考です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/agent_thoughts/title",
+      "source_sha256": "2184f8609c9c4feeeb57c0b2cf05c2fde85cdf9cf74b0ce38155990fd5e63d18"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/answer/description",
+      "value": "アシスタントの回答テキストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/answer_tokens/description",
+      "value": "生成された回答のトークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/answer_tokens/title",
+      "source_sha256": "1b572d1e3ea69bf0ee0a51abcffa0431b7b84eb28ed5913becebec76d5046063"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/conversation_id/description",
+      "value": "会話 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/created_at/description",
+      "value": "作成タイムスタンプ（Unix エポック秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/currency/description",
+      "value": "`total_price` の通貨（例：`USD`）です。価格情報が利用できない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/currency/title",
+      "source_sha256": "dc3eb42975d1c1fd78c9d592adde6dbe02d004e08e7cd0dfd3951c84900b875e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/error/description",
+      "value": "`status` が `error` の場合のエラーメッセージです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/extra_contents/description",
+      "value": "このメッセージに関連する追加の実行コンテンツです。chatflow ワークフローの人間の入力ノードからのフォームデータなどが含まれます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/extra_contents/title",
+      "source_sha256": "ddc4b3e9e40fc66023e5a3b362c7383a7ff50cd282944c3e04fcdfe0fb040bf6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/feedback/description",
+      "value": "このメッセージのユーザーフィードバックです。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/id/description",
+      "value": "メッセージ ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/inputs/description",
+      "value": "このメッセージの入力変数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/message_files/description",
+      "value": "このメッセージに添付されたファイルです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/message_files/title",
+      "source_sha256": "019a4253ead76b257c4cd8c39037108752829deb2cab847c8c8784d81c88dc47"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/message_tokens/description",
+      "value": "入力メッセージのトークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/message_tokens/title",
+      "source_sha256": "dc40a100e53d859ae80ed9200353283259695db35d73ab038a376d75bc54ba8b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/parent_message_id/description",
+      "value": "スレッド会話の親メッセージ ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/parent_message_id/title",
+      "source_sha256": "9a5f1265a74baedbf683b3f039d7f0b6a0c19d2068c1b990b19b23bc6990c17e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/provider_response_latency/description",
+      "value": "モデルプロバイダーの応答レイテンシ（秒）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/provider_response_latency/title",
+      "source_sha256": "9db4fbca93f3cc70bbd13f2ad2095fc676b4252db5422e7079e92dd3fef05d1a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/query/description",
+      "value": "ユーザークエリテキストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/retriever_resources/description",
+      "value": "このメッセージに使用された検索リソースです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/retriever_resources/title",
+      "source_sha256": "0cad6b9867870a47877812c4336c83401368174ab4b1b3d3de4636bb6b1e42b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/status/description",
+      "value": "メッセージステータスです。成功したメッセージの場合は `normal`、生成に失敗した場合は `error` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/total_price/description",
+      "value": "使用されたトークンの合計金額です。価格情報が利用できない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/total_price/title",
+      "source_sha256": "3576c59289ecc321e2cfdba5f8a98bfe257996dc1fbc54b4ea53fe287e7987e2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/total_tokens/description",
+      "value": "使用されたトークンの合計。`message_tokens` と `answer_tokens` の合計です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/title",
+      "source_sha256": "0fcf1f5699aeec1e3e5bbd380e3499c1378e4bd8f3acb4a9cb644541571ce995"
     },
     {
       "op": "replace",
@@ -1040,6 +4388,1384 @@
       "op": "remove",
       "path": "/components/schemas/MessageListQuery/title",
       "source_sha256": "17997d5395df2c93391badf0ba144f4ca86426f5b37ae14fd35d9c873a56e906"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/OptionalServiceApiUserPayload/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/OptionalServiceApiUserPayload/title",
+      "source_sha256": "a1269019db4ddc7c919d3b0447ea781251fcad5e3c189d0d8214785fae80891d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ParagraphInputConfig/description",
+      "source_sha256": "c6c0d53443470d46c4bc5114ca40026044e9522ca48e39d40471201cd3b7fbdd",
+      "value": "フォーム入力の定義。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ParagraphInputConfig/properties/default/description",
+      "value": "`paragraph` 入力の生のデフォルト値設定。クライアントはこのフィールドを直接解決すべきではありません。デフォルトの表示には `resolved_default_values` を使用してください。その他の入力タイプ、またはデフォルト値が未設定の場合、このキーは含まれません。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ParagraphInputConfig/properties/output_variable_name/description",
+      "value": "ワークフロー内でこの入力の送信値を参照する際の変数名。送信リクエストの `inputs` オブジェクトのキーに対応します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ParagraphInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ParagraphInputConfig/properties/type/description",
+      "value": "フォーム入力コントロールの種類。利用可能な値： `paragraph` （複数行テキスト入力）、 `select` （リストからの単一選択）、 `file` （単一ファイルアップロード）、 `file-list` （複数ファイルアップロード）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ParagraphInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ParagraphInputConfig/title",
+      "source_sha256": "f9a2dc09b2ae099fc58a4f362ed79a143bbccf3f8c122c3c7477a007c73776f1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/annotation_reply/description",
+      "value": "アノテーション返信機能の設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/annotation_reply/properties/enabled/description",
+      "value": "この機能が有効かどうか。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/description",
+      "value": "ファイルアップロードの設定。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/allowed_file_extensions/description",
+      "value": "アプリケーションが受け付けるカスタムファイル拡張子です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/allowed_file_types/description",
+      "value": "アプリケーションが受け付けるファイルタイプです。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/allowed_file_upload_methods/description",
+      "value": "アプリケーションが受け付けるファイル転送方法です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/enabled/description",
+      "value": "ファイルアップロードが有効かどうか。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/description",
+      "value": "画像アップロード設定。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/detail/description",
+      "value": "ビジョンモデルの画像詳細レベルです。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/enabled/description",
+      "value": "画像アップロードが有効かどうか。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/number_limits/description",
+      "value": "アップロード可能な画像の最大数です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/transfer_methods/description",
+      "value": "画像アップロードで許可される転送方法です。`remote_url` はファイル URL 経由、`local_file` はアップロード済みファイルを示します。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/number_limits/description",
+      "value": "アップロード可能なファイルの最大数です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/more_like_this/description",
+      "value": "類似コンテンツ機能の設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/more_like_this/properties/enabled/description",
+      "value": "この機能が有効かどうか。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/opening_statement/description",
+      "value": "オープニングステートメントのテキストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/properties/opening_statement/title",
+      "source_sha256": "e555de2768123fb1fa943d99a2fb5549af0702ba1f3969de47bb55e9904ab890"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/retriever_resource/description",
+      "value": "ナレッジ検索の引用リソース設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/retriever_resource/properties/enabled/description",
+      "value": "この機能が有効かどうか。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/sensitive_word_avoidance/description",
+      "value": "コンテンツモデレーション機能の設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/sensitive_word_avoidance/properties/enabled/description",
+      "value": "この機能が有効かどうか。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/speech_to_text/description",
+      "value": "音声テキスト変換機能の設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/speech_to_text/properties/enabled/description",
+      "value": "この機能が有効かどうか。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/suggested_questions/description",
+      "value": "提案された質問のリストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/properties/suggested_questions/title",
+      "source_sha256": "1033a0922394dc3617fd9d04bcbcdc9bdb42377312d236a2f54e8fd8ad417d6b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/suggested_questions_after_answer/description",
+      "value": "回答後の提案質問の設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/suggested_questions_after_answer/properties/enabled/description",
+      "value": "この機能が有効かどうか。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/system_parameters/description",
+      "value": "システムレベルのパラメータ制限です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/description",
+      "value": "テキスト音声変換機能の設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/autoPlay/description",
+      "value": "自動再生設定です。音声を自動再生するには `enabled`、手動再生を要求するには `disabled` を指定します。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/enabled/description",
+      "value": "この機能が有効かどうか。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/language/description",
+      "value": "TTS 言語。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/voice/description",
+      "value": "TTS 音声識別子。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/description",
+      "value": "ユーザー入力フォームの設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/description",
+      "value": "テキスト入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/allowed_file_extensions/description",
+      "value": "この入力がファイルを受け付ける場合に許可される拡張子。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/allowed_file_types/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/allowed_file_upload_methods/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるアップロード方法。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/config/description",
+      "value": "追加の入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/default/description",
+      "value": "デフォルト値です。JSON の型はフォームタイプによって異なります。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/description/description",
+      "value": "入力項目の任意の説明です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/hide/description",
+      "value": "公開フォームで入力項目を非表示にするかどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/json_schema/description",
+      "value": "JSON オブジェクト入力の検証に使用する JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/label/description",
+      "value": "入力項目の表示ラベルです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/max_length/description",
+      "value": "入力タイプが長さ制限をサポートする場合の最大入力長。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/options/description",
+      "value": "このフォームコントロールの選択可能な値のリスト。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/required/description",
+      "value": "入力が必須かどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/type/description",
+      "value": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/variable/description",
+      "value": "アプリケーションで使用される変数名です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/description",
+      "value": "選択入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/allowed_file_extensions/description",
+      "value": "この入力がファイルを受け付ける場合に許可される拡張子。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/allowed_file_types/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/allowed_file_upload_methods/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるアップロード方法。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/config/description",
+      "value": "追加の入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/default/description",
+      "value": "デフォルト値です。JSON の型はフォームタイプによって異なります。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/description/description",
+      "value": "入力項目の任意の説明です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/hide/description",
+      "value": "公開フォームで入力項目を非表示にするかどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/json_schema/description",
+      "value": "JSON オブジェクト入力の検証に使用する JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/label/description",
+      "value": "入力項目の表示ラベルです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/max_length/description",
+      "value": "入力タイプが長さ制限をサポートする場合の最大入力長。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/options/description",
+      "value": "このフォームコントロールの選択可能な値のリスト。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/required/description",
+      "value": "入力が必須かどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/type/description",
+      "value": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/variable/description",
+      "value": "アプリケーションで使用される変数名です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/description",
+      "value": "段落入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/allowed_file_extensions/description",
+      "value": "この入力がファイルを受け付ける場合に許可される拡張子。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/allowed_file_types/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/allowed_file_upload_methods/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるアップロード方法。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/config/description",
+      "value": "追加の入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/default/description",
+      "value": "デフォルト値です。JSON の型はフォームタイプによって異なります。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/description/description",
+      "value": "入力項目の任意の説明です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/hide/description",
+      "value": "公開フォームで入力項目を非表示にするかどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/json_schema/description",
+      "value": "JSON オブジェクト入力の検証に使用する JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/label/description",
+      "value": "入力項目の表示ラベルです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/max_length/description",
+      "value": "入力タイプが長さ制限をサポートする場合の最大入力長。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/options/description",
+      "value": "このフォームコントロールの選択可能な値のリスト。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/required/description",
+      "value": "入力が必須かどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/type/description",
+      "value": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/variable/description",
+      "value": "アプリケーションで使用される変数名です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/description",
+      "value": "数値入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/allowed_file_extensions/description",
+      "value": "この入力がファイルを受け付ける場合に許可される拡張子。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/allowed_file_types/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/allowed_file_upload_methods/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるアップロード方法。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/config/description",
+      "value": "追加の入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/default/description",
+      "value": "デフォルト値です。JSON の型はフォームタイプによって異なります。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/description/description",
+      "value": "入力項目の任意の説明です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/hide/description",
+      "value": "公開フォームで入力項目を非表示にするかどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/json_schema/description",
+      "value": "JSON オブジェクト入力の検証に使用する JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/label/description",
+      "value": "入力項目の表示ラベルです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/max_length/description",
+      "value": "入力タイプが長さ制限をサポートする場合の最大入力長。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/options/description",
+      "value": "このフォームコントロールの選択可能な値のリスト。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/required/description",
+      "value": "入力が必須かどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/type/description",
+      "value": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/variable/description",
+      "value": "アプリケーションで使用される変数名です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/description",
+      "value": "外部データツール入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/allowed_file_extensions/description",
+      "value": "この入力がファイルを受け付ける場合に許可される拡張子。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/allowed_file_types/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/allowed_file_upload_methods/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるアップロード方法。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/config/description",
+      "value": "追加の入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/default/description",
+      "value": "デフォルト値です。JSON の型はフォームタイプによって異なります。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/description/description",
+      "value": "入力項目の任意の説明です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/hide/description",
+      "value": "公開フォームで入力項目を非表示にするかどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/json_schema/description",
+      "value": "JSON オブジェクト入力の検証に使用する JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/label/description",
+      "value": "入力項目の表示ラベルです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/max_length/description",
+      "value": "入力タイプが長さ制限をサポートする場合の最大入力長。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/options/description",
+      "value": "このフォームコントロールの選択可能な値のリスト。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/required/description",
+      "value": "入力が必須かどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/type/description",
+      "value": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/variable/description",
+      "value": "アプリケーションで使用される変数名です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/description",
+      "value": "アプリケーションが返すファイルフォームコントロールの設定です。ラベル、変数名、必須かどうか、許可するファイルカテゴリと拡張子、対応する転送方法を表します。アップロード済みの multipart ファイルではありません。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/allowed_file_extensions/description",
+      "value": "この入力がファイルを受け付ける場合に許可される拡張子。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/allowed_file_types/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/allowed_file_upload_methods/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるアップロード方法。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/config/description",
+      "value": "追加の入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/default/description",
+      "value": "デフォルト値です。JSON の型はフォームタイプによって異なります。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/description/description",
+      "value": "入力項目の任意の説明です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/hide/description",
+      "value": "公開フォームで入力項目を非表示にするかどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/json_schema/description",
+      "value": "JSON オブジェクト入力の検証に使用する JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/label/description",
+      "value": "入力項目の表示ラベルです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/max_length/description",
+      "value": "入力タイプが長さ制限をサポートする場合の最大入力長。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/options/description",
+      "value": "このフォームコントロールの選択可能な値のリスト。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/required/description",
+      "value": "入力が必須かどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/type/description",
+      "value": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/variable/description",
+      "value": "アプリケーションで使用される変数名です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/description",
+      "value": "ファイルリスト入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/allowed_file_extensions/description",
+      "value": "この入力がファイルを受け付ける場合に許可される拡張子。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/allowed_file_types/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/allowed_file_upload_methods/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるアップロード方法。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/config/description",
+      "value": "追加の入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/default/description",
+      "value": "デフォルト値です。JSON の型はフォームタイプによって異なります。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/description/description",
+      "value": "入力項目の任意の説明です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/hide/description",
+      "value": "公開フォームで入力項目を非表示にするかどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/json_schema/description",
+      "value": "JSON オブジェクト入力の検証に使用する JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/label/description",
+      "value": "入力項目の表示ラベルです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/max_length/description",
+      "value": "入力タイプが長さ制限をサポートする場合の最大入力長。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/options/description",
+      "value": "このフォームコントロールの選択可能な値のリスト。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/required/description",
+      "value": "入力が必須かどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/type/description",
+      "value": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/variable/description",
+      "value": "アプリケーションで使用される変数名です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/description",
+      "value": "チェックボックス入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/allowed_file_extensions/description",
+      "value": "この入力がファイルを受け付ける場合に許可される拡張子。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/allowed_file_types/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/allowed_file_upload_methods/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるアップロード方法。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/config/description",
+      "value": "追加の入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/default/description",
+      "value": "デフォルト値です。JSON の型はフォームタイプによって異なります。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/description/description",
+      "value": "入力項目の任意の説明です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/hide/description",
+      "value": "公開フォームで入力項目を非表示にするかどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/json_schema/description",
+      "value": "JSON オブジェクト入力の検証に使用する JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/label/description",
+      "value": "入力項目の表示ラベルです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/max_length/description",
+      "value": "入力タイプが長さ制限をサポートする場合の最大入力長。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/options/description",
+      "value": "このフォームコントロールの選択可能な値のリスト。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/required/description",
+      "value": "入力が必須かどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/type/description",
+      "value": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/variable/description",
+      "value": "アプリケーションで使用される変数名です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/description",
+      "value": "JSON オブジェクト入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/allowed_file_extensions/description",
+      "value": "この入力がファイルを受け付ける場合に許可される拡張子。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/allowed_file_types/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるファイルカテゴリ。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/allowed_file_upload_methods/description",
+      "value": "この入力がファイルを受け付ける場合に許可されるアップロード方法。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/config/description",
+      "value": "追加の入力設定。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/default/description",
+      "value": "デフォルト値です。JSON の型はフォームタイプによって異なります。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/description/description",
+      "value": "入力項目の任意の説明です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/hide/description",
+      "value": "公開フォームで入力項目を非表示にするかどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/json_schema/description",
+      "value": "JSON オブジェクト入力の検証に使用する JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/label/description",
+      "value": "入力項目の表示ラベルです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/max_length/description",
+      "value": "入力タイプが長さ制限をサポートする場合の最大入力長。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/options/description",
+      "value": "このフォームコントロールの選択可能な値のリスト。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/required/description",
+      "value": "入力が必須かどうかです。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/type/description",
+      "value": "レスポンス内で重複するフォームタイプ値です。存在する場合は外側のフォームキーと一致します。コントロールの形を選ぶ際は外側のキーを使用してください。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/variable/description",
+      "value": "アプリケーションで使用される変数名です。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/properties/user_input_form/title",
+      "source_sha256": "4f7c88fdb1fe5aaacc59e28f6ab6fe531304cea4523e39a724d8a4d43a768ca1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/title",
+      "source_sha256": "373b929318436fe3d709c2edd9dcb1f01d7a1b015ae52113396d8adb8f50d07f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RequiredServiceApiUserPayload/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RequiredServiceApiUserPayload/title",
+      "source_sha256": "a1269019db4ddc7c919d3b0447ea781251fcad5e3c189d0d8214785fae80891d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ResultResponse/properties/result/description",
+      "value": "操作結果。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ResultResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ResultResponse/title",
+      "source_sha256": "01088850b9c319d53d821afeaed65bffdaeb842f51b877c8b03a85f6877dc8da"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/description",
+      "value": "検索リソースの引用および帰属情報です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/content/description",
+      "value": "リソースからのコンテンツスニペット。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/created_at/description",
+      "value": "作成タイムスタンプ（Unix エポック秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/data_source_type/description",
+      "value": "データソースのタイプ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_id/description",
+      "value": "ナレッジベース ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_id/title",
+      "source_sha256": "afd32ed627cd32334bfc447d13eeaef88fe7365a20bbe496d1b65e238ab4a97e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_name/description",
+      "value": "ナレッジベース名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_name/title",
+      "source_sha256": "c3f0ca5a47fcaf871602dc501da109161cf99c427aa29ab8b20ab03813246be5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/document_id/description",
+      "value": "ドキュメント ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/document_name/description",
+      "value": "ドキュメント名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/document_name/title",
+      "source_sha256": "afa98fb25c89955f16c5857a64ca57eeab8ad2fdfc7eaba13a79ddac268a3624"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/hit_count/description",
+      "value": "このチャンクがヒットした回数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/id/description",
+      "value": "検索リソースの一意の ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/index_node_hash/description",
+      "value": "インデックスノードのハッシュ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/message_id/description",
+      "value": "このリソースが属するメッセージの ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/position/description",
+      "value": "リスト内のリソースの位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/score/description",
+      "value": "リソースの関連性スコア。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/segment_id/description",
+      "value": "ドキュメント内の特定のチャンクの ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/segment_id/title",
+      "source_sha256": "7290170777560d41462deb95fa0c1a27884f2e487befa6820e24cf1acedb6131"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/segment_position/description",
+      "value": "ドキュメント内のチャンクの位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/segment_position/title",
+      "source_sha256": "0bb9927f845754cf77570f81fd42d7660562e2b888a96d5ffbe8bfd2a1353d23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/summary/description",
+      "value": "チャンクコンテンツの要約。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/word_count/description",
+      "value": "チャンクの単語数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/title",
+      "source_sha256": "8de104f17ff021d40479f94786508b6a09f0cd2fdaa9e3eee9cff2efd7cc02f9"
     },
     {
       "op": "replace",
@@ -1092,6 +5818,206 @@
     },
     {
       "op": "add",
+      "path": "/components/schemas/SelectInputConfig/properties/option_source/description",
+      "value": "`select` 入力の選択肢のソース。 `type` が `select` の場合のみ含まれます。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SelectInputConfig/properties/output_variable_name/description",
+      "value": "ワークフロー内でこの入力の送信値を参照する際の変数名。送信リクエストの `inputs` オブジェクトのキーに対応します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SelectInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SelectInputConfig/properties/type/description",
+      "value": "フォーム入力コントロールの種類。利用可能な値： `paragraph` （複数行テキスト入力）、 `select` （リストからの単一選択）、 `file` （単一ファイルアップロード）、 `file-list` （複数ファイルアップロード）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SelectInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SelectInputConfig/title",
+      "source_sha256": "66e1ade121cd346fdaa6d2736f8281eaadb98ac2a2982ddf88a9c526c6f06896"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleAccountResponse/properties/email/description",
+      "value": "アカウントメールアドレス。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/properties/email/title",
+      "source_sha256": "0b57e967ff55ce5d934b1ac35a1e4a404e69444be35dba221b8a345b161d4ec6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleAccountResponse/properties/id/description",
+      "value": "アカウント ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleAccountResponse/properties/name/description",
+      "value": "アカウント表示名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/title",
+      "source_sha256": "074038de7e175ff8c2c27288070f216316be12924a10cbd2cb4b46e65b9597fc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/created_at/description",
+      "value": "作成時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/id/description",
+      "value": "会話 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/inputs/description",
+      "value": "会話の入力変数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/introduction/description",
+      "value": "会話の紹介文です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/introduction/title",
+      "source_sha256": "3d8ebba814c39a18678feb6015bc971c5603aaf487b51f141fd911ac77481409"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/name/description",
+      "value": "会話名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/status/description",
+      "value": "会話ステータスです。アクティブな会話の場合は `normal` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/updated_at/description",
+      "value": "最終更新時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/title",
+      "source_sha256": "5aad3cc59041619d3a39704700a243adea52d63f141cf1802f5d8d20bee1e015"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/id/description",
+      "value": "エンドユーザー ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/is_anonymous/description",
+      "value": "エンドユーザーが匿名かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/is_anonymous/title",
+      "source_sha256": "042cb8fffd7f6edb56ac128deed67f447ceb287cd716f3056d4ee0d5cee10114"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/session_id/description",
+      "value": "セッション識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/session_id/title",
+      "source_sha256": "eb75473dc0fd06e0d9e515069eb952720ae3d0b7edfe76d2e7a922d225818a47"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/type/description",
+      "value": "エンドユーザーの種類です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/title",
+      "source_sha256": "84f1217c362fa4b0b1ea92b19043514bd209a298151ac1671404067828738398"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleFeedback/properties/rating/description",
+      "value": "フィードバック評価。肯定的な場合は `like`、否定的な場合は `dislike`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleFeedback/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleFeedback/title",
+      "source_sha256": "e44c1483d3675a29e09484fe6e7392ba98494d7e638966ad3dfaf382debb0c4e"
+    },
+    {
+      "op": "add",
       "path": "/components/schemas/SimpleResultResponse/properties/result/description",
       "value": "操作結果。"
     },
@@ -1104,6 +6030,307 @@
       "op": "remove",
       "path": "/components/schemas/SimpleResultResponse/title",
       "source_sha256": "412feb3d6da0cbf2901a8634d7612e513ffb59141b7369d0048187cfca1c7a73"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/data/description",
+      "value": "提案された質問のリストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/result/description",
+      "value": "結果ステータス。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultStringListResponse/title",
+      "source_sha256": "a2760999e2320b93524528206e20f1a332ca5f97fe86255b94a71f940a73a6df"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/chat_color_theme/description",
+      "value": "チャットカラーテーマ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/chat_color_theme/title",
+      "source_sha256": "41ced5ae48a2a6e7bd660a8b5e94294e3c8e96e034f46bae09e0b8b552de4d72"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/chat_color_theme_inverted/description",
+      "value": "チャットカラーテーマが反転しているかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/chat_color_theme_inverted/title",
+      "source_sha256": "2872ca62bcb754d2f8d716df0d771a2970c96ab3b1b9d5d0e1052fcfce9a0a76"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/copyright/description",
+      "value": "著作権テキスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/copyright/title",
+      "source_sha256": "47ccad55c912b7daeec42e936d198cee6dbe394ab811d4d3b3937b5fb3597f03"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/custom_disclaimer/description",
+      "value": "カスタム免責事項テキスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/custom_disclaimer/title",
+      "source_sha256": "7d49493fafa647a9b42d3afda0937aa5fcf13486bfa359ade5cedf99a8320d67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/default_language/description",
+      "value": "デフォルト言語コード。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/default_language/title",
+      "source_sha256": "571d638d9ee456f58df3dc2d950a6ae524563eb69128509ae7bb19adf67ffd23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/description/description",
+      "value": "Web アプリの説明。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon/description",
+      "value": "アイコンのコンテンツ（絵文字または画像 ID）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon/title",
+      "source_sha256": "a4c7282e026e9c0eb1fc174c7d813fb7e1fc644829b38d12c28db5f9b9514330"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon_background/description",
+      "value": "アイコンの背景色。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon_background/title",
+      "source_sha256": "15067379b68b825a8c24c73dca876adf650c51636467e4209270fac5b87c6dda"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon_type/description",
+      "value": "使用されるアイコンのタイプ。`emoji` は絵文字アイコン、`image` はアップロードされた画像アイコンです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon_type/title",
+      "source_sha256": "285323907b457c9b9afe39555fbc8def3298246940561fc8587bfb6e657e3170"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon_url/description",
+      "value": "アイコン画像の URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon_url/title",
+      "source_sha256": "2002ea73f523b651e2e6f4c79f87fcd5231a172d575ec276ef2bbcee3d338405"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/input_placeholder/description",
+      "value": "Web アプリのメッセージ入力ボックスに表示されるプレースホルダーテキストです。設定されていない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/input_placeholder/title",
+      "source_sha256": "0b023e2beb71ec1aac71e42ede317609d11892d3eae9bb7bf5177eabb7f59eb0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/privacy_policy/description",
+      "value": "プライバシーポリシー URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/privacy_policy/title",
+      "source_sha256": "0afb547bbe92b2430806c1c57aedf2081ba43740a6ff896b1b7595fa12514a74"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/show_workflow_steps/description",
+      "value": "ワークフローステップを表示するかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/show_workflow_steps/title",
+      "source_sha256": "531c481f887f460d3971490ccf48093486d7e61e2c39258ea736553a70ee42f4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/title/description",
+      "value": "Web アプリタイトル。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/title/title",
+      "source_sha256": "4be9d4f1daabdb03afb07253382b19d77501261a6106d734746734605436aa77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/use_icon_as_answer_icon/description",
+      "value": "アプリアイコンを回答アイコンとして使用するかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/use_icon_as_answer_icon/title",
+      "source_sha256": "4a4c7e5ebdfefcddb3ae4e26e41d919118a63cd8fcbd3a72f66a54866f3c85f0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/title",
+      "source_sha256": "91f90818d42a984e64dccf6f8b2bf80fba7cd3948ecd51daa40aa2b27624baec"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringListSource/properties/selector/description",
+      "value": "`type` が `variable` の場合の変数参照パス。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringListSource/properties/selector/title",
+      "source_sha256": "c542de810cd37268c31367eddb90015a9ed2c3ab5c55bc664e19ac59527ca14d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringListSource/properties/type/description",
+      "value": "選択肢のソース。 `constant` は `value` に選択肢を直接列挙することを示します。 `variable` は `selector` が選択肢を提供する `array[string]` 型のワークフロー変数を指すことを示します。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringListSource/properties/value/description",
+      "value": "`type` が `constant` の場合のリテラルな選択肢リスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringListSource/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringListSource/title",
+      "source_sha256": "8b070b8435acce4ef835c16fb7a002405384b6950aa38d44f5889179ac10f7a1"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/StringSource/description",
+      "source_sha256": "cd268d677d8402fb9e4fcb830e69b35b5719cfcb0fa070ab3d4f8d7a795f1b3a",
+      "value": "フォーム入力のデフォルト設定。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringSource/properties/selector/description",
+      "value": "`type` が `variable` の場合の変数参照パス（例： `[\"node_id\", \"var_name\"]`）。少なくとも 2 つの要素を含む必要があります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringSource/properties/selector/title",
+      "source_sha256": "c542de810cd37268c31367eddb90015a9ed2c3ab5c55bc664e19ac59527ca14d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringSource/properties/type/description",
+      "value": "デフォルト値のソース。 `constant` は `value` をリテラル文字列として使用することを示します。 `variable` は `selector` がワークフロー変数を指すことを示します。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringSource/properties/value/description",
+      "value": "`type` が `constant` の場合のリテラルなデフォルト値。常に文字列です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringSource/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringSource/title",
+      "source_sha256": "bf9bd9920a45c7d6f459cbf55c4060f98add35f38e77e9f6ba732c85737fb219"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/audio_file_size_limit/description",
+      "value": "最大音声ファイルサイズ（MB）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/audio_file_size_limit/title",
+      "source_sha256": "ad2d08a17949c0e6e8f4a1021c9d11806e21507b453f895e5933ce4b83d83b17"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/file_size_limit/description",
+      "value": "一般ファイルの最大サイズ（MB）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/file_size_limit/title",
+      "source_sha256": "5dbcce634cd4848d0b5480c1ddf4884bf1a4170090f844c08b88648b08ad2574"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/image_file_size_limit/description",
+      "value": "最大画像ファイルサイズ（MB）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/image_file_size_limit/title",
+      "source_sha256": "a1bfda249e18ed4d84c7682eb63a00f762f8c0bbfc7ce8c816b6f1746d25a751"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/video_file_size_limit/description",
+      "value": "最大動画ファイルサイズ（MB）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/video_file_size_limit/title",
+      "source_sha256": "3d23d0e91fcffafd34c8b833160bdb31bb78589e47b0b77ad8d8409a0e251792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/workflow_file_upload_limit/description",
+      "value": "ワークフロー実行ごとの最大ファイル数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/workflow_file_upload_limit/title",
+      "source_sha256": "4a0348537154080e395851404929faff73f15cc25337d34f5ff8f7ca3f6a90fb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/title",
+      "source_sha256": "124b91697511ce88de874095c8edaf4bbf7c369aaaed03a7bf2bff88fe04e270"
     },
     {
       "op": "replace",
@@ -1153,6 +6380,258 @@
       "op": "remove",
       "path": "/components/schemas/TextToAudioPayload/title",
       "source_sha256": "21460ec2d744ed638ddcc8912fa8e504c6ad781a6a7ad4206976f4aeb17aaab9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/message_id/description",
+      "source_sha256": "47f5efd48161cf7478427652060c2fbe41c0ffd3adea29c80a7e92824fb6f704",
+      "value": "メッセージ ID。両方を指定した場合は `text` より優先されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/streaming/description",
+      "source_sha256": "bbbeba9487a0113a787e0ed2b2a3e0d6ab588013080484518fdadd925438c956",
+      "value": "互換性のために予約されています。TTS レスポンスのストリーミングはプロバイダーの出力によって決まります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/streaming/title",
+      "source_sha256": "99c855ec96bb79eda46be7218b5ac2045b607b2135c1181034e6746519b88b06"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/text/description",
+      "source_sha256": "efbe836ec14e32683d74f164f15caf0c25a45c490c6c4ac6fb2c7db6e5918db7",
+      "value": "変換する音声内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/voice/description",
+      "source_sha256": "093f32f71464b6ee988240562bff4f647ec3d81381328089f3daaf171c1bd766",
+      "value": "テキスト読み上げに使用する音声です。利用可能な音声は、このアプリに設定された TTS プロバイダーによって異なります。省略すると、利用可能な場合はアプリに設定された音声を使用します。この値は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)の `text_to_speech.voice` で確認できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/voice/title",
+      "source_sha256": "75d5a120334e208c41bdff270efdb5ed48de029fa6a9399b5897166f2dc6baf2"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/title",
+      "source_sha256": "21460ec2d744ed638ddcc8912fa8e504c6ad781a6a7ad4206976f4aeb17aaab9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ToolIcon/properties/background/description",
+      "value": "16進数形式の背景色。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ToolIcon/properties/background/title",
+      "source_sha256": "7d67b6c9f37716ad92890af3917606fbdc14a776e1a03b9e40c58171ca128af4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ToolIcon/properties/content/description",
+      "value": "Emoji コンテンツ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ToolIcon/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ToolIcon/title",
+      "source_sha256": "25ff44cb5514b1148a3243ce18e6135333123c6a437c924be3bd88f8be03028f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/UserActionConfig/description",
+      "source_sha256": "8335dbe54deb6d63d84583f2441b28057935bc5a7df092b6bb344bfd813b5f78",
+      "value": "ユーザーアクション設定。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/UserActionConfig/properties/button_style/description",
+      "value": "ボタンの視覚スタイル。利用可能な値： `primary`、 `default`、 `accent`、 `ghost`。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/UserActionConfig/properties/id/description",
+      "value": "アクションボタンの識別子。受信者がこのボタンを選択したときに、[人間の入力フォームを送信](/ja/api-reference/human-input/submit-human-input-form) エンドポイントの `action` として渡します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UserActionConfig/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/UserActionConfig/properties/title/description",
+      "value": "アクションボタンのラベル。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UserActionConfig/properties/title/title",
+      "source_sha256": "4be9d4f1daabdb03afb07253382b19d77501261a6106d734746734605436aa77"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UserActionConfig/title",
+      "source_sha256": "8cc1df1dc023895b6b786fd37c77c50adbe3df59295854f93b10148de97ea429"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ValueSourceType/description",
+      "source_sha256": "198f808b08cd9599fce0b4778c7050170a44a01ede8619242d400739206dcb67",
+      "value": "`ValueSourceType` は、値がフォーム定義の静的設定から取得されたか、ワークフロー実行中の変数から取得されたかを記録します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ValueSourceType/title",
+      "source_sha256": "b27082732c38a38ed5997a127490a1121fdd96ed9079027df4ac09ff3e557856"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/data/description",
+      "value": "現在のページのワークフローログレコード。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/has_more/description",
+      "value": "さらにワークフローログレコードがあるかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/limit/description",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/page/description",
+      "value": "現在のページ番号です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/total/description",
+      "value": "一致するワークフローログレコードの総数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/title",
+      "source_sha256": "6c3caf31a556cc72f384dea999bacd03aaaee6e71d7d8354ee9a34aa8f91e4ae"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_at/description",
+      "value": "作成時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_account/description",
+      "value": "管理者ユーザーが作成した場合のアカウント詳細です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_end_user/description",
+      "value": "ワークフロー実行を作成したエンドユーザー。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_role/description",
+      "value": "作成者のロール（例：`end_user`、`account`）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_role/title",
+      "source_sha256": "e9f5487fc14e6afc3a6b15262084175591249b08d500c3d3de5c3b17d7f65a74"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_from/description",
+      "value": "ワークフロー実行のソース（例：`service-api`）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_from/title",
+      "source_sha256": "ac7605d36b5da31a00bcf6692a557183ddce029a6ca4c5fb5cc911c9e9fd1495"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/details/description",
+      "value": "ログエントリの追加詳細です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/details/title",
+      "source_sha256": "ebc7bf40f12e237ea22047135a6283ad553d28145e437123173175174e8a40c0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/id/description",
+      "value": "ログエントリ ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/workflow_run/description",
+      "value": "このログエントリのワークフロー実行詳細。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/title",
+      "source_sha256": "87d57c23bd12acd83d7db989a402f37910d6d9d1e8035e483782f75ab988defc"
     },
     {
       "op": "remove",
@@ -1737,6 +7216,121 @@
       "source_sha256": "dbfd757fad089c9351abf34e0ded1ad305716aa9cf964d9dc5dabecd6141e448"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/created_at/description",
+      "value": "作成時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/elapsed_time/description",
+      "value": "合計経過時間（秒）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/error/description",
+      "value": "ワークフローが失敗した場合のエラーメッセージです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/exceptions_count/description",
+      "value": "実行中に発生した例外の数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/exceptions_count/title",
+      "source_sha256": "94e4767e69ec132353328419cbe108ea7d347436868ffbdfb66ed053976c364f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/finished_at/description",
+      "value": "終了時刻（Unix 秒タイムスタンプ）。未終了の場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/id/description",
+      "value": "ワークフロー実行 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/status/description",
+      "value": "ワークフローの実行ステータスです。`running` は実行中、`succeeded` は正常完了、`failed` は実行エラー、`stopped` は手動停止、`partial-succeeded` は一部のノードが成功し他が失敗、`paused` は人間の入力待ちを示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_steps/description",
+      "value": "実行されたワークフローの合計ステップ数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_tokens/description",
+      "value": "消費された合計トークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/triggered_from/description",
+      "value": "ワークフロー実行をトリガーしたソースです。`app-run` はアプリまたは API からの実行、`webhook` は Webhook トリガーによる実行、`schedule` はスケジュールトリガーによる実行、`plugin` はインテグレーショントリガーによる実行を示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/triggered_from/title",
+      "source_sha256": "ed0a91c6e5551150e5188bca26e06188f8a9cff5b3b66868e436008ced2d2a0b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/version/description",
+      "value": "ワークフローバージョン識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/version/title",
+      "source_sha256": "6a0ad2bedc57dba081cb41b98d36276eb4ebe6e16bf6523b185216d5b6dc0b0a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/title",
+      "source_sha256": "047103a06c1f0961fca15bedbd7e2e217512505bf65e5c4b52994216ae29a0b3"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
       "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
@@ -1933,6 +7527,325 @@
       "op": "remove",
       "path": "/components/schemas/WorkflowRunPayload/title",
       "source_sha256": "610156d74f8171372740a56b3a96632a903151f9cbfcc6f0ada83493fd50cf49"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "`transfer_method` が `remote_url` の場合に使用できる `url` のレガシーエイリアスです。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "転送方法。ファイル URL または保存済みアップロードファイル参照には `remote_url`、アップロード済みファイルには `local_file` を使用します。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "ファイルタイプ。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "[ファイルをアップロード](/ja/api-reference/files/upload-file) API で取得したファイル ID。`local_file` では必須です。保存済みファイル参照との互換性のため、`remote_url` と併用することもできます。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "`transfer_method` が `remote_url` の場合に使用するファイル URL です。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/description",
+      "source_sha256": "2b389dd61c5418f868e8d3f5f8741a3cbfb1b9e4fb15604bdc8e72f0c2649974",
+      "value": "ワークフローのシステムファイル入力の一覧です。ワークフローでファイルアップロードが有効な場合に使用できます。ローカルファイルを添付するには、まず[ファイルをアップロード](/ja/api-reference/files/upload-file)し、返された `id` を `upload_file_id` に指定して、`transfer_method` を `local_file` に設定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/inputs/description",
+      "source_sha256": "048d45b6175968d587d71c3ac5f810521aafb994d9f016b592b5a23e353f186f",
+      "value": "ワークフロー入力変数のキーと値のペアです。ファイル型変数の値は、`type`、`transfer_method`、および `url` または `upload_file_id` を含むファイルオブジェクトの配列にします。アプリが要求する変数名と型は、[アプリパラメーターを取得](/ja/api-reference/applications/get-app-parameters)のレスポンスにある `user_input_form` フィールドで確認できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/response_mode/description",
+      "source_sha256": "a05eb85e740430b5fc70be8c963c4dacf30a2ca5059ffe72433c24101ed10462",
+      "value": "レスポンスモード。同期レスポンスには `blocking`、Server-Sent Events（SSE）には `streaming` を使用します。省略するとブロッキングモードで実行されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/title",
+      "source_sha256": "610156d74f8171372740a56b3a96632a903151f9cbfcc6f0ada83493fd50cf49"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/created_at/description",
+      "value": "作成時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/elapsed_time/description",
+      "value": "合計経過時間（秒）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/error/description",
+      "value": "ワークフローが失敗した場合のエラーメッセージです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/finished_at/description",
+      "value": "終了時刻（Unix 秒タイムスタンプ）。未終了の場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/id/description",
+      "value": "ワークフロー実行 ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/inputs/description",
+      "value": "ワークフロー実行に渡された入力です。JSON 値はオブジェクト、配列、プリミティブ、または `null` です。レスポンス schema に従ってすでにデコードされているため、追加の JSON 解析は不要です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/outputs/description",
+      "value": "ワークフローからの出力データです。出力がまだない場合は空のオブジェクトです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/outputs/title",
+      "source_sha256": "d65ed4159859975e88dbd98c69421ec1e5cc195d03f8dfcec429a5d57839e838"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/status/description",
+      "value": "ワークフローの実行ステータスです。`running` は実行中、`succeeded` は正常完了、`failed` は実行エラー、`stopped` は手動停止、`partial-succeeded` は一部のノードが成功し他が失敗、`paused` は人間の入力待ちを示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_steps/description",
+      "value": "実行されたワークフローの合計ステップ数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_tokens/description",
+      "value": "消費された合計トークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/workflow_id/description",
+      "value": "この実行で使用したワークフロー定義 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/title",
+      "source_sha256": "32535d42024ce5ae678a114565b28cb2d20517bf30a926b010c497834d0c94ba"
     },
     {
       "op": "replace",

--- a/tools/api-pipeline/service_api_overlays/zh.json
+++ b/tools/api-pipeline/service_api_overlays/zh.json
@@ -46,6 +46,323 @@
       "value": "值错误。"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/answer/description",
+      "value": "与此思考过程关联的工具或模型答案。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/chain_id/description",
+      "value": "该思考的链 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/chain_id/title",
+      "source_sha256": "295f6a392c61fdbbb6ef9abb1b4b8147059908a23e28a9e94d796e20422a86fd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/created_at/description",
+      "value": "创建时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/files/description",
+      "value": "与该思考相关的文件 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/id/description",
+      "value": "Agent 思考 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/message_id/description",
+      "value": "该思考所属的唯一消息 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/observation/description",
+      "value": "工具调用的响应。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/observation/title",
+      "source_sha256": "c4a6f6ba9024a0dbab79416f13405fe844b0c7bf192602e88e513be9a52d79d8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/position/description",
+      "value": "该思考的位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/thought/description",
+      "value": "LLM 正在思考的内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/thought/title",
+      "source_sha256": "02bf582eb1a75c8e50c3bdcd83f2a7709b766e8a2665ab35eea31f9da2ac047e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/tool/description",
+      "value": "调用的工具，以 `;` 分隔。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/tool/title",
+      "source_sha256": "077dcaba577a59acd143ab78b5a82a1aecf5e12e5df0fc8a7bebfae7b492a894"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/tool_input/description",
+      "value": "工具输入（JSON 格式）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/properties/tool_input/title",
+      "source_sha256": "e6c0015853f82e8c5fa6ea7ac0d578344f50eee52392b5ca2cd4aeeca9b6d01d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AgentThought/properties/tool_labels/description",
+      "value": "已使用工具的标签。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AgentThought/title",
+      "source_sha256": "2e64047dcc72e66d47b39c7f80a94f47e35b0fc7ff3afa3e5b2c945840a567d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/answer/description",
+      "value": "标注被匹配时返回的预定义回答。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/created_at/description",
+      "value": "创建时间戳（Unix 纪元秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/hit_count/description",
+      "value": "该标注被匹配并作为回复返回的次数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/id/description",
+      "value": "标注唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Annotation/properties/question/description",
+      "value": "触发该标注的问题文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/properties/question/title",
+      "source_sha256": "b9af1957d9fdeaa7a00f9959b1d3d7a0b86e7668490814638482312eddff520e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Annotation/title",
+      "source_sha256": "1d156a865fcd9720975862e919faa36a4b7ea8f663d0755308e270e8501d8126"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationCreatePayload/properties/answer/description",
+      "source_sha256": "6de2ba7c6fafc16674eaa715351462f3f48378ac96c6abe2849def2cff32a83c",
+      "value": "标注答案。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationCreatePayload/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationCreatePayload/properties/question/description",
+      "source_sha256": "6594a0e78509693283abe64f502b3569b96e53dd1caa5e2abd93bf26265b3158",
+      "value": "标注问题。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationCreatePayload/properties/question/title",
+      "source_sha256": "b9af1957d9fdeaa7a00f9959b1d3d7a0b86e7668490814638482312eddff520e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationCreatePayload/title",
+      "source_sha256": "413a6ae76b1d2bfe14c473638acdad02036b866edfe5a1457bc47b09ed2d0a7b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/error_msg/description",
+      "value": "描述任务失败原因的错误消息。当 `job_status` 不是 `error` 时为空字符串。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/error_msg/title",
+      "source_sha256": "67b237015aff3ff7c6bd9b6b3efd48804f142eb82797cf06fe5a8ad1fa7b9f6a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_id/description",
+      "value": "来自 [配置标注回复](/zh/api-reference/annotations/configure-annotation-reply) 调用的任务 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_id/title",
+      "source_sha256": "0e9ad890b0e8639f3521d2e36b860c41a72abef7b2752efd1288cb7aaf51f61a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_status/description",
+      "value": "当前任务状态。`waiting` 表示排队中，`processing` 表示处理中，`completed` 表示已完成，`error` 表示失败。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/properties/job_status/title",
+      "source_sha256": "9a40e8f9b1ac49b7bf83d3f139b4200b18138cf7ae61765baeac6f0f6fe3a8e9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusDetailResponse/title",
+      "source_sha256": "a1cfc801d1b6e994cf2bc8080150df8f25096803221200581a99bca5ef2196ec"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_id/description",
+      "value": "异步任务 ID。配合 [查询标注回复配置任务状态](/zh/api-reference/annotations/get-annotation-reply-job-status) 使用以跟踪进度。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_id/title",
+      "source_sha256": "0e9ad890b0e8639f3521d2e36b860c41a72abef7b2752efd1288cb7aaf51f61a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_status/description",
+      "value": "当前任务状态，仅为 `waiting`（排队中）或 `processing`（处理中）；`completed` 和 `error` 仅由 [查询标注回复配置任务状态](/zh/api-reference/annotations/get-annotation-reply-job-status) 返回。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusResponse/properties/job_status/title",
+      "source_sha256": "9a40e8f9b1ac49b7bf83d3f139b4200b18138cf7ae61765baeac6f0f6fe3a8e9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationJobStatusResponse/title",
+      "source_sha256": "35a266556dc525b5163ab1c4a9532dd08c70ba24bbc049ac94ea1a2680f7542e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/data/description",
+      "value": "当前页的标注列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/has_more/description",
+      "value": "是否还有更多标注。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/limit/description",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/page/description",
+      "value": "当前页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AnnotationList/properties/total/description",
+      "value": "匹配的标注总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationList/title",
+      "source_sha256": "2d0d76736240133bea40a30d2182193901623f5a9d376f31a75e0e437ea89554"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/AnnotationListQuery/properties/keyword/description",
       "source_sha256": "5fd30b8249e33765d94bb777c6421570c4fb1faf94ab41cbac0d1e0b7f763233",
@@ -84,14 +401,1111 @@
       "source_sha256": "eb84fea86ba7ca8a051d796765be892d20a92ecd050e29212f7498902bab4536"
     },
     {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_model_name/description",
+      "source_sha256": "c97df7b88c3b777272905064d453ebc60cc5f76c3d1cdabf236e29a079952ba2",
+      "value": "使用 [获取可用模型](/zh/api-reference/models/get-available-models) 在 `model_type=text-embedding` 时返回的 `model` 字段，例如 `text-embedding-3-small`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_model_name/title",
+      "source_sha256": "4d79d966137d5bf514424da3770d0535ef6289a20ce67d7d5be6038198ccd6bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_provider_name/description",
+      "source_sha256": "7708e9e2750cbc449cb13498e296c0079bfa6dbd04969ed0e586b855d76ff8eb",
+      "value": "使用 [获取可用模型](/zh/api-reference/models/get-available-models) 在 `model_type=text-embedding` 时返回的 `provider` 字段，例如 `openai`；不要使用展示名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/embedding_provider_name/title",
+      "source_sha256": "4e0310d84c92f0465d3c1184754fbd60864f0d6925435fa6eff884947966e073"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/score_threshold/description",
+      "source_sha256": "78137b1381fc7cbe544de27fe6fe7ab2d01dbd702e4001e00b643290214b86c1",
+      "value": "标注匹配的最低相似度分数，取值范围为 0 到 1。值越高，匹配要求越严格。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AnnotationReplyActionPayload/title",
+      "source_sha256": "b64b023cf7b9b8c2d5885e5766acb46dfdcdc788e3999ab6dbfad1ddeb03741f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackListResponse/properties/data/description",
+      "value": "当前页的反馈记录。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackListResponse/title",
+      "source_sha256": "e4c6386ce897eb0ca2e13e996a1088fbcf09fe754f8d83417256df2bb95ce897"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/app_id/description",
+      "value": "应用 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/app_id/title",
+      "source_sha256": "9bb6aa4fb1320b37040e3c92ca381635520a01dab3a13c05e5058b135db6de04"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/content/description",
+      "value": "可选的文字反馈。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/conversation_id/description",
+      "value": "会话 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/created_at/description",
+      "value": "创建时间，RFC 3339 日期时间字符串。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_account_id/description",
+      "value": "提交反馈的账户 ID。当 `from_source` 为 `admin` 时存在。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_account_id/title",
+      "source_sha256": "cf6be2adfe52b9a1e32690eb1459bb3b20be1cf8fc055f7f7156102c5e59503b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_end_user_id/description",
+      "value": "提交反馈的终端用户 ID。当 `from_source` 为 `user` 时存在。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_end_user_id/title",
+      "source_sha256": "6da19052c4804db16313c62d79be1a72ef4475a68ddc28566b4770664cdd7e32"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_source/description",
+      "value": "反馈来源。`user` 为终端用户通过 API 提交的反馈，`admin` 为从控制台提交的反馈。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/from_source/title",
+      "source_sha256": "9a626efdfa6afdf31c0c0116f75a7858cb12aeca76c605c7fad2a276d2d2547d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/id/description",
+      "value": "反馈 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/message_id/description",
+      "value": "消息 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/rating/description",
+      "value": "反馈评分。`like` 为正面，`dislike` 为负面。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppFeedbackResponse/properties/updated_at/description",
+      "value": "最后更新时间，RFC 3339 日期时间字符串。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppFeedbackResponse/title",
+      "source_sha256": "e32e96636947952e56902bb4f92cee12934f772ba0e4c6bebf793ab3c2064dc2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/author_name/description",
+      "value": "应用作者名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/author_name/title",
+      "source_sha256": "184bab624ca3534f57b76d065cf11c51a641c53cceed8e6b5f7909a253e49313"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/description/description",
+      "value": "应用描述。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/mode/description",
+      "value": "应用模式。`completion` 为文本生成应用，`chat` 为基础聊天助手，`agent-chat` 为旧版 Agent 应用，`advanced-chat` 为 Chatflow（对话式工作流），`workflow` 为非对话式 Workflow 应用，`agent` 为新版 Agent 应用。每个接口的说明会标明支持的模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/name/description",
+      "value": "应用名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppInfoResponse/properties/tags/description",
+      "value": "应用标签。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/properties/tags/title",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppInfoResponse/title",
+      "source_sha256": "d5b9c094d6791f9b503a3c097df4bc53a1e28c0b129cd294641a8d900d74a8b0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppMetaResponse/properties/tool_icons/additionalProperties/anyOf/0/description",
+      "value": "图标的 URL。",
+      "context_path": "/components/schemas/AppMetaResponse/properties/tool_icons/additionalProperties/anyOf/0",
+      "context_sha256": "7cda4ff9a25f90d276ecdd759f6660841ebf4aef042e04abe3635927522db28b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/AppMetaResponse/properties/tool_icons/description",
+      "value": "工具图标。键为工具名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppMetaResponse/properties/tool_icons/title",
+      "source_sha256": "a8cf9cfba30dbe3b343ffd1308aec61813daf50b8a95956dbc1f4a035c0a1ea9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AppMetaResponse/title",
+      "source_sha256": "b50a0719720ed8b5183b9db8f973221fff3081a4e29db2d876bf65cc74cc7ea5"
+    },
+    {
       "op": "remove",
       "path": "/components/schemas/AudioBinaryResponse/title",
       "source_sha256": "ef754dee1a457218bc6c216dbd5138062dae750a388d7af5791b480dbf56c417"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/AudioTranscriptResponse/properties/text/description",
+      "value": "语音识别输出的文字。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AudioTranscriptResponse/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/AudioTranscriptResponse/title",
+      "source_sha256": "41e01a98ed9542dd3ad194f18ddb4af06fe1d0beb98f35acac5dc3d18cbcd158"
+    },
+    {
       "op": "remove",
       "path": "/components/schemas/BinaryFileResponse/title",
       "source_sha256": "40ee4d6aa1f0027872e6b1bea14f0389f51e33afdf6edbf84edc04f56b572787"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingMetadataResponse/description",
+      "value": "包含用量和检索资源的元数据。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingMetadataResponse/properties/retriever_resources/description",
+      "value": "使用的检索资源列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingMetadataResponse/properties/retriever_resources/title",
+      "source_sha256": "0cad6b9867870a47877812c4336c83401368174ab4b1b3d3de4636bb6b1e42b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingMetadataResponse/properties/usage/description",
+      "value": "模型使用信息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingMetadataResponse/title",
+      "source_sha256": "7fe0af522608ffffa14de6ad92786cbfaac522effc05308872c5a57e3f796820"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/content/description",
+      "value": "资源的内容片段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/created_at/description",
+      "value": "创建时间戳（Unix 纪元秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/data_source_type/description",
+      "value": "数据源类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_id/description",
+      "value": "知识库 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_id/title",
+      "source_sha256": "afd32ed627cd32334bfc447d13eeaef88fe7365a20bbe496d1b65e238ab4a97e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_name/description",
+      "value": "知识库名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/dataset_name/title",
+      "source_sha256": "c3f0ca5a47fcaf871602dc501da109161cf99c427aa29ab8b20ab03813246be5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_id/description",
+      "value": "文档 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_name/description",
+      "value": "文档名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/document_name/title",
+      "source_sha256": "afa98fb25c89955f16c5857a64ca57eeab8ad2fdfc7eaba13a79ddac268a3624"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/hit_count/description",
+      "value": "该块被命中的次数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/id/description",
+      "value": "检索资源的唯一 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/index_node_hash/description",
+      "value": "索引节点的哈希值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/message_id/description",
+      "value": "该资源所属消息的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/position/description",
+      "value": "资源在列表中的位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/score/description",
+      "value": "资源的相关性评分。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_id/description",
+      "value": "文档中特定块的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_id/title",
+      "source_sha256": "7290170777560d41462deb95fa0c1a27884f2e487befa6820e24cf1acedb6131"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_position/description",
+      "value": "块在文档中的位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/segment_position/title",
+      "source_sha256": "0bb9927f845754cf77570f81fd42d7660562e2b888a96d5ffbe8bfd2a1353d23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/summary/description",
+      "value": "块内容的摘要。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/word_count/description",
+      "value": "块的字数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingRetrieverResourceResponse/title",
+      "source_sha256": "562f01953930e507e89d83f36436ed273caf2e0d7710f93757efdf32d5767ade"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price/description",
+      "value": "补全令牌的总价。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price/title",
+      "source_sha256": "29d9f1eee907e3c79c50ce304a90fb9e166f0b6923150c2168fea6f305f8ac6d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price_unit/description",
+      "value": "补全令牌的价格单位。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_price_unit/title",
+      "source_sha256": "7b51570d42e18985f1af94caada87243925486380581e2b09744ddb5c9329055"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_tokens/description",
+      "value": "补全内容中的令牌数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_tokens/title",
+      "source_sha256": "fba7b76f7b0ed47936475461d4f609cfee6f2de15766d690821b86c3545f4f92"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_unit_price/description",
+      "value": "每个补全令牌的单价。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/completion_unit_price/title",
+      "source_sha256": "8361013d73ca8fb1331aedf884946e7bc243afdb8fff3fbbccacd1227f6e7f35"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/currency/description",
+      "value": "计价货币。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/currency/title",
+      "source_sha256": "dc3eb42975d1c1fd78c9d592adde6dbe02d004e08e7cd0dfd3951c84900b875e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/latency/description",
+      "value": "延迟时间（秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/latency/title",
+      "source_sha256": "3265005a867197e7e231cd75b93d66feb7416493c730b6fb5cb643ce6a91e069"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price/description",
+      "value": "提示词令牌的总价。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price/title",
+      "source_sha256": "6896cdeb14e5bfe7e9318f7da7e125e7938a304bb6ef3596e98142bdf229ca7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price_unit/description",
+      "value": "提示词令牌的价格单位。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_price_unit/title",
+      "source_sha256": "83edd2617fd5182b95235c3150c4c6da8764c1ee436568aeaa20f177a5ecc709"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_tokens/description",
+      "value": "提示词中的令牌数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_tokens/title",
+      "source_sha256": "00b76256407926bda0ce2732b9782cb51da7cb0df679f87c21321ee1cfc36788"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_unit_price/description",
+      "value": "每个提示词令牌的单价。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/prompt_unit_price/title",
+      "source_sha256": "9340411003259c99bfef4879cd17201753522ff030ed12bfa326b087eb9fe872"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_price/description",
+      "value": "所有令牌的总价。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_price/title",
+      "source_sha256": "3576c59289ecc321e2cfdba5f8a98bfe257996dc1fbc54b4ea53fe287e7987e2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_tokens/description",
+      "value": "使用的令牌总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/BlockingUsageResponse/title",
+      "source_sha256": "39a4eb04a7c3190dc2b3ac19dcc6ed01d33411dcc9daaecfcc089ca5c9589c18"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ButtonStyle/description",
+      "source_sha256": "026b21982c1217d0f6864e5b4247161bf98a7dc43fef34b381ddf865a1e19e0b",
+      "value": "用户操作按钮样式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ButtonStyle/title",
+      "source_sha256": "0e4f7e534381b07844aae6f722fe74e489ba76de6af52373084a21916c6abef7"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatBlockingResponse/description",
+      "source_sha256": "6855f2011b3097c7af89ef5d153387cf65e59df1ed9f3cb2ed30f99595532b5a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatBlockingResponse/title",
+      "source_sha256": "ae94d0636dd14bc30ed94d2e44c244ed20cbdea93abc003e90b6fb96612aaa38"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/description",
+      "value": "事件类型，固定为 `message`。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/answer/description",
+      "value": "完整的响应内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/conversation_id/description",
+      "value": "会话 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/created_at/description",
+      "value": "消息创建时间戳（Unix 纪元秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/event/description",
+      "value": "事件类型，固定为 `message`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/event/title",
+      "source_sha256": "426621e6a36074101f2af3e84f1bcc0a3df129e85946330dbece4d333264f5dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/id/description",
+      "value": "该响应事件的唯一 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/message_id/description",
+      "value": "唯一的消息 ID。调用反馈或推荐问题接口时，将此值作为 `message_id` 参数使用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/metadata/description",
+      "value": "包含用量和检索资源的元数据。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/mode/description",
+      "value": "应用模式。`chat` 表示聊天助手应用，`agent-chat` 表示 Agent 应用，`advanced-chat` 表示 Chatflow 应用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/task_id/description",
+      "value": "用于请求追踪和停止响应 API 的任务 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatMessageBlockingResponse/title",
+      "source_sha256": "621cbd41e3abe7a913f3d24026a9e4a9772b928f3fabb276dfa8790ad6b53330"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatPauseReasonResponse/description",
+      "source_sha256": "1417d50eba847462718505449c0df336db0d597c4b1d553ab05db5aaf44983f5",
+      "value": "阻塞式 Chatflow 执行暂停原因的公开详情。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/TYPE/description",
+      "value": "暂停原因类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/TYPE/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/actions/description",
+      "value": "人工介入表单中可执行的操作。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/actions/title",
+      "source_sha256": "aa6d82bdb3cc1d9a5e542ae2669fef27690019ab5d7b20f17d9f1331a6a942fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/approval_channels/description",
+      "value": "已配置的审批渠道。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/approval_channels/title",
+      "source_sha256": "e8dc5bb01a260360a49a9e3ee2b7e7ecc9e6b4f68aaf2bf205e3a4bcfc747d63"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/display_in_ui/description",
+      "value": "是否在 UI 中显示该暂停原因。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/display_in_ui/title",
+      "source_sha256": "8c71965fd96e6f8b785ae269402727f478472205a018ad31c70fd0860c046614"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/expiration_time/description",
+      "value": "人工介入表单的过期时间（Unix 时间戳）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_content/description",
+      "value": "人工介入表单中显示的内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_id/description",
+      "value": "人工介入表单 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_id/title",
+      "source_sha256": "fafd71c45b122dd8a3264f51789d5b76c7b77ff8dc669263056f89c55464dd7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_token/description",
+      "value": "调用人工介入表单 API 时使用的访问令牌。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/form_token/title",
+      "source_sha256": "7a13fbb60d7b9386e1e508b9270fcf384926bf6ed214f4b6523f46e5946f2c67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/inputs/description",
+      "value": "人工介入表单的输入字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/message/description",
+      "value": "说明工作流暂停原因的消息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/message/title",
+      "source_sha256": "be1af94c8c00110d748345ea5e25cfc3aca39055ab9101ab1d8d551928445819"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_id/description",
+      "value": "暂停的工作流节点 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_title/description",
+      "value": "暂停的工作流节点标题。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/resolved_default_values/description",
+      "value": "表单输入解析后的默认值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPauseReasonResponse/title",
+      "source_sha256": "6bd7d1ff1401cbea01fb89343104f99acc66302933d2c9d54b62ee9c1b97cf6a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/description",
+      "value": "Chatflow 工作流运行的暂停详情。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/answer/description",
+      "value": "完整的响应内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/conversation_id/description",
+      "value": "会话 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/created_at/description",
+      "value": "消息创建时间戳（Unix 纪元秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/elapsed_time/description",
+      "value": "总耗时（秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/id/description",
+      "value": "该响应事件的唯一 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/message_id/description",
+      "value": "唯一的消息 ID。调用反馈或推荐问题接口时，将此值作为 `message_id` 参数使用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/metadata/description",
+      "value": "包含用量和检索资源的元数据。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/mode/description",
+      "value": "应用模式。`chat` 表示聊天助手应用，`agent-chat` 表示 Agent 应用，`advanced-chat` 表示 Chatflow 应用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/paused_nodes/description",
+      "value": "等待输入的工作流节点 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/paused_nodes/title",
+      "source_sha256": "1be2bcf1f1cac22fee5004654f91685bb8d677de3e9c946a311420a413e25f98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/reasons/description",
+      "value": "工作流暂停原因，包括人工介入表单详情。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/reasons/title",
+      "source_sha256": "c9f903172d68246eaeee2c130b732b3b5596a22100ff964b1a54aa9351f20b08"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/status/description",
+      "value": "工作流执行状态，固定为 `paused`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_steps/description",
+      "value": "已执行的工作流步骤总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_tokens/description",
+      "value": "所有节点消耗的 Token 总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/workflow_run_id/description",
+      "value": "已暂停工作流运行的持久标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingDataResponse/title",
+      "source_sha256": "cd61aef73a52645cfb71fe9879437e410b1afca2dac696a60f25998ad657099d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/description",
+      "value": "Chatflow 等待人工输入时返回的阻塞响应。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/answer/description",
+      "value": "完整的响应内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/conversation_id/description",
+      "value": "会话 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/created_at/description",
+      "value": "消息创建时间戳（Unix 纪元秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/data/description",
+      "value": "Chatflow 工作流运行的暂停详情。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/event/description",
+      "value": "Chatflow 等待人工输入时，事件类型固定为 `workflow_paused`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/event/title",
+      "source_sha256": "426621e6a36074101f2af3e84f1bcc0a3df129e85946330dbece4d333264f5dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/id/description",
+      "value": "该响应事件的唯一 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/message_id/description",
+      "value": "唯一的消息 ID。调用反馈或推荐问题接口时，将此值作为 `message_id` 参数使用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/metadata/description",
+      "value": "包含用量和检索资源的元数据。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/mode/description",
+      "value": "应用模式。`chat` 表示聊天助手应用，`agent-chat` 表示 Agent 应用，`advanced-chat` 表示 Chatflow 应用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/task_id/description",
+      "value": "用于请求追踪和停止响应 API 的任务 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/workflow_run_id/description",
+      "value": "已暂停工作流运行的持久标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatPausedBlockingResponse/title",
+      "source_sha256": "d5bf66fb39bbc16156f497f3a3126daab95b1f0125b5be3ba9e53d967b5ca843"
     },
     {
       "op": "replace",
@@ -337,6 +1751,254 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/auto_generate_name/description",
+      "source_sha256": "e5973e5a893cd7bdbc306bccb9e8dad1cc4cdd20f63d801ac823cd1d07119df8",
+      "value": "是否自动生成会话标题。若为 `false`，可调用重命名会话 API，并设置 `auto_generate: true` 来异步生成标题。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/auto_generate_name/title",
+      "source_sha256": "3ed483bca55763140ff1d72d40e67e287249200e1fa7c544a8cf98312bcff07d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/conversation_id/description",
+      "source_sha256": "27e05c95b7ec09544d57afd7b24bb352c65a4bce2ab5f86401b97d3c5d7a4511",
+      "value": "用于继续会话的会话 ID。省略此字段或传入空字符串可开始新会话，后续请求再传入返回的 `conversation_id`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "用于多模态输入的文件。新客户端只需实现两种规范形式：公共文件 URL 使用 `transfer_method: remote_url` 和 `url`；本地文件先通过[上传文件](/zh/api-reference/files/upload-file)上传，再使用 `transfer_method: local_file`，并将返回的 `id` 作为 `upload_file_id`。生成的其他 `anyOf` 组合仅用于兼容已存储的旧版引用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "应用自定义变量的值。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解预期的变量名称和类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/query/description",
+      "source_sha256": "471e3964eb5e828809bb8ce8b7df96c8aba289839bd3521465e3cc501332c2d4",
+      "value": "用户输入或问题内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/response_mode/description",
+      "source_sha256": "c581b2c300c810f3aee9272bcd889e500a65443b16a9729c8538d3b4540237d1",
+      "value": "响应模式。`streaming` 使用服务器发送事件（SSE）；`blocking` 在执行完成后返回。新版 Agent 应用仅支持流式模式。省略时，非 Agent 应用使用阻塞模式，新版 Agent 应用使用流式模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/workflow_id/description",
+      "source_sha256": "73733c8ea4eb596b707394ec840174c0200e4c3c4ffb2c523f0f1e7af3c9abc3",
+      "value": "高级聊天要执行的已发布工作流版本 ID。省略时，使用应用当前已发布的工作流。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChatRequestPayloadWithUser/title",
+      "source_sha256": "737ed654af2d15b7259a6742f94f2f965deeff0143b24f8c6394a335a43318e6"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/ChildChunkListQuery/properties/keyword/description",
       "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
       "value": "搜索关键词。"
@@ -372,6 +2034,86 @@
       "op": "remove",
       "path": "/components/schemas/ChildChunkListQuery/title",
       "source_sha256": "b1c6a7020550b6caf74316c4f6f0d9a79bb59b5fe961a3d65331855b2e4fa238"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/answer/description",
+      "value": "完整的响应内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/created_at/description",
+      "value": "消息创建时间戳（Unix 纪元秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/event/description",
+      "value": "事件类型，固定为 `message`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/event/title",
+      "source_sha256": "426621e6a36074101f2af3e84f1bcc0a3df129e85946330dbece4d333264f5dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/id/description",
+      "value": "该响应事件的唯一 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/message_id/description",
+      "value": "唯一消息 ID。提交反馈时将其作为 `message_id`。文本生成应用不支持生成推荐问题。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/metadata/description",
+      "value": "包含用量和检索资源的元数据。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/mode/description",
+      "value": "应用模式，固定为 `completion`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/mode/title",
+      "source_sha256": "b47ccf6a866623446835c8cbc9969b65323deae00d4e9b721ed7a40539ddd3f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/task_id/description",
+      "value": "用于请求追踪和 [停止响应](/zh/api-reference/completion-messages/stop-completion-message-generation) API 的任务 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/properties/task_id/title",
+      "source_sha256": "a9e7c96ada3932f4ade318a363f7fd6ef00bbc19a31571a7493bc69618b2fc80"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionBlockingResponse/title",
+      "source_sha256": "ee47e2a5e80d35feab4cf22bdf5ddc102cd7a070d83df22ca8e2b1fc9e22302b"
     },
     {
       "op": "replace",
@@ -584,6 +2326,256 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/description",
+      "source_sha256": "e4475712dd2a0e0d972a5d82d12ec929fc25f250c0e63791da52c5aa409d4543",
+      "value": "用于多模态输入的文件。新客户端只需实现两种规范形式：公共文件 URL 使用 `transfer_method: remote_url` 和 `url`；本地文件先通过[上传文件](/zh/api-reference/files/upload-file)上传，再使用 `transfer_method: local_file`，并将返回的 `id` 作为 `upload_file_id`。生成的其他 `anyOf` 组合仅用于兼容已存储的旧版引用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/inputs/description",
+      "source_sha256": "824c8855b24af13abe1b2e17912fdc48f360b60a60e4bf11e5d7e4748d62c8d9",
+      "value": "应用自定义变量的值。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解预期的变量名称和类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/query/description",
+      "source_sha256": "ce812efc2fab57a97815d53cc2e428893ce5a4e5b29c9f0289f5e19f4178d4c3",
+      "value": "用户输入或提示词内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/response_mode/description",
+      "source_sha256": "b3d5908801262c0944f042ea2597fca96c2cfff286dfcf52f032c9c966ce3f5a",
+      "value": "响应模式。`streaming` 使用服务器发送事件（SSE）；`blocking` 在执行完成后返回。省略时，请求使用阻塞模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CompletionRequestPayloadWithUser/title",
+      "source_sha256": "af0367558fbca9f02fe0c6614e89b0fbaddd2d5462f4aa34f224f2cdf7e90469"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/data/description",
+      "value": "当前页的会话列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/has_more/description",
+      "value": "是否还有更早的会话。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/limit/description",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationInfiniteScrollPagination/title",
+      "source_sha256": "8d2c26d65f5574e6f0a965a27176479d828da87cfa8522634b679257d805d213"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/ConversationListQuery/properties/last_id/description",
       "source_sha256": "f766603b3efb94aa18c59ff583b84741e8ba3fa64045be1bdd854b3aa1141eae",
       "value": "当前页面最后一条记录的 ID，用于获取下一页。"
@@ -708,6 +2700,224 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/name/description",
+      "source_sha256": "246b01fd801492655f586faef4387a5106f549fdd898de10259a0308868ea580",
+      "value": "会话名称。当 `auto_generate` 为 `false` 时必填。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/0",
+      "context_sha256": "6324f0a253b5f05d279c407bab27a2739f99be49ca89906869c055b11e683648"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/name/description",
+      "value": "新的会话名称。除非 `auto_generate` 为 `true`，否则必填。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+      "context_path": "/components/schemas/ConversationRenamePayloadWithUser/anyOf/1",
+      "context_sha256": "142400eeb4b9c8885c80841c4765ce135724fa49a0a95283e6245e3451619340"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/auto_generate/description",
+      "source_sha256": "2d94e97bc325380c588beddcf222cfe0e64749bcbc232e1c2d5f401675eaffc4",
+      "value": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/auto_generate/title",
+      "source_sha256": "4e8b01b267a883dccb9fd84d6bc1eb262353ed82f5cd37654ec0bed4f2ae7f8e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/name/description",
+      "source_sha256": "246b01fd801492655f586faef4387a5106f549fdd898de10259a0308868ea580",
+      "value": "会话名称。当 `auto_generate` 为 `false` 时必填。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationRenamePayloadWithUser/title",
+      "source_sha256": "5007bf01416d1203f9aeac8979d407c9432d6420dfba585d65249853164be8b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/data/description",
+      "value": "当前页的会话变量列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/has_more/description",
+      "value": "是否还有更多会话变量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/limit/description",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableInfiniteScrollPaginationResponse/title",
+      "source_sha256": "40398eaf223ae268d6ca662c0553a3b63efc0726833ecbdce3ec3e188c44a994"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/created_at/description",
+      "value": "创建时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/description/description",
+      "value": "变量描述。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/id/description",
+      "value": "变量 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/name/description",
+      "value": "变量名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/updated_at/description",
+      "value": "最后更新时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value/description",
+      "value": "变量值（复杂类型可以是 JSON 字符串）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value_type/description",
+      "value": "变量值类型。可选值：`string`、`number`、`object`、`secret`、`file`、`boolean`、`array[any]`、`array[string]`、`array[number]`、`array[object]`、`array[file]`、`array[boolean]`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/properties/value_type/title",
+      "source_sha256": "1990c83514aae4414c3c0cdfe9926c617cf3a92057cf60c43cecfe243bf75d44"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableResponse/title",
+      "source_sha256": "8b07df8ff6c7bff5a6a4267191363393127c16f84cb667540cd56afdcbfce36e"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/ConversationVariableUpdatePayload/properties/value/description",
       "source_sha256": "c023a9fd7cdee70eae72c18bb8bd84cd7c51f6170d4b075f585b72d55ea046de",
       "value": "变量的新值。必须与变量的预期类型匹配。"
@@ -720,6 +2930,28 @@
     {
       "op": "remove",
       "path": "/components/schemas/ConversationVariableUpdatePayload/title",
+      "source_sha256": "ab9aedc458ad087c3e8f47e9d46c7180ff78e73b058595f23c06153749e8d9be"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariableUpdatePayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ConversationVariableUpdatePayloadWithUser/properties/value/description",
+      "source_sha256": "c023a9fd7cdee70eae72c18bb8bd84cd7c51f6170d4b075f585b72d55ea046de",
+      "value": "变量的新值。必须与变量的预期类型匹配。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayloadWithUser/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ConversationVariableUpdatePayloadWithUser/title",
       "source_sha256": "ab9aedc458ad087c3e8f47e9d46c7180ff78e73b058595f23c06153749e8d9be"
     },
     {
@@ -903,8 +3135,123 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/EndUserDetail/description",
+      "source_sha256": "aa3c373c92f25d2f94b8e188c71129841d23355dfed0285bf4e926738925d270"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/app_id/description",
+      "value": "应用 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/app_id/title",
+      "source_sha256": "9bb6aa4fb1320b37040e3c92ca381635520a01dab3a13c05e5058b135db6de04"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/created_at/description",
+      "value": "创建时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/external_user_id/description",
+      "value": "API 请求中提供的 `user` 标识符（例如 [发送对话消息](/zh/api-reference/chat-messages/send-chat-message) 中的 `user` 字段）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/external_user_id/title",
+      "source_sha256": "73e63201b85107943bdd55a6e70905be50c4051b74922599d44bb3fe6a233f72"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/id/description",
+      "value": "终端用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/is_anonymous/description",
+      "value": "用户是否为匿名用户。当原始 API 请求中未提供 `user` 标识符时，值为 `true`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/is_anonymous/title",
+      "source_sha256": "042cb8fffd7f6edb56ac128deed67f447ceb287cd716f3056d4ee0d5cee10114"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/name/description",
+      "value": "终端用户名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/session_id/description",
+      "value": "会话标识符。默认为 `external_user_id` 的值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/session_id/title",
+      "source_sha256": "eb75473dc0fd06e0d9e515069eb952720ae3d0b7edfe76d2e7a922d225818a47"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/tenant_id/description",
+      "value": "租户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/tenant_id/title",
+      "source_sha256": "ae18aae49d3ccc237cd61077f9e1235aa293a131da760623f83eab7b5e51d944"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/type/description",
+      "value": "终端用户类型。Service API 用户固定为 `service-api`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/EndUserDetail/properties/updated_at/description",
+      "value": "最后更新时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/EndUserDetail/title",
+      "source_sha256": "e280f5d56814b84006ebaa503204543732987703d54509b41ea6279aae618405"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/EventStreamResponse/title",
       "source_sha256": "cb598d0c9427cccc89d63f389617e8966efeffc6cf0b9bad1c5823624bf470d3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ExecutionContentType/title",
+      "source_sha256": "3b2b49df41fa1f57efbdf69684f4846436696825906cc5908b47a6d9dcb38165"
     },
     {
       "op": "replace",
@@ -934,6 +3281,126 @@
       "source_sha256": "2ee2ef5a0b8833947992d468c455c3ec9722d91f0512455ef418a2ca9fa97e89"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_extensions/description",
+      "value": "当 `allowed_file_types` 包含 `custom` 时允许的文件扩展名。每个扩展名都需要包含前导 `.`，例如 `.md`。`file` 和 `file-list` 输入会包含此字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_extensions/title",
+      "source_sha256": "a9fbd8515a7570cbf8527621d2dfef68843739b7f642385e7614124dbf62c207"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_types/description",
+      "value": "接收人可上传的文件类别。`file` 和 `file-list` 输入会包含此字段。可用值：`image`、`document`、`audio`、`video`、`custom`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_types/title",
+      "source_sha256": "dc39dad025bd4f01f3683f0b4275c0cfc39242bcd63c9df3a018450cb31a54b1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_upload_methods/description",
+      "value": "接收人可使用的上传方式。可用值：`local_file`、`remote_url`。`file` 和 `file-list` 输入会包含此字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/allowed_file_upload_methods/title",
+      "source_sha256": "27ec3b14f4b815bd97063c77366bd8925f2475e48b86322fc51ffee8a68010f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/output_variable_name/description",
+      "value": "引用该输入提交值在工作流中使用的变量名。对应提交 `inputs` 对象中的键。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileInputConfig/properties/type/description",
+      "value": "表单输入控件类型。可用值：`paragraph`（多行文本输入）、`select`（从列表中单选）、`file`（单个文件上传）和 `file-list`（多个文件上传）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileInputConfig/title",
+      "source_sha256": "c16f00d355344aabe5c8f9d3ee46f954b3955758cbe7e98128580690751590f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_extensions/description",
+      "value": "当 `allowed_file_types` 包含 `custom` 时允许的文件扩展名。每个扩展名都需要包含前导 `.`，例如 `.md`。`file` 和 `file-list` 输入会包含此字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_extensions/title",
+      "source_sha256": "a9fbd8515a7570cbf8527621d2dfef68843739b7f642385e7614124dbf62c207"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_types/description",
+      "value": "接收人可上传的文件类别。`file` 和 `file-list` 输入会包含此字段。可用值：`image`、`document`、`audio`、`video`、`custom`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_types/title",
+      "source_sha256": "dc39dad025bd4f01f3683f0b4275c0cfc39242bcd63c9df3a018450cb31a54b1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_upload_methods/description",
+      "value": "接收人可使用的上传方式。可用值：`local_file`、`remote_url`。`file` 和 `file-list` 输入会包含此字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/allowed_file_upload_methods/title",
+      "source_sha256": "27ec3b14f4b815bd97063c77366bd8925f2475e48b86322fc51ffee8a68010f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/number_limits/description",
+      "value": "接收人可上传的最大文件数。仅 `file-list` 输入会包含此字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/number_limits/title",
+      "source_sha256": "cffcf3dbc6eeea7d5b96f1a6c3695f1060321b5ddd099aa47ac900873301da17"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/output_variable_name/description",
+      "value": "引用该输入提交值在工作流中使用的变量名。对应提交 `inputs` 对象中的键。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileListInputConfig/properties/type/description",
+      "value": "表单输入控件类型。可用值：`paragraph`（多行文本输入）、`select`（从列表中单选）、`file`（单个文件上传）和 `file-list`（多个文件上传）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileListInputConfig/title",
+      "source_sha256": "f523cc0240880eba6ee6fafc4c09c042bca376e0ac425c0bab976088289c0527"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/FilePreviewQuery/properties/as_attachment/description",
       "source_sha256": "f9c567f7630732e17ddcbf65657256aba6e339dfe6b252545230bd8b32ff53b3",
@@ -948,6 +3415,451 @@
       "op": "remove",
       "path": "/components/schemas/FilePreviewQuery/title",
       "source_sha256": "34f058141cf139f35d0840e326719c0af503c33e745ab65d911e0449050fe2b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/conversation_id/description",
+      "value": "关联的会话 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/created_at/description",
+      "value": "上传时间戳（Unix 纪元秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/created_by/description",
+      "value": "上传者的终端用户 ID。可通过 [获取终端用户信息](/zh/api-reference/end-users/get-end-user-info) 查询详情。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/extension/description",
+      "value": "文件扩展名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/file_key/description",
+      "value": "未使用，始终为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/file_key/title",
+      "source_sha256": "e40ccb27af6fbb5ca42abd5c75fab69254329e65482470315875be7ab053799d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/id/description",
+      "value": "唯一文件 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/mime_type/description",
+      "value": "文件的 MIME 类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/name/description",
+      "value": "文件名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/original_url/description",
+      "value": "文件的原始 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/original_url/title",
+      "source_sha256": "c4888fa31ede45075f22f445e420c81308f0e7926289179c73243e106dce12f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/preview_url/description",
+      "value": "文件的预览 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/preview_url/title",
+      "source_sha256": "5032783bebaa4d692996f8a238e903dff18dcde3b433a8a12f5ce10b8723d5c1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/reference/description",
+      "value": "在 Agent 和工具场景中附加文件时内部使用的不透明文件引用。通过此端点上传的文件始终为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/reference/title",
+      "source_sha256": "62bf2677b9ec30fcd1213616c78b6ede91fcf2778e6e1e06139f7a0ee9a2f22b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/size/description",
+      "value": "文件大小（字节）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/source_url/description",
+      "value": "文件的签名下载 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/source_url/title",
+      "source_sha256": "3d48f2577f877973dd0a3ab85975e367b5a9ab1964eb533d2cb3dd317134d453"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/tenant_id/description",
+      "value": "关联的租户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/tenant_id/title",
+      "source_sha256": "ae18aae49d3ccc237cd61077f9e1235aa293a131da760623f83eab7b5e51d944"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/FileResponse/properties/user_id/description",
+      "value": "未使用，始终为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/properties/user_id/title",
+      "source_sha256": "61a98a9e2d63198ff47128e3e2b20573e9cd81c7bfaac7b52679c167124b4618"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileResponse/title",
+      "source_sha256": "e1fde1b159c838025a2bd05b8a08f570c7b8a335d4c17984cc000fdccc597bac"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileTransferMethod/title",
+      "source_sha256": "89ade223b5ca2b5b6c7b8c9b94144a779e59d931884fd19c951ea02efcd0900b"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FileType/title",
+      "source_sha256": "1146fdf89b9afd90dd54e7a8a49cc084960dbe6ab3cb3c9ddb13494be2676ed7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/description",
+      "value": "人工介入节点的执行内容，包括表单定义和提交数据。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/form_definition/description",
+      "value": "人工介入节点的表单定义。当内容表示提交响应时为 `null`。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/form_submission_data/description",
+      "value": "已提交的表单数据。表单尚未提交时为 `null`。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/submitted/description",
+      "value": "人工介入表单是否已提交。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputContent/properties/submitted/title",
+      "source_sha256": "c6c415f99181251a358bb051196877f12f5d92f48454d2b3f0975426b3d77197"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/type/description",
+      "value": "`human_input` 表示人工介入内容。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputContent/properties/workflow_run_id/description",
+      "value": "该内容所属的工作流运行 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputContent/properties/workflow_run_id/title",
+      "source_sha256": "fa6cf57391aac77a6527ade33b838dfb36eaedf1575cf05d3ae55538392d2e04"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputContent/title",
+      "source_sha256": "8be8a12c2e3e7a84b72adcf514810d1fa1ec486ad223eb6eedfe4fcbb840c83d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/description",
+      "value": "由人工介入节点渲染的人工介入表单定义。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/actions/description",
+      "value": "表单上可用的操作按钮。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/actions/title",
+      "source_sha256": "aa6d82bdb3cc1d9a5e542ae2669fef27690019ab5d7b20f17d9f1331a6a942fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/display_in_ui/description",
+      "value": "表单是否应在 UI 中显示。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/display_in_ui/title",
+      "source_sha256": "8c71965fd96e6f8b785ae269402727f478472205a018ad31c70fd0860c046614"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/expiration_time/description",
+      "value": "表单过期的 Unix 时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_content/description",
+      "value": "与表单一起显示的 Markdown 或文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_id/description",
+      "value": "表单唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_id/title",
+      "source_sha256": "fafd71c45b122dd8a3264f51789d5b76c7b77ff8dc669263056f89c55464dd7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_token/description",
+      "value": "表单提交认证的令牌。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/form_token/title",
+      "source_sha256": "7a13fbb60d7b9386e1e508b9270fcf384926bf6ed214f4b6523f46e5946f2c67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/inputs/description",
+      "value": "表单中的输入字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_id/description",
+      "value": "生成该表单的人工介入节点 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_title/description",
+      "value": "人工介入节点的标题。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/resolved_default_values/description",
+      "value": "表单输入的已解析默认值，按输出变量名称索引。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinition/title",
+      "source_sha256": "fca56dea40adeb7da6dc4dc9897a9d70e622d8794384f3f0a9a1bde76efebab6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/expiration_time/description",
+      "value": "Unix 时间戳（秒），超过该时间后表单将不可提交。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/expiration_time/title",
+      "source_sha256": "41ed78342c6673ea5d48577e2084ff3d23679d70a0221f566577e79dd45c9096"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/form_content/description",
+      "value": "已替换工作流变量的预渲染表单正文。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/form_content/title",
+      "source_sha256": "024cfd5ae22761afa734c98d15aac7e12aa0f8d7b6cd6aa227f67602e9f34efe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/inputs/description",
+      "value": "表单输入字段定义。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/resolved_default_values/description",
+      "value": "用于在表单中展示的预渲染默认值，按输入的 `output_variable_name` 分组。仅当 `paragraph` 输入的默认值可由工作流变量解析时填充；无可解析默认值的输入为空。客户端请直接展示这些值，无需在前端再次解析 `default`。所有值均为字符串。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/resolved_default_values/title",
+      "source_sha256": "036c4c928660e1437254d5acfca10a5d2599791a969a26b26918895b12593b65"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/user_actions/description",
+      "value": "可用的提交操作。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/properties/user_actions/title",
+      "source_sha256": "1a4ed49eb5af3941bf9d0e30899e2a9c0be82d2089efadc9ac3c422e06580f1e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormDefinitionResponse/title",
+      "source_sha256": "efe9278e93efddf0770298b0baa1af36c79f83167e15fe64c7e9ddcaa07917a0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/description",
+      "value": "来自已提交的人工介入表单的数据。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_id/description",
+      "value": "被点击的操作按钮的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_id/title",
+      "source_sha256": "7e4688059b07745f9eac7661edcd135651dd97f393de9fd273c1fe29cd654215"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_text/description",
+      "value": "被点击的操作按钮的显示文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/action_text/title",
+      "source_sha256": "6d4c58126485bf41fe4903c696afd5f42aa118b96787a3bf97382b3e088c33cf"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_id/description",
+      "value": "人工介入节点的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_title/description",
+      "value": "人工介入节点的标题。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/node_title/title",
+      "source_sha256": "f5ceada36f13c400d40e2ac22b6dd7319590e4f62de0e2b8a0bd4c7a4836880d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/rendered_content/description",
+      "value": "表单提交的渲染内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/rendered_content/title",
+      "source_sha256": "7a73e1acdc736489774de1b928d6e98015e2ec121a590938f8954eef240d6044"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/submitted_data/description",
+      "value": "接收者提交的表单值，以各输入项的 `output_variable_name` 为键。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/properties/submitted_data/title",
+      "source_sha256": "a3f562e953210d2b0de95dcc91dbe78484cf58cfde9918a87c2cf39a3e8aecf1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmissionData/title",
+      "source_sha256": "8949c480137e5d219cf4f5313442efea2336e23601e1837935795cf3936c0e3a"
     },
     {
       "op": "replace",
@@ -978,6 +3890,79 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/action/description",
+      "source_sha256": "3da3bf444ea4552df683d22e39bbba3d292b7270d42e322568b9dbf85cbf9d7f",
+      "value": "接收者所选操作按钮的 ID，必须与表单 `user_actions` 列表中的某个 `id` 值匹配。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/action/title",
+      "source_sha256": "5efcc1e437cbeada52653f133121f3ca259b84b74a51e15c277b4de93f11bd75"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/inputs/description",
+      "source_sha256": "1f22c5be035a6620b87ddfb1582988875cfc11dec9117525dc371f0db59c5961",
+      "value": "按输出变量名称组织的人工输入值。段落或选择输入使用字符串，文件输入使用文件映射，文件列表输入使用文件映射列表。本地文件映射使用 `transfer_method=local_file` 和 `upload_file_id`；远程文件映射使用 `transfer_method=remote_url` 和 `url` 或 `remote_url`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitPayloadWithUser/title",
+      "source_sha256": "38a626e4a4e1642a39e35116d44bec129a532a22191e06434ecc3c9b4c51c3d3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HumanInputFormSubmitResponse/title",
+      "source_sha256": "aa2f56fbcc6b021221b64c92e880abaccf77304d4960f15e77f766fae9e7c1e1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/IndexInfoResponse/properties/api_version/description",
+      "value": "Service API 版本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/properties/api_version/title",
+      "source_sha256": "ae9fbe000bcc107626c6a7562db6d9dbfdf0fc84bf08e7e3a160b90d59be00cd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/IndexInfoResponse/properties/server_version/description",
+      "value": "Dify 服务器版本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/properties/server_version/title",
+      "source_sha256": "474479a19ac772ca7e9bdb8d22a2c24622e90170553d6fbe287d9cec70165ced"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/IndexInfoResponse/properties/welcome/description",
+      "value": "服务欢迎信息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/properties/welcome/title",
+      "source_sha256": "1fa79baa5f6a65d49bbee9e12d6e320e542885ad389f26f8b744a14608e68cbb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/IndexInfoResponse/title",
+      "source_sha256": "39bae08b9ff59cac2e8753bfc4a2e27ee7493eb5d4f6402c2f1c354436048e6e"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/MessageFeedbackPayload/properties/content/description",
       "source_sha256": "f1b13f33ce2fae7757c4b30cad4a78f091f9ff5ed649c04f9d9851e7f7dad06b",
       "value": "提供额外详情的可选文字反馈。"
@@ -1002,6 +3987,369 @@
       "op": "remove",
       "path": "/components/schemas/MessageFeedbackPayload/title",
       "source_sha256": "dc826ad9804a26c2e92124a2d20c938b54f7e6abf59d8fbccb326f20ac4e7c70"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/content/description",
+      "source_sha256": "f1b13f33ce2fae7757c4b30cad4a78f091f9ff5ed649c04f9d9851e7f7dad06b",
+      "value": "提供额外详情的可选文字反馈。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/rating/description",
+      "source_sha256": "a22a86af4ca3b6b23b547b829f67d88997e274ed483d1ddd4d6fd916fadc8c44",
+      "value": "反馈评分。设为 `null` 可撤销之前提交的反馈。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFeedbackPayloadWithUser/title",
+      "source_sha256": "dc826ad9804a26c2e92124a2d20c938b54f7e6abf59d8fbccb326f20ac4e7c70"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/belongs_to/description",
+      "value": "该文件的所属者。用户上传的文件为 `user`，助手生成的文件为 `assistant`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/belongs_to/title",
+      "source_sha256": "9c4f84210a02189552fb0d669344eff0190bf70baef043015aef34ed8c0ac152"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/filename/description",
+      "value": "原始文件名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/filename/title",
+      "source_sha256": "fa233e390655e8ee27cb179523ba2c9fe37aae77a8f531ee59cd9af15377806d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/id/description",
+      "value": "消息文件 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/mime_type/description",
+      "value": "文件的 MIME 类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/size/description",
+      "value": "文件大小（字节）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/transfer_method/description",
+      "value": "使用的传输方式。`remote_url` 表示基于 URL 的文件，`local_file` 表示已上传的文件，`tool_file` 表示工具生成的文件。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/transfer_method/title",
+      "source_sha256": "b44be7211a456d1bd0ae715137a36e970b9f722bee23006b86ecab3bfc9d49d7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/type/description",
+      "value": "文件类型，例如 `image`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/upload_file_id/description",
+      "value": "通过 `local_file` 传输时的上传文件 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/upload_file_id/title",
+      "source_sha256": "f29fbbf25b1c3154216e20e3583a05c7ed965a056bcd8f30a5c5ed91a33678d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageFile/properties/url/description",
+      "value": "文件的预览 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/properties/url/title",
+      "source_sha256": "0146bf069164386d9cbddfbb77eed14df29c3fbf0326244f5676fc1c06a30963"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageFile/title",
+      "source_sha256": "60f8396dde335458941fb0c59e5e4e7cbf2e36309e02c32c0b98f69ca3e444a3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/data/description",
+      "value": "当前页的消息列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/has_more/description",
+      "value": "是否还有更早的消息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/limit/description",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageInfiniteScrollPagination/title",
+      "source_sha256": "e74af12050ecc369553e1acd525a8588c859d754655ae355c3a25b4306393107"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/agent_thoughts/description",
+      "value": "该消息的 Agent 思考。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/agent_thoughts/title",
+      "source_sha256": "2184f8609c9c4feeeb57c0b2cf05c2fde85cdf9cf74b0ce38155990fd5e63d18"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/answer/description",
+      "value": "助手回答文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/answer_tokens/description",
+      "value": "生成回答的 token 数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/answer_tokens/title",
+      "source_sha256": "1b572d1e3ea69bf0ee0a51abcffa0431b7b84eb28ed5913becebec76d5046063"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/conversation_id/description",
+      "value": "会话 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/conversation_id/title",
+      "source_sha256": "96ded82c65c8e63dac4ff1433dbef0fe77ea58790166d550c3a3840128414f84"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/created_at/description",
+      "value": "创建时间戳（Unix 纪元秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/currency/description",
+      "value": "`total_price` 的货币单位（例如 `USD`），无定价信息时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/currency/title",
+      "source_sha256": "dc3eb42975d1c1fd78c9d592adde6dbe02d004e08e7cd0dfd3951c84900b875e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/error/description",
+      "value": "当 `status` 为 `error` 时的错误消息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/extra_contents/description",
+      "value": "与此消息关联的附加执行内容，例如 Chatflow 工作流中人工介入节点的表单数据。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/extra_contents/title",
+      "source_sha256": "ddc4b3e9e40fc66023e5a3b362c7383a7ff50cd282944c3e04fcdfe0fb040bf6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/feedback/description",
+      "value": "该消息的用户反馈。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/id/description",
+      "value": "消息 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/inputs/description",
+      "value": "该消息的输入变量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/message_files/description",
+      "value": "附加到该消息的文件。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/message_files/title",
+      "source_sha256": "019a4253ead76b257c4cd8c39037108752829deb2cab847c8c8784d81c88dc47"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/message_tokens/description",
+      "value": "输入消息的 token 数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/message_tokens/title",
+      "source_sha256": "dc40a100e53d859ae80ed9200353283259695db35d73ab038a376d75bc54ba8b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/parent_message_id/description",
+      "value": "线程会话的父消息 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/parent_message_id/title",
+      "source_sha256": "9a5f1265a74baedbf683b3f039d7f0b6a0c19d2068c1b990b19b23bc6990c17e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/provider_response_latency/description",
+      "value": "模型供应商的响应延迟，单位为秒。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/provider_response_latency/title",
+      "source_sha256": "9db4fbca93f3cc70bbd13f2ad2095fc676b4252db5422e7079e92dd3fef05d1a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/query/description",
+      "value": "用户查询文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/retriever_resources/description",
+      "value": "该消息使用的检索资源。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/retriever_resources/title",
+      "source_sha256": "0cad6b9867870a47877812c4336c83401368174ab4b1b3d3de4636bb6b1e42b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/status/description",
+      "value": "消息状态。成功消息为 `normal`，生成失败时为 `error`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/total_price/description",
+      "value": "所用 token 的总价，无定价信息时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/total_price/title",
+      "source_sha256": "3576c59289ecc321e2cfdba5f8a98bfe257996dc1fbc54b4ea53fe287e7987e2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/MessageListItem/properties/total_tokens/description",
+      "value": "使用的 token 总数，即 `message_tokens` 与 `answer_tokens` 之和。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MessageListItem/title",
+      "source_sha256": "0fcf1f5699aeec1e3e5bbd380e3499c1378e4bd8f3acb4a9cb644541571ce995"
     },
     {
       "op": "replace",
@@ -1040,6 +4388,1384 @@
       "op": "remove",
       "path": "/components/schemas/MessageListQuery/title",
       "source_sha256": "17997d5395df2c93391badf0ba144f4ca86426f5b37ae14fd35d9c873a56e906"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/OptionalServiceApiUserPayload/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/OptionalServiceApiUserPayload/title",
+      "source_sha256": "a1269019db4ddc7c919d3b0447ea781251fcad5e3c189d0d8214785fae80891d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ParagraphInputConfig/description",
+      "source_sha256": "c6c0d53443470d46c4bc5114ca40026044e9522ca48e39d40471201cd3b7fbdd",
+      "value": "表单输入定义。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ParagraphInputConfig/properties/default/description",
+      "value": "`paragraph` 输入的原始默认值配置。客户端不应直接解析此字段，请使用 `resolved_default_values` 来展示默认值。其他输入类型或未配置默认值时，不包含该键。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ParagraphInputConfig/properties/output_variable_name/description",
+      "value": "引用该输入提交值在工作流中使用的变量名。对应提交 `inputs` 对象中的键。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ParagraphInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ParagraphInputConfig/properties/type/description",
+      "value": "表单输入控件类型。可用值：`paragraph`（多行文本输入）、`select`（从列表中单选）、`file`（单个文件上传）和 `file-list`（多个文件上传）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ParagraphInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ParagraphInputConfig/title",
+      "source_sha256": "f9a2dc09b2ae099fc58a4f362ed79a143bbccf3f8c122c3c7477a007c73776f1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/annotation_reply/description",
+      "value": "标注回复功能配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/annotation_reply/properties/enabled/description",
+      "value": "是否启用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/description",
+      "value": "文件上传配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/allowed_file_extensions/description",
+      "value": "应用接受的自定义文件扩展名。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/allowed_file_types/description",
+      "value": "应用接受的文件类型。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/allowed_file_upload_methods/description",
+      "value": "应用接受的文件传输方式。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/enabled/description",
+      "value": "是否启用文件上传。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/description",
+      "value": "图片上传设置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/detail/description",
+      "value": "视觉模型的图像细节级别。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/enabled/description",
+      "value": "是否启用图片上传。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/number_limits/description",
+      "value": "可上传的最大图片数量。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/image/properties/transfer_methods/description",
+      "value": "图片上传允许的传输方式。`remote_url` 表示通过文件 URL 上传，`local_file` 表示上传本地文件。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/file_upload/properties/number_limits/description",
+      "value": "可上传的最大文件数量。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/more_like_this/description",
+      "value": "更多类似推荐功能配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/more_like_this/properties/enabled/description",
+      "value": "是否启用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/opening_statement/description",
+      "value": "开场白文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/properties/opening_statement/title",
+      "source_sha256": "e555de2768123fb1fa943d99a2fb5549af0702ba1f3969de47bb55e9904ab890"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/retriever_resource/description",
+      "value": "知识检索引用资源配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/retriever_resource/properties/enabled/description",
+      "value": "是否启用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/sensitive_word_avoidance/description",
+      "value": "内容审核功能配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/sensitive_word_avoidance/properties/enabled/description",
+      "value": "是否启用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/speech_to_text/description",
+      "value": "语音转文字功能配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/speech_to_text/properties/enabled/description",
+      "value": "是否启用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/suggested_questions/description",
+      "value": "建议问题列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/properties/suggested_questions/title",
+      "source_sha256": "1033a0922394dc3617fd9d04bcbcdc9bdb42377312d236a2f54e8fd8ad417d6b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/suggested_questions_after_answer/description",
+      "value": "回答后建议问题的配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/suggested_questions_after_answer/properties/enabled/description",
+      "value": "是否启用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/system_parameters/description",
+      "value": "系统级参数限制。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/description",
+      "value": "文字转语音功能配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/autoPlay/description",
+      "value": "自动播放设置。`enabled` 为自动播放音频，`disabled` 为需要手动播放。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/enabled/description",
+      "value": "是否启用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/language/description",
+      "value": "TTS 语言。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/text_to_speech/properties/voice/description",
+      "value": "TTS 声音标识符。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/description",
+      "value": "用户输入表单配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/description",
+      "value": "文本输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/allowed_file_extensions/description",
+      "value": "此输入接受文件时允许的文件扩展名。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/allowed_file_types/description",
+      "value": "此输入接受文件时允许的文件类别。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/allowed_file_upload_methods/description",
+      "value": "此输入接受文件时允许的上传方式。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/config/description",
+      "value": "其他输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/default/description",
+      "value": "默认值，其 JSON 类型取决于表单类型。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/description/description",
+      "value": "可选的输入项说明。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/hide/description",
+      "value": "是否在公开表单中隐藏该输入项。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/json_schema/description",
+      "value": "用于验证 JSON 对象输入的 JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/label/description",
+      "value": "输入项的显示标签。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/max_length/description",
+      "value": "输入类型支持长度限制时的最大输入长度。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/options/description",
+      "value": "此表单控件的可选值列表。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/required/description",
+      "value": "输入项是否必填。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/type/description",
+      "value": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0/properties/text-input/properties/variable/description",
+      "value": "应用使用的变量名称。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/0",
+      "context_sha256": "48ac29a5ead241a021bb5a354a135cff24e91aaffd03f905efbc8e03084ee1d0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/description",
+      "value": "选择输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/allowed_file_extensions/description",
+      "value": "此输入接受文件时允许的文件扩展名。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/allowed_file_types/description",
+      "value": "此输入接受文件时允许的文件类别。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/allowed_file_upload_methods/description",
+      "value": "此输入接受文件时允许的上传方式。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/config/description",
+      "value": "其他输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/default/description",
+      "value": "默认值，其 JSON 类型取决于表单类型。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/description/description",
+      "value": "可选的输入项说明。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/hide/description",
+      "value": "是否在公开表单中隐藏该输入项。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/json_schema/description",
+      "value": "用于验证 JSON 对象输入的 JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/label/description",
+      "value": "输入项的显示标签。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/max_length/description",
+      "value": "输入类型支持长度限制时的最大输入长度。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/options/description",
+      "value": "此表单控件的可选值列表。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/required/description",
+      "value": "输入项是否必填。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/type/description",
+      "value": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1/properties/select/properties/variable/description",
+      "value": "应用使用的变量名称。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/1",
+      "context_sha256": "c8a2de15f57f5b95c7df673599a4fa0b5f2b33a8944f1e48aad2f0bd0866638c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/description",
+      "value": "段落输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/allowed_file_extensions/description",
+      "value": "此输入接受文件时允许的文件扩展名。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/allowed_file_types/description",
+      "value": "此输入接受文件时允许的文件类别。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/allowed_file_upload_methods/description",
+      "value": "此输入接受文件时允许的上传方式。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/config/description",
+      "value": "其他输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/default/description",
+      "value": "默认值，其 JSON 类型取决于表单类型。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/description/description",
+      "value": "可选的输入项说明。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/hide/description",
+      "value": "是否在公开表单中隐藏该输入项。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/json_schema/description",
+      "value": "用于验证 JSON 对象输入的 JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/label/description",
+      "value": "输入项的显示标签。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/max_length/description",
+      "value": "输入类型支持长度限制时的最大输入长度。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/options/description",
+      "value": "此表单控件的可选值列表。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/required/description",
+      "value": "输入项是否必填。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/type/description",
+      "value": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2/properties/paragraph/properties/variable/description",
+      "value": "应用使用的变量名称。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/2",
+      "context_sha256": "ca1549da2784cff487d54b73d615842d9437bcd44c6eeb2a23a6c13cc554188f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/description",
+      "value": "数字输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/allowed_file_extensions/description",
+      "value": "此输入接受文件时允许的文件扩展名。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/allowed_file_types/description",
+      "value": "此输入接受文件时允许的文件类别。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/allowed_file_upload_methods/description",
+      "value": "此输入接受文件时允许的上传方式。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/config/description",
+      "value": "其他输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/default/description",
+      "value": "默认值，其 JSON 类型取决于表单类型。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/description/description",
+      "value": "可选的输入项说明。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/hide/description",
+      "value": "是否在公开表单中隐藏该输入项。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/json_schema/description",
+      "value": "用于验证 JSON 对象输入的 JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/label/description",
+      "value": "输入项的显示标签。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/max_length/description",
+      "value": "输入类型支持长度限制时的最大输入长度。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/options/description",
+      "value": "此表单控件的可选值列表。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/required/description",
+      "value": "输入项是否必填。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/type/description",
+      "value": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3/properties/number/properties/variable/description",
+      "value": "应用使用的变量名称。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/3",
+      "context_sha256": "be71c0b42d5568e8805cd6868d1b2f3085bacd8a064e79225badecf5e011e84e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/description",
+      "value": "外部数据工具输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/allowed_file_extensions/description",
+      "value": "此输入接受文件时允许的文件扩展名。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/allowed_file_types/description",
+      "value": "此输入接受文件时允许的文件类别。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/allowed_file_upload_methods/description",
+      "value": "此输入接受文件时允许的上传方式。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/config/description",
+      "value": "其他输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/default/description",
+      "value": "默认值，其 JSON 类型取决于表单类型。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/description/description",
+      "value": "可选的输入项说明。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/hide/description",
+      "value": "是否在公开表单中隐藏该输入项。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/json_schema/description",
+      "value": "用于验证 JSON 对象输入的 JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/label/description",
+      "value": "输入项的显示标签。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/max_length/description",
+      "value": "输入类型支持长度限制时的最大输入长度。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/options/description",
+      "value": "此表单控件的可选值列表。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/required/description",
+      "value": "输入项是否必填。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/type/description",
+      "value": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4/properties/external_data_tool/properties/variable/description",
+      "value": "应用使用的变量名称。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/4",
+      "context_sha256": "5d686a01fe527013f81f874a39570089e68662047a2a4605e740988ab7d786c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/description",
+      "value": "应用返回的文件表单控件配置。它描述标签、变量名、是否必填、允许的文件类别与扩展名以及支持的传输方式；它不是上传的 multipart 文件。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/allowed_file_extensions/description",
+      "value": "此输入接受文件时允许的文件扩展名。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/allowed_file_types/description",
+      "value": "此输入接受文件时允许的文件类别。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/allowed_file_upload_methods/description",
+      "value": "此输入接受文件时允许的上传方式。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/config/description",
+      "value": "其他输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/default/description",
+      "value": "默认值，其 JSON 类型取决于表单类型。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/description/description",
+      "value": "可选的输入项说明。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/hide/description",
+      "value": "是否在公开表单中隐藏该输入项。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/json_schema/description",
+      "value": "用于验证 JSON 对象输入的 JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/label/description",
+      "value": "输入项的显示标签。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/max_length/description",
+      "value": "输入类型支持长度限制时的最大输入长度。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/options/description",
+      "value": "此表单控件的可选值列表。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/required/description",
+      "value": "输入项是否必填。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/type/description",
+      "value": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5/properties/file/properties/variable/description",
+      "value": "应用使用的变量名称。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/5",
+      "context_sha256": "ea30cf5ad09913629be968c29598f5b6c4cebaf36e1ed3aec0e5f62d7b27fc7e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/description",
+      "value": "文件列表输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/allowed_file_extensions/description",
+      "value": "此输入接受文件时允许的文件扩展名。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/allowed_file_types/description",
+      "value": "此输入接受文件时允许的文件类别。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/allowed_file_upload_methods/description",
+      "value": "此输入接受文件时允许的上传方式。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/config/description",
+      "value": "其他输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/default/description",
+      "value": "默认值，其 JSON 类型取决于表单类型。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/description/description",
+      "value": "可选的输入项说明。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/hide/description",
+      "value": "是否在公开表单中隐藏该输入项。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/json_schema/description",
+      "value": "用于验证 JSON 对象输入的 JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/label/description",
+      "value": "输入项的显示标签。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/max_length/description",
+      "value": "输入类型支持长度限制时的最大输入长度。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/options/description",
+      "value": "此表单控件的可选值列表。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/required/description",
+      "value": "输入项是否必填。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/type/description",
+      "value": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6/properties/file-list/properties/variable/description",
+      "value": "应用使用的变量名称。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/6",
+      "context_sha256": "b47548032c89b3f76ff627f48cf5370077949682156faf0c13c6af095a9392c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/description",
+      "value": "复选框输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/allowed_file_extensions/description",
+      "value": "此输入接受文件时允许的文件扩展名。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/allowed_file_types/description",
+      "value": "此输入接受文件时允许的文件类别。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/allowed_file_upload_methods/description",
+      "value": "此输入接受文件时允许的上传方式。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/config/description",
+      "value": "其他输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/default/description",
+      "value": "默认值，其 JSON 类型取决于表单类型。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/description/description",
+      "value": "可选的输入项说明。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/hide/description",
+      "value": "是否在公开表单中隐藏该输入项。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/json_schema/description",
+      "value": "用于验证 JSON 对象输入的 JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/label/description",
+      "value": "输入项的显示标签。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/max_length/description",
+      "value": "输入类型支持长度限制时的最大输入长度。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/options/description",
+      "value": "此表单控件的可选值列表。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/required/description",
+      "value": "输入项是否必填。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/type/description",
+      "value": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7/properties/checkbox/properties/variable/description",
+      "value": "应用使用的变量名称。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/7",
+      "context_sha256": "6ebd92b52e59b0c6d8c3e5aed6075bc68d6b5181f12fbe47eed6335ab76b317d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/description",
+      "value": "JSON 对象输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/allowed_file_extensions/description",
+      "value": "此输入接受文件时允许的文件扩展名。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/allowed_file_types/description",
+      "value": "此输入接受文件时允许的文件类别。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/allowed_file_upload_methods/description",
+      "value": "此输入接受文件时允许的上传方式。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/config/description",
+      "value": "其他输入配置。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/default/description",
+      "value": "默认值，其 JSON 类型取决于表单类型。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/description/description",
+      "value": "可选的输入项说明。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/hide/description",
+      "value": "是否在公开表单中隐藏该输入项。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/json_schema/description",
+      "value": "用于验证 JSON 对象输入的 JSON Schema。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/label/description",
+      "value": "输入项的显示标签。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/max_length/description",
+      "value": "输入类型支持长度限制时的最大输入长度。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/options/description",
+      "value": "此表单控件的可选值列表。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/required/description",
+      "value": "输入项是否必填。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/type/description",
+      "value": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8/properties/json_object/properties/variable/description",
+      "value": "应用使用的变量名称。",
+      "context_path": "/components/schemas/Parameters/properties/user_input_form/items/oneOf/8",
+      "context_sha256": "0ae2ffa8429bfe9dc09d8f1eaead77282176d30d8175309bb4c3ab19c3a890c3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/properties/user_input_form/title",
+      "source_sha256": "4f7c88fdb1fe5aaacc59e28f6ab6fe531304cea4523e39a724d8a4d43a768ca1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Parameters/title",
+      "source_sha256": "373b929318436fe3d709c2edd9dcb1f01d7a1b015ae52113396d8adb8f50d07f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RequiredServiceApiUserPayload/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RequiredServiceApiUserPayload/title",
+      "source_sha256": "a1269019db4ddc7c919d3b0447ea781251fcad5e3c189d0d8214785fae80891d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ResultResponse/properties/result/description",
+      "value": "操作结果。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ResultResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ResultResponse/title",
+      "source_sha256": "01088850b9c319d53d821afeaed65bffdaeb842f51b877c8b03a85f6877dc8da"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/description",
+      "value": "检索资源的引用和归属信息。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/content/description",
+      "value": "资源的内容片段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/created_at/description",
+      "value": "创建时间戳（Unix 纪元秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/data_source_type/description",
+      "value": "数据源类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_id/description",
+      "value": "知识库 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_id/title",
+      "source_sha256": "afd32ed627cd32334bfc447d13eeaef88fe7365a20bbe496d1b65e238ab4a97e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_name/description",
+      "value": "知识库名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/dataset_name/title",
+      "source_sha256": "c3f0ca5a47fcaf871602dc501da109161cf99c427aa29ab8b20ab03813246be5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/document_id/description",
+      "value": "文档 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/document_name/description",
+      "value": "文档名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/document_name/title",
+      "source_sha256": "afa98fb25c89955f16c5857a64ca57eeab8ad2fdfc7eaba13a79ddac268a3624"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/hit_count/description",
+      "value": "该块被命中的次数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/id/description",
+      "value": "检索资源的唯一 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/index_node_hash/description",
+      "value": "索引节点的哈希值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/message_id/description",
+      "value": "该资源所属消息的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/position/description",
+      "value": "资源在列表中的位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/score/description",
+      "value": "资源的相关性评分。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/segment_id/description",
+      "value": "文档中特定块的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/segment_id/title",
+      "source_sha256": "7290170777560d41462deb95fa0c1a27884f2e487befa6820e24cf1acedb6131"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/segment_position/description",
+      "value": "块在文档中的位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/segment_position/title",
+      "source_sha256": "0bb9927f845754cf77570f81fd42d7660562e2b888a96d5ffbe8bfd2a1353d23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/summary/description",
+      "value": "块内容的摘要。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/RetrieverResource/properties/word_count/description",
+      "value": "块的字数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrieverResource/title",
+      "source_sha256": "8de104f17ff021d40479f94786508b6a09f0cd2fdaa9e3eee9cff2efd7cc02f9"
     },
     {
       "op": "replace",
@@ -1092,6 +5818,206 @@
     },
     {
       "op": "add",
+      "path": "/components/schemas/SelectInputConfig/properties/option_source/description",
+      "value": "`select` 输入的选项来源。仅当 `type` 为 `select` 时出现。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SelectInputConfig/properties/output_variable_name/description",
+      "value": "引用该输入提交值在工作流中使用的变量名。对应提交 `inputs` 对象中的键。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SelectInputConfig/properties/output_variable_name/title",
+      "source_sha256": "236271afcb4e7db6683920de552d6d432e2d534748f5cebceef159823047e120"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SelectInputConfig/properties/type/description",
+      "value": "表单输入控件类型。可用值：`paragraph`（多行文本输入）、`select`（从列表中单选）、`file`（单个文件上传）和 `file-list`（多个文件上传）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SelectInputConfig/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SelectInputConfig/title",
+      "source_sha256": "66e1ade121cd346fdaa6d2736f8281eaadb98ac2a2982ddf88a9c526c6f06896"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleAccountResponse/properties/email/description",
+      "value": "账户邮箱地址。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/properties/email/title",
+      "source_sha256": "0b57e967ff55ce5d934b1ac35a1e4a404e69444be35dba221b8a345b161d4ec6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleAccountResponse/properties/id/description",
+      "value": "账户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleAccountResponse/properties/name/description",
+      "value": "账户显示名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleAccountResponse/title",
+      "source_sha256": "074038de7e175ff8c2c27288070f216316be12924a10cbd2cb4b46e65b9597fc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/created_at/description",
+      "value": "创建时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/id/description",
+      "value": "会话 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/inputs/description",
+      "value": "会话的输入变量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/introduction/description",
+      "value": "会话介绍。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/introduction/title",
+      "source_sha256": "3d8ebba814c39a18678feb6015bc971c5603aaf487b51f141fd911ac77481409"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/name/description",
+      "value": "会话名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/status/description",
+      "value": "会话状态。活跃会话为 `normal`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleConversation/properties/updated_at/description",
+      "value": "最后更新时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleConversation/title",
+      "source_sha256": "5aad3cc59041619d3a39704700a243adea52d63f141cf1802f5d8d20bee1e015"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/id/description",
+      "value": "终端用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/is_anonymous/description",
+      "value": "终端用户是否为匿名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/is_anonymous/title",
+      "source_sha256": "042cb8fffd7f6edb56ac128deed67f447ceb287cd716f3056d4ee0d5cee10114"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/session_id/description",
+      "value": "会话标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/session_id/title",
+      "source_sha256": "eb75473dc0fd06e0d9e515069eb952720ae3d0b7edfe76d2e7a922d225818a47"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleEndUser/properties/type/description",
+      "value": "终端用户类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleEndUser/title",
+      "source_sha256": "84f1217c362fa4b0b1ea92b19043514bd209a298151ac1671404067828738398"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleFeedback/properties/rating/description",
+      "value": "反馈评分。`like` 为正面，`dislike` 为负面。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleFeedback/properties/rating/title",
+      "source_sha256": "dc8880b9272dc093e920e3afe9a2fda4aaa295744d59921ecb7abbacd9384134"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleFeedback/title",
+      "source_sha256": "e44c1483d3675a29e09484fe6e7392ba98494d7e638966ad3dfaf382debb0c4e"
+    },
+    {
+      "op": "add",
       "path": "/components/schemas/SimpleResultResponse/properties/result/description",
       "value": "操作结果。"
     },
@@ -1104,6 +6030,307 @@
       "op": "remove",
       "path": "/components/schemas/SimpleResultResponse/title",
       "source_sha256": "412feb3d6da0cbf2901a8634d7612e513ffb59141b7369d0048187cfca1c7a73"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/data/description",
+      "value": "建议问题列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/result/description",
+      "value": "结果状态。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultStringListResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SimpleResultStringListResponse/title",
+      "source_sha256": "a2760999e2320b93524528206e20f1a332ca5f97fe86255b94a71f940a73a6df"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/chat_color_theme/description",
+      "value": "聊天主题颜色。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/chat_color_theme/title",
+      "source_sha256": "41ced5ae48a2a6e7bd660a8b5e94294e3c8e96e034f46bae09e0b8b552de4d72"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/chat_color_theme_inverted/description",
+      "value": "聊天主题颜色是否反转。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/chat_color_theme_inverted/title",
+      "source_sha256": "2872ca62bcb754d2f8d716df0d771a2970c96ab3b1b9d5d0e1052fcfce9a0a76"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/copyright/description",
+      "value": "版权文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/copyright/title",
+      "source_sha256": "47ccad55c912b7daeec42e936d198cee6dbe394ab811d4d3b3937b5fb3597f03"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/custom_disclaimer/description",
+      "value": "自定义免责声明文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/custom_disclaimer/title",
+      "source_sha256": "7d49493fafa647a9b42d3afda0937aa5fcf13486bfa359ade5cedf99a8320d67"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/default_language/description",
+      "value": "默认语言代码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/default_language/title",
+      "source_sha256": "571d638d9ee456f58df3dc2d950a6ae524563eb69128509ae7bb19adf67ffd23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/description/description",
+      "value": "Web 应用描述。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon/description",
+      "value": "图标内容（表情或图片 ID）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon/title",
+      "source_sha256": "a4c7282e026e9c0eb1fc174c7d813fb7e1fc644829b38d12c28db5f9b9514330"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon_background/description",
+      "value": "图标背景颜色。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon_background/title",
+      "source_sha256": "15067379b68b825a8c24c73dca876adf650c51636467e4209270fac5b87c6dda"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon_type/description",
+      "value": "使用的图标类型。`emoji` 为表情图标，`image` 为上传的图片图标。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon_type/title",
+      "source_sha256": "285323907b457c9b9afe39555fbc8def3298246940561fc8587bfb6e657e3170"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/icon_url/description",
+      "value": "图标图片的 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/icon_url/title",
+      "source_sha256": "2002ea73f523b651e2e6f4c79f87fcd5231a172d575ec276ef2bbcee3d338405"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/input_placeholder/description",
+      "value": "Web 应用消息输入框中显示的占位文本。未配置时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/input_placeholder/title",
+      "source_sha256": "0b023e2beb71ec1aac71e42ede317609d11892d3eae9bb7bf5177eabb7f59eb0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/privacy_policy/description",
+      "value": "隐私政策 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/privacy_policy/title",
+      "source_sha256": "0afb547bbe92b2430806c1c57aedf2081ba43740a6ff896b1b7595fa12514a74"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/show_workflow_steps/description",
+      "value": "是否显示工作流步骤。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/show_workflow_steps/title",
+      "source_sha256": "531c481f887f460d3971490ccf48093486d7e61e2c39258ea736553a70ee42f4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/title/description",
+      "value": "Web 应用标题。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/title/title",
+      "source_sha256": "4be9d4f1daabdb03afb07253382b19d77501261a6106d734746734605436aa77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/Site/properties/use_icon_as_answer_icon/description",
+      "value": "是否使用应用图标作为回答图标。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/properties/use_icon_as_answer_icon/title",
+      "source_sha256": "4a4c7e5ebdfefcddb3ae4e26e41d919118a63cd8fcbd3a72f66a54866f3c85f0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Site/title",
+      "source_sha256": "91f90818d42a984e64dccf6f8b2bf80fba7cd3948ecd51daa40aa2b27624baec"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringListSource/properties/selector/description",
+      "value": "当 `type` 为 `variable` 时的变量引用路径。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringListSource/properties/selector/title",
+      "source_sha256": "c542de810cd37268c31367eddb90015a9ed2c3ab5c55bc664e19ac59527ca14d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringListSource/properties/type/description",
+      "value": "选项来源。`constant` 表示 `value` 直接列出选项；`variable` 表示 `selector` 指向提供选项的 `array[string]` 工作流变量。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringListSource/properties/value/description",
+      "value": "当 `type` 为 `constant` 时的字面选项列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringListSource/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringListSource/title",
+      "source_sha256": "8b070b8435acce4ef835c16fb7a002405384b6950aa38d44f5889179ac10f7a1"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/StringSource/description",
+      "source_sha256": "cd268d677d8402fb9e4fcb830e69b35b5719cfcb0fa070ab3d4f8d7a795f1b3a",
+      "value": "表单输入的默认配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringSource/properties/selector/description",
+      "value": "当 `type` 为 `variable` 时的变量引用路径（例如 `[\"node_id\", \"var_name\"]`）。至少包含两个元素。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringSource/properties/selector/title",
+      "source_sha256": "c542de810cd37268c31367eddb90015a9ed2c3ab5c55bc664e19ac59527ca14d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringSource/properties/type/description",
+      "value": "默认值来源。`constant` 表示将 `value` 作为字面字符串；`variable` 表示 `selector` 指向工作流变量。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/StringSource/properties/value/description",
+      "value": "当 `type` 为 `constant` 时的字面默认值。始终为字符串。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringSource/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/StringSource/title",
+      "source_sha256": "bf9bd9920a45c7d6f459cbf55c4060f98add35f38e77e9f6ba732c85737fb219"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/audio_file_size_limit/description",
+      "value": "最大音频文件大小（MB）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/audio_file_size_limit/title",
+      "source_sha256": "ad2d08a17949c0e6e8f4a1021c9d11806e21507b453f895e5933ce4b83d83b17"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/file_size_limit/description",
+      "value": "常规文件最大大小（MB）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/file_size_limit/title",
+      "source_sha256": "5dbcce634cd4848d0b5480c1ddf4884bf1a4170090f844c08b88648b08ad2574"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/image_file_size_limit/description",
+      "value": "最大图片文件大小（MB）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/image_file_size_limit/title",
+      "source_sha256": "a1bfda249e18ed4d84c7682eb63a00f762f8c0bbfc7ce8c816b6f1746d25a751"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/video_file_size_limit/description",
+      "value": "最大视频文件大小（MB）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/video_file_size_limit/title",
+      "source_sha256": "3d23d0e91fcffafd34c8b833160bdb31bb78589e47b0b77ad8d8409a0e251792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SystemParameters/properties/workflow_file_upload_limit/description",
+      "value": "每次工作流执行的最大文件数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/properties/workflow_file_upload_limit/title",
+      "source_sha256": "4a0348537154080e395851404929faff73f15cc25337d34f5ff8f7ca3f6a90fb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SystemParameters/title",
+      "source_sha256": "124b91697511ce88de874095c8edaf4bbf7c369aaaed03a7bf2bff88fe04e270"
     },
     {
       "op": "replace",
@@ -1153,6 +6380,258 @@
       "op": "remove",
       "path": "/components/schemas/TextToAudioPayload/title",
       "source_sha256": "21460ec2d744ed638ddcc8912fa8e504c6ad781a6a7ad4206976f4aeb17aaab9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/message_id/description",
+      "source_sha256": "47f5efd48161cf7478427652060c2fbe41c0ffd3adea29c80a7e92824fb6f704",
+      "value": "消息 ID。同时提供时，其优先级高于 `text`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/message_id/title",
+      "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/streaming/description",
+      "source_sha256": "bbbeba9487a0113a787e0ed2b2a3e0d6ab588013080484518fdadd925438c956",
+      "value": "为兼容性保留；TTS 响应是否流式传输由提供商输出决定。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/streaming/title",
+      "source_sha256": "99c855ec96bb79eda46be7218b5ac2045b607b2135c1181034e6746519b88b06"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/text/description",
+      "source_sha256": "efbe836ec14e32683d74f164f15caf0c25a45c490c6c4ac6fb2c7db6e5918db7",
+      "value": "要转换的语音内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/voice/description",
+      "source_sha256": "093f32f71464b6ee988240562bff4f647ec3d81381328089f3daaf171c1bd766",
+      "value": "文本转语音使用的声音。可用声音取决于此应用配置的 TTS 提供商。省略时会尽可能使用应用配置的声音；可通过[获取应用参数](/zh/api-reference/applications/get-app-parameters)返回的 `text_to_speech.voice` 查看该值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/properties/voice/title",
+      "source_sha256": "75d5a120334e208c41bdff270efdb5ed48de029fa6a9399b5897166f2dc6baf2"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TextToAudioPayloadWithUser/title",
+      "source_sha256": "21460ec2d744ed638ddcc8912fa8e504c6ad781a6a7ad4206976f4aeb17aaab9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ToolIcon/properties/background/description",
+      "value": "十六进制格式的背景颜色。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ToolIcon/properties/background/title",
+      "source_sha256": "7d67b6c9f37716ad92890af3917606fbdc14a776e1a03b9e40c58171ca128af4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ToolIcon/properties/content/description",
+      "value": "Emoji 内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ToolIcon/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ToolIcon/title",
+      "source_sha256": "25ff44cb5514b1148a3243ce18e6135333123c6a437c924be3bd88f8be03028f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/UserActionConfig/description",
+      "source_sha256": "8335dbe54deb6d63d84583f2441b28057935bc5a7df092b6bb344bfd813b5f78",
+      "value": "用户操作配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/UserActionConfig/properties/button_style/description",
+      "value": "按钮的视觉样式。可用值：`primary`、`default`、`accent`、`ghost`。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/UserActionConfig/properties/id/description",
+      "value": "操作按钮的标识。当接收人选择该按钮时，作为 `action` 传入 [提交人工介入表单](/zh/api-reference/human-input/submit-human-input-form)。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UserActionConfig/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/UserActionConfig/properties/title/description",
+      "value": "操作按钮标签。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UserActionConfig/properties/title/title",
+      "source_sha256": "4be9d4f1daabdb03afb07253382b19d77501261a6106d734746734605436aa77"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UserActionConfig/title",
+      "source_sha256": "8cc1df1dc023895b6b786fd37c77c50adbe3df59295854f93b10148de97ea429"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ValueSourceType/description",
+      "source_sha256": "198f808b08cd9599fce0b4778c7050170a44a01ede8619242d400739206dcb67",
+      "value": "`ValueSourceType` 记录值来自表单定义中的静态设置，还是工作流运行期间的变量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ValueSourceType/title",
+      "source_sha256": "b27082732c38a38ed5997a127490a1121fdd96ed9079027df4ac09ff3e557856"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/data/description",
+      "value": "当前页的工作流日志记录。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/has_more/description",
+      "value": "是否还有更多工作流日志记录。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/limit/description",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/page/description",
+      "value": "当前页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/total/description",
+      "value": "匹配的工作流日志记录总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPaginationResponse/title",
+      "source_sha256": "6c3caf31a556cc72f384dea999bacd03aaaee6e71d7d8354ee9a34aa8f91e4ae"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_at/description",
+      "value": "创建时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_account/description",
+      "value": "由管理员用户创建时的账户详情。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_end_user/description",
+      "value": "创建工作流运行的终端用户。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_role/description",
+      "value": "创建者的角色（例如 `end_user`、`account`）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_by_role/title",
+      "source_sha256": "e9f5487fc14e6afc3a6b15262084175591249b08d500c3d3de5c3b17d7f65a74"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_from/description",
+      "value": "工作流运行的来源（例如 `service-api`）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/created_from/title",
+      "source_sha256": "ac7605d36b5da31a00bcf6692a557183ddce029a6ca4c5fb5cc911c9e9fd1495"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/details/description",
+      "value": "日志条目的附加详情。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/details/title",
+      "source_sha256": "ebc7bf40f12e237ea22047135a6283ad553d28145e437123173175174e8a40c0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/id/description",
+      "value": "日志条目 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/properties/workflow_run/description",
+      "value": "此日志条目的工作流运行详情。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowAppLogPartialResponse/title",
+      "source_sha256": "87d57c23bd12acd83d7db989a402f37910d6d9d1e8035e483782f75ab988defc"
     },
     {
       "op": "remove",
@@ -1737,6 +7216,121 @@
       "source_sha256": "dbfd757fad089c9351abf34e0ded1ad305716aa9cf964d9dc5dabecd6141e448"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/created_at/description",
+      "value": "创建时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/elapsed_time/description",
+      "value": "总耗时（秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/error/description",
+      "value": "工作流失败时的错误消息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/exceptions_count/description",
+      "value": "执行期间发生的异常数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/exceptions_count/title",
+      "source_sha256": "94e4767e69ec132353328419cbe108ea7d347436868ffbdfb66ed053976c364f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/finished_at/description",
+      "value": "结束时间，Unix 秒级时间戳；未结束时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/id/description",
+      "value": "工作流运行 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/status/description",
+      "value": "工作流执行状态。`running` 表示执行中，`succeeded` 表示成功完成，`failed` 表示执行出错，`stopped` 表示手动停止，`partial-succeeded` 表示部分节点成功但其他失败，`paused` 表示等待人工介入。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_steps/description",
+      "value": "已执行的工作流总步数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_tokens/description",
+      "value": "消耗的总令牌数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/triggered_from/description",
+      "value": "触发工作流运行的来源。`app-run` 表示从应用或 API 发起的运行，`webhook` 表示由 Webhook 触发器发起的运行，`schedule` 表示由定时触发器发起的运行，`plugin` 表示由集成触发器发起的运行。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/triggered_from/title",
+      "source_sha256": "ed0a91c6e5551150e5188bca26e06188f8a9cff5b3b66868e436008ced2d2a0b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/version/description",
+      "value": "工作流版本标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/properties/version/title",
+      "source_sha256": "6a0ad2bedc57dba081cb41b98d36276eb4ebe6e16bf6523b185216d5b6dc0b0a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunForLogResponse/title",
+      "source_sha256": "047103a06c1f0961fca15bedbd7e2e217512505bf65e5c4b52994216ae29a0b3"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/WorkflowRunPayload/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
       "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
@@ -1933,6 +7527,325 @@
       "op": "remove",
       "path": "/components/schemas/WorkflowRunPayload/title",
       "source_sha256": "610156d74f8171372740a56b3a96632a903151f9cbfcc6f0ada83493fd50cf49"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/0",
+      "context_sha256": "fd263e3be84568c4d3b395d4e335dec044f36aecffd0c86f32320609fc1301bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/1",
+      "context_sha256": "696835270789710534539fb547f134c9fdd97ee6fb6ede413c4050dc063559da"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/2",
+      "context_sha256": "eb349433abccb024f29f1b12de9da78e10b672d58d09cffd695467eb3c36b894"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/remote_url/description",
+      "source_sha256": "4ac0979e3150f4bda4aac8f545e413201495e6af7535c6006989f81e0d8104c0",
+      "value": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/transfer_method/description",
+      "source_sha256": "0f88e30c21184135a508649563338a1e69fb2a481124ccd30459d0351fe0b202",
+      "value": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/type/description",
+      "source_sha256": "1dc1df55f554e1eca9ab4b792eca09bed93acdd97255f6cb11bbb23e5af935c1",
+      "value": "文件类型。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/upload_file_id/description",
+      "source_sha256": "6a357c81f1e29aeff4babf962a112583b01089d007277e26ce637edd8289f2e5",
+      "value": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3/properties/url/description",
+      "source_sha256": "03ee1ce6179fb2e45354c888387becd800b9a6924bda560483023378ee788aec",
+      "value": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+      "context_path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/anyOf/0/items/anyOf/3",
+      "context_sha256": "37fb79ddfa58fb7ec0f945fd3baef4fedd75ea3807d97c65e53afc0cc1b714e7"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/description",
+      "source_sha256": "2b389dd61c5418f868e8d3f5f8741a3cbfb1b9e4fb15604bdc8e72f0c2649974",
+      "value": "工作流系统文件输入列表。仅在工作流启用文件上传时可用。要附加本地文件，请先通过[上传文件](/zh/api-reference/files/upload-file)上传，然后将返回的 `id` 用作 `upload_file_id`，并将 `transfer_method` 设置为 `local_file`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/inputs/description",
+      "source_sha256": "048d45b6175968d587d71c3ac5f810521aafb994d9f016b592b5a23e353f186f",
+      "value": "工作流输入变量的键值对。文件类型变量的值应为文件对象数组，每个对象包含 `type`、`transfer_method`，以及 `url` 或 `upload_file_id`。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解应用所需的变量名称和类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/response_mode/description",
+      "source_sha256": "a05eb85e740430b5fc70be8c963c4dacf30a2ca5059ffe72433c24101ed10462",
+      "value": "响应模式。同步响应使用 `blocking`，服务器发送事件（SSE）使用 `streaming`。省略时，请求使用阻塞模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/properties/user/description",
+      "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
+      "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunPayloadWithUser/title",
+      "source_sha256": "610156d74f8171372740a56b3a96632a903151f9cbfcc6f0ada83493fd50cf49"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/created_at/description",
+      "value": "创建时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/elapsed_time/description",
+      "value": "总耗时（秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/elapsed_time/title",
+      "source_sha256": "9dc7511e28da0f124ce8fc3297aa327ae235f90456c99a6c5131881a60207d2d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/error/description",
+      "value": "工作流失败时的错误消息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/finished_at/description",
+      "value": "结束时间，Unix 秒级时间戳；未结束时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/finished_at/title",
+      "source_sha256": "354cb884689fd4e8a3fa35e286153fcf2cb246904215bcd4884963fd63179337"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/id/description",
+      "value": "工作流运行 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/inputs/description",
+      "value": "工作流运行的输入。JSON 值可以是对象、数组、基本类型或 `null`；它已按响应 schema 解码，无需再次进行 JSON 解析。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/outputs/description",
+      "value": "工作流的输出数据。尚无输出时为空对象。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/outputs/title",
+      "source_sha256": "d65ed4159859975e88dbd98c69421ec1e5cc195d03f8dfcec429a5d57839e838"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/status/description",
+      "value": "工作流执行状态。`running` 表示执行中，`succeeded` 表示成功完成，`failed` 表示执行出错，`stopped` 表示手动停止，`partial-succeeded` 表示部分节点成功但其他失败，`paused` 表示等待人工介入。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_steps/description",
+      "value": "已执行的工作流总步数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_steps/title",
+      "source_sha256": "34ddda964b0819c4a667ac52ab665ddf008b91f34bc2831441ba054fa39fe3b4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_tokens/description",
+      "value": "消耗的总令牌数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/total_tokens/title",
+      "source_sha256": "ae381cdc5d41ce5e17af3ed40d6c6c3af1bddd879ab65d4e9a0cab8d0b3c7a77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/WorkflowRunResponse/properties/workflow_id/description",
+      "value": "此次运行使用的工作流定义 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/properties/workflow_id/title",
+      "source_sha256": "0410431612220ad7d69febe3acecc6278860057b2f1da8c832f4ee4afea9658e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WorkflowRunResponse/title",
+      "source_sha256": "32535d42024ce5ae678a114565b28cb2d20517bf30a926b010c497834d0c94ba"
     },
     {
       "op": "replace",

--- a/zh/api-reference/openapi_service.json
+++ b/zh/api-reference/openapi_service.json
@@ -13223,6 +13223,280 @@
       }
     },
     "schemas": {
+      "AgentThought": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "与此思考过程关联的工具或模型答案。"
+          },
+          "chain_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该思考的链 ID。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间，Unix 秒级时间戳。"
+          },
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "与该思考相关的文件 ID。"
+          },
+          "id": {
+            "type": "string",
+            "description": "Agent 思考 ID。"
+          },
+          "message_id": {
+            "type": "string",
+            "description": "该思考所属的唯一消息 ID。"
+          },
+          "observation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "工具调用的响应。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "该思考的位置。"
+          },
+          "thought": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM 正在思考的内容。"
+          },
+          "tool": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "调用的工具，以 `;` 分隔。"
+          },
+          "tool_input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "工具输入（JSON 格式）。"
+          },
+          "tool_labels": {
+            "$ref": "#/components/schemas/JSONValue",
+            "description": "已使用工具的标签。"
+          }
+        },
+        "required": [
+          "files",
+          "id",
+          "message_id",
+          "position",
+          "tool_labels"
+        ],
+        "type": "object"
+      },
+      "Annotation": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "标注被匹配时返回的预定义回答。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间戳（Unix 纪元秒）。"
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该标注被匹配并作为回复返回的次数。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "标注唯一标识符。"
+          },
+          "question": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "触发该标注的问题文本。"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "AnnotationCreatePayload": {
+        "properties": {
+          "answer": {
+            "description": "标注答案。",
+            "type": "string"
+          },
+          "question": {
+            "description": "标注问题。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "answer",
+          "question"
+        ],
+        "type": "object"
+      },
+      "AnnotationJobStatusDetailResponse": {
+        "properties": {
+          "error_msg": {
+            "default": "",
+            "type": "string",
+            "description": "描述任务失败原因的错误消息。当 `job_status` 不是 `error` 时为空字符串。"
+          },
+          "job_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "来自 [配置标注回复](/zh/api-reference/annotations/configure-annotation-reply) 调用的任务 ID。"
+          },
+          "job_status": {
+            "type": "string",
+            "description": "当前任务状态。`waiting` 表示排队中，`processing` 表示处理中，`completed` 表示已完成，`error` 表示失败。"
+          }
+        },
+        "required": [
+          "job_id",
+          "job_status"
+        ],
+        "type": "object"
+      },
+      "AnnotationJobStatusResponse": {
+        "properties": {
+          "job_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "异步任务 ID。配合 [查询标注回复配置任务状态](/zh/api-reference/annotations/get-annotation-reply-job-status) 使用以跟踪进度。"
+          },
+          "job_status": {
+            "type": "string",
+            "description": "当前任务状态，仅为 `waiting`（排队中）或 `processing`（处理中）；`completed` 和 `error` 仅由 [查询标注回复配置任务状态](/zh/api-reference/annotations/get-annotation-reply-job-status) 返回。"
+          }
+        },
+        "required": [
+          "job_id",
+          "job_status"
+        ],
+        "type": "object"
+      },
+      "AnnotationList": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            },
+            "type": "array",
+            "description": "当前页的标注列表。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "是否还有更多标注。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "每页条目数。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "当前页码。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "匹配的标注总数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
       "AnnotationListQuery": {
         "properties": {
           "keyword": {
@@ -13245,63 +13519,1014 @@
         },
         "type": "object"
       },
-      "AppInfoResponse": {
-        "type": "object",
+      "AnnotationReplyActionPayload": {
         "properties": {
+          "embedding_model_name": {
+            "description": "使用 [获取可用模型](/zh/api-reference/models/get-available-models) 在 `model_type=text-embedding` 时返回的 `model` 字段，例如 `text-embedding-3-small`。",
+            "type": "string"
+          },
+          "embedding_provider_name": {
+            "description": "使用 [获取可用模型](/zh/api-reference/models/get-available-models) 在 `model_type=text-embedding` 时返回的 `provider` 字段，例如 `openai`；不要使用展示名称。",
+            "type": "string"
+          },
+          "score_threshold": {
+            "description": "标注匹配的最低相似度分数，取值范围为 0 到 1。值越高，匹配要求越严格。",
+            "format": "float",
+            "type": "number"
+          }
+        },
+        "required": [
+          "embedding_model_name",
+          "embedding_provider_name",
+          "score_threshold"
+        ],
+        "type": "object"
+      },
+      "AppFeedbackListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AppFeedbackResponse"
+            },
+            "type": "array",
+            "description": "当前页的反馈记录。"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "AppFeedbackResponse": {
+        "properties": {
+          "app_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "应用 ID。"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "可选的文字反馈。"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会话 ID。"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "创建时间，RFC 3339 日期时间字符串。"
+          },
+          "from_account_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "提交反馈的账户 ID。当 `from_source` 为 `admin` 时存在。"
+          },
+          "from_end_user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "提交反馈的终端用户 ID。当 `from_source` 为 `user` 时存在。"
+          },
+          "from_source": {
+            "type": "string",
+            "description": "反馈来源。`user` 为终端用户通过 API 提交的反馈，`admin` 为从控制台提交的反馈。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "反馈 ID。"
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "消息 ID。"
+          },
+          "rating": {
+            "type": "string",
+            "description": "反馈评分。`like` 为正面，`dislike` 为负面。"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "最后更新时间，RFC 3339 日期时间字符串。"
+          }
+        },
+        "required": [
+          "app_id",
+          "conversation_id",
+          "created_at",
+          "from_source",
+          "id",
+          "message_id",
+          "rating",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "AppInfoResponse": {
+        "properties": {
+          "author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "应用作者名称。"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "应用描述。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "应用模式。`completion` 为文本生成应用，`chat` 为基础聊天助手，`agent-chat` 为旧版 Agent 应用，`advanced-chat` 为 Chatflow（对话式工作流），`workflow` 为非对话式 Workflow 应用，`agent` 为新版 Agent 应用。每个接口的说明会标明支持的模式。"
+          },
           "name": {
             "type": "string",
             "description": "应用名称。"
           },
-          "description": {
-            "type": "string",
-            "description": "应用描述。"
-          },
           "tags": {
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "type": "array",
             "description": "应用标签。"
-          },
-          "mode": {
-            "type": "string",
-            "description": "应用模式。`completion` 为文本生成应用，`chat` 为基础对话应用，`agent-chat` 为 Agent 应用，`advanced-chat` 为 Chatflow 应用，`workflow` 为 Workflow 应用，`agent` 为新 Agent 应用。"
-          },
-          "author_name": {
-            "type": "string",
-            "description": "应用作者名称。"
           }
-        }
+        },
+        "required": [
+          "author_name",
+          "description",
+          "mode",
+          "name",
+          "tags"
+        ],
+        "type": "object"
       },
       "AppMetaResponse": {
-        "type": "object",
         "properties": {
           "tool_icons": {
-            "type": "object",
             "additionalProperties": {
-              "oneOf": [
+              "anyOf": [
                 {
-                  "title": "Icon URL",
-                  "type": "string",
                   "format": "url",
+                  "type": "string",
                   "description": "图标的 URL。"
                 },
                 {
-                  "$ref": "#/components/schemas/ToolIconDetail"
+                  "$ref": "#/components/schemas/ToolIcon"
                 }
               ]
             },
+            "type": "object",
             "description": "工具图标。键为工具名称。"
           }
-        }
+        },
+        "type": "object"
       },
       "AudioBinaryResponse": {
         "format": "binary",
         "type": "string"
       },
+      "AudioTranscriptResponse": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "语音识别输出的文字。"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
       "BinaryFileResponse": {
         "format": "binary",
         "type": "string"
+      },
+      "BlockingMetadataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "retriever_resources": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/BlockingRetrieverResourceResponse"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "使用的检索资源列表。"
+          },
+          "usage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BlockingUsageResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "模型使用信息。"
+          }
+        },
+        "type": "object",
+        "description": "包含用量和检索资源的元数据。"
+      },
+      "BlockingRetrieverResourceResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "资源的内容片段。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间戳（Unix 纪元秒）。"
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "数据源类型。"
+          },
+          "dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "知识库 ID。"
+          },
+          "dataset_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "知识库名称。"
+          },
+          "document_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档 ID。"
+          },
+          "document_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档名称。"
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该块被命中的次数。"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "检索资源的唯一 ID。"
+          },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "索引节点的哈希值。"
+          },
+          "message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该资源所属消息的 ID。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "资源在列表中的位置。"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "资源的相关性评分。"
+          },
+          "segment_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档中特定块的 ID。"
+          },
+          "segment_position": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "块在文档中的位置。"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "块内容的摘要。"
+          },
+          "word_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "块的字数。"
+          }
+        },
+        "required": [
+          "position"
+        ],
+        "type": "object"
+      },
+      "BlockingUsageResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "completion_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "补全令牌的总价。"
+          },
+          "completion_price_unit": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "补全令牌的价格单位。"
+          },
+          "completion_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "补全内容中的令牌数。"
+          },
+          "completion_unit_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "每个补全令牌的单价。"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "计价货币。"
+          },
+          "latency": {
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "延迟时间（秒）。"
+          },
+          "prompt_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "提示词令牌的总价。"
+          },
+          "prompt_price_unit": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "提示词令牌的价格单位。"
+          },
+          "prompt_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "提示词中的令牌数。"
+          },
+          "prompt_unit_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "每个提示词令牌的单价。"
+          },
+          "total_price": {
+            "anyOf": [
+              {
+                "format": "decimal",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "所有令牌的总价。"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "使用的令牌总数。"
+          }
+        },
+        "type": "object"
+      },
+      "ButtonStyle": {
+        "description": "用户操作按钮样式。",
+        "enum": [
+          "accent",
+          "default",
+          "ghost",
+          "primary"
+        ],
+        "type": "string"
+      },
+      "ChatBlockingResponse": {
+        "discriminator": {
+          "mapping": {
+            "message": "#/components/schemas/ChatMessageBlockingResponse",
+            "workflow_paused": "#/components/schemas/ChatPausedBlockingResponse"
+          },
+          "propertyName": "event"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatMessageBlockingResponse"
+          },
+          {
+            "$ref": "#/components/schemas/ChatPausedBlockingResponse"
+          }
+        ]
+      },
+      "ChatMessageBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "完整的响应内容。"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会话 ID。"
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "消息创建时间戳（Unix 纪元秒）。"
+          },
+          "event": {
+            "const": "message",
+            "type": "string",
+            "description": "事件类型，固定为 `message`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "该响应事件的唯一 ID。"
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "唯一的消息 ID。调用反馈或推荐问题接口时，将此值作为 `message_id` 参数使用。"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "包含用量和检索资源的元数据。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "应用模式。`chat` 表示聊天助手应用，`agent-chat` 表示 Agent 应用，`advanced-chat` 表示 Chatflow 应用。"
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "用于请求追踪和停止响应 API 的任务 ID。"
+          }
+        },
+        "required": [
+          "answer",
+          "conversation_id",
+          "created_at",
+          "event",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "task_id"
+        ],
+        "type": "object",
+        "description": "事件类型，固定为 `message`。"
+      },
+      "ChatPauseReasonResponse": {
+        "additionalProperties": true,
+        "description": "阻塞式 Chatflow 执行暂停原因的公开详情。",
+        "properties": {
+          "TYPE": {
+            "type": "string",
+            "description": "暂停原因类型。"
+          },
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "人工介入表单中可执行的操作。"
+          },
+          "approval_channels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "已配置的审批渠道。"
+          },
+          "display_in_ui": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "是否在 UI 中显示该暂停原因。"
+          },
+          "expiration_time": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人工介入表单的过期时间（Unix 时间戳）。"
+          },
+          "form_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人工介入表单中显示的内容。"
+          },
+          "form_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人工介入表单 ID。"
+          },
+          "form_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "调用人工介入表单 API 时使用的访问令牌。"
+          },
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/JSONObject"
+            },
+            "type": "array",
+            "description": "人工介入表单的输入字段。"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "说明工作流暂停原因的消息。"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "暂停的工作流节点 ID。"
+          },
+          "node_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "暂停的工作流节点标题。"
+          },
+          "resolved_default_values": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "表单输入解析后的默认值。"
+          }
+        },
+        "required": [
+          "TYPE"
+        ],
+        "type": "object"
+      },
+      "ChatPausedBlockingDataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "完整的响应内容。"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会话 ID。"
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "消息创建时间戳（Unix 纪元秒）。"
+          },
+          "elapsed_time": {
+            "format": "float",
+            "type": "number",
+            "description": "总耗时（秒）。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "该响应事件的唯一 ID。"
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "唯一的消息 ID。调用反馈或推荐问题接口时，将此值作为 `message_id` 参数使用。"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "包含用量和检索资源的元数据。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "应用模式。`chat` 表示聊天助手应用，`agent-chat` 表示 Agent 应用，`advanced-chat` 表示 Chatflow 应用。"
+          },
+          "paused_nodes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "等待输入的工作流节点 ID。"
+          },
+          "reasons": {
+            "items": {
+              "$ref": "#/components/schemas/ChatPauseReasonResponse"
+            },
+            "type": "array",
+            "description": "工作流暂停原因，包括人工介入表单详情。"
+          },
+          "status": {
+            "const": "paused",
+            "type": "string",
+            "description": "工作流执行状态，固定为 `paused`。"
+          },
+          "total_steps": {
+            "type": "integer",
+            "description": "已执行的工作流步骤总数。"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "所有节点消耗的 Token 总数。"
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "已暂停工作流运行的持久标识符。"
+          }
+        },
+        "required": [
+          "answer",
+          "conversation_id",
+          "created_at",
+          "elapsed_time",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "paused_nodes",
+          "reasons",
+          "status",
+          "total_steps",
+          "total_tokens",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "Chatflow 工作流运行的暂停详情。"
+      },
+      "ChatPausedBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "完整的响应内容。"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会话 ID。"
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "消息创建时间戳（Unix 纪元秒）。"
+          },
+          "data": {
+            "$ref": "#/components/schemas/ChatPausedBlockingDataResponse",
+            "description": "Chatflow 工作流运行的暂停详情。"
+          },
+          "event": {
+            "const": "workflow_paused",
+            "type": "string",
+            "description": "Chatflow 等待人工输入时，事件类型固定为 `workflow_paused`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "该响应事件的唯一 ID。"
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "唯一的消息 ID。调用反馈或推荐问题接口时，将此值作为 `message_id` 参数使用。"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "包含用量和检索资源的元数据。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "应用模式。`chat` 表示聊天助手应用，`agent-chat` 表示 Agent 应用，`advanced-chat` 表示 Chatflow 应用。"
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "用于请求追踪和停止响应 API 的任务 ID。"
+          },
+          "workflow_run_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "已暂停工作流运行的持久标识符。"
+          }
+        },
+        "required": [
+          "answer",
+          "conversation_id",
+          "created_at",
+          "data",
+          "event",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "task_id",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "Chatflow 等待人工输入时返回的阻塞响应。"
       },
       "ChatRequestPayload": {
         "properties": {
@@ -13551,6 +14776,259 @@
         ],
         "type": "object"
       },
+      "ChatRequestPayloadWithUser": {
+        "properties": {
+          "auto_generate_name": {
+            "default": true,
+            "description": "是否自动生成会话标题。若为 `false`，可调用重命名会话 API，并设置 `auto_generate: true` 来异步生成标题。",
+            "type": "boolean"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于继续会话的会话 ID。省略此字段或传入空字符串可开始新会话，后续请求再传入返回的 `conversation_id`。"
+          },
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于多模态输入的文件。新客户端只需实现两种规范形式：公共文件 URL 使用 `transfer_method: remote_url` 和 `url`；本地文件先通过[上传文件](/zh/api-reference/files/upload-file)上传，再使用 `transfer_method: local_file`，并将返回的 `id` 作为 `upload_file_id`。生成的其他 `anyOf` 组合仅用于兼容已存储的旧版引用。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "应用自定义变量的值。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解预期的变量名称和类型。",
+            "type": "object"
+          },
+          "query": {
+            "description": "用户输入或问题内容。",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "响应模式。`streaming` 使用服务器发送事件（SSE）；`blocking` 在执行完成后返回。新版 Agent 应用仅支持流式模式。省略时，非 Agent 应用使用阻塞模式，新版 Agent 应用使用流式模式。"
+          },
+          "user": {
+            "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+            "type": "string"
+          },
+          "workflow_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "高级聊天要执行的已发布工作流版本 ID。省略时，使用应用当前已发布的工作流。"
+          }
+        },
+        "required": [
+          "inputs",
+          "query",
+          "user"
+        ],
+        "type": "object"
+      },
       "ChildChunkListQuery": {
         "properties": {
           "keyword": {
@@ -13578,6 +15056,58 @@
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "CompletionBlockingResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "完整的响应内容。"
+          },
+          "created_at": {
+            "format": "int64",
+            "type": "integer",
+            "description": "消息创建时间戳（Unix 纪元秒）。"
+          },
+          "event": {
+            "type": "string",
+            "description": "事件类型，固定为 `message`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "该响应事件的唯一 ID。"
+          },
+          "message_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "唯一消息 ID。提交反馈时将其作为 `message_id`。文本生成应用不支持生成推荐问题。"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/BlockingMetadataResponse",
+            "description": "包含用量和检索资源的元数据。"
+          },
+          "mode": {
+            "type": "string",
+            "description": "应用模式，固定为 `completion`。"
+          },
+          "task_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "用于请求追踪和 [停止响应](/zh/api-reference/completion-messages/stop-completion-message-generation) API 的任务 ID。"
+          }
+        },
+        "required": [
+          "answer",
+          "created_at",
+          "event",
+          "id",
+          "message_id",
+          "metadata",
+          "mode",
+          "task_id"
+        ],
         "type": "object"
       },
       "CompletionRequestPayload": {
@@ -13799,6 +15329,255 @@
         ],
         "type": "object"
       },
+      "CompletionRequestPayloadWithUser": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式。新请求使用 `remote_url` 与 `url`，或使用 `local_file` 与 `upload_file_id`。生成的其他组合是向后兼容的旧版形式。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于多模态输入的文件。新客户端只需实现两种规范形式：公共文件 URL 使用 `transfer_method: remote_url` 和 `url`；本地文件先通过[上传文件](/zh/api-reference/files/upload-file)上传，再使用 `transfer_method: local_file`，并将返回的 `id` 作为 `upload_file_id`。生成的其他 `anyOf` 组合仅用于兼容已存储的旧版引用。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "应用自定义变量的值。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解预期的变量名称和类型。",
+            "type": "object"
+          },
+          "query": {
+            "default": "",
+            "description": "用户输入或提示词内容。",
+            "type": "string"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "响应模式。`streaming` 使用服务器发送事件（SSE）；`blocking` 在执行完成后返回。省略时，请求使用阻塞模式。"
+          },
+          "user": {
+            "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputs",
+          "user"
+        ],
+        "type": "object"
+      },
+      "ConversationInfiniteScrollPagination": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SimpleConversation"
+            },
+            "type": "array",
+            "description": "当前页的会话列表。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "是否还有更早的会话。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "每页条目数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit"
+        ],
+        "type": "object"
+      },
       "ConversationListQuery": {
         "properties": {
           "last_id": {
@@ -13906,8 +15685,205 @@
         },
         "type": "object"
       },
+      "ConversationRenamePayloadWithUser": {
+        "anyOf": [
+          {
+            "properties": {
+              "auto_generate": {
+                "description": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。",
+                "enum": [
+                  true
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "会话名称。当 `auto_generate` 为 `false` 时必填。"
+              },
+              "user": {
+                "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+                "type": "string"
+              }
+            },
+            "required": [
+              "auto_generate"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "auto_generate": {
+                "default": false,
+                "description": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。",
+                "enum": [
+                  false
+                ],
+                "type": "boolean"
+              },
+              "name": {
+                "pattern": ".*\\S.*",
+                "type": "string",
+                "description": "新的会话名称。除非 `auto_generate` 为 `true`，否则必填。"
+              },
+              "user": {
+                "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "auto_generate": {
+            "default": false,
+            "description": "自动生成会话名称。当为 `true` 时，`name` 字段将被忽略。",
+            "type": "boolean"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "会话名称。当 `auto_generate` 为 `false` 时必填。"
+          },
+          "user": {
+            "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ConversationVariableInfiniteScrollPaginationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationVariableResponse"
+            },
+            "type": "array",
+            "description": "当前页的会话变量列表。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "是否还有更多会话变量。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "每页条目数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit"
+        ],
+        "type": "object"
+      },
+      "ConversationVariableResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间，Unix 秒级时间戳。"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "变量描述。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "变量 ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "变量名称。"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "最后更新时间，Unix 秒级时间戳。"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "变量值（复杂类型可以是 JSON 字符串）。"
+          },
+          "value_type": {
+            "type": "string",
+            "description": "变量值类型。可选值：`string`、`number`、`object`、`secret`、`file`、`boolean`、`array[any]`、`array[string]`、`array[number]`、`array[object]`、`array[file]`、`array[boolean]`。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "value_type"
+        ],
+        "type": "object"
+      },
       "ConversationVariableUpdatePayload": {
         "properties": {
+          "value": {
+            "description": "变量的新值。必须与变量的预期类型匹配。"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "ConversationVariableUpdatePayloadWithUser": {
+        "properties": {
+          "user": {
+            "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+            "type": "string"
+          },
           "value": {
             "description": "变量的新值。必须与变量的预期类型匹配。"
           }
@@ -14068,59 +16044,95 @@
         "type": "object"
       },
       "EndUserDetail": {
-        "type": "object",
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "终端用户 ID。"
-          },
-          "tenant_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "租户 ID。"
-          },
           "app_id": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true,
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "应用 ID。"
           },
-          "type": {
+          "created_at": {
+            "format": "date-time",
             "type": "string",
-            "description": "终端用户类型。Service API 用户固定为 `service-api`。"
+            "description": "创建时间戳。"
           },
           "external_user_id": {
-            "type": "string",
-            "nullable": true,
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "API 请求中提供的 `user` 标识符（例如 [发送对话消息](/zh/api-reference/chat-messages/send-chat-message) 中的 `user` 字段）。"
           },
-          "name": {
+          "id": {
+            "format": "uuid",
             "type": "string",
-            "nullable": true,
-            "description": "终端用户名称。"
+            "description": "终端用户 ID。"
           },
           "is_anonymous": {
             "type": "boolean",
             "description": "用户是否为匿名用户。当原始 API 请求中未提供 `user` 标识符时，值为 `true`。"
           },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "终端用户名称。"
+          },
           "session_id": {
             "type": "string",
             "description": "会话标识符。默认为 `external_user_id` 的值。"
           },
-          "created_at": {
+          "tenant_id": {
+            "format": "uuid",
             "type": "string",
-            "format": "date-time",
-            "description": "创建时间戳。"
+            "description": "租户 ID。"
+          },
+          "type": {
+            "type": "string",
+            "description": "终端用户类型。Service API 用户固定为 `service-api`。"
           },
           "updated_at": {
-            "type": "string",
             "format": "date-time",
+            "type": "string",
             "description": "最后更新时间戳。"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "id",
+          "is_anonymous",
+          "session_id",
+          "tenant_id",
+          "type",
+          "updated_at"
+        ],
+        "type": "object"
       },
       "EventStreamResponse": {
+        "type": "string"
+      },
+      "ExecutionContentType": {
+        "enum": [
+          "human_input"
+        ],
         "type": "string"
       },
       "FeedbackListQuery": {
@@ -14141,6 +16153,90 @@
         },
         "type": "object"
       },
+      "FileInputConfig": {
+        "properties": {
+          "allowed_file_extensions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "当 `allowed_file_types` 包含 `custom` 时允许的文件扩展名。每个扩展名都需要包含前导 `.`，例如 `.md`。`file` 和 `file-list` 输入会包含此字段。"
+          },
+          "allowed_file_types": {
+            "items": {
+              "$ref": "#/components/schemas/FileType"
+            },
+            "type": "array",
+            "description": "接收人可上传的文件类别。`file` 和 `file-list` 输入会包含此字段。可用值：`image`、`document`、`audio`、`video`、`custom`。"
+          },
+          "allowed_file_upload_methods": {
+            "items": {
+              "$ref": "#/components/schemas/FileTransferMethod"
+            },
+            "type": "array",
+            "description": "接收人可使用的上传方式。可用值：`local_file`、`remote_url`。`file` 和 `file-list` 输入会包含此字段。"
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "引用该输入提交值在工作流中使用的变量名。对应提交 `inputs` 对象中的键。"
+          },
+          "type": {
+            "const": "file",
+            "default": "file",
+            "type": "string",
+            "description": "表单输入控件类型。可用值：`paragraph`（多行文本输入）、`select`（从列表中单选）、`file`（单个文件上传）和 `file-list`（多个文件上传）。"
+          }
+        },
+        "required": [
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
+      "FileListInputConfig": {
+        "properties": {
+          "allowed_file_extensions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "当 `allowed_file_types` 包含 `custom` 时允许的文件扩展名。每个扩展名都需要包含前导 `.`，例如 `.md`。`file` 和 `file-list` 输入会包含此字段。"
+          },
+          "allowed_file_types": {
+            "items": {
+              "$ref": "#/components/schemas/FileType"
+            },
+            "type": "array",
+            "description": "接收人可上传的文件类别。`file` 和 `file-list` 输入会包含此字段。可用值：`image`、`document`、`audio`、`video`、`custom`。"
+          },
+          "allowed_file_upload_methods": {
+            "items": {
+              "$ref": "#/components/schemas/FileTransferMethod"
+            },
+            "type": "array",
+            "description": "接收人可使用的上传方式。可用值：`local_file`、`remote_url`。`file` 和 `file-list` 输入会包含此字段。"
+          },
+          "number_limits": {
+            "default": 0,
+            "minimum": 0,
+            "type": "integer",
+            "description": "接收人可上传的最大文件数。仅 `file-list` 输入会包含此字段。"
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "引用该输入提交值在工作流中使用的变量名。对应提交 `inputs` 对象中的键。"
+          },
+          "type": {
+            "const": "file-list",
+            "default": "file-list",
+            "type": "string",
+            "description": "表单输入控件类型。可用值：`paragraph`（多行文本输入）、`select`（从列表中单选）、`file`（单个文件上传）和 `file-list`（多个文件上传）。"
+          }
+        },
+        "required": [
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
       "FilePreviewQuery": {
         "properties": {
           "as_attachment": {
@@ -14151,41 +16247,313 @@
         },
         "type": "object"
       },
-      "HumanInputContent": {
-        "type": "object",
-        "description": "人工介入节点的执行内容，包括表单定义和提交数据。",
+      "FileResponse": {
         "properties": {
-          "workflow_run_id": {
+          "conversation_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "关联的会话 ID。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "上传时间戳（Unix 纪元秒）。"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "上传者的终端用户 ID。可通过 [获取终端用户信息](/zh/api-reference/end-users/get-end-user-info) 查询详情。"
+          },
+          "extension": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文件扩展名。"
+          },
+          "file_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "未使用，始终为 `null`。"
+          },
+          "id": {
+            "format": "uuid",
             "type": "string",
-            "description": "该内容所属的工作流运行 ID。"
+            "description": "唯一文件 ID。"
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文件的 MIME 类型。"
+          },
+          "name": {
+            "type": "string",
+            "description": "文件名。"
+          },
+          "original_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文件的原始 URL。"
+          },
+          "preview_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文件的预览 URL。"
+          },
+          "reference": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "在 Agent 和工具场景中附加文件时内部使用的不透明文件引用。通过此端点上传的文件始终为 `null`。"
+          },
+          "size": {
+            "type": "integer",
+            "description": "文件大小（字节）。"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文件的签名下载 URL。"
+          },
+          "tenant_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "关联的租户 ID。"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "未使用，始终为 `null`。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "size"
+        ],
+        "type": "object"
+      },
+      "FileTransferMethod": {
+        "enum": [
+          "datasource_file",
+          "local_file",
+          "remote_url",
+          "tool_file"
+        ],
+        "type": "string"
+      },
+      "FileType": {
+        "enum": [
+          "audio",
+          "custom",
+          "document",
+          "image",
+          "video"
+        ],
+        "type": "string"
+      },
+      "FormInputConfig": {
+        "discriminator": {
+          "mapping": {
+            "file": "#/components/schemas/FileInputConfig",
+            "file-list": "#/components/schemas/FileListInputConfig",
+            "paragraph": "#/components/schemas/ParagraphInputConfig",
+            "select": "#/components/schemas/SelectInputConfig"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ParagraphInputConfig"
+          },
+          {
+            "$ref": "#/components/schemas/SelectInputConfig"
+          },
+          {
+            "$ref": "#/components/schemas/FileInputConfig"
+          },
+          {
+            "$ref": "#/components/schemas/FileListInputConfig"
+          }
+        ]
+      },
+      "HumanInputContent": {
+        "properties": {
+          "form_definition": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HumanInputFormDefinition"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "人工介入节点的表单定义。当内容表示提交响应时为 `null`。"
+          },
+          "form_submission_data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HumanInputFormSubmissionData"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "已提交的表单数据。表单尚未提交时为 `null`。"
           },
           "submitted": {
             "type": "boolean",
             "description": "人工介入表单是否已提交。"
           },
           "type": {
-            "type": "string",
+            "$ref": "#/components/schemas/ExecutionContentType",
+            "default": "human_input",
             "description": "`human_input` 表示人工介入内容。"
           },
-          "form_definition": {
-            "nullable": true,
-            "description": "人工介入节点的表单定义。当内容表示提交响应时为 `null`。",
-            "$ref": "#/components/schemas/HumanInputFormDefinition"
-          },
-          "form_submission_data": {
-            "nullable": true,
-            "description": "已提交的表单数据。表单尚未提交时为 `null`。",
-            "$ref": "#/components/schemas/HumanInputFormSubmissionData"
+          "workflow_run_id": {
+            "type": "string",
+            "description": "该内容所属的工作流运行 ID。"
           }
-        }
+        },
+        "required": [
+          "submitted",
+          "workflow_run_id"
+        ],
+        "type": "object",
+        "description": "人工介入节点的执行内容，包括表单定义和提交数据。"
       },
       "HumanInputFormDefinition": {
-        "type": "object",
-        "description": "由人工介入节点渲染的人工介入表单定义。",
         "properties": {
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/UserActionConfig"
+            },
+            "type": "array",
+            "description": "表单上可用的操作按钮。"
+          },
+          "display_in_ui": {
+            "default": false,
+            "type": "boolean",
+            "description": "表单是否应在 UI 中显示。"
+          },
+          "expiration_time": {
+            "type": "integer",
+            "description": "表单过期的 Unix 时间戳。"
+          },
+          "form_content": {
+            "type": "string",
+            "description": "与表单一起显示的 Markdown 或文本内容。"
+          },
           "form_id": {
             "type": "string",
             "description": "表单唯一标识符。"
+          },
+          "form_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "表单提交认证的令牌。"
+          },
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/FormInputConfig"
+            },
+            "type": "array",
+            "description": "表单中的输入字段。"
           },
           "node_id": {
             "type": "string",
@@ -14195,48 +16563,81 @@
             "type": "string",
             "description": "人工介入节点的标题。"
           },
+          "resolved_default_values": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "表单输入的已解析默认值，按输出变量名称索引。"
+          }
+        },
+        "required": [
+          "expiration_time",
+          "form_content",
+          "form_id",
+          "node_id",
+          "node_title"
+        ],
+        "type": "object",
+        "description": "由人工介入节点渲染的人工介入表单定义。"
+      },
+      "HumanInputFormDefinitionResponse": {
+        "properties": {
+          "expiration_time": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unix 时间戳（秒），超过该时间后表单将不可提交。"
+          },
           "form_content": {
             "type": "string",
-            "description": "与表单一起显示的 Markdown 或文本内容。"
+            "description": "已替换工作流变量的预渲染表单正文。"
           },
           "inputs": {
-            "type": "array",
-            "description": "表单中的输入字段。",
             "items": {
-              "$ref": "#/components/schemas/FormInput"
-            }
-          },
-          "actions": {
+              "$ref": "#/components/schemas/FormInputConfig"
+            },
             "type": "array",
-            "description": "表单上可用的操作按钮。",
-            "items": {
-              "$ref": "#/components/schemas/UserAction"
-            }
-          },
-          "display_in_ui": {
-            "type": "boolean",
-            "description": "表单是否应在 UI 中显示。"
-          },
-          "form_token": {
-            "type": "string",
-            "nullable": true,
-            "description": "表单提交认证的令牌。"
+            "description": "表单输入字段定义。"
           },
           "resolved_default_values": {
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
-            "additionalProperties": true,
-            "description": "表单输入的已解析默认值，按输出变量名称索引。"
+            "description": "用于在表单中展示的预渲染默认值，按输入的 `output_variable_name` 分组。仅当 `paragraph` 输入的默认值可由工作流变量解析时填充；无可解析默认值的输入为空。客户端请直接展示这些值，无需在前端再次解析 `default`。所有值均为字符串。"
           },
-          "expiration_time": {
-            "type": "integer",
-            "description": "表单过期的 Unix 时间戳。"
+          "user_actions": {
+            "items": {
+              "$ref": "#/components/schemas/UserActionConfig"
+            },
+            "type": "array",
+            "description": "可用的提交操作。"
           }
-        }
+        },
+        "required": [
+          "form_content",
+          "inputs",
+          "resolved_default_values",
+          "user_actions"
+        ],
+        "type": "object"
       },
       "HumanInputFormSubmissionData": {
-        "type": "object",
-        "description": "来自已提交的人工介入表单的数据。",
         "properties": {
+          "action_id": {
+            "type": "string",
+            "description": "被点击的操作按钮的 ID。"
+          },
+          "action_text": {
+            "type": "string",
+            "description": "被点击的操作按钮的显示文本。"
+          },
           "node_id": {
             "type": "string",
             "description": "人工介入节点的 ID。"
@@ -14249,15 +16650,31 @@
             "type": "string",
             "description": "表单提交的渲染内容。"
           },
-          "action_id": {
-            "type": "string",
-            "description": "被点击的操作按钮的 ID。"
-          },
-          "action_text": {
-            "type": "string",
-            "description": "被点击的操作按钮的显示文本。"
+          "submitted_data": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "接收者提交的表单值，以各输入项的 `output_variable_name` 为键。"
           }
-        }
+        },
+        "required": [
+          "action_id",
+          "action_text",
+          "node_id",
+          "node_title",
+          "rendered_content"
+        ],
+        "type": "object",
+        "description": "来自已提交的人工介入表单的数据。"
       },
       "HumanInputFormSubmitPayload": {
         "properties": {
@@ -14301,10 +16718,87 @@
         ],
         "type": "object"
       },
+      "HumanInputFormSubmitPayloadWithUser": {
+        "properties": {
+          "action": {
+            "description": "接收者所选操作按钮的 ID，必须与表单 `user_actions` 列表中的某个 `id` 值匹配。",
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "description": "按输出变量名称组织的人工输入值。段落或选择输入使用字符串，文件输入使用文件映射，文件列表输入使用文件映射列表。本地文件映射使用 `transfer_method=local_file` 和 `upload_file_id`；远程文件映射使用 `transfer_method=remote_url` 和 `url` 或 `remote_url`。",
+            "examples": [
+              {
+                "attachment": {
+                  "transfer_method": "local_file",
+                  "type": "document",
+                  "upload_file_id": "4e0d1b87-52f2-49f6-b8c6-95cd9c954b3e"
+                },
+                "attachments": [
+                  {
+                    "transfer_method": "local_file",
+                    "type": "document",
+                    "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee"
+                  },
+                  {
+                    "transfer_method": "remote_url",
+                    "type": "document",
+                    "url": "https://example.com/report.pdf"
+                  }
+                ],
+                "decision": "approve"
+              }
+            ],
+            "type": "object"
+          },
+          "user": {
+            "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action",
+          "inputs",
+          "user"
+        ],
+        "type": "object"
+      },
+      "HumanInputFormSubmitResponse": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "IndexInfoResponse": {
+        "properties": {
+          "api_version": {
+            "type": "string",
+            "description": "Service API 版本。"
+          },
+          "server_version": {
+            "type": "string",
+            "description": "Dify 服务器版本。"
+          },
+          "welcome": {
+            "type": "string",
+            "description": "服务欢迎信息。"
+          }
+        },
+        "required": [
+          "api_version",
+          "server_version",
+          "welcome"
+        ],
+        "type": "object"
+      },
       "JSONObject": {
         "additionalProperties": true,
         "type": "object"
       },
+      "JSONValue": {},
+      "JSONValueType": {},
+      "JsonValue": {},
       "MessageFeedbackPayload": {
         "properties": {
           "content": {
@@ -14338,6 +16832,332 @@
         },
         "type": "object"
       },
+      "MessageFeedbackPayloadWithUser": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "提供额外详情的可选文字反馈。"
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "enum": [
+                  "dislike",
+                  "like"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "反馈评分。设为 `null` 可撤销之前提交的反馈。"
+          },
+          "user": {
+            "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "type": "object"
+      },
+      "MessageFile": {
+        "properties": {
+          "belongs_to": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该文件的所属者。用户上传的文件为 `user`，助手生成的文件为 `assistant`。"
+          },
+          "filename": {
+            "type": "string",
+            "description": "原始文件名。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "消息文件 ID。"
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文件的 MIME 类型。"
+          },
+          "size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文件大小（字节）。"
+          },
+          "transfer_method": {
+            "type": "string",
+            "description": "使用的传输方式。`remote_url` 表示基于 URL 的文件，`local_file` 表示已上传的文件，`tool_file` 表示工具生成的文件。"
+          },
+          "type": {
+            "type": "string",
+            "description": "文件类型，例如 `image`。"
+          },
+          "upload_file_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "通过 `local_file` 传输时的上传文件 ID。"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "format": "url",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文件的预览 URL。"
+          }
+        },
+        "required": [
+          "filename",
+          "id",
+          "transfer_method",
+          "type"
+        ],
+        "type": "object"
+      },
+      "MessageInfiniteScrollPagination": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/MessageListItem"
+            },
+            "type": "array",
+            "description": "当前页的消息列表。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "是否还有更早的消息。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "每页条目数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit"
+        ],
+        "type": "object"
+      },
+      "MessageListItem": {
+        "properties": {
+          "agent_thoughts": {
+            "items": {
+              "$ref": "#/components/schemas/AgentThought"
+            },
+            "type": "array",
+            "description": "该消息的 Agent 思考。"
+          },
+          "answer": {
+            "type": "string",
+            "description": "助手回答文本。"
+          },
+          "answer_tokens": {
+            "default": 0,
+            "type": "integer",
+            "description": "生成回答的 token 数量。"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会话 ID。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间戳（Unix 纪元秒）。"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`total_price` 的货币单位（例如 `USD`），无定价信息时为 `null`。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "当 `status` 为 `error` 时的错误消息。"
+          },
+          "extra_contents": {
+            "items": {
+              "$ref": "#/components/schemas/HumanInputContent"
+            },
+            "type": "array",
+            "description": "与此消息关联的附加执行内容，例如 Chatflow 工作流中人工介入节点的表单数据。"
+          },
+          "feedback": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleFeedback"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该消息的用户反馈。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "消息 ID。"
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JSONValueType"
+            },
+            "type": "object",
+            "description": "该消息的输入变量。"
+          },
+          "message_files": {
+            "items": {
+              "$ref": "#/components/schemas/MessageFile"
+            },
+            "type": "array",
+            "description": "附加到该消息的文件。"
+          },
+          "message_tokens": {
+            "default": 0,
+            "type": "integer",
+            "description": "输入消息的 token 数量。"
+          },
+          "parent_message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "线程会话的父消息 ID。"
+          },
+          "provider_response_latency": {
+            "default": 0,
+            "format": "float",
+            "type": "number",
+            "description": "模型供应商的响应延迟，单位为秒。"
+          },
+          "query": {
+            "type": "string",
+            "description": "用户查询文本。"
+          },
+          "retriever_resources": {
+            "items": {
+              "$ref": "#/components/schemas/RetrieverResource"
+            },
+            "type": "array",
+            "description": "该消息使用的检索资源。"
+          },
+          "status": {
+            "type": "string",
+            "description": "消息状态。成功消息为 `normal`，生成失败时为 `error`。"
+          },
+          "total_price": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "所用 token 的总价，无定价信息时为 `null`。"
+          },
+          "total_tokens": {
+            "readOnly": true,
+            "type": "integer",
+            "description": "使用的 token 总数，即 `message_tokens` 与 `answer_tokens` 之和。"
+          }
+        },
+        "required": [
+          "agent_thoughts",
+          "answer",
+          "conversation_id",
+          "extra_contents",
+          "id",
+          "inputs",
+          "message_files",
+          "query",
+          "retriever_resources",
+          "status",
+          "total_tokens"
+        ],
+        "type": "object"
+      },
       "MessageListQuery": {
         "properties": {
           "conversation_id": {
@@ -14366,6 +17186,1479 @@
         },
         "required": [
           "conversation_id"
+        ],
+        "type": "object"
+      },
+      "OptionalServiceApiUserPayload": {
+        "properties": {
+          "user": {
+            "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ParagraphInputConfig": {
+        "description": "表单输入定义。",
+        "properties": {
+          "default": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringSource"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`paragraph` 输入的原始默认值配置。客户端不应直接解析此字段，请使用 `resolved_default_values` 来展示默认值。其他输入类型或未配置默认值时，不包含该键。"
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "引用该输入提交值在工作流中使用的变量名。对应提交 `inputs` 对象中的键。"
+          },
+          "type": {
+            "const": "paragraph",
+            "default": "paragraph",
+            "type": "string",
+            "description": "表单输入控件类型。可用值：`paragraph`（多行文本输入）、`select`（从列表中单选）、`file`（单个文件上传）和 `file-list`（多个文件上传）。"
+          }
+        },
+        "required": [
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
+      "Parameters": {
+        "properties": {
+          "annotation_reply": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "是否启用此功能。"
+              }
+            },
+            "type": "object",
+            "description": "标注回复功能配置。"
+          },
+          "file_upload": {
+            "properties": {
+              "allowed_file_extensions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "应用接受的自定义文件扩展名。"
+              },
+              "allowed_file_types": {
+                "items": {
+                  "enum": [
+                    "audio",
+                    "custom",
+                    "document",
+                    "image",
+                    "video"
+                  ],
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "应用接受的文件类型。"
+              },
+              "allowed_file_upload_methods": {
+                "items": {
+                  "enum": [
+                    "local_file",
+                    "remote_url"
+                  ],
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "应用接受的文件传输方式。"
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "是否启用文件上传。"
+              },
+              "image": {
+                "properties": {
+                  "detail": {
+                    "type": "string",
+                    "description": "视觉模型的图像细节级别。"
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "是否启用图片上传。"
+                  },
+                  "number_limits": {
+                    "type": "integer",
+                    "description": "可上传的最大图片数量。"
+                  },
+                  "transfer_methods": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "description": "图片上传允许的传输方式。`remote_url` 表示通过文件 URL 上传，`local_file` 表示上传本地文件。"
+                  }
+                },
+                "type": "object",
+                "description": "图片上传设置。"
+              },
+              "number_limits": {
+                "type": "integer",
+                "description": "可上传的最大文件数量。"
+              }
+            },
+            "type": "object",
+            "description": "文件上传配置。"
+          },
+          "more_like_this": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "是否启用此功能。"
+              }
+            },
+            "type": "object",
+            "description": "更多类似推荐功能配置。"
+          },
+          "opening_statement": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "开场白文本。"
+          },
+          "retriever_resource": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "是否启用此功能。"
+              }
+            },
+            "type": "object",
+            "description": "知识检索引用资源配置。"
+          },
+          "sensitive_word_avoidance": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "是否启用此功能。"
+              }
+            },
+            "type": "object",
+            "description": "内容审核功能配置。"
+          },
+          "speech_to_text": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "是否启用此功能。"
+              }
+            },
+            "type": "object",
+            "description": "语音转文字功能配置。"
+          },
+          "suggested_questions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "建议问题列表。"
+          },
+          "suggested_questions_after_answer": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "是否启用此功能。"
+              }
+            },
+            "type": "object",
+            "description": "回答后建议问题的配置。"
+          },
+          "system_parameters": {
+            "$ref": "#/components/schemas/SystemParameters",
+            "description": "系统级参数限制。"
+          },
+          "text_to_speech": {
+            "properties": {
+              "autoPlay": {
+                "type": "string",
+                "description": "自动播放设置。`enabled` 为自动播放音频，`disabled` 为需要手动播放。"
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "是否启用此功能。"
+              },
+              "language": {
+                "type": "string",
+                "description": "TTS 语言。"
+              },
+              "voice": {
+                "type": "string",
+                "description": "TTS 声音标识符。"
+              }
+            },
+            "type": "object",
+            "description": "文字转语音功能配置。"
+          },
+          "user_input_form": {
+            "items": {
+              "oneOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "text-input": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件扩展名。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件类别。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的上传方式。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "其他输入配置。"
+                        },
+                        "default": {
+                          "description": "默认值，其 JSON 类型取决于表单类型。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "可选的输入项说明。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "是否在公开表单中隐藏该输入项。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "用于验证 JSON 对象输入的 JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "输入项的显示标签。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "输入类型支持长度限制时的最大输入长度。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "此表单控件的可选值列表。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "输入项是否必填。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "应用使用的变量名称。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "文本输入配置。"
+                    }
+                  },
+                  "required": [
+                    "text-input"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "select": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件扩展名。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件类别。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的上传方式。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "其他输入配置。"
+                        },
+                        "default": {
+                          "description": "默认值，其 JSON 类型取决于表单类型。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "可选的输入项说明。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "是否在公开表单中隐藏该输入项。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "用于验证 JSON 对象输入的 JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "输入项的显示标签。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "输入类型支持长度限制时的最大输入长度。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "此表单控件的可选值列表。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "输入项是否必填。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "应用使用的变量名称。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "选择输入配置。"
+                    }
+                  },
+                  "required": [
+                    "select"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "paragraph": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件扩展名。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件类别。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的上传方式。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "其他输入配置。"
+                        },
+                        "default": {
+                          "description": "默认值，其 JSON 类型取决于表单类型。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "可选的输入项说明。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "是否在公开表单中隐藏该输入项。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "用于验证 JSON 对象输入的 JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "输入项的显示标签。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "输入类型支持长度限制时的最大输入长度。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "此表单控件的可选值列表。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "输入项是否必填。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "应用使用的变量名称。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "段落输入配置。"
+                    }
+                  },
+                  "required": [
+                    "paragraph"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "number": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件扩展名。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件类别。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的上传方式。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "其他输入配置。"
+                        },
+                        "default": {
+                          "description": "默认值，其 JSON 类型取决于表单类型。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "可选的输入项说明。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "是否在公开表单中隐藏该输入项。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "用于验证 JSON 对象输入的 JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "输入项的显示标签。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "输入类型支持长度限制时的最大输入长度。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "此表单控件的可选值列表。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "输入项是否必填。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "应用使用的变量名称。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "数字输入配置。"
+                    }
+                  },
+                  "required": [
+                    "number"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "external_data_tool": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件扩展名。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件类别。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的上传方式。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "其他输入配置。"
+                        },
+                        "default": {
+                          "description": "默认值，其 JSON 类型取决于表单类型。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "可选的输入项说明。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "是否在公开表单中隐藏该输入项。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "用于验证 JSON 对象输入的 JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "输入项的显示标签。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "输入类型支持长度限制时的最大输入长度。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "此表单控件的可选值列表。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "输入项是否必填。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "应用使用的变量名称。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "外部数据工具输入配置。"
+                    }
+                  },
+                  "required": [
+                    "external_data_tool"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "file": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件扩展名。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件类别。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的上传方式。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "其他输入配置。"
+                        },
+                        "default": {
+                          "description": "默认值，其 JSON 类型取决于表单类型。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "可选的输入项说明。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "是否在公开表单中隐藏该输入项。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "用于验证 JSON 对象输入的 JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "输入项的显示标签。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "输入类型支持长度限制时的最大输入长度。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "此表单控件的可选值列表。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "输入项是否必填。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "应用使用的变量名称。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "应用返回的文件表单控件配置。它描述标签、变量名、是否必填、允许的文件类别与扩展名以及支持的传输方式；它不是上传的 multipart 文件。"
+                    }
+                  },
+                  "required": [
+                    "file"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "file-list": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件扩展名。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件类别。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的上传方式。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "其他输入配置。"
+                        },
+                        "default": {
+                          "description": "默认值，其 JSON 类型取决于表单类型。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "可选的输入项说明。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "是否在公开表单中隐藏该输入项。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "用于验证 JSON 对象输入的 JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "输入项的显示标签。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "输入类型支持长度限制时的最大输入长度。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "此表单控件的可选值列表。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "输入项是否必填。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "应用使用的变量名称。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "文件列表输入配置。"
+                    }
+                  },
+                  "required": [
+                    "file-list"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "checkbox": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件扩展名。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件类别。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的上传方式。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "其他输入配置。"
+                        },
+                        "default": {
+                          "description": "默认值，其 JSON 类型取决于表单类型。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "可选的输入项说明。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "是否在公开表单中隐藏该输入项。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "用于验证 JSON 对象输入的 JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "输入项的显示标签。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "输入类型支持长度限制时的最大输入长度。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "此表单控件的可选值列表。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "输入项是否必填。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "应用使用的变量名称。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "复选框输入配置。"
+                    }
+                  },
+                  "required": [
+                    "checkbox"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "json_object": {
+                      "properties": {
+                        "allowed_file_extensions": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件扩展名。"
+                        },
+                        "allowed_file_types": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的文件类别。"
+                        },
+                        "allowed_file_upload_methods": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "此输入接受文件时允许的上传方式。"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "description": "其他输入配置。"
+                        },
+                        "default": {
+                          "description": "默认值，其 JSON 类型取决于表单类型。"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "可选的输入项说明。"
+                        },
+                        "hide": {
+                          "type": "boolean",
+                          "description": "是否在公开表单中隐藏该输入项。"
+                        },
+                        "json_schema": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "用于验证 JSON 对象输入的 JSON Schema。"
+                        },
+                        "label": {
+                          "type": "string",
+                          "description": "输入项的显示标签。"
+                        },
+                        "max_length": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "输入类型支持长度限制时的最大输入长度。"
+                        },
+                        "options": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "description": "此表单控件的可选值列表。"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "输入项是否必填。"
+                        },
+                        "type": {
+                          "enum": [
+                            "checkbox",
+                            "external_data_tool",
+                            "file",
+                            "file-list",
+                            "json_object",
+                            "number",
+                            "paragraph",
+                            "select",
+                            "text-input"
+                          ],
+                          "type": "string",
+                          "description": "响应中重复的表单类型值。存在时应与外层表单键一致；请使用外层键选择控件结构。"
+                        },
+                        "variable": {
+                          "type": "string",
+                          "description": "应用使用的变量名称。"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "variable"
+                      ],
+                      "type": "object",
+                      "description": "JSON 对象输入配置。"
+                    }
+                  },
+                  "required": [
+                    "json_object"
+                  ],
+                  "type": "object"
+                }
+              ],
+              "type": "object"
+            },
+            "type": "array",
+            "description": "用户输入表单配置。"
+          }
+        },
+        "required": [
+          "annotation_reply",
+          "file_upload",
+          "more_like_this",
+          "retriever_resource",
+          "sensitive_word_avoidance",
+          "speech_to_text",
+          "suggested_questions",
+          "suggested_questions_after_answer",
+          "system_parameters",
+          "text_to_speech",
+          "user_input_form"
+        ],
+        "type": "object"
+      },
+      "RequiredServiceApiUserPayload": {
+        "properties": {
+          "user": {
+            "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "type": "object"
+      },
+      "ResultResponse": {
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "操作结果。"
+          }
+        },
+        "required": [
+          "result"
         ],
         "type": "object"
       },
@@ -14552,86 +18845,200 @@
         }
       },
       "RetrieverResource": {
-        "type": "object",
-        "description": "检索资源的引用和归属信息。",
         "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "资源的内容片段。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间戳（Unix 纪元秒）。"
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "数据源类型。"
+          },
+          "dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "知识库 ID。"
+          },
+          "dataset_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "知识库名称。"
+          },
+          "document_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档 ID。"
+          },
+          "document_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档名称。"
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该块被命中的次数。"
+          },
           "id": {
-            "type": "string",
             "format": "uuid",
+            "type": "string",
             "description": "检索资源的唯一 ID。"
           },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "索引节点的哈希值。"
+          },
           "message_id": {
-            "type": "string",
             "format": "uuid",
+            "type": "string",
             "description": "该资源所属消息的 ID。"
           },
           "position": {
             "type": "integer",
             "description": "资源在列表中的位置。"
           },
-          "dataset_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "知识库 ID。"
-          },
-          "dataset_name": {
-            "type": "string",
-            "description": "知识库名称。"
-          },
-          "document_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "文档 ID。"
-          },
-          "document_name": {
-            "type": "string",
-            "description": "文档名称。"
-          },
-          "data_source_type": {
-            "type": "string",
-            "description": "数据源类型。"
-          },
-          "segment_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "文档中特定块的 ID。"
-          },
           "score": {
-            "type": "number",
-            "format": "float",
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "资源的相关性评分。"
           },
-          "hit_count": {
-            "type": "integer",
-            "description": "该块被命中的次数。"
-          },
-          "word_count": {
-            "type": "integer",
-            "description": "块的字数。"
+          "segment_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档中特定块的 ID。"
           },
           "segment_position": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "块在文档中的位置。"
           },
-          "index_node_hash": {
-            "type": "string",
-            "description": "索引节点的哈希值。"
-          },
-          "content": {
-            "type": "string",
-            "description": "资源的内容片段。"
-          },
           "summary": {
-            "type": "string",
-            "nullable": true,
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "块内容的摘要。"
           },
-          "created_at": {
-            "type": "integer",
-            "format": "int64",
-            "description": "创建时间戳（Unix 纪元秒）。"
+          "word_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "块的字数。"
           }
-        }
+        },
+        "required": [
+          "position"
+        ],
+        "type": "object",
+        "description": "检索资源的引用和归属信息。"
       },
       "SegmentListQuery": {
         "properties": {
@@ -14669,6 +19076,171 @@
         },
         "type": "object"
       },
+      "SelectInputConfig": {
+        "properties": {
+          "option_source": {
+            "$ref": "#/components/schemas/StringListSource",
+            "description": "`select` 输入的选项来源。仅当 `type` 为 `select` 时出现。"
+          },
+          "output_variable_name": {
+            "type": "string",
+            "description": "引用该输入提交值在工作流中使用的变量名。对应提交 `inputs` 对象中的键。"
+          },
+          "type": {
+            "const": "select",
+            "default": "select",
+            "type": "string",
+            "description": "表单输入控件类型。可用值：`paragraph`（多行文本输入）、`select`（从列表中单选）、`file`（单个文件上传）和 `file-list`（多个文件上传）。"
+          }
+        },
+        "required": [
+          "option_source",
+          "output_variable_name"
+        ],
+        "type": "object"
+      },
+      "SimpleAccountResponse": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "账户邮箱地址。"
+          },
+          "id": {
+            "type": "string",
+            "description": "账户 ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "账户显示名称。"
+          }
+        },
+        "required": [
+          "email",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "SimpleConversation": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间，Unix 秒级时间戳。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "会话 ID。"
+          },
+          "inputs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JSONValue"
+            },
+            "type": "object",
+            "description": "会话的输入变量。"
+          },
+          "introduction": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "会话介绍。"
+          },
+          "name": {
+            "type": "string",
+            "description": "会话名称。"
+          },
+          "status": {
+            "type": "string",
+            "description": "会话状态。活跃会话为 `normal`。"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "最后更新时间，Unix 秒级时间戳。"
+          }
+        },
+        "required": [
+          "id",
+          "inputs",
+          "name",
+          "status"
+        ],
+        "type": "object"
+      },
+      "SimpleEndUser": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "终端用户 ID。"
+          },
+          "is_anonymous": {
+            "type": "boolean",
+            "description": "终端用户是否为匿名。"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "会话标识符。"
+          },
+          "type": {
+            "type": "string",
+            "description": "终端用户类型。"
+          }
+        },
+        "required": [
+          "id",
+          "is_anonymous",
+          "type"
+        ],
+        "type": "object"
+      },
+      "SimpleFeedback": {
+        "properties": {
+          "rating": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "反馈评分。`like` 为正面，`dislike` 为负面。"
+          }
+        },
+        "type": "object"
+      },
       "SimpleResultResponse": {
         "properties": {
           "result": {
@@ -14678,6 +19250,263 @@
         },
         "required": [
           "result"
+        ],
+        "type": "object"
+      },
+      "SimpleResultStringListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "建议问题列表。"
+          },
+          "result": {
+            "type": "string",
+            "description": "结果状态。"
+          }
+        },
+        "required": [
+          "data",
+          "result"
+        ],
+        "type": "object"
+      },
+      "Site": {
+        "properties": {
+          "chat_color_theme": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "聊天主题颜色。"
+          },
+          "chat_color_theme_inverted": {
+            "type": "boolean",
+            "description": "聊天主题颜色是否反转。"
+          },
+          "copyright": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "版权文本。"
+          },
+          "custom_disclaimer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "自定义免责声明文本。"
+          },
+          "default_language": {
+            "type": "string",
+            "description": "默认语言代码。"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Web 应用描述。"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "图标内容（表情或图片 ID）。"
+          },
+          "icon_background": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "图标背景颜色。"
+          },
+          "icon_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "使用的图标类型。`emoji` 为表情图标，`image` 为上传的图片图标。"
+          },
+          "icon_url": {
+            "anyOf": [
+              {
+                "format": "url",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "readOnly": true,
+            "description": "图标图片的 URL。"
+          },
+          "input_placeholder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Web 应用消息输入框中显示的占位文本。未配置时为 `null`。"
+          },
+          "privacy_policy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "隐私政策 URL。"
+          },
+          "show_workflow_steps": {
+            "type": "boolean",
+            "description": "是否显示工作流步骤。"
+          },
+          "title": {
+            "type": "string",
+            "description": "Web 应用标题。"
+          },
+          "use_icon_as_answer_icon": {
+            "type": "boolean",
+            "description": "是否使用应用图标作为回答图标。"
+          }
+        },
+        "required": [
+          "chat_color_theme_inverted",
+          "default_language",
+          "icon_url",
+          "show_workflow_steps",
+          "title",
+          "use_icon_as_answer_icon"
+        ],
+        "type": "object"
+      },
+      "StringListSource": {
+        "properties": {
+          "selector": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "当 `type` 为 `variable` 时的变量引用路径。"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ValueSourceType",
+            "description": "选项来源。`constant` 表示 `value` 直接列出选项；`variable` 表示 `selector` 指向提供选项的 `array[string]` 工作流变量。"
+          },
+          "value": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "当 `type` 为 `constant` 时的字面选项列表。"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "StringSource": {
+        "description": "表单输入的默认配置。",
+        "properties": {
+          "selector": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "当 `type` 为 `variable` 时的变量引用路径（例如 `[\"node_id\", \"var_name\"]`）。至少包含两个元素。"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ValueSourceType",
+            "description": "默认值来源。`constant` 表示将 `value` 作为字面字符串；`variable` 表示 `selector` 指向工作流变量。"
+          },
+          "value": {
+            "default": "",
+            "type": "string",
+            "description": "当 `type` 为 `constant` 时的字面默认值。始终为字符串。"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "SystemParameters": {
+        "properties": {
+          "audio_file_size_limit": {
+            "type": "integer",
+            "description": "最大音频文件大小（MB）。"
+          },
+          "file_size_limit": {
+            "type": "integer",
+            "description": "常规文件最大大小（MB）。"
+          },
+          "image_file_size_limit": {
+            "type": "integer",
+            "description": "最大图片文件大小（MB）。"
+          },
+          "video_file_size_limit": {
+            "type": "integer",
+            "description": "最大视频文件大小（MB）。"
+          },
+          "workflow_file_upload_limit": {
+            "type": "integer",
+            "description": "每次工作流执行的最大文件数量。"
+          }
+        },
+        "required": [
+          "audio_file_size_limit",
+          "file_size_limit",
+          "image_file_size_limit",
+          "video_file_size_limit",
+          "workflow_file_upload_limit"
         ],
         "type": "object"
       },
@@ -14733,6 +19562,265 @@
             "description": "文本转语音使用的声音。可用声音取决于此应用配置的 TTS 提供商。省略时会尽可能使用应用配置的声音；可通过[获取应用参数](/zh/api-reference/applications/get-app-parameters)返回的 `text_to_speech.voice` 查看该值。"
           }
         },
+        "type": "object"
+      },
+      "TextToAudioPayloadWithUser": {
+        "properties": {
+          "message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "消息 ID。同时提供时，其优先级高于 `text`。"
+          },
+          "streaming": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "为兼容性保留；TTS 响应是否流式传输由提供商输出决定。"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "要转换的语音内容。"
+          },
+          "user": {
+            "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+            "type": "string"
+          },
+          "voice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文本转语音使用的声音。可用声音取决于此应用配置的 TTS 提供商。省略时会尽可能使用应用配置的声音；可通过[获取应用参数](/zh/api-reference/applications/get-app-parameters)返回的 `text_to_speech.voice` 查看该值。"
+          }
+        },
+        "type": "object"
+      },
+      "ToolIcon": {
+        "properties": {
+          "background": {
+            "type": "string",
+            "description": "十六进制格式的背景颜色。"
+          },
+          "content": {
+            "type": "string",
+            "description": "Emoji 内容。"
+          }
+        },
+        "required": [
+          "background",
+          "content"
+        ],
+        "type": "object"
+      },
+      "UserActionConfig": {
+        "description": "用户操作配置。",
+        "properties": {
+          "button_style": {
+            "$ref": "#/components/schemas/ButtonStyle",
+            "default": "default",
+            "description": "按钮的视觉样式。可用值：`primary`、`default`、`accent`、`ghost`。"
+          },
+          "id": {
+            "maxLength": 20,
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+            "type": "string",
+            "description": "操作按钮的标识。当接收人选择该按钮时，作为 `action` 传入 [提交人工介入表单](/zh/api-reference/human-input/submit-human-input-form)。"
+          },
+          "title": {
+            "maxLength": 100,
+            "type": "string",
+            "description": "操作按钮标签。"
+          }
+        },
+        "required": [
+          "id",
+          "title"
+        ],
+        "type": "object"
+      },
+      "ValueSourceType": {
+        "description": "`ValueSourceType` 记录值来自表单定义中的静态设置，还是工作流运行期间的变量。",
+        "enum": [
+          "constant",
+          "variable"
+        ],
+        "type": "string"
+      },
+      "WorkflowAppLogPaginationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WorkflowAppLogPartialResponse"
+            },
+            "type": "array",
+            "description": "当前页的工作流日志记录。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "是否还有更多工作流日志记录。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "每页条目数。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "当前页码。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "匹配的工作流日志记录总数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "WorkflowAppLogPartialResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间，Unix 秒级时间戳。"
+          },
+          "created_by_account": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleAccountResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "由管理员用户创建时的账户详情。"
+          },
+          "created_by_end_user": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleEndUser"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建工作流运行的终端用户。"
+          },
+          "created_by_role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建者的角色（例如 `end_user`、`account`）。"
+          },
+          "created_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "工作流运行的来源（例如 `service-api`）。"
+          },
+          "details": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "日志条目的附加详情。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "日志条目 ID。"
+          },
+          "workflow_run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowRunForLogResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "此日志条目的工作流运行详情。"
+          }
+        },
+        "required": [
+          "id"
+        ],
         "type": "object"
       },
       "WorkflowBlockingResponse": {
@@ -15248,6 +20336,145 @@
         "type": "object",
         "description": "工作流执行等待人工输入时返回的阻塞响应。"
       },
+      "WorkflowRunForLogResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间，Unix 秒级时间戳。"
+          },
+          "elapsed_time": {
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "总耗时（秒）。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "工作流失败时的错误消息。"
+          },
+          "exceptions_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "执行期间发生的异常数量。"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "结束时间，Unix 秒级时间戳；未结束时为 `null`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "工作流运行 ID。"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "工作流执行状态。`running` 表示执行中，`succeeded` 表示成功完成，`failed` 表示执行出错，`stopped` 表示手动停止，`partial-succeeded` 表示部分节点成功但其他失败，`paused` 表示等待人工介入。"
+          },
+          "total_steps": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "已执行的工作流总步数。"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "消耗的总令牌数。"
+          },
+          "triggered_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "触发工作流运行的来源。`app-run` 表示从应用或 API 发起的运行，`webhook` 表示由 Webhook 触发器发起的运行，`schedule` 表示由定时触发器发起的运行，`plugin` 表示由集成触发器发起的运行。"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "工作流版本标识符。"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
       "WorkflowRunPayload": {
         "properties": {
           "files": {
@@ -15459,6 +20686,361 @@
         },
         "required": [
           "inputs"
+        ],
+        "type": "object"
+      },
+      "WorkflowRunPayloadWithUser": {
+        "properties": {
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remote_url",
+                        "transfer_method",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+                          "enum": [
+                            "remote_url"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "remote_url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时，`remote_url` 是 `url` 的旧版别名。",
+                          "format": "url",
+                          "type": "string"
+                        },
+                        "transfer_method": {
+                          "description": "传输方式：`url` 使用 `remote_url`；[上传文件](/zh/api-reference/files/upload-file)返回的 `id` 使用 `local_file`。为兼容已存储的旧版引用，`remote_url` 也可能与 `upload_file_id` 同时出现。",
+                          "enum": [
+                            "local_file"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "文件类型。",
+                          "enum": [
+                            "audio",
+                            "custom",
+                            "document",
+                            "image",
+                            "video"
+                          ],
+                          "type": "string"
+                        },
+                        "upload_file_id": {
+                          "description": "从[上传文件](/zh/api-reference/files/upload-file) API 获取的文件 ID。使用 `local_file` 时必填；为兼容已持久化的文件引用，也可与 `remote_url` 一起使用。",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "当 `transfer_method` 为 `remote_url` 时使用的文件 URL。",
+                          "format": "url",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "transfer_method",
+                        "type",
+                        "upload_file_id"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "工作流系统文件输入列表。仅在工作流启用文件上传时可用。要附加本地文件，请先通过[上传文件](/zh/api-reference/files/upload-file)上传，然后将返回的 `id` 用作 `upload_file_id`，并将 `transfer_method` 设置为 `local_file`。"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "工作流输入变量的键值对。文件类型变量的值应为文件对象数组，每个对象包含 `type`、`transfer_method`，以及 `url` 或 `upload_file_id`。请参考[获取应用参数](/zh/api-reference/applications/get-app-parameters)响应中的 `user_input_form` 字段，了解应用所需的变量名称和类型。",
+            "type": "object"
+          },
+          "response_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "blocking",
+                  "streaming"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "响应模式。同步响应使用 `blocking`，服务器发送事件（SSE）使用 `streaming`。省略时，请求使用阻塞模式。"
+          },
+          "user": {
+            "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputs",
+          "user"
+        ],
+        "type": "object"
+      },
+      "WorkflowRunResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间，Unix 秒级时间戳。"
+          },
+          "elapsed_time": {
+            "anyOf": [
+              {
+                "format": "float",
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "总耗时（秒）。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "工作流失败时的错误消息。"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "int64",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "结束时间，Unix 秒级时间戳；未结束时为 `null`。"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "工作流运行 ID。"
+          },
+          "inputs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "工作流运行的输入。JSON 值可以是对象、数组、基本类型或 `null`；它已按响应 schema 解码，无需再次进行 JSON 解析。"
+          },
+          "outputs": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "工作流的输出数据。尚无输出时为空对象。"
+          },
+          "status": {
+            "type": "string",
+            "description": "工作流执行状态。`running` 表示执行中，`succeeded` 表示成功完成，`failed` 表示执行出错，`stopped` 表示手动停止，`partial-succeeded` 表示部分节点成功但其他失败，`paused` 表示等待人工介入。"
+          },
+          "total_steps": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "已执行的工作流总步数。"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "消耗的总令牌数。"
+          },
+          "workflow_id": {
+            "format": "uuid",
+            "type": "string",
+            "description": "此次运行使用的工作流定义 ID。"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "workflow_id"
         ],
         "type": "object"
       },


### PR DESCRIPTION
## Summary

- align 76 schemas used only by application Service API operations
- add the corresponding reviewed English, Chinese, and Japanese overlay actions
- leave operation paths unchanged for the dedicated application-reference layer

## Validation

- three-locale structural parity — 0 issues