### PR TITLE
docs: align knowledge api schemas

### DIFF
--- a/en/api-reference/openapi_service.json
+++ b/en/api-reference/openapi_service.json
@@ -15029,6 +15029,30 @@
         ],
         "type": "object"
       },
+      "ChildChunkCreatePayload": {
+        "properties": {
+          "content": {
+            "description": "Child chunk text content.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "ChildChunkDetailResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ChildChunkResponse",
+            "description": "Child chunk details."
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "ChildChunkListQuery": {
         "properties": {
           "keyword": {
@@ -15056,6 +15080,100 @@
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "ChildChunkListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ChildChunkResponse"
+            },
+            "type": "array",
+            "description": "List of child chunks."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Number of items per page."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number."
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of child chunks."
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "Total number of pages."
+          }
+        },
+        "required": [
+          "data",
+          "limit",
+          "page",
+          "total",
+          "total_pages"
+        ],
+        "type": "object"
+      },
+      "ChildChunkResponse": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Text content of the child chunk."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "Creation timestamp (Unix epoch in seconds)."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the child chunk."
+          },
+          "position": {
+            "type": "integer",
+            "description": "Position of the child chunk within the parent chunk."
+          },
+          "segment_id": {
+            "type": "string",
+            "description": "ID of the parent chunk this child chunk belongs to."
+          },
+          "type": {
+            "type": "string",
+            "description": "How the child chunk was created. Child chunks created or updated through the API are always `customized`. System-generated child chunks are `automatic`."
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "Last update timestamp (Unix epoch in seconds)."
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "Word count of the child chunk content."
+          }
+        },
+        "required": [
+          "content",
+          "created_at",
+          "id",
+          "position",
+          "segment_id",
+          "type",
+          "updated_at",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "ChildChunkUpdatePayload": {
+        "properties": {
+          "content": {
+            "description": "Child chunk text content.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
         "type": "object"
       },
       "CompletionBlockingResponse": {
@@ -15553,6 +15671,65 @@
         ],
         "type": "object"
       },
+      "Condition": {
+        "description": "Condition detail",
+        "properties": {
+          "comparison_operator": {
+            "description": "Comparison to apply. String operators (`contains`, `not contains`, `start with`, `end with`, `is`, `is not`, `empty`, `not empty`, `in`, `not in`) act on string or array metadata; numeric operators (`=`, `≠`, `>`, `<`, `≥`, `≤`) act on numeric metadata; time operators (`before`, `after`) act on time metadata.",
+            "enum": [
+              "<",
+              "=",
+              ">",
+              "after",
+              "before",
+              "contains",
+              "empty",
+              "end with",
+              "in",
+              "is",
+              "is not",
+              "not contains",
+              "not empty",
+              "not in",
+              "start with",
+              "≠",
+              "≤",
+              "≥"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "description": "Metadata field name to compare against.",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Value to compare against. Type depends on `comparison_operator`: string for most string operators, array of strings for `in` and `not in`, number for numeric operators, and omit or use `null` for `empty` and `not empty`."
+          }
+        },
+        "required": [
+          "comparison_operator",
+          "name"
+        ],
+        "type": "object"
+      },
       "ConversationInfiniteScrollPagination": {
         "properties": {
           "data": {
@@ -15931,6 +16108,984 @@
         },
         "type": "object"
       },
+      "CustomConfigurationStatus": {
+        "description": "Enum class for custom configuration status.",
+        "enum": [
+          "active",
+          "no-configure"
+        ],
+        "type": "string"
+      },
+      "DatasetBoundTagListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetBoundTagResponse"
+            },
+            "type": "array",
+            "description": "List of tags bound to this knowledge base."
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of tags bound to this knowledge base."
+          }
+        },
+        "required": [
+          "data",
+          "total"
+        ],
+        "type": "object"
+      },
+      "DatasetBoundTagResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Tag identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Tag display name."
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "DatasetCreatePayload": {
+        "properties": {
+          "description": {
+            "default": "",
+            "description": "Description of the knowledge base.",
+            "maxLength": 400,
+            "type": "string"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Embedding model name. Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Embedding model provider. Use the `provider` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+          },
+          "external_knowledge_api_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the external knowledge API."
+          },
+          "external_knowledge_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the external knowledge base."
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "enum": [
+                  "economy",
+                  "high_quality"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`high_quality` uses embedding models for precise search; `economy` uses keyword-based indexing."
+          },
+          "name": {
+            "description": "Name of the knowledge base.",
+            "maxLength": 40,
+            "minLength": 1,
+            "type": "string"
+          },
+          "permission": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PermissionEnum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "only_me",
+            "description": "Controls who can access this knowledge base. `only_me` restricts access to the creator, `all_team_members` grants workspace-wide access, and `partial_members` grants access to specified members."
+          },
+          "provider": {
+            "default": "vendor",
+            "description": "Knowledge base provider: `vendor` for internal knowledge bases, `external` for external ones.",
+            "enum": [
+              "external",
+              "vendor"
+            ],
+            "type": "string"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Retrieval model configuration. Controls how chunks are searched and ranked."
+          },
+          "summary_index_setting": {
+            "anyOf": [
+              {
+                "properties": {
+                  "enable": {
+                    "description": "Whether to enable summary indexing.",
+                    "type": "boolean"
+                  },
+                  "model_name": {
+                    "description": "Name of the model used for generating summaries.",
+                    "type": "string"
+                  },
+                  "model_provider_name": {
+                    "description": "Provider of the summary generation model.",
+                    "type": "string"
+                  },
+                  "summary_prompt": {
+                    "description": "Custom prompt template for summary generation.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Summary index configuration."
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "DatasetDetailResponse": {
+        "properties": {
+          "app_count": {
+            "type": "integer",
+            "description": "Number of applications currently using this knowledge base."
+          },
+          "author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the creator."
+          },
+          "built_in_field_enabled": {
+            "type": "boolean",
+            "description": "Whether built-in metadata fields (e.g., `document_name`, `uploader`) are enabled."
+          },
+          "chunk_structure": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Chunk structure configuration."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "Creation timestamp (Unix epoch in seconds)."
+          },
+          "created_by": {
+            "type": "string",
+            "description": "ID of the user who created the knowledge base."
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Data source type of the documents, `null` if not yet configured."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional text describing the purpose or contents of the knowledge base."
+          },
+          "doc_form": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Document chunking mode. `text_model` for standard text chunking, `hierarchical_model` for parent-child structure, `qa_model` for QA pair extraction."
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetDocMetadataResponse"
+            },
+            "type": "array",
+            "description": "Metadata field definitions for the knowledge base."
+          },
+          "document_count": {
+            "type": "integer",
+            "description": "Total number of documents in the knowledge base."
+          },
+          "embedding_available": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether the configured embedding model is currently available."
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Name of the embedding model used for indexing."
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Embedding model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). Legacy knowledge bases may return the bare short form (e.g. `openai`)."
+          },
+          "enable_api": {
+            "type": "boolean",
+            "description": "Whether API access is enabled for this knowledge base."
+          },
+          "external_knowledge_info": {
+            "$ref": "#/components/schemas/DatasetExternalKnowledgeInfoResponse",
+            "description": "Connection details for external knowledge bases. Present when `provider` is `external`."
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetExternalRetrievalModelResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Retrieval settings for external knowledge bases. `null` for internal knowledge bases."
+          },
+          "icon_info": {
+            "$ref": "#/components/schemas/DatasetIconInfoResponse",
+            "description": "Icon display configuration for the knowledge base."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the knowledge base."
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "`high_quality` uses embedding models for precise search; `economy` uses keyword-based indexing."
+          },
+          "is_multimodal": {
+            "type": "boolean",
+            "description": "Whether multimodal content processing is enabled."
+          },
+          "is_published": {
+            "type": "boolean",
+            "description": "Whether the knowledge base is published."
+          },
+          "maintainer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Display name of the knowledge base maintainer. `null` if not set."
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name of the knowledge base. Unique within the workspace."
+          },
+          "permission": {
+            "type": "string",
+            "description": "Controls who can access this knowledge base. Possible values: `only_me`, `all_team_members`, `partial_members`."
+          },
+          "permission_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Permission identifiers granted to the current caller."
+          },
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Pipeline ID, if a custom processing pipeline is configured."
+          },
+          "provider": {
+            "type": "string",
+            "description": "Provider type. `vendor` for internally managed, `external` for external knowledge base connections."
+          },
+          "retrieval_model_dict": {
+            "$ref": "#/components/schemas/DatasetRetrievalModelResponse",
+            "description": "Retrieval configuration for the knowledge base."
+          },
+          "runtime_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Runtime processing mode."
+          },
+          "summary_index_setting": {
+            "$ref": "#/components/schemas/DatasetSummaryIndexSettingResponse",
+            "description": "Summary index configuration."
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetTagResponse"
+            },
+            "type": "array",
+            "description": "Tags associated with this knowledge base."
+          },
+          "total_available_documents": {
+            "type": "integer",
+            "description": "Number of documents that are enabled and available."
+          },
+          "total_documents": {
+            "type": "integer",
+            "description": "Total number of documents."
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "Last update timestamp (Unix epoch in seconds)."
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the user who last updated the knowledge base."
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "Total word count across all documents."
+          }
+        },
+        "required": [
+          "app_count",
+          "author_name",
+          "built_in_field_enabled",
+          "chunk_structure",
+          "created_at",
+          "created_by",
+          "data_source_type",
+          "description",
+          "doc_form",
+          "doc_metadata",
+          "document_count",
+          "embedding_model",
+          "embedding_model_provider",
+          "enable_api",
+          "external_retrieval_model",
+          "id",
+          "indexing_technique",
+          "is_multimodal",
+          "is_published",
+          "name",
+          "permission",
+          "pipeline_id",
+          "provider",
+          "retrieval_model_dict",
+          "runtime_mode",
+          "tags",
+          "total_available_documents",
+          "total_documents",
+          "updated_at",
+          "updated_by",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "DatasetDetailWithPartialMembersResponse": {
+        "properties": {
+          "app_count": {
+            "type": "integer",
+            "description": "Number of applications currently using this knowledge base."
+          },
+          "author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the creator."
+          },
+          "built_in_field_enabled": {
+            "type": "boolean",
+            "description": "Whether built-in metadata fields (e.g., `document_name`, `uploader`) are enabled."
+          },
+          "chunk_structure": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Chunk structure configuration."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "Creation timestamp (Unix epoch in seconds)."
+          },
+          "created_by": {
+            "type": "string",
+            "description": "ID of the user who created the knowledge base."
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Data source type of the documents, `null` if not yet configured."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional text describing the purpose or contents of the knowledge base."
+          },
+          "doc_form": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Document chunking mode. `text_model` for standard text chunking, `hierarchical_model` for parent-child structure, `qa_model` for QA pair extraction."
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetDocMetadataResponse"
+            },
+            "type": "array",
+            "description": "Metadata field definitions for the knowledge base."
+          },
+          "document_count": {
+            "type": "integer",
+            "description": "Total number of documents in the knowledge base."
+          },
+          "embedding_available": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether the configured embedding model is currently available."
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Name of the embedding model used for indexing."
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Embedding model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). Legacy knowledge bases may return the bare short form (e.g. `openai`)."
+          },
+          "enable_api": {
+            "type": "boolean",
+            "description": "Whether API access is enabled for this knowledge base."
+          },
+          "external_knowledge_info": {
+            "$ref": "#/components/schemas/DatasetExternalKnowledgeInfoResponse",
+            "description": "Connection details for external knowledge bases. Present when `provider` is `external`."
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetExternalRetrievalModelResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Retrieval settings for external knowledge bases. `null` for internal knowledge bases."
+          },
+          "icon_info": {
+            "$ref": "#/components/schemas/DatasetIconInfoResponse",
+            "description": "Icon display configuration for the knowledge base."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the knowledge base."
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "`high_quality` uses embedding models for precise search; `economy` uses keyword-based indexing."
+          },
+          "is_multimodal": {
+            "type": "boolean",
+            "description": "Whether multimodal content processing is enabled."
+          },
+          "is_published": {
+            "type": "boolean",
+            "description": "Whether the knowledge base is published."
+          },
+          "maintainer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Display name of the knowledge base maintainer. `null` if not set."
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name of the knowledge base. Unique within the workspace."
+          },
+          "partial_member_list": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Account IDs of members granted access when `permission` is `partial_members`. Always present on the update response; on the detail response, present only when `permission` is `partial_members`."
+          },
+          "permission": {
+            "type": "string",
+            "description": "Controls who can access this knowledge base. Possible values: `only_me`, `all_team_members`, `partial_members`."
+          },
+          "permission_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Permission identifiers granted to the current caller."
+          },
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Pipeline ID, if a custom processing pipeline is configured."
+          },
+          "provider": {
+            "type": "string",
+            "description": "Provider type. `vendor` for internally managed, `external` for external knowledge base connections."
+          },
+          "retrieval_model_dict": {
+            "$ref": "#/components/schemas/DatasetRetrievalModelResponse",
+            "description": "Retrieval configuration for the knowledge base."
+          },
+          "runtime_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Runtime processing mode."
+          },
+          "summary_index_setting": {
+            "$ref": "#/components/schemas/DatasetSummaryIndexSettingResponse",
+            "description": "Summary index configuration."
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetTagResponse"
+            },
+            "type": "array",
+            "description": "Tags associated with this knowledge base."
+          },
+          "total_available_documents": {
+            "type": "integer",
+            "description": "Number of documents that are enabled and available."
+          },
+          "total_documents": {
+            "type": "integer",
+            "description": "Total number of documents."
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "Last update timestamp (Unix epoch in seconds)."
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the user who last updated the knowledge base."
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "Total word count across all documents."
+          }
+        },
+        "required": [
+          "app_count",
+          "author_name",
+          "built_in_field_enabled",
+          "chunk_structure",
+          "created_at",
+          "created_by",
+          "data_source_type",
+          "description",
+          "doc_form",
+          "doc_metadata",
+          "document_count",
+          "embedding_model",
+          "embedding_model_provider",
+          "enable_api",
+          "external_retrieval_model",
+          "id",
+          "indexing_technique",
+          "is_multimodal",
+          "is_published",
+          "name",
+          "permission",
+          "pipeline_id",
+          "provider",
+          "retrieval_model_dict",
+          "runtime_mode",
+          "tags",
+          "total_available_documents",
+          "total_documents",
+          "updated_at",
+          "updated_by",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "DatasetDocMetadataResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Metadata field ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Metadata field name."
+          },
+          "type": {
+            "type": "string",
+            "description": "Metadata value type."
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetExternalKnowledgeInfoResponse": {
+        "properties": {
+          "external_knowledge_api_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Endpoint URL of the external knowledge API."
+          },
+          "external_knowledge_api_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the external knowledge API connection."
+          },
+          "external_knowledge_api_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Display name of the external knowledge API."
+          },
+          "external_knowledge_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the external knowledge base."
+          }
+        },
+        "type": "object"
+      },
+      "DatasetExternalRetrievalModelResponse": {
+        "properties": {
+          "score_threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Minimum score required for a retrieval result."
+          },
+          "score_threshold_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether score threshold filtering is enabled."
+          },
+          "top_k": {
+            "type": "integer",
+            "description": "Maximum number of retrieval results."
+          }
+        },
+        "required": [
+          "top_k"
+        ],
+        "type": "object"
+      },
+      "DatasetIconInfoResponse": {
+        "properties": {
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Icon identifier or emoji."
+          },
+          "icon_background": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Background color for the icon."
+          },
+          "icon_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Type of icon."
+          },
+          "icon_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "URL of a custom icon image."
+          }
+        },
+        "type": "object"
+      },
+      "DatasetKeywordSettingResponse": {
+        "properties": {
+          "keyword_weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Weight assigned to keyword search results."
+          }
+        },
+        "type": "object"
+      },
       "DatasetListQuery": {
         "properties": {
           "include_all": {
@@ -15970,6 +17125,738 @@
         },
         "type": "object"
       },
+      "DatasetListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetDetailResponse"
+            },
+            "type": "array",
+            "description": "Knowledge bases on the current page."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether more knowledge bases are available."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Number of items per page."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number."
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of matching knowledge bases."
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataActionResponse": {
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "Result of the metadata action."
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataBuiltInFieldResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Built-in metadata field name."
+          },
+          "type": {
+            "type": "string",
+            "description": "Built-in metadata value type."
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataBuiltInFieldsResponse": {
+        "properties": {
+          "fields": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetMetadataBuiltInFieldResponse"
+            },
+            "type": "array",
+            "description": "List of system-provided metadata fields."
+          }
+        },
+        "required": [
+          "fields"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataListItemResponse": {
+        "properties": {
+          "count": {
+            "default": 0,
+            "type": "integer",
+            "description": "Number of documents using this metadata field."
+          },
+          "id": {
+            "type": "string",
+            "description": "Metadata field identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Metadata field name."
+          },
+          "type": {
+            "type": "string",
+            "description": "Metadata field type."
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataListResponse": {
+        "properties": {
+          "built_in_field_enabled": {
+            "type": "boolean",
+            "description": "Whether built-in metadata fields are enabled for this knowledge base."
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetMetadataListItemResponse"
+            },
+            "type": "array",
+            "description": "List of metadata field definitions."
+          }
+        },
+        "required": [
+          "built_in_field_enabled",
+          "doc_metadata"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Metadata field ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Metadata field name."
+          },
+          "type": {
+            "type": "string",
+            "description": "Metadata value type."
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetRerankingModelResponse": {
+        "properties": {
+          "reranking_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the reranking model."
+          },
+          "reranking_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Provider of the reranking model."
+          }
+        },
+        "type": "object"
+      },
+      "DatasetRetrievalModelResponse": {
+        "properties": {
+          "reranking_enable": {
+            "type": "boolean",
+            "description": "Whether reranking is enabled."
+          },
+          "reranking_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Reranking mode. `reranking_model` for model-based reranking, `weighted_score` for score-based weighting. `null` if reranking is disabled."
+          },
+          "reranking_model": {
+            "$ref": "#/components/schemas/DatasetRerankingModelResponse",
+            "description": "Reranking model configuration."
+          },
+          "score_threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Minimum similarity score for results. Only effective when `score_threshold_enabled` is `true`."
+          },
+          "score_threshold_enabled": {
+            "type": "boolean",
+            "description": "Whether score threshold filtering is enabled."
+          },
+          "search_method": {
+            "type": "string",
+            "description": "Search method used for retrieval. `keyword_search` for keyword matching, `semantic_search` for embedding-based similarity, `full_text_search` for full-text indexing, `hybrid_search` for a combination of semantic and keyword approaches."
+          },
+          "top_k": {
+            "type": "integer",
+            "description": "Maximum number of results to return."
+          },
+          "weights": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetWeightedScoreResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Weight configuration for hybrid search."
+          }
+        },
+        "required": [
+          "reranking_enable",
+          "score_threshold_enabled",
+          "search_method",
+          "top_k"
+        ],
+        "type": "object"
+      },
+      "DatasetSummaryIndexSettingResponse": {
+        "properties": {
+          "enable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether summary indexing is enabled."
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the model used for generating summaries."
+          },
+          "model_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Provider of the summary generation model."
+          },
+          "summary_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Prompt used to generate document summaries."
+          }
+        },
+        "type": "object"
+      },
+      "DatasetTagResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Tag ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Tag name."
+          },
+          "type": {
+            "type": "string",
+            "description": "Tag type."
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetUpdatePayload": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 400,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Description of the knowledge base."
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Embedding model name. Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Embedding model provider. Use the `provider` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+          },
+          "external_knowledge_api_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the external knowledge API."
+          },
+          "external_knowledge_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the external knowledge base."
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "properties": {
+                  "score_threshold": {
+                    "description": "Minimum similarity score threshold for filtering results.",
+                    "type": "number"
+                  },
+                  "score_threshold_enabled": {
+                    "description": "Whether score threshold filtering is enabled.",
+                    "type": "boolean"
+                  },
+                  "top_k": {
+                    "description": "Maximum number of results to return.",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Retrieval settings for external knowledge bases."
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "enum": [
+                  "economy",
+                  "high_quality"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`high_quality` uses embedding models for precise search; `economy` uses keyword-based indexing."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 40,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the knowledge base."
+          },
+          "partial_member_list": {
+            "anyOf": [
+              {
+                "items": {
+                  "properties": {
+                    "user_id": {
+                      "description": "ID of the team member to grant access.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "List of team members with access when `permission` is `partial_members`."
+          },
+          "permission": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PermissionEnum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Controls who can access this knowledge base. `only_me` restricts access to the creator, `all_team_members` grants workspace-wide access, and `partial_members` grants access to specified members."
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Retrieval model configuration. Controls how chunks are searched and ranked."
+          }
+        },
+        "type": "object"
+      },
+      "DatasetVectorSettingResponse": {
+        "properties": {
+          "embedding_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the embedding model used for vector search."
+          },
+          "embedding_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Provider of the embedding model used for vector search."
+          },
+          "vector_weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Weight assigned to semantic (vector) search results."
+          }
+        },
+        "type": "object"
+      },
+      "DatasetWeightedScoreResponse": {
+        "properties": {
+          "keyword_setting": {
+            "$ref": "#/components/schemas/DatasetKeywordSettingResponse",
+            "description": "Keyword search weight settings."
+          },
+          "vector_setting": {
+            "$ref": "#/components/schemas/DatasetVectorSettingResponse",
+            "description": "Semantic search weight settings."
+          },
+          "weight_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Strategy for balancing semantic and keyword search weights."
+          }
+        },
+        "type": "object"
+      },
+      "DatasourceCredentialInfoResponse": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Credential ID. Pass this as `credential_id` to [Run Datasource Node](/en/api-reference/knowledge-pipeline/run-datasource-node) or in per-item `credential_id` fields of [Run Pipeline](/en/api-reference/knowledge-pipeline/run-pipeline)."
+          },
+          "is_default": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether this credential is the default for the provider."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Display name of the credential."
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Credential type defined by the datasource plugin."
+          }
+        },
+        "type": "object"
+      },
+      "DatasourceNodeRunPayload": {
+        "properties": {
+          "credential_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Datasource credential ID. Uses the default if omitted."
+          },
+          "datasource_type": {
+            "description": "Type of the datasource.",
+            "enum": [
+              "local_file",
+              "online_document",
+              "online_drive",
+              "website_crawl"
+            ],
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "Input variables for the datasource node.",
+            "type": "object"
+          },
+          "is_published": {
+            "description": "Whether to run the published or draft version of the node. `true` runs the published version, `false` runs the draft.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "datasource_type",
+          "inputs",
+          "is_published"
+        ],
+        "type": "object"
+      },
+      "DatasourcePluginListResponse": {
+        "items": {
+          "$ref": "#/components/schemas/DatasourcePluginResponse"
+        },
+        "type": "array"
+      },
+      "DatasourcePluginResponse": {
+        "properties": {
+          "credentials": {
+            "items": {
+              "$ref": "#/components/schemas/DatasourceCredentialInfoResponse"
+            },
+            "type": "array",
+            "description": "Credentials available for authenticating with this datasource."
+          },
+          "datasource_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Type of datasource. One of `local_file`, `online_document`, `online_drive`, `website_crawl`."
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the datasource node in the pipeline workflow. Pass this as `node_id` to [Run Datasource Node](/en/api-reference/knowledge-pipeline/run-datasource-node), or as `start_node_id` to [Run Pipeline](/en/api-reference/knowledge-pipeline/run-pipeline)."
+          },
+          "plugin_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the datasource plugin providing this node."
+          },
+          "provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Provider name registered by the datasource plugin."
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Plugin display title."
+          },
+          "user_input_variables": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "description": "Pipeline input variables the caller must supply for this datasource, derived from `{{#...#}}` references in the node's datasource parameters. Each item follows the pipeline variable schema used by the workflow."
+          }
+        },
+        "type": "object"
+      },
       "DatasourcePluginsQuery": {
         "properties": {
           "is_published": {
@@ -15978,6 +17865,312 @@
             "type": "boolean"
           }
         },
+        "type": "object"
+      },
+      "DocumentAndBatchResponse": {
+        "properties": {
+          "batch": {
+            "type": "string",
+            "description": "Batch ID for tracking indexing progress."
+          },
+          "document": {
+            "$ref": "#/components/schemas/DocumentResponse",
+            "description": "Parent document information for the matched chunk."
+          }
+        },
+        "required": [
+          "batch",
+          "document"
+        ],
+        "type": "object"
+      },
+      "DocumentBatchDownloadZipPayload": {
+        "description": "Request payload for bulk downloading documents as a zip archive.",
+        "properties": {
+          "document_ids": {
+            "description": "List of document IDs to include in the ZIP download.",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "document_ids"
+        ],
+        "type": "object"
+      },
+      "DocumentDetailResponse": {
+        "properties": {
+          "archived": {
+            "default": null,
+            "type": "boolean",
+            "description": "Whether the document is archived."
+          },
+          "average_segment_length": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "default": null,
+            "description": "Average character length of chunks."
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Completion time as a Unix timestamp in seconds; `null` if not completed."
+          },
+          "created_at": {
+            "default": null,
+            "type": "integer",
+            "description": "Creation time as a Unix timestamp in seconds."
+          },
+          "created_by": {
+            "default": null,
+            "type": "string",
+            "description": "ID of the user who created the document."
+          },
+          "created_from": {
+            "default": null,
+            "type": "string",
+            "description": "Origin of the document. `api` for API creation, `web` for UI creation."
+          },
+          "data_source_info": {
+            "additionalProperties": true,
+            "default": null,
+            "type": "object",
+            "description": "Data source details. For file uploads, this detail endpoint returns the full file object under `upload_file` (the list endpoint returns only `upload_file_id`)."
+          },
+          "data_source_type": {
+            "default": null,
+            "type": "string",
+            "description": "How the document was uploaded. `upload_file` for file uploads, `notion_import` for Notion imports."
+          },
+          "dataset_process_rule": {
+            "additionalProperties": true,
+            "default": null,
+            "type": "object",
+            "description": "Knowledge-base-level processing rule configuration."
+          },
+          "dataset_process_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the processing rule applied to this document."
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Disable time as a Unix timestamp in seconds; `null` if enabled."
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the user who disabled the document, `null` if enabled."
+          },
+          "display_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Display-friendly indexing status for the UI."
+          },
+          "doc_form": {
+            "default": null,
+            "type": "string",
+            "description": "Document chunking mode. `text_model` for standard text, `hierarchical_model` for parent-child, `qa_model` for QA pairs."
+          },
+          "doc_language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Language of the document content."
+          },
+          "doc_metadata": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DocumentMetadataResponse"
+                },
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Custom metadata key-value pairs for this document."
+          },
+          "doc_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Document type classification, `null` if not set."
+          },
+          "document_process_rule": {
+            "additionalProperties": true,
+            "default": null,
+            "type": "object",
+            "description": "Document-level processing rule configuration."
+          },
+          "enabled": {
+            "default": null,
+            "type": "boolean",
+            "description": "Whether the document is enabled for retrieval."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Error message if indexing failed, `null` otherwise."
+          },
+          "hit_count": {
+            "default": null,
+            "type": "integer",
+            "description": "Number of times this document has been retrieved."
+          },
+          "id": {
+            "type": "string",
+            "description": "Document identifier."
+          },
+          "indexing_latency": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Time taken for indexing in seconds, `null` if not completed."
+          },
+          "indexing_status": {
+            "default": null,
+            "type": "string",
+            "description": "Current indexing status, e.g. `waiting`, `parsing`, `cleaning`, `splitting`, `indexing`, `completed`, `error`, `paused`."
+          },
+          "name": {
+            "default": null,
+            "type": "string",
+            "description": "Document name."
+          },
+          "need_summary": {
+            "default": null,
+            "type": "boolean",
+            "description": "Whether the document needs summary generation."
+          },
+          "position": {
+            "default": null,
+            "type": "integer",
+            "description": "Position index within the knowledge base."
+          },
+          "segment_count": {
+            "default": null,
+            "type": "integer",
+            "description": "Number of chunks in the document."
+          },
+          "summary_index_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Status of summary indexing, `null` if summary index is not enabled."
+          },
+          "tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Number of tokens in the document."
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Last update time as a Unix timestamp in seconds."
+          }
+        },
+        "required": [
+          "id"
+        ],
         "type": "object"
       },
       "DocumentGetQuery": {
@@ -16039,6 +18232,877 @@
             ],
             "default": null,
             "description": "Filter by display status."
+          }
+        },
+        "type": "object"
+      },
+      "DocumentListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentResponse"
+            },
+            "type": "array",
+            "description": "Documents on the current page."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether more documents are available."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Number of items per page."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number."
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of matching documents."
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "DocumentMetadataOperation": {
+        "properties": {
+          "document_id": {
+            "description": "Document ID whose metadata should be updated.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "metadata_list": {
+            "description": "Metadata fields to update.",
+            "items": {
+              "$ref": "#/components/schemas/MetadataDetail"
+            },
+            "type": "array"
+          },
+          "partial_update": {
+            "default": false,
+            "description": "Whether to partially update metadata, keeping existing values for unspecified fields.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "document_id",
+          "metadata_list"
+        ],
+        "type": "object"
+      },
+      "DocumentMetadataResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Metadata field identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Metadata field name."
+          },
+          "type": {
+            "type": "string",
+            "description": "Metadata field value type."
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Metadata value for this document."
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DocumentResponse": {
+        "properties": {
+          "archived": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether the document is archived."
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Creation timestamp (Unix epoch in seconds)."
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the user who created the document."
+          },
+          "created_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Origin of the document. `api` for API creation, `web` for UI creation."
+          },
+          "data_source_detail_dict": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "Detailed data source information including file details."
+          },
+          "data_source_info": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Raw data source information, varies by `data_source_type`."
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "How the document was created. `upload_file` for file uploads, `notion_import` for Notion imports."
+          },
+          "dataset_process_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the processing rule applied to this document."
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Disable time as a Unix timestamp in seconds; `null` if enabled."
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the user who disabled the document. `null` if enabled."
+          },
+          "display_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "User-facing display status derived from `indexing_status` and `enabled` state."
+          },
+          "doc_form": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Document chunking mode. `text_model` for standard text chunking, `hierarchical_model` for parent-child structure, `qa_model` for QA pair extraction."
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentMetadataResponse"
+            },
+            "type": "array",
+            "description": "Metadata values assigned to this document."
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether the document is enabled for retrieval."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Error message if indexing failed. `null` when no error."
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Number of times the document has been matched in retrieval queries."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the document."
+          },
+          "indexing_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Current indexing status. `waiting` for queued, `parsing` while extracting content, `cleaning` while removing noise, `splitting` while chunking, `indexing` while building vectors, `completed` when ready, `error` if failed, `paused` if manually paused."
+          },
+          "name": {
+            "type": "string",
+            "description": "Document name."
+          },
+          "need_summary": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether a summary needs to be generated for this document."
+          },
+          "position": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Display position of the document in the list."
+          },
+          "summary_index_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Status of the summary index for this document. `null` if summary indexing is not configured."
+          },
+          "tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total number of tokens in the document."
+          },
+          "word_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total word count of the document."
+          }
+        },
+        "required": [
+          "data_source_detail_dict",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "DocumentStatusListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentStatusResponse"
+            },
+            "type": "array",
+            "description": "Document processing status records."
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "DocumentStatusPayload": {
+        "properties": {
+          "document_ids": {
+            "description": "List of document IDs to update. This field is optional for compatibility; when omitted or empty, the request succeeds without updating any documents.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentStatusResponse": {
+        "properties": {
+          "cleaning_completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unix timestamp in seconds when cleaning completed."
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unix timestamp in seconds when indexing completed."
+          },
+          "completed_segments": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Number of chunks that have been indexed."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error message if indexing failed. `null` if no error."
+          },
+          "error_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Processing error code, or `null` when no error occurred."
+          },
+          "estimated_vector_space_mb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Estimated vector storage usage in megabytes."
+          },
+          "id": {
+            "type": "string",
+            "description": "Document identifier."
+          },
+          "indexing_status": {
+            "type": "string",
+            "description": "Current indexing status: `waiting`, `parsing`, `cleaning`, `splitting`, `indexing`, `completed`, `error`, or `paused`. Treat `completed` and `error` as terminal. The Service API cannot resume `paused` documents; resume them in the Dify knowledge-base console before polling again."
+          },
+          "parsing_completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unix timestamp in seconds when parsing completed."
+          },
+          "paused_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unix timestamp in seconds when indexing was paused. `null` if not paused."
+          },
+          "processing_started_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unix timestamp in seconds when processing started."
+          },
+          "splitting_completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unix timestamp in seconds when splitting completed."
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unix timestamp in seconds when indexing was stopped. `null` if not stopped."
+          },
+          "total_segments": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total number of chunks to be indexed."
+          },
+          "vector_space_limit_mb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Vector storage limit in megabytes."
+          }
+        },
+        "required": [
+          "cleaning_completed_at",
+          "completed_at",
+          "error",
+          "id",
+          "indexing_status",
+          "parsing_completed_at",
+          "paused_at",
+          "processing_started_at",
+          "splitting_completed_at",
+          "stopped_at"
+        ],
+        "type": "object"
+      },
+      "DocumentTextCreatePayload": {
+        "properties": {
+          "doc_form": {
+            "default": "text_model",
+            "description": "`text_model` for standard text chunking, `hierarchical_model` for parent-child chunk structure, `qa_model` for question-answer pair extraction.",
+            "enum": [
+              "hierarchical_model",
+              "qa_model",
+              "text_model"
+            ],
+            "type": "string"
+          },
+          "doc_language": {
+            "default": "English",
+            "description": "Language of the document for processing optimization.",
+            "type": "string"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Embedding model name. Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Embedding model provider. Use the `provider` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "enum": [
+                  "economy",
+                  "high_quality"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`high_quality` uses embedding models for precise search; `economy` uses keyword-based indexing. Required when adding the first document to a knowledge base; subsequent documents inherit the knowledge base's indexing technique if omitted."
+          },
+          "name": {
+            "description": "Document name.",
+            "type": "string"
+          },
+          "original_document_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Original document ID for replacement."
+          },
+          "process_rule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProcessRule"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Processing rules for chunking."
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Retrieval model configuration. Controls how chunks are searched and ranked."
+          },
+          "text": {
+            "description": "Document text content.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "text"
+        ],
+        "type": "object"
+      },
+      "DocumentTextUpdate": {
+        "anyOf": [
+          {
+            "properties": {
+              "doc_form": {
+                "default": "text_model",
+                "description": "`text_model` for standard text chunking, `hierarchical_model` for parent-child chunk structure, `qa_model` for question-answer pair extraction.",
+                "enum": [
+                  "hierarchical_model",
+                  "qa_model",
+                  "text_model"
+                ],
+                "type": "string"
+              },
+              "doc_language": {
+                "default": "English",
+                "description": "Language of the document for processing optimization.",
+                "type": "string"
+              },
+              "name": {
+                "default": null,
+                "description": "Document name. Required when `text` is provided.",
+                "type": "string"
+              },
+              "process_rule": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ProcessRule"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Processing rules for chunking."
+              },
+              "retrieval_model": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RetrievalModel"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Retrieval model configuration. Controls how chunks are searched and ranked."
+              },
+              "text": {
+                "default": null,
+                "description": "Document text content.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "text"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "doc_form": {
+                "default": "text_model",
+                "description": "`text_model` for standard text chunking, `hierarchical_model` for parent-child chunk structure, `qa_model` for question-answer pair extraction.",
+                "enum": [
+                  "hierarchical_model",
+                  "qa_model",
+                  "text_model"
+                ],
+                "type": "string"
+              },
+              "doc_language": {
+                "default": "English",
+                "description": "Language of the document for processing optimization.",
+                "type": "string"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Document name. Required when `text` is provided."
+              },
+              "process_rule": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ProcessRule"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Processing rules for chunking."
+              },
+              "retrieval_model": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RetrievalModel"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Retrieval model configuration. Controls how chunks are searched and ranked."
+              },
+              "text": {
+                "description": "Document text content.",
+                "type": "null"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "doc_form": {
+            "default": "text_model",
+            "description": "`text_model` for standard text chunking, `hierarchical_model` for parent-child chunk structure, `qa_model` for question-answer pair extraction.",
+            "enum": [
+              "hierarchical_model",
+              "qa_model",
+              "text_model"
+            ],
+            "type": "string"
+          },
+          "doc_language": {
+            "default": "English",
+            "description": "Language of the document for processing optimization.",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Document name. Required when `text` is provided."
+          },
+          "process_rule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProcessRule"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Processing rules for chunking."
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Retrieval model configuration. Controls how chunks are searched and ranked."
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Document text content."
           }
         },
         "type": "object"
@@ -16152,6 +19216,14 @@
           }
         },
         "type": "object"
+      },
+      "FetchFrom": {
+        "description": "Enum class for fetch from.",
+        "enum": [
+          "customizable-model",
+          "predefined-model"
+        ],
+        "type": "string"
       },
       "FileInputConfig": {
         "properties": {
@@ -16463,6 +19535,469 @@
           }
         ]
       },
+      "HitTestingChildChunk": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Text content of the child chunk."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the child chunk."
+          },
+          "position": {
+            "type": "integer",
+            "description": "Position of the child chunk within the parent chunk."
+          },
+          "score": {
+            "type": "number",
+            "description": "Similarity score of the child chunk."
+          }
+        },
+        "required": [
+          "content",
+          "id",
+          "position",
+          "score"
+        ],
+        "type": "object"
+      },
+      "HitTestingDocument": {
+        "properties": {
+          "data_source_type": {
+            "type": "string",
+            "description": "How the document was created."
+          },
+          "doc_metadata": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Metadata values for the document. `null` if no metadata is configured."
+          },
+          "doc_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Document type classification. `null` if not set."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the document."
+          },
+          "name": {
+            "type": "string",
+            "description": "Document name."
+          }
+        },
+        "required": [
+          "data_source_type",
+          "doc_metadata",
+          "doc_type",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "HitTestingFile": {
+        "properties": {
+          "extension": {
+            "type": "string",
+            "description": "File extension."
+          },
+          "id": {
+            "type": "string",
+            "description": "Attachment file identifier."
+          },
+          "mime_type": {
+            "type": "string",
+            "description": "MIME type of the file."
+          },
+          "name": {
+            "type": "string",
+            "description": "Original file name."
+          },
+          "size": {
+            "type": "integer",
+            "description": "File size in bytes."
+          },
+          "source_url": {
+            "type": "string",
+            "description": "URL to access the attachment."
+          }
+        },
+        "required": [
+          "extension",
+          "id",
+          "mime_type",
+          "name",
+          "size",
+          "source_url"
+        ],
+        "type": "object"
+      },
+      "HitTestingPayload": {
+        "properties": {
+          "attachment_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "IDs of image files already attached to knowledge-base chunks, as returned when those chunk attachments are uploaded or created in the Dify console. They add image context to multimodal retrieval testing."
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "properties": {
+                  "score_threshold": {
+                    "description": "Minimum similarity score threshold for filtering results.",
+                    "type": "number"
+                  },
+                  "score_threshold_enabled": {
+                    "description": "Whether score threshold filtering is enabled.",
+                    "type": "boolean"
+                  },
+                  "top_k": {
+                    "description": "Maximum number of results to return.",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Retrieval settings for external knowledge bases."
+          },
+          "query": {
+            "description": "Search query text.",
+            "maxLength": 250,
+            "type": "string"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Retrieval model configuration. Controls how chunks are searched and ranked."
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "HitTestingQuery": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Query text used for retrieval testing."
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "HitTestingRecord": {
+        "properties": {
+          "child_chunks": {
+            "items": {
+              "$ref": "#/components/schemas/HitTestingChildChunk"
+            },
+            "type": "array",
+            "description": "Matched child chunks within the chunk, if using hierarchical indexing."
+          },
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/HitTestingFile"
+            },
+            "type": "array",
+            "description": "Files attached to this chunk."
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Similarity score."
+          },
+          "segment": {
+            "$ref": "#/components/schemas/HitTestingSegment",
+            "description": "Matched chunk from the knowledge base."
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Summary content if retrieved via summary index."
+          },
+          "tsne_position": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "description": "t-SNE visualization position."
+          }
+        },
+        "required": [
+          "child_chunks",
+          "files",
+          "score",
+          "segment",
+          "summary",
+          "tsne_position"
+        ],
+        "type": "object"
+      },
+      "HitTestingResponse": {
+        "properties": {
+          "query": {
+            "$ref": "#/components/schemas/HitTestingQuery",
+            "description": "The original query object."
+          },
+          "records": {
+            "items": {
+              "$ref": "#/components/schemas/HitTestingRecord"
+            },
+            "type": "array",
+            "description": "List of matched retrieval records."
+          }
+        },
+        "required": [
+          "query",
+          "records"
+        ],
+        "type": "object"
+      },
+      "HitTestingSegment": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Answer content, used in Q&A mode documents."
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Completion time as a Unix timestamp in seconds; `null` if not completed."
+          },
+          "content": {
+            "type": "string",
+            "description": "Text content of the chunk."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "Creation timestamp (Unix epoch in seconds)."
+          },
+          "created_by": {
+            "type": "string",
+            "description": "ID of the user who created the chunk."
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Disable time as a Unix timestamp in seconds; `null` if enabled."
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the user who disabled the chunk. `null` if enabled."
+          },
+          "document": {
+            "$ref": "#/components/schemas/HitTestingDocument",
+            "description": "Parent document information for the matched chunk."
+          },
+          "document_id": {
+            "type": "string",
+            "description": "ID of the document this chunk belongs to."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the chunk is enabled for retrieval."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error message if indexing failed. `null` when no error."
+          },
+          "hit_count": {
+            "type": "integer",
+            "description": "Number of times this chunk has been matched in retrieval queries."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the chunk."
+          },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Hash of the indexed content, used to detect changes."
+          },
+          "index_node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the index node in the vector store."
+          },
+          "indexing_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Indexing start time as a Unix timestamp in seconds; `null` if not started."
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Keywords associated with this chunk for keyword-based retrieval."
+          },
+          "position": {
+            "type": "integer",
+            "description": "Position of the chunk within the document."
+          },
+          "sign_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Signed content hash for integrity verification."
+          },
+          "status": {
+            "type": "string",
+            "description": "Indexing status of the chunk."
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Indexing stop time as a Unix timestamp in seconds; `null` if not stopped."
+          },
+          "tokens": {
+            "type": "integer",
+            "description": "Token count of the chunk content."
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "Word count of the chunk content."
+          }
+        },
+        "required": [
+          "answer",
+          "completed_at",
+          "content",
+          "created_at",
+          "created_by",
+          "disabled_at",
+          "disabled_by",
+          "document",
+          "document_id",
+          "enabled",
+          "error",
+          "hit_count",
+          "id",
+          "index_node_hash",
+          "index_node_id",
+          "indexing_at",
+          "keywords",
+          "position",
+          "sign_content",
+          "status",
+          "stopped_at",
+          "tokens",
+          "word_count"
+        ],
+        "type": "object"
+      },
       "HumanInputContent": {
         "properties": {
           "form_definition": {
@@ -16770,6 +20305,31 @@
         "properties": {},
         "type": "object"
       },
+      "I18nObject": {
+        "description": "Model class for i18n object.",
+        "properties": {
+          "en_US": {
+            "type": "string",
+            "description": "English (United States) text."
+          },
+          "zh_Hans": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Simplified Chinese text."
+          }
+        },
+        "required": [
+          "en_US"
+        ],
+        "type": "object"
+      },
       "IndexInfoResponse": {
         "properties": {
           "api_version": {
@@ -16799,6 +20359,46 @@
       "JSONValue": {},
       "JSONValueType": {},
       "JsonValue": {},
+      "KnowledgeTagListResponse": {
+        "items": {
+          "$ref": "#/components/schemas/KnowledgeTagResponse"
+        },
+        "type": "array"
+      },
+      "KnowledgeTagResponse": {
+        "properties": {
+          "binding_count": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Number of knowledge bases bound to this tag."
+          },
+          "id": {
+            "type": "string",
+            "description": "Tag identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Tag display name."
+          },
+          "type": {
+            "type": "string",
+            "description": "Tag type. Always `knowledge` for knowledge base tags."
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
       "MessageFeedbackPayload": {
         "properties": {
           "content": {
@@ -17188,6 +20788,187 @@
           "conversation_id"
         ],
         "type": "object"
+      },
+      "MetadataArgs": {
+        "properties": {
+          "name": {
+            "description": "Metadata field name.",
+            "type": "string"
+          },
+          "type": {
+            "description": "`string` for text values, `number` for numeric values, `time` for date/time values.",
+            "enum": [
+              "number",
+              "string",
+              "time"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "MetadataDetail": {
+        "properties": {
+          "id": {
+            "description": "Metadata field ID.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Metadata field name.",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Metadata value. Can be a string, number, or `null`."
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "MetadataFilteringCondition": {
+        "description": "Metadata Filtering Condition.",
+        "properties": {
+          "conditions": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Condition"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "deprecated": true,
+            "description": "List of metadata conditions to evaluate."
+          },
+          "logical_operator": {
+            "anyOf": [
+              {
+                "enum": [
+                  "and",
+                  "or"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "and",
+            "description": "How to combine multiple conditions."
+          }
+        },
+        "type": "object"
+      },
+      "MetadataOperationData": {
+        "description": "Metadata operation data",
+        "properties": {
+          "operation_data": {
+            "description": "Array of document metadata update operations. Each entry maps a document ID to its metadata values.",
+            "items": {
+              "$ref": "#/components/schemas/DocumentMetadataOperation"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "operation_data"
+        ],
+        "type": "object"
+      },
+      "MetadataUpdatePayload": {
+        "properties": {
+          "name": {
+            "description": "New metadata field name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "ModelFeature": {
+        "description": "Enum class for llm feature.",
+        "enum": [
+          "agent-thought",
+          "audio",
+          "document",
+          "multi-tool-call",
+          "polling",
+          "stream-tool-call",
+          "structured-output",
+          "tool-call",
+          "video",
+          "vision"
+        ],
+        "type": "string"
+      },
+      "ModelPropertyKey": {
+        "description": "Enum class for model property key.",
+        "enum": [
+          "audio_type",
+          "context_size",
+          "default_voice",
+          "file_upload_limit",
+          "max_characters_per_chunk",
+          "max_chunks",
+          "max_workers",
+          "mode",
+          "supported_file_extensions",
+          "voices",
+          "word_limit"
+        ],
+        "type": "string"
+      },
+      "ModelStatus": {
+        "description": "Enum class for model status.",
+        "enum": [
+          "active",
+          "credential-removed",
+          "disabled",
+          "no-configure",
+          "no-permission",
+          "quota-exceeded"
+        ],
+        "type": "string"
+      },
+      "ModelType": {
+        "description": "Enum class for model type.",
+        "enum": [
+          "llm",
+          "moderation",
+          "rerank",
+          "speech2text",
+          "text-embedding",
+          "tts"
+        ],
+        "type": "string"
       },
       "OptionalServiceApiUserPayload": {
         "properties": {
@@ -18638,6 +22419,557 @@
         ],
         "type": "object"
       },
+      "PermissionEnum": {
+        "description": "Shared permission levels for resources (datasets, credentials, etc.)",
+        "enum": [
+          "all_team_members",
+          "only_me",
+          "partial_members"
+        ],
+        "type": "string"
+      },
+      "PipelineDataset": {
+        "properties": {
+          "chunk_structure": {
+            "type": "string",
+            "description": "Chunking structure configured for the knowledge base."
+          },
+          "description": {
+            "default": "",
+            "description": "Knowledge base description.",
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "Resource ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Resource name."
+          }
+        },
+        "required": [
+          "chunk_structure",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "PipelineDocument": {
+        "properties": {
+          "data_source_info": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Datasource-specific metadata, when available."
+          },
+          "data_source_type": {
+            "type": "string",
+            "description": "Datasource type."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the document is enabled for retrieval."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Indexing error, or `null` when no error has occurred."
+          },
+          "id": {
+            "type": "string",
+            "description": "Resource ID."
+          },
+          "indexing_status": {
+            "type": "string",
+            "description": "Current indexing status for the queued document. Use the response `batch` with [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status) for stage-by-stage progress; `completed` and `error` are terminal, while `paused` requires a resume before polling continues."
+          },
+          "name": {
+            "type": "string",
+            "description": "Resource name."
+          },
+          "position": {
+            "type": "integer",
+            "description": "Document position within the batch."
+          }
+        },
+        "required": [
+          "data_source_type",
+          "enabled",
+          "id",
+          "indexing_status",
+          "name",
+          "position"
+        ],
+        "type": "object"
+      },
+      "PipelineRunApiEntity": {
+        "properties": {
+          "datasource_info_list": {
+            "description": "List of datasource objects to process. `datasource_type` selects the item shape: `local_file` uses `reference`; `online_document` uses `workspace_id` and `page`; `online_drive` uses `id` and `type` (plus optional `bucket`); `website_crawl` uses `url`. The `oneOf` branches are emitted in local-file, online-document, website-crawl, online-drive order.",
+            "items": {
+              "oneOf": [
+                {
+                  "properties": {
+                    "name": {
+                      "description": "Document title. Defaults to `untitled`.",
+                      "type": "string"
+                    },
+                    "reference": {
+                      "description": "Use the `id` returned by the [Upload Pipeline File](/en/api-reference/knowledge-pipeline/upload-pipeline-file) endpoint. `related_id` is accepted as an alias.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "reference"
+                  ],
+                  "title": "Local file",
+                  "type": "object",
+                  "description": "Local file reference."
+                },
+                {
+                  "properties": {
+                    "credential_id": {
+                      "description": "Credential for authenticating with the external platform. If omitted, the provider's default credential is used.",
+                      "type": "string"
+                    },
+                    "page": {
+                      "description": "Page details.",
+                      "properties": {
+                        "page_id": {
+                          "description": "Page ID returned by the configured online-document provider when its workspace or database is browsed in Dify.",
+                          "type": "string"
+                        },
+                        "page_name": {
+                          "description": "Display name. Defaults to `untitled`.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "Page type defined by the datasource plugin.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "page_id",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    "workspace_id": {
+                      "description": "Workspace or database ID from the configured online-document provider. Obtain it while selecting or browsing the provider in Dify; it is the provider's own resource ID, not a Dify workspace ID.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "page",
+                    "workspace_id"
+                  ],
+                  "title": "Online document",
+                  "type": "object",
+                  "description": "Page in an online document provider."
+                },
+                {
+                  "properties": {
+                    "title": {
+                      "description": "Used as the document name. Defaults to `untitled`.",
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "URL to crawl.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ],
+                  "title": "Website crawl",
+                  "type": "object",
+                  "description": "Website URL to crawl."
+                },
+                {
+                  "properties": {
+                    "bucket": {
+                      "description": "Storage bucket name. Required by some drive providers, such as S3-compatible stores; omit if the provider does not use buckets.",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "File or folder ID returned by the configured online-drive provider when the drive is browsed in Dify.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "File name. Defaults to `untitled`.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Whether this entry is a single file or a folder to expand.",
+                      "enum": [
+                        "file",
+                        "folder"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "type"
+                  ],
+                  "title": "Online drive",
+                  "type": "object",
+                  "description": "File or folder in an online drive provider."
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "datasource_type": {
+            "description": "Type of the datasource. Determines which fields are expected in `datasource_info_list` items.",
+            "enum": [
+              "local_file",
+              "online_document",
+              "online_drive",
+              "website_crawl"
+            ],
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "Key-value pairs for pipeline input variables defined in the workflow. Pass `{}` if the pipeline has no input variables.",
+            "type": "object"
+          },
+          "is_published": {
+            "description": "Whether to run the published or draft version of the pipeline. `true` runs the latest published version; `false` runs the current draft (useful for testing unpublished changes).",
+            "type": "boolean"
+          },
+          "response_mode": {
+            "description": "Response mode for draft runs. Use `streaming` for SSE or `blocking` for JSON. Published runs are queued and always return batch metadata as JSON.",
+            "enum": [
+              "blocking",
+              "streaming"
+            ],
+            "type": "string"
+          },
+          "start_node_id": {
+            "description": "Datasource node ID where the run starts. A datasource node is the knowledge pipeline's entry step that reads files, provider pages, drives, or URLs. Use `node_id` from [List Datasource Plugins](/en/api-reference/knowledge-pipeline/list-datasource-plugins).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "datasource_info_list",
+          "datasource_type",
+          "inputs",
+          "is_published",
+          "response_mode",
+          "start_node_id"
+        ],
+        "type": "object"
+      },
+      "PipelineRunJsonResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PublishedPipelineRunResponse"
+          },
+          {
+            "$ref": "#/components/schemas/WorkflowBlockingResponse"
+          }
+        ]
+      },
+      "PipelineUploadFileResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Upload timestamp in ISO 8601 format. May be `null` while the record is being created."
+          },
+          "created_by": {
+            "type": "string",
+            "description": "ID of the user who uploaded the file."
+          },
+          "extension": {
+            "type": "string",
+            "description": "File extension."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the uploaded file."
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "MIME type of the file. May be `null` if the upload did not include one."
+          },
+          "name": {
+            "type": "string",
+            "description": "Original file name."
+          },
+          "size": {
+            "type": "integer",
+            "description": "File size in bytes."
+          }
+        },
+        "required": [
+          "created_by",
+          "extension",
+          "id",
+          "name",
+          "size"
+        ],
+        "type": "object"
+      },
+      "PreProcessingRule": {
+        "properties": {
+          "enabled": {
+            "description": "Whether this preprocessing rule is enabled.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Rule identifier.",
+            "enum": [
+              "remove_extra_spaces",
+              "remove_stopwords",
+              "remove_urls_emails"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "enabled",
+          "id"
+        ],
+        "type": "object"
+      },
+      "ProcessRule": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/ProcessRuleMode",
+            "description": "Processing mode. `automatic` uses built-in rules, `custom` allows manual configuration, and `hierarchical` enables parent-child chunk structure for `doc_form: hierarchical_model`."
+          },
+          "rules": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Rule"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Custom processing rules."
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "ProcessRuleMode": {
+        "description": "Dataset Process Rule Mode",
+        "enum": [
+          "automatic",
+          "custom",
+          "hierarchical"
+        ],
+        "type": "string"
+      },
+      "ProviderModelWithStatusEntity": {
+        "description": "Model class for model response.",
+        "properties": {
+          "deprecated": {
+            "default": false,
+            "type": "boolean",
+            "description": "Whether the model is deprecated."
+          },
+          "features": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ModelFeature"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Supported features of the model, `null` if none."
+          },
+          "fetch_from": {
+            "$ref": "#/components/schemas/FetchFrom",
+            "description": "Where the model definition comes from. `predefined-model` for built-in models, `customizable-model` for user-configured models."
+          },
+          "has_invalid_load_balancing_configs": {
+            "default": false,
+            "type": "boolean",
+            "description": "Whether the model has invalid load-balancing configurations."
+          },
+          "label": {
+            "$ref": "#/components/schemas/I18nObject",
+            "description": "Localized display name of the model."
+          },
+          "load_balancing_enabled": {
+            "default": false,
+            "type": "boolean",
+            "description": "Whether load balancing is enabled for the model."
+          },
+          "model": {
+            "type": "string",
+            "description": "Model identifier. Use this as the `embedding_model` value when creating or updating a knowledge base."
+          },
+          "model_properties": {
+            "additionalProperties": true,
+            "propertyNames": {
+              "$ref": "#/components/schemas/ModelPropertyKey"
+            },
+            "type": "object",
+            "description": "Model-specific properties such as `context_size`."
+          },
+          "model_type": {
+            "$ref": "#/components/schemas/ModelType",
+            "description": "Type of the model, matching the `model_type` path parameter."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ModelStatus",
+            "description": "Model availability status. `active` when ready to use."
+          }
+        },
+        "required": [
+          "fetch_from",
+          "label",
+          "model",
+          "model_properties",
+          "model_type",
+          "status"
+        ],
+        "type": "object"
+      },
+      "ProviderWithModelsListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ProviderWithModelsResponse"
+            },
+            "type": "array",
+            "description": "Model providers and their available models."
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ProviderWithModelsResponse": {
+        "description": "Model class for provider with models response.",
+        "properties": {
+          "icon_small": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/I18nObject"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "URL of the provider's small icon."
+          },
+          "icon_small_dark": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/I18nObject"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Dark-mode icon URLs; `null` when the provider has none."
+          },
+          "label": {
+            "$ref": "#/components/schemas/I18nObject",
+            "description": "Localized display name of the provider."
+          },
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/ProviderModelWithStatusEntity"
+            },
+            "type": "array",
+            "description": "List of available models from this provider."
+          },
+          "provider": {
+            "type": "string",
+            "description": "Model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). Legacy providers may return the bare short form (e.g. `openai`)."
+          },
+          "status": {
+            "$ref": "#/components/schemas/CustomConfigurationStatus",
+            "description": "Provider status. `active` when credentials are configured and valid."
+          },
+          "tenant_id": {
+            "type": "string",
+            "description": "Workspace ID the provider configuration belongs to."
+          }
+        },
+        "required": [
+          "label",
+          "models",
+          "provider",
+          "status",
+          "tenant_id"
+        ],
+        "type": "object"
+      },
+      "PublishedPipelineRunResponse": {
+        "properties": {
+          "batch": {
+            "type": "string",
+            "description": "Batch ID for the queued published run. Pass it as `batch` to [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status) and poll until every document is completed, failed, or paused."
+          },
+          "dataset": {
+            "$ref": "#/components/schemas/PipelineDataset",
+            "description": "Knowledge base receiving the generated documents."
+          },
+          "documents": {
+            "items": {
+              "$ref": "#/components/schemas/PipelineDocument"
+            },
+            "type": "array",
+            "description": "Documents created and queued for indexing."
+          }
+        },
+        "required": [
+          "batch",
+          "dataset",
+          "documents"
+        ],
+        "type": "object"
+      },
       "RequiredServiceApiUserPayload": {
         "properties": {
           "user": {
@@ -18648,6 +22980,35 @@
         "required": [
           "user"
         ],
+        "type": "object"
+      },
+      "RerankingModel": {
+        "properties": {
+          "reranking_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the reranking model."
+          },
+          "reranking_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Provider name of the reranking model."
+          }
+        },
         "type": "object"
       },
       "ResultResponse": {
@@ -18662,187 +23023,105 @@
         ],
         "type": "object"
       },
-      "RetrievalModel": {
-        "type": "object",
-        "required": [
-          "search_method",
-          "reranking_enable",
-          "top_k",
-          "score_threshold_enabled"
+      "RetrievalMethod": {
+        "enum": [
+          "full_text_search",
+          "hybrid_search",
+          "keyword_search",
+          "semantic_search"
         ],
+        "type": "string"
+      },
+      "RetrievalModel": {
         "properties": {
-          "search_method": {
-            "type": "string",
-            "description": "Search method used for retrieval.",
-            "enum": [
-              "keyword_search",
-              "semantic_search",
-              "full_text_search",
-              "hybrid_search"
-            ]
+          "metadata_filtering_conditions": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MetadataFilteringCondition"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Restrict retrieval to chunks whose document metadata matches the given conditions. Conditions are evaluated server-side against document metadata fields."
           },
           "reranking_enable": {
-            "type": "boolean",
-            "description": "Whether reranking is enabled."
-          },
-          "reranking_model": {
-            "type": "object",
-            "description": "Reranking model configuration.",
-            "properties": {
-              "reranking_provider_name": {
-                "type": "string",
-                "description": "Reranking model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/cohere/cohere`). A bare name like `cohere` expands to `langgenius/<name>/<name>` and works only for langgenius-published plugins.\n\nGet valid values from the `provider` field of [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=rerank`."
-              },
-              "reranking_model_name": {
-                "type": "string",
-                "description": "Name of the reranking model."
-              }
-            }
+            "description": "Whether reranking is enabled.",
+            "type": "boolean"
           },
           "reranking_mode": {
-            "type": "string",
-            "enum": [
-              "reranking_model",
-              "weighted_score"
+            "anyOf": [
+              {
+                "enum": [
+                  "reranking_model",
+                  "weighted_score"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "nullable": true,
+            "default": null,
             "description": "Reranking mode. Required when `reranking_enable` is `true`."
           },
-          "top_k": {
-            "type": "integer",
-            "description": "Maximum number of results to return."
-          },
-          "score_threshold_enabled": {
-            "type": "boolean",
-            "description": "Whether score threshold filtering is enabled."
+          "reranking_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RerankingModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Reranking model configuration."
           },
           "score_threshold": {
-            "type": "number",
-            "nullable": true,
-            "description": "Minimum similarity score for results. Only effective when `score_threshold_enabled` is `true`."
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Minimum similarity score from 0 to 1. Only effective when `score_threshold_enabled` is `true`."
+          },
+          "score_threshold_enabled": {
+            "description": "Whether score threshold filtering is enabled.",
+            "type": "boolean"
+          },
+          "search_method": {
+            "$ref": "#/components/schemas/RetrievalMethod",
+            "description": "Search method used for retrieval."
+          },
+          "top_k": {
+            "description": "Maximum number of results to return.",
+            "type": "integer"
           },
           "weights": {
-            "type": "object",
-            "nullable": true,
-            "description": "Weight configuration for hybrid search.",
-            "properties": {
-              "weight_type": {
-                "type": "string",
-                "description": "Strategy for balancing semantic and keyword search weights.",
-                "enum": [
-                  "semantic_first",
-                  "keyword_first",
-                  "customized"
-                ]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WeightModel"
               },
-              "vector_setting": {
-                "type": "object",
-                "description": "Semantic search weight settings.",
-                "properties": {
-                  "vector_weight": {
-                    "type": "number",
-                    "description": "Weight assigned to semantic (vector) search results."
-                  },
-                  "embedding_provider_name": {
-                    "type": "string",
-                    "description": "Provider of the embedding model used for vector search."
-                  },
-                  "embedding_model_name": {
-                    "type": "string",
-                    "description": "Name of the embedding model used for vector search."
-                  }
-                }
-              },
-              "keyword_setting": {
-                "type": "object",
-                "description": "Keyword search weight settings.",
-                "properties": {
-                  "keyword_weight": {
-                    "type": "number",
-                    "description": "Weight assigned to keyword search results."
-                  }
-                }
+              {
+                "type": "null"
               }
-            }
-          },
-          "metadata_filtering_conditions": {
-            "type": "object",
-            "nullable": true,
-            "description": "Restrict retrieval to chunks whose document metadata matches the given conditions. Conditions are evaluated server-side against document metadata fields.",
-            "properties": {
-              "logical_operator": {
-                "type": "string",
-                "enum": [
-                  "and",
-                  "or"
-                ],
-                "default": "and",
-                "nullable": true,
-                "description": "How to combine multiple conditions."
-              },
-              "conditions": {
-                "type": "array",
-                "nullable": true,
-                "description": "List of metadata conditions to evaluate.",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "name",
-                    "comparison_operator"
-                  ],
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "Metadata field name to compare against."
-                    },
-                    "comparison_operator": {
-                      "type": "string",
-                      "description": "Comparison to apply, by metadata type:\n\n- String or array metadata: `contains`, `not contains`, `start with`, `end with`, `is`, `is not`, `empty`, `not empty`, `in`, `not in`\n- Numeric metadata: `=`, `≠`, `>`, `<`, `≥`, `≤`\n- Time metadata: `before`, `after`",
-                      "enum": [
-                        "contains",
-                        "not contains",
-                        "start with",
-                        "end with",
-                        "is",
-                        "is not",
-                        "empty",
-                        "not empty",
-                        "in",
-                        "not in",
-                        "=",
-                        "≠",
-                        ">",
-                        "<",
-                        "≥",
-                        "≤",
-                        "before",
-                        "after"
-                      ]
-                    },
-                    "value": {
-                      "nullable": true,
-                      "description": "Value to compare against. Type depends on `comparison_operator`: string for most string operators, array of strings for `in` and `not in`, number for numeric operators, and omitted for `empty` and `not empty`.",
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        {
-                          "type": "number"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
+            ],
+            "default": null,
+            "description": "Weight configuration for hybrid search."
           }
-        }
+        },
+        "required": [
+          "reranking_enable",
+          "score_threshold_enabled",
+          "search_method",
+          "top_k"
+        ],
+        "type": "object"
       },
       "RetrieverResource": {
         "properties": {
@@ -19040,6 +23319,218 @@
         "type": "object",
         "description": "Citation and attribution information for a retriever resource."
       },
+      "Rule": {
+        "properties": {
+          "parent_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "full-doc",
+                  "paragraph"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Parent-child segmentation mode."
+          },
+          "pre_processing_rules": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PreProcessingRule"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Pre-processing rules to apply before segmentation."
+          },
+          "segmentation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Segmentation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Parent chunk segmentation settings."
+          },
+          "subchunk_segmentation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Segmentation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Child chunk segmentation settings."
+          }
+        },
+        "type": "object"
+      },
+      "SegmentAttachmentResponse": {
+        "properties": {
+          "extension": {
+            "type": "string",
+            "description": "File extension."
+          },
+          "id": {
+            "type": "string",
+            "description": "Attachment file identifier."
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "MIME type of the file."
+          },
+          "name": {
+            "type": "string",
+            "description": "Original file name."
+          },
+          "size": {
+            "type": "integer",
+            "description": "File size in bytes."
+          },
+          "source_url": {
+            "type": "string",
+            "description": "URL to access the attachment."
+          }
+        },
+        "required": [
+          "extension",
+          "id",
+          "mime_type",
+          "name",
+          "size",
+          "source_url"
+        ],
+        "type": "object"
+      },
+      "SegmentCreateItemPayload": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Answer content for QA mode."
+          },
+          "attachment_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Attachment file IDs."
+          },
+          "content": {
+            "description": "Chunk text content.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Keywords for the chunk."
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "SegmentCreateListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SegmentResponse"
+            },
+            "type": "array",
+            "description": "List of created chunks."
+          },
+          "doc_form": {
+            "type": "string",
+            "description": "Document chunking mode used by this document."
+          }
+        },
+        "required": [
+          "data",
+          "doc_form"
+        ],
+        "type": "object"
+      },
+      "SegmentCreatePayload": {
+        "properties": {
+          "segments": {
+            "description": "Array of chunk objects to create.",
+            "items": {
+              "$ref": "#/components/schemas/SegmentCreateItemPayload"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "segments"
+        ],
+        "type": "object"
+      },
+      "SegmentDetailResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SegmentResponse",
+            "description": "List of created chunks."
+          },
+          "doc_form": {
+            "type": "string",
+            "description": "Document chunking mode used by this document."
+          }
+        },
+        "required": [
+          "data",
+          "doc_form"
+        ],
+        "type": "object"
+      },
       "SegmentListQuery": {
         "properties": {
           "keyword": {
@@ -19074,6 +23565,403 @@
             "type": "array"
           }
         },
+        "type": "object"
+      },
+      "SegmentListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SegmentResponse"
+            },
+            "type": "array",
+            "description": "List of chunks."
+          },
+          "doc_form": {
+            "type": "string",
+            "description": "Document chunking mode used by this document."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether more items exist on the next page."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Number of items per page."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number."
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of matching chunks."
+          }
+        },
+        "required": [
+          "data",
+          "doc_form",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "SegmentResponse": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Answer content, used in Q&A mode documents."
+          },
+          "attachments": {
+            "items": {
+              "$ref": "#/components/schemas/SegmentAttachmentResponse"
+            },
+            "type": "array",
+            "description": "Files attached to this chunk."
+          },
+          "child_chunks": {
+            "items": {
+              "$ref": "#/components/schemas/ChildChunkResponse"
+            },
+            "type": "array",
+            "description": "Child chunks belonging to this chunk. Only present for hierarchical mode documents."
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Completion time as a Unix timestamp in seconds; `null` if not completed."
+          },
+          "content": {
+            "type": "string",
+            "description": "Text content of the chunk."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "Creation timestamp (Unix epoch in seconds)."
+          },
+          "created_by": {
+            "type": "string",
+            "description": "ID of the user who created the chunk."
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Disable time as a Unix timestamp in seconds; `null` if enabled."
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the user who disabled the chunk. `null` if enabled."
+          },
+          "document_id": {
+            "type": "string",
+            "description": "ID of the document this chunk belongs to."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the chunk is enabled for retrieval."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error message if indexing failed. `null` when no error."
+          },
+          "hit_count": {
+            "type": "integer",
+            "description": "Number of times this chunk has been matched in retrieval queries."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the chunk."
+          },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Hash of the indexed content, used to detect changes."
+          },
+          "index_node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the index node in the vector store."
+          },
+          "indexing_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Indexing start time as a Unix timestamp in seconds; `null` if not started."
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Keywords associated with this chunk for keyword-based retrieval."
+          },
+          "position": {
+            "type": "integer",
+            "description": "Position of the chunk within the document."
+          },
+          "sign_content": {
+            "type": "string",
+            "description": "Signed content hash for integrity verification."
+          },
+          "status": {
+            "type": "string",
+            "description": "Current indexing status of the chunk, e.g. `completed`, `indexing`, `error`."
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Indexing stop time as a Unix timestamp in seconds; `null` if not stopped."
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "AI-generated summary of the chunk content. `null` if summary indexing is not enabled."
+          },
+          "tokens": {
+            "type": "integer",
+            "description": "Token count of the chunk content."
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "Last update timestamp (Unix epoch in seconds)."
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the user who last updated the chunk."
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "Word count of the chunk content."
+          }
+        },
+        "required": [
+          "answer",
+          "attachments",
+          "child_chunks",
+          "completed_at",
+          "content",
+          "created_at",
+          "created_by",
+          "disabled_at",
+          "disabled_by",
+          "document_id",
+          "enabled",
+          "error",
+          "hit_count",
+          "id",
+          "index_node_hash",
+          "index_node_id",
+          "indexing_at",
+          "keywords",
+          "position",
+          "sign_content",
+          "status",
+          "stopped_at",
+          "summary",
+          "tokens",
+          "updated_at",
+          "updated_by",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "SegmentUpdateArgs": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Updated answer content for QA mode."
+          },
+          "attachment_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Attachment file IDs."
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Updated chunk text content."
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether the chunk is enabled."
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Updated keywords for the chunk."
+          },
+          "regenerate_child_chunks": {
+            "default": false,
+            "description": "Whether to regenerate child chunks after updating a parent chunk.",
+            "type": "boolean"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Summary content for summary index."
+          }
+        },
+        "type": "object"
+      },
+      "SegmentUpdatePayload": {
+        "properties": {
+          "segment": {
+            "$ref": "#/components/schemas/SegmentUpdateArgs",
+            "description": "Chunk update payload."
+          }
+        },
+        "required": [
+          "segment"
+        ],
+        "type": "object"
+      },
+      "Segmentation": {
+        "properties": {
+          "chunk_overlap": {
+            "default": 0,
+            "description": "Token overlap between chunks.",
+            "type": "integer"
+          },
+          "max_tokens": {
+            "description": "Maximum token count per chunk.",
+            "type": "integer"
+          },
+          "separator": {
+            "default": "\n",
+            "description": "Custom separator for splitting text.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "max_tokens"
+        ],
         "type": "object"
       },
       "SelectInputConfig": {
@@ -19510,6 +24398,136 @@
         ],
         "type": "object"
       },
+      "TagBindingPayload": {
+        "properties": {
+          "tag_ids": {
+            "description": "Tag IDs to bind.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "target_id": {
+            "description": "Knowledge base ID to bind the tags to.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag_ids",
+          "target_id"
+        ],
+        "type": "object"
+      },
+      "TagCreatePayload": {
+        "properties": {
+          "name": {
+            "description": "Tag name.",
+            "maxLength": 50,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "TagDeletePayload": {
+        "properties": {
+          "tag_id": {
+            "description": "Tag ID to delete.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag_id"
+        ],
+        "type": "object"
+      },
+      "TagUnbindingPayload": {
+        "anyOf": [
+          {
+            "properties": {
+              "tag_id": {
+                "deprecated": true,
+                "description": "Legacy single tag ID accepted by the Service API.",
+                "type": "string"
+              },
+              "tag_ids": {
+                "description": "Tag IDs to unbind. Use this for new integrations.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "target_id": {
+                "description": "Knowledge base ID.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "tag_id",
+              "target_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "tag_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "deprecated": true,
+                "description": "Legacy single tag ID accepted by the Service API."
+              },
+              "tag_ids": {
+                "description": "Tag IDs to unbind. Use this for new integrations.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "target_id": {
+                "description": "Knowledge base ID.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "tag_ids",
+              "target_id"
+            ],
+            "type": "object"
+          }
+        ],
+        "description": "Accepts either the legacy tag_id payload or the normalized tag_ids payload."
+      },
+      "TagUpdatePayload": {
+        "properties": {
+          "name": {
+            "description": "Tag name.",
+            "maxLength": 50,
+            "minLength": 1,
+            "type": "string"
+          },
+          "tag_id": {
+            "description": "Tag ID to update.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "tag_id"
+        ],
+        "type": "object"
+      },
       "TextToAudioPayload": {
         "properties": {
           "message_id": {
@@ -19639,6 +24657,18 @@
         ],
         "type": "object"
       },
+      "UrlResponse": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Signed URL to download the original uploaded file."
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
       "UserActionConfig": {
         "description": "User action configuration.",
         "properties": {
@@ -19672,6 +24702,86 @@
           "variable"
         ],
         "type": "string"
+      },
+      "WeightKeywordSetting": {
+        "properties": {
+          "keyword_weight": {
+            "description": "Keyword-search weight from 0 to 1. For `customized` weighting, use it with `vector_weight` so the two weights total 1.",
+            "type": "number"
+          }
+        },
+        "required": [
+          "keyword_weight"
+        ],
+        "type": "object"
+      },
+      "WeightModel": {
+        "properties": {
+          "keyword_setting": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WeightKeywordSetting"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Keyword search weight settings."
+          },
+          "vector_setting": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WeightVectorSetting"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Semantic search weight settings."
+          },
+          "weight_type": {
+            "anyOf": [
+              {
+                "enum": [
+                  "customized",
+                  "keyword_first",
+                  "semantic_first"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Strategy for balancing semantic and keyword search weights."
+          }
+        },
+        "type": "object"
+      },
+      "WeightVectorSetting": {
+        "properties": {
+          "embedding_model_name": {
+            "description": "Name of the embedding model used for vector search.",
+            "type": "string"
+          },
+          "embedding_provider_name": {
+            "description": "Provider of the embedding model used for vector search.",
+            "type": "string"
+          },
+          "vector_weight": {
+            "description": "Semantic vector-search weight from 0 to 1. For `customized` weighting, use it with `keyword_weight` so the two weights total 1.",
+            "type": "number"
+          }
+        },
+        "required": [
+          "embedding_model_name",
+          "embedding_provider_name",
+          "vector_weight"
+        ],
+        "type": "object"
       },
       "WorkflowAppLogPaginationResponse": {
         "properties": {

--- a/ja/api-reference/openapi_service.json
+++ b/ja/api-reference/openapi_service.json
@@ -15029,6 +15029,30 @@
         ],
         "type": "object"
       },
+      "ChildChunkCreatePayload": {
+        "properties": {
+          "content": {
+            "description": "子チャンクのテキスト内容です。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "ChildChunkDetailResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ChildChunkResponse",
+            "description": "子チャンクの詳細。"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "ChildChunkListQuery": {
         "properties": {
           "keyword": {
@@ -15056,6 +15080,100 @@
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "ChildChunkListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ChildChunkResponse"
+            },
+            "type": "array",
+            "description": "子チャンクのリスト。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "1 ページあたりの件数です。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "現在のページ番号です。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "子チャンクの合計数です。"
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "合計ページ数です。"
+          }
+        },
+        "required": [
+          "data",
+          "limit",
+          "page",
+          "total",
+          "total_pages"
+        ],
+        "type": "object"
+      },
+      "ChildChunkResponse": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "子チャンクのテキスト内容です。"
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "子チャンクの一意識別子です。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "親チャンク内の子チャンクの位置です。"
+          },
+          "segment_id": {
+            "type": "string",
+            "description": "この子チャンクが属する親チャンクの ID です。"
+          },
+          "type": {
+            "type": "string",
+            "description": "子チャンクの作成方法です。API から作成または更新された子チャンクは常に `customized` です。システム生成の子チャンクは `automatic` です。"
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "最終更新タイムスタンプ（Unix エポック、秒単位）です。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "子チャンク内容の単語数です。"
+          }
+        },
+        "required": [
+          "content",
+          "created_at",
+          "id",
+          "position",
+          "segment_id",
+          "type",
+          "updated_at",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "ChildChunkUpdatePayload": {
+        "properties": {
+          "content": {
+            "description": "子チャンクのテキスト内容です。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
         "type": "object"
       },
       "CompletionBlockingResponse": {
@@ -15553,6 +15671,65 @@
         ],
         "type": "object"
       },
+      "Condition": {
+        "description": "条件の詳細。",
+        "properties": {
+          "comparison_operator": {
+            "description": "適用する比較方法。文字列演算子（`contains`、`not contains`、`start with`、`end with`、`is`、`is not`、`empty`、`not empty`、`in`、`not in`）は文字列または配列メタデータ、数値演算子（`=`、`≠`、`>`、`<`、`≥`、`≤`）は数値メタデータ、時間演算子（`before`、`after`）は時間メタデータに適用されます。",
+            "enum": [
+              "<",
+              "=",
+              ">",
+              "after",
+              "before",
+              "contains",
+              "empty",
+              "end with",
+              "in",
+              "is",
+              "is not",
+              "not contains",
+              "not empty",
+              "not in",
+              "start with",
+              "≠",
+              "≤",
+              "≥"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "description": "比較対象とするメタデータフィールド名です。",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "比較する値。型は `comparison_operator` によって異なります。ほとんどの文字列演算子は文字列、`in` と `not in` は文字列配列、数値演算子は数値を使用し、`empty` と `not empty` では省略するか `null` を使用します。"
+          }
+        },
+        "required": [
+          "comparison_operator",
+          "name"
+        ],
+        "type": "object"
+      },
       "ConversationInfiniteScrollPagination": {
         "properties": {
           "data": {
@@ -15931,6 +16108,984 @@
         },
         "type": "object"
       },
+      "CustomConfigurationStatus": {
+        "description": "カスタム設定状態の列挙型。",
+        "enum": [
+          "active",
+          "no-configure"
+        ],
+        "type": "string"
+      },
+      "DatasetBoundTagListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetBoundTagResponse"
+            },
+            "type": "array",
+            "description": "このナレッジベースにバインドされたタグのリスト。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "このナレッジベースにバインドされたタグの合計数です。"
+          }
+        },
+        "required": [
+          "data",
+          "total"
+        ],
+        "type": "object"
+      },
+      "DatasetBoundTagResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "タグ識別子です。"
+          },
+          "name": {
+            "type": "string",
+            "description": "タグの表示名です。"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "DatasetCreatePayload": {
+        "properties": {
+          "description": {
+            "default": "",
+            "description": "ナレッジベースの説明です。",
+            "maxLength": 400,
+            "type": "string"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "埋め込みモデル名。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `model` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "埋め込みモデルプロバイダー。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `provider` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+          },
+          "external_knowledge_api_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部ナレッジ API の ID。"
+          },
+          "external_knowledge_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部ナレッジベースの ID です。"
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "enum": [
+                  "economy",
+                  "high_quality"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`high_quality` は埋め込みモデルを使用した精密検索、`economy` はキーワードベースのインデキシングです。"
+          },
+          "name": {
+            "description": "ナレッジベース名。",
+            "maxLength": 40,
+            "minLength": 1,
+            "type": "string"
+          },
+          "permission": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PermissionEnum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "only_me",
+            "description": "このナレッジベースにアクセスできるユーザーを制御します。`only_me` は作成者のみ、`all_team_members` はワークスペース全体、`partial_members` は指定したメンバーにアクセスを許可します。"
+          },
+          "provider": {
+            "default": "vendor",
+            "description": "ナレッジベースのプロバイダー。内部ナレッジベースは `vendor`、外部ナレッジベースは `external`。",
+            "enum": [
+              "external",
+              "vendor"
+            ],
+            "type": "string"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+          },
+          "summary_index_setting": {
+            "anyOf": [
+              {
+                "properties": {
+                  "enable": {
+                    "description": "サマリーインデックスを有効にするかどうかです。",
+                    "type": "boolean"
+                  },
+                  "model_name": {
+                    "description": "要約生成に使用されるモデルの名前です。",
+                    "type": "string"
+                  },
+                  "model_provider_name": {
+                    "description": "要約生成モデルのプロバイダーです。",
+                    "type": "string"
+                  },
+                  "summary_prompt": {
+                    "description": "要約生成用のカスタムプロンプトテンプレートです。",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "サマリーインデックスの設定です。"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "DatasetDetailResponse": {
+        "properties": {
+          "app_count": {
+            "type": "integer",
+            "description": "現在このナレッジベースを使用しているアプリケーションの数です。"
+          },
+          "author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "作成者の表示名です。"
+          },
+          "built_in_field_enabled": {
+            "type": "boolean",
+            "description": "組み込みメタデータフィールド（例：`document_name`、`uploader`）が有効かどうかです。"
+          },
+          "chunk_structure": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "チャンク構造の設定です。"
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "ナレッジベースを作成したユーザーの ID です。"
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ドキュメントのデータソースタイプです。まだ設定されていない場合は `null` です。"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ナレッジベースの目的または内容を説明するオプションのテキストです。"
+          },
+          "doc_form": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ドキュメントのチャンキングモードです。`text_model` は標準テキストチャンキング、`hierarchical_model` は親子構造、`qa_model` は QA ペア抽出を示します。"
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetDocMetadataResponse"
+            },
+            "type": "array",
+            "description": "ナレッジベースのメタデータフィールド定義です。"
+          },
+          "document_count": {
+            "type": "integer",
+            "description": "ナレッジベース内のドキュメント総数です。"
+          },
+          "embedding_available": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "設定された埋め込みモデルが現在利用可能かどうかです。"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス作成に使用される埋め込みモデルの名前です。"
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "埋め込みモデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。以前のナレッジベースでは短縮形（例：`openai`）が返される場合があります。"
+          },
+          "enable_api": {
+            "type": "boolean",
+            "description": "このナレッジベースで API アクセスが有効かどうかです。"
+          },
+          "external_knowledge_info": {
+            "$ref": "#/components/schemas/DatasetExternalKnowledgeInfoResponse",
+            "description": "外部ナレッジベースの接続詳細です。`provider` が `external` の場合に存在します。"
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetExternalRetrievalModelResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "外部ナレッジベースの検索設定です。内部ナレッジベースの場合は `null` です。"
+          },
+          "icon_info": {
+            "$ref": "#/components/schemas/DatasetIconInfoResponse",
+            "description": "ナレッジベースのアイコン表示設定です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "ナレッジベースの一意識別子です。"
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "`high_quality` は埋め込みモデルを使用した精密検索、`economy` はキーワードベースのインデキシングです。"
+          },
+          "is_multimodal": {
+            "type": "boolean",
+            "description": "マルチモーダルコンテンツ処理が有効かどうかです。"
+          },
+          "is_published": {
+            "type": "boolean",
+            "description": "ナレッジベースが公開済みかどうかです。"
+          },
+          "maintainer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ナレッジベースのメンテナーの表示名です。設定されていない場合は `null` です。"
+          },
+          "name": {
+            "type": "string",
+            "description": "ナレッジベースの表示名です。ワークスペース内で一意です。"
+          },
+          "permission": {
+            "type": "string",
+            "description": "このナレッジベースにアクセスできるユーザーを制御します。指定可能な値：`only_me`、`all_team_members`、`partial_members`。"
+          },
+          "permission_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "現在の呼び出し元に付与された権限識別子。"
+          },
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "カスタム処理パイプラインが設定されている場合のパイプライン ID です。"
+          },
+          "provider": {
+            "type": "string",
+            "description": "プロバイダータイプです。内部管理の場合は `vendor`、外部ナレッジベース接続の場合は `external` です。"
+          },
+          "retrieval_model_dict": {
+            "$ref": "#/components/schemas/DatasetRetrievalModelResponse",
+            "description": "ナレッジベースの検索設定です。"
+          },
+          "runtime_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ランタイム処理モードです。"
+          },
+          "summary_index_setting": {
+            "$ref": "#/components/schemas/DatasetSummaryIndexSettingResponse",
+            "description": "サマリーインデックスの設定です。"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetTagResponse"
+            },
+            "type": "array",
+            "description": "このナレッジベースに関連付けられたタグです。"
+          },
+          "total_available_documents": {
+            "type": "integer",
+            "description": "有効で利用可能なドキュメントの数です。"
+          },
+          "total_documents": {
+            "type": "integer",
+            "description": "ドキュメントの合計数です。"
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "最終更新タイムスタンプ（Unix エポック、秒単位）です。"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ナレッジベースを最後に更新したユーザーの ID です。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "全ドキュメントの合計単語数です。"
+          }
+        },
+        "required": [
+          "app_count",
+          "author_name",
+          "built_in_field_enabled",
+          "chunk_structure",
+          "created_at",
+          "created_by",
+          "data_source_type",
+          "description",
+          "doc_form",
+          "doc_metadata",
+          "document_count",
+          "embedding_model",
+          "embedding_model_provider",
+          "enable_api",
+          "external_retrieval_model",
+          "id",
+          "indexing_technique",
+          "is_multimodal",
+          "is_published",
+          "name",
+          "permission",
+          "pipeline_id",
+          "provider",
+          "retrieval_model_dict",
+          "runtime_mode",
+          "tags",
+          "total_available_documents",
+          "total_documents",
+          "updated_at",
+          "updated_by",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "DatasetDetailWithPartialMembersResponse": {
+        "properties": {
+          "app_count": {
+            "type": "integer",
+            "description": "現在このナレッジベースを使用しているアプリケーションの数です。"
+          },
+          "author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "作成者の表示名です。"
+          },
+          "built_in_field_enabled": {
+            "type": "boolean",
+            "description": "組み込みメタデータフィールド（例：`document_name`、`uploader`）が有効かどうかです。"
+          },
+          "chunk_structure": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "チャンク構造の設定です。"
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "ナレッジベースを作成したユーザーの ID です。"
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ドキュメントのデータソースタイプです。まだ設定されていない場合は `null` です。"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ナレッジベースの目的または内容を説明するオプションのテキストです。"
+          },
+          "doc_form": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ドキュメントのチャンキングモードです。`text_model` は標準テキストチャンキング、`hierarchical_model` は親子構造、`qa_model` は QA ペア抽出を示します。"
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetDocMetadataResponse"
+            },
+            "type": "array",
+            "description": "ナレッジベースのメタデータフィールド定義です。"
+          },
+          "document_count": {
+            "type": "integer",
+            "description": "ナレッジベース内のドキュメント総数です。"
+          },
+          "embedding_available": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "設定された埋め込みモデルが現在利用可能かどうかです。"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス作成に使用される埋め込みモデルの名前です。"
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "埋め込みモデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。以前のナレッジベースでは短縮形（例：`openai`）が返される場合があります。"
+          },
+          "enable_api": {
+            "type": "boolean",
+            "description": "このナレッジベースで API アクセスが有効かどうかです。"
+          },
+          "external_knowledge_info": {
+            "$ref": "#/components/schemas/DatasetExternalKnowledgeInfoResponse",
+            "description": "外部ナレッジベースの接続詳細です。`provider` が `external` の場合に存在します。"
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetExternalRetrievalModelResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "外部ナレッジベースの検索設定です。内部ナレッジベースの場合は `null` です。"
+          },
+          "icon_info": {
+            "$ref": "#/components/schemas/DatasetIconInfoResponse",
+            "description": "ナレッジベースのアイコン表示設定です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "ナレッジベースの一意識別子です。"
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "`high_quality` は埋め込みモデルを使用した精密検索、`economy` はキーワードベースのインデキシングです。"
+          },
+          "is_multimodal": {
+            "type": "boolean",
+            "description": "マルチモーダルコンテンツ処理が有効かどうかです。"
+          },
+          "is_published": {
+            "type": "boolean",
+            "description": "ナレッジベースが公開済みかどうかです。"
+          },
+          "maintainer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ナレッジベースのメンテナーの表示名です。設定されていない場合は `null` です。"
+          },
+          "name": {
+            "type": "string",
+            "description": "ナレッジベースの表示名です。ワークスペース内で一意です。"
+          },
+          "partial_member_list": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`permission` が `partial_members` の場合にアクセスを許可されたメンバーのアカウント ID です。更新レスポンスでは常に含まれ、詳細レスポンスでは `permission` が `partial_members` の場合にのみ含まれます。"
+          },
+          "permission": {
+            "type": "string",
+            "description": "このナレッジベースにアクセスできるユーザーを制御します。指定可能な値：`only_me`、`all_team_members`、`partial_members`。"
+          },
+          "permission_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "現在の呼び出し元に付与された権限識別子。"
+          },
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "カスタム処理パイプラインが設定されている場合のパイプライン ID です。"
+          },
+          "provider": {
+            "type": "string",
+            "description": "プロバイダータイプです。内部管理の場合は `vendor`、外部ナレッジベース接続の場合は `external` です。"
+          },
+          "retrieval_model_dict": {
+            "$ref": "#/components/schemas/DatasetRetrievalModelResponse",
+            "description": "ナレッジベースの検索設定です。"
+          },
+          "runtime_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ランタイム処理モードです。"
+          },
+          "summary_index_setting": {
+            "$ref": "#/components/schemas/DatasetSummaryIndexSettingResponse",
+            "description": "サマリーインデックスの設定です。"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetTagResponse"
+            },
+            "type": "array",
+            "description": "このナレッジベースに関連付けられたタグです。"
+          },
+          "total_available_documents": {
+            "type": "integer",
+            "description": "有効で利用可能なドキュメントの数です。"
+          },
+          "total_documents": {
+            "type": "integer",
+            "description": "ドキュメントの合計数です。"
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "最終更新タイムスタンプ（Unix エポック、秒単位）です。"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ナレッジベースを最後に更新したユーザーの ID です。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "全ドキュメントの合計単語数です。"
+          }
+        },
+        "required": [
+          "app_count",
+          "author_name",
+          "built_in_field_enabled",
+          "chunk_structure",
+          "created_at",
+          "created_by",
+          "data_source_type",
+          "description",
+          "doc_form",
+          "doc_metadata",
+          "document_count",
+          "embedding_model",
+          "embedding_model_provider",
+          "enable_api",
+          "external_retrieval_model",
+          "id",
+          "indexing_technique",
+          "is_multimodal",
+          "is_published",
+          "name",
+          "permission",
+          "pipeline_id",
+          "provider",
+          "retrieval_model_dict",
+          "runtime_mode",
+          "tags",
+          "total_available_documents",
+          "total_documents",
+          "updated_at",
+          "updated_by",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "DatasetDocMetadataResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "メタデータフィールド ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "メタデータフィールド名。"
+          },
+          "type": {
+            "type": "string",
+            "description": "メタデータ値の型。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetExternalKnowledgeInfoResponse": {
+        "properties": {
+          "external_knowledge_api_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部ナレッジ API のエンドポイント URL です。"
+          },
+          "external_knowledge_api_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部ナレッジ API 接続の ID です。"
+          },
+          "external_knowledge_api_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部ナレッジ API の表示名です。"
+          },
+          "external_knowledge_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部ナレッジベースの ID です。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetExternalRetrievalModelResponse": {
+        "properties": {
+          "score_threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "検索結果に必要な最小スコア。"
+          },
+          "score_threshold_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "スコアしきい値によるフィルタリングを有効にするかどうか。"
+          },
+          "top_k": {
+            "type": "integer",
+            "description": "検索結果の最大数。"
+          }
+        },
+        "required": [
+          "top_k"
+        ],
+        "type": "object"
+      },
+      "DatasetIconInfoResponse": {
+        "properties": {
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "アイコン識別子または絵文字です。"
+          },
+          "icon_background": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "アイコンの背景色です。"
+          },
+          "icon_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "アイコンの種類です。"
+          },
+          "icon_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "カスタムアイコン画像の URL です。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetKeywordSettingResponse": {
+        "properties": {
+          "keyword_weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "キーワード検索結果に割り当てられた重みです。"
+          }
+        },
+        "type": "object"
+      },
       "DatasetListQuery": {
         "properties": {
           "include_all": {
@@ -15970,6 +17125,738 @@
         },
         "type": "object"
       },
+      "DatasetListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetDetailResponse"
+            },
+            "type": "array",
+            "description": "現在のページのナレッジベース一覧。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "さらにナレッジベースがあるかどうか。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "1 ページあたりの件数です。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "現在のページ番号です。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "一致するナレッジベースの総数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataActionResponse": {
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "メタデータ操作の結果。"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataBuiltInFieldResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "組み込みメタデータフィールド名。"
+          },
+          "type": {
+            "type": "string",
+            "description": "組み込みメタデータ値の型。"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataBuiltInFieldsResponse": {
+        "properties": {
+          "fields": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetMetadataBuiltInFieldResponse"
+            },
+            "type": "array",
+            "description": "システム提供のメタデータフィールドのリストです。"
+          }
+        },
+        "required": [
+          "fields"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataListItemResponse": {
+        "properties": {
+          "count": {
+            "default": 0,
+            "type": "integer",
+            "description": "このメタデータフィールドを使用しているドキュメント数です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "メタデータフィールドの識別子です。"
+          },
+          "name": {
+            "type": "string",
+            "description": "メタデータフィールド名です。"
+          },
+          "type": {
+            "type": "string",
+            "description": "メタデータフィールドの種類です。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataListResponse": {
+        "properties": {
+          "built_in_field_enabled": {
+            "type": "boolean",
+            "description": "このナレッジベースで組み込みメタデータフィールドが有効かどうかです。"
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetMetadataListItemResponse"
+            },
+            "type": "array",
+            "description": "メタデータフィールド定義のリスト。"
+          }
+        },
+        "required": [
+          "built_in_field_enabled",
+          "doc_metadata"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "メタデータフィールド ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "メタデータフィールド名。"
+          },
+          "type": {
+            "type": "string",
+            "description": "メタデータ値の型。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetRerankingModelResponse": {
+        "properties": {
+          "reranking_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "リランキングモデル名です。"
+          },
+          "reranking_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "再ランキングモデルのプロバイダー。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetRetrievalModelResponse": {
+        "properties": {
+          "reranking_enable": {
+            "type": "boolean",
+            "description": "リランキングが有効かどうかです。"
+          },
+          "reranking_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "リランキングモードです。`reranking_model` はモデルベースのリランキング、`weighted_score` はスコアベースの重み付けを示します。リランキングが無効の場合は `null` です。"
+          },
+          "reranking_model": {
+            "$ref": "#/components/schemas/DatasetRerankingModelResponse",
+            "description": "リランキングモデルの設定です。"
+          },
+          "score_threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "結果の最小関連性スコアです。`score_threshold_enabled` が `true` の場合にのみ有効です。"
+          },
+          "score_threshold_enabled": {
+            "type": "boolean",
+            "description": "スコア閾値フィルタリングが有効かどうかです。"
+          },
+          "search_method": {
+            "type": "string",
+            "description": "検索に使用する検索方法です。`keyword_search` はキーワードマッチング、`semantic_search` は埋め込みベースの類似度検索、`full_text_search` は全文インデックス検索、`hybrid_search` はセマンティックとキーワードの組み合わせ検索を示します。"
+          },
+          "top_k": {
+            "type": "integer",
+            "description": "返す結果の最大数です。"
+          },
+          "weights": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetWeightedScoreResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ハイブリッド検索の重み設定です。"
+          }
+        },
+        "required": [
+          "reranking_enable",
+          "score_threshold_enabled",
+          "search_method",
+          "top_k"
+        ],
+        "type": "object"
+      },
+      "DatasetSummaryIndexSettingResponse": {
+        "properties": {
+          "enable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "要約インデックスを有効にするかどうか。"
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "要約生成に使用されるモデルの名前です。"
+          },
+          "model_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "要約生成モデルのプロバイダーです。"
+          },
+          "summary_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント要約の生成に使用するプロンプト。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetTagResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "タグ ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "タグ名。"
+          },
+          "type": {
+            "type": "string",
+            "description": "タグの種類。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetUpdatePayload": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 400,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ナレッジベースの説明です。"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "埋め込みモデル名。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `model` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "埋め込みモデルプロバイダー。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `provider` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+          },
+          "external_knowledge_api_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部ナレッジ API の ID。"
+          },
+          "external_knowledge_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部ナレッジベースの ID です。"
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "properties": {
+                  "score_threshold": {
+                    "description": "結果を絞り込む最小類似度スコアのしきい値。",
+                    "type": "number"
+                  },
+                  "score_threshold_enabled": {
+                    "description": "スコアしきい値によるフィルタリングを有効にするかどうか。",
+                    "type": "boolean"
+                  },
+                  "top_k": {
+                    "description": "返す結果の最大数です。",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部ナレッジベースの検索設定です。"
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "enum": [
+                  "economy",
+                  "high_quality"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`high_quality` は埋め込みモデルを使用した精密検索、`economy` はキーワードベースのインデキシングです。"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 40,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ナレッジベース名。"
+          },
+          "partial_member_list": {
+            "anyOf": [
+              {
+                "items": {
+                  "properties": {
+                    "user_id": {
+                      "description": "アクセス権を付与するチームメンバーの ID です。",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`permission` が `partial_members` の場合にアクセス権を持つチームメンバーのリストです。"
+          },
+          "permission": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PermissionEnum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このナレッジベースにアクセスできるユーザーを制御します。`only_me` は作成者のみ、`all_team_members` はワークスペース全体、`partial_members` は指定したメンバーにアクセスを許可します。"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetVectorSettingResponse": {
+        "properties": {
+          "embedding_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ベクトル検索に使用される埋め込みモデルの名前です。"
+          },
+          "embedding_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ベクトル検索に使用される埋め込みモデルのプロバイダーです。"
+          },
+          "vector_weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "セマンティック（ベクトル）検索結果に割り当てられた重みです。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetWeightedScoreResponse": {
+        "properties": {
+          "keyword_setting": {
+            "$ref": "#/components/schemas/DatasetKeywordSettingResponse",
+            "description": "キーワード検索の重み設定です。"
+          },
+          "vector_setting": {
+            "$ref": "#/components/schemas/DatasetVectorSettingResponse",
+            "description": "セマンティック検索の重み設定です。"
+          },
+          "weight_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "セマンティック検索とキーワード検索の重みを調整するための戦略です。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasourceCredentialInfoResponse": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "資格情報の ID です。 [データソースノードを実行](/ja/api-reference/knowledge-pipeline/run-datasource-node) では `credential_id` として、 [パイプラインを実行](/ja/api-reference/knowledge-pipeline/run-pipeline) の各データソース項目の `credential_id` フィールドとして渡します。"
+          },
+          "is_default": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "この資格情報がプロバイダーのデフォルトかどうかを示します。"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "資格情報の表示名です。"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "データソースプラグインが定義する資格情報のタイプです。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasourceNodeRunPayload": {
+        "properties": {
+          "credential_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "データソース認証情報 ID。省略するとデフォルトを使用します。"
+          },
+          "datasource_type": {
+            "description": "データソースの種類です。",
+            "enum": [
+              "local_file",
+              "online_document",
+              "online_drive",
+              "website_crawl"
+            ],
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "データソースノードの入力変数です。",
+            "type": "object"
+          },
+          "is_published": {
+            "description": "ノードの公開済みまたはドラフトバージョンを実行するかどうか。`true` は公開済み、`false` はドラフトを実行します。",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "datasource_type",
+          "inputs",
+          "is_published"
+        ],
+        "type": "object"
+      },
+      "DatasourcePluginListResponse": {
+        "items": {
+          "$ref": "#/components/schemas/DatasourcePluginResponse"
+        },
+        "type": "array"
+      },
+      "DatasourcePluginResponse": {
+        "properties": {
+          "credentials": {
+            "items": {
+              "$ref": "#/components/schemas/DatasourceCredentialInfoResponse"
+            },
+            "type": "array",
+            "description": "このデータソースの認証に利用できる資格情報のリストです。"
+          },
+          "datasource_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "データソースのタイプです。`local_file`、`online_document`、`online_drive`、`website_crawl` のいずれかです。"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "パイプラインワークフロー内のデータソースノードの ID です。 [データソースノードを実行](/ja/api-reference/knowledge-pipeline/run-datasource-node) では `node_id` として、 [パイプラインを実行](/ja/api-reference/knowledge-pipeline/run-pipeline) では `start_node_id` として渡します。"
+          },
+          "plugin_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このノードを提供するデータソースプラグインの ID です。"
+          },
+          "provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "データソースプラグインが登録するプロバイダー名です。"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "プラグインの表示タイトル。"
+          },
+          "user_input_variables": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "description": "このデータソースに対して呼び出し元が指定するパイプライン入力変数です。ノードのデータソースパラメータ内の `{{#...#}}` 参照から導出されます。各要素はワークフローが使用するパイプライン変数のスキーマに従います。"
+          }
+        },
+        "type": "object"
+      },
       "DatasourcePluginsQuery": {
         "properties": {
           "is_published": {
@@ -15978,6 +17865,312 @@
             "type": "boolean"
           }
         },
+        "type": "object"
+      },
+      "DocumentAndBatchResponse": {
+        "properties": {
+          "batch": {
+            "type": "string",
+            "description": "インデックス進捗を追跡するためのバッチ ID です。"
+          },
+          "document": {
+            "$ref": "#/components/schemas/DocumentResponse",
+            "description": "マッチしたチャンクの親ドキュメント情報です。"
+          }
+        },
+        "required": [
+          "batch",
+          "document"
+        ],
+        "type": "object"
+      },
+      "DocumentBatchDownloadZipPayload": {
+        "description": "ドキュメントを ZIP アーカイブとして一括ダウンロードするリクエストペイロード。",
+        "properties": {
+          "document_ids": {
+            "description": "ZIP ダウンロードに含めるドキュメント ID のリスト。",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "document_ids"
+        ],
+        "type": "object"
+      },
+      "DocumentDetailResponse": {
+        "properties": {
+          "archived": {
+            "default": null,
+            "type": "boolean",
+            "description": "ドキュメントがアーカイブ済みかどうかです。"
+          },
+          "average_segment_length": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "default": null,
+            "description": "チャンクの平均文字長です。"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "完了時刻（Unix 秒タイムスタンプ）。未完了の場合は `null`。"
+          },
+          "created_at": {
+            "default": null,
+            "type": "integer",
+            "description": "作成時刻（Unix 秒タイムスタンプ）。"
+          },
+          "created_by": {
+            "default": null,
+            "type": "string",
+            "description": "ドキュメントを作成したユーザーの ID です。"
+          },
+          "created_from": {
+            "default": null,
+            "type": "string",
+            "description": "ドキュメントの作成元です。API で作成した場合は `api`、UI で作成した場合は `web` です。"
+          },
+          "data_source_info": {
+            "additionalProperties": true,
+            "default": null,
+            "type": "object",
+            "description": "データソースの詳細です。ファイルアップロードの場合、この詳細エンドポイントは `upload_file` 配下に完全なファイルオブジェクトを返します（リストエンドポイントは `upload_file_id` のみを返します）。"
+          },
+          "data_source_type": {
+            "default": null,
+            "type": "string",
+            "description": "ドキュメントのアップロード方法です。ファイルアップロードの場合は `upload_file`、Notion インポートの場合は `notion_import` です。"
+          },
+          "dataset_process_rule": {
+            "additionalProperties": true,
+            "default": null,
+            "type": "object",
+            "description": "ナレッジベースレベルの処理ルール設定です。"
+          },
+          "dataset_process_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このドキュメントに適用された処理ルールの ID です。"
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "無効化時刻（Unix 秒タイムスタンプ）。有効な場合は `null`。"
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントを無効化したユーザーの ID です。有効な場合は `null` です。"
+          },
+          "display_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "UI 向けの表示用インデックスステータスです。"
+          },
+          "doc_form": {
+            "default": null,
+            "type": "string",
+            "description": "ドキュメントのチャンキングモードです。`text_model` は標準テキスト、`hierarchical_model` は親子構造、`qa_model` は QA ペアを示します。"
+          },
+          "doc_language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント内容の言語です。"
+          },
+          "doc_metadata": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DocumentMetadataResponse"
+                },
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このドキュメントのカスタムメタデータキーバリューペア。"
+          },
+          "doc_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントタイプの分類です。未設定の場合は `null` です。"
+          },
+          "document_process_rule": {
+            "additionalProperties": true,
+            "default": null,
+            "type": "object",
+            "description": "ドキュメントレベルの処理ルール設定です。"
+          },
+          "enabled": {
+            "default": null,
+            "type": "boolean",
+            "description": "このドキュメントが検索に対して有効かどうかです。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "インデックス作成が失敗した場合のエラーメッセージです。それ以外は `null` です。"
+          },
+          "hit_count": {
+            "default": null,
+            "type": "integer",
+            "description": "このドキュメントが検索された回数です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "ドキュメント識別子です。"
+          },
+          "indexing_latency": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "インデックス作成にかかった時間（秒）です。未完了の場合は `null` です。"
+          },
+          "indexing_status": {
+            "default": null,
+            "type": "string",
+            "description": "現在のインデックスステータスです（例：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、`error`、`paused`）。"
+          },
+          "name": {
+            "default": null,
+            "type": "string",
+            "description": "ドキュメント名です。"
+          },
+          "need_summary": {
+            "default": null,
+            "type": "boolean",
+            "description": "このドキュメントが要約生成を必要とするかどうかです。"
+          },
+          "position": {
+            "default": null,
+            "type": "integer",
+            "description": "ナレッジベース内の位置インデックスです。"
+          },
+          "segment_count": {
+            "default": null,
+            "type": "integer",
+            "description": "ドキュメント内のチャンク数です。"
+          },
+          "summary_index_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "要約インデックスのステータスです。要約インデックスが有効でない場合は `null` です。"
+          },
+          "tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント内のトークン数です。"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "最終更新時刻（Unix 秒タイムスタンプ）。"
+          }
+        },
+        "required": [
+          "id"
+        ],
         "type": "object"
       },
       "DocumentGetQuery": {
@@ -16039,6 +18232,877 @@
             ],
             "default": null,
             "description": "表示ステータスでフィルタリングします。"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentResponse"
+            },
+            "type": "array",
+            "description": "現在のページのドキュメント一覧。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "さらにドキュメントがあるかどうか。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "1 ページあたりの件数です。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "現在のページ番号です。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "一致するドキュメントの総数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "DocumentMetadataOperation": {
+        "properties": {
+          "document_id": {
+            "description": "メタデータを更新するドキュメント ID。",
+            "format": "uuid",
+            "type": "string"
+          },
+          "metadata_list": {
+            "description": "更新するメタデータフィールド。",
+            "items": {
+              "$ref": "#/components/schemas/MetadataDetail"
+            },
+            "type": "array"
+          },
+          "partial_update": {
+            "default": false,
+            "description": "メタデータを部分的に更新し、未指定フィールドの既存の値を保持するかどうかです。",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "document_id",
+          "metadata_list"
+        ],
+        "type": "object"
+      },
+      "DocumentMetadataResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "メタデータフィールドの識別子です。"
+          },
+          "name": {
+            "type": "string",
+            "description": "メタデータフィールド名です。"
+          },
+          "type": {
+            "type": "string",
+            "description": "メタデータフィールドの値の種類です。"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このドキュメントのメタデータ値。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DocumentResponse": {
+        "properties": {
+          "archived": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントがアーカイブ済みかどうかです。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントを作成したユーザーの ID です。"
+          },
+          "created_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントの作成元です。API で作成した場合は `api`、UI で作成した場合は `web` です。"
+          },
+          "data_source_detail_dict": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "ファイル詳細を含む詳細なデータソース情報です。"
+          },
+          "data_source_info": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "生のデータソース情報です。`data_source_type` によって異なります。"
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントの作成方法です。ファイルアップロードの場合は `upload_file`、Notion インポートの場合は `notion_import` です。"
+          },
+          "dataset_process_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このドキュメントに適用された処理ルールの ID です。"
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "無効化時刻（Unix 秒タイムスタンプ）。有効な場合は `null`。"
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントを無効化したユーザーの ID です。有効な場合は `null` です。"
+          },
+          "display_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`indexing_status` と `enabled` 状態から導出されたユーザー向け表示ステータスです。"
+          },
+          "doc_form": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントのチャンキングモードです。`text_model` は標準テキストチャンキング、`hierarchical_model` は親子構造、`qa_model` は QA ペア抽出を示します。"
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentMetadataResponse"
+            },
+            "type": "array",
+            "description": "このドキュメントに割り当てられたメタデータ値です。"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このドキュメントが検索に対して有効かどうかです。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "インデックス作成が失敗した場合のエラーメッセージです。エラーなしの場合は `null` です。"
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントが検索クエリでマッチした回数です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "ドキュメントの一意識別子です。"
+          },
+          "indexing_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "現在のインデックスステータスです。`waiting` はキュー待ち、`parsing` はコンテンツ抽出中、`cleaning` はノイズ除去中、`splitting` はチャンキング中、`indexing` はベクトル構築中、`completed` は準備完了、`error` は失敗、`paused` は手動一時停止を示します。"
+          },
+          "name": {
+            "type": "string",
+            "description": "ドキュメント名です。"
+          },
+          "need_summary": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このドキュメントに要約を生成する必要があるかどうかです。"
+          },
+          "position": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "リスト内のドキュメントの表示位置です。"
+          },
+          "summary_index_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このドキュメントの要約インデックスのステータスです。要約インデックスが設定されていない場合は `null` です。"
+          },
+          "tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント内の合計トークン数です。"
+          },
+          "word_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントの合計単語数です。"
+          }
+        },
+        "required": [
+          "data_source_detail_dict",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "DocumentStatusListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentStatusResponse"
+            },
+            "type": "array",
+            "description": "ドキュメント処理状態のレコード。"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "DocumentStatusPayload": {
+        "properties": {
+          "document_ids": {
+            "description": "更新するドキュメント ID のリストです。互換性のため任意です。省略するか空配列を渡すと、リクエストは成功しますがドキュメントは更新されません。",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentStatusResponse": {
+        "properties": {
+          "cleaning_completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "クリーニング完了時刻（Unix 秒タイムスタンプ）。"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス完了時刻（Unix 秒タイムスタンプ）。"
+          },
+          "completed_segments": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "インデックス済みのチャンク数です。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデキシングが失敗した場合のエラーメッセージ。エラーがない場合は `null`。"
+          },
+          "error_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "処理エラーコード。エラーがない場合は `null`。"
+          },
+          "estimated_vector_space_mb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "推定ベクトルストレージ使用量（MB）。"
+          },
+          "id": {
+            "type": "string",
+            "description": "ドキュメント識別子です。"
+          },
+          "indexing_status": {
+            "type": "string",
+            "description": "現在のインデックス状態：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、`error`、または `paused`。`completed` と `error` は終端状態です。Service API では `paused` のドキュメントを再開できません。Dify のナレッジベース画面で再開してからポーリングを続けてください。"
+          },
+          "parsing_completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "解析完了時刻（Unix 秒タイムスタンプ）。"
+          },
+          "paused_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス一時停止時刻（Unix 秒タイムスタンプ）。一時停止していない場合は `null`。"
+          },
+          "processing_started_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "処理開始時刻（Unix 秒タイムスタンプ）。"
+          },
+          "splitting_completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "分割完了時刻（Unix 秒タイムスタンプ）。"
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス停止時刻（Unix 秒タイムスタンプ）。停止していない場合は `null`。"
+          },
+          "total_segments": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "インデックス対象のチャンクの合計数です。"
+          },
+          "vector_space_limit_mb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ベクトルストレージ上限（MB）。"
+          }
+        },
+        "required": [
+          "cleaning_completed_at",
+          "completed_at",
+          "error",
+          "id",
+          "indexing_status",
+          "parsing_completed_at",
+          "paused_at",
+          "processing_started_at",
+          "splitting_completed_at",
+          "stopped_at"
+        ],
+        "type": "object"
+      },
+      "DocumentTextCreatePayload": {
+        "properties": {
+          "doc_form": {
+            "default": "text_model",
+            "description": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。",
+            "enum": [
+              "hierarchical_model",
+              "qa_model",
+              "text_model"
+            ],
+            "type": "string"
+          },
+          "doc_language": {
+            "default": "English",
+            "description": "処理最適化のためのドキュメント言語です。",
+            "type": "string"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "埋め込みモデル名。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `model` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "埋め込みモデルプロバイダー。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `provider` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "enum": [
+                  "economy",
+                  "high_quality"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`high_quality` は埋め込みモデルによる高精度検索、`economy` はキーワードベースのインデックスを使用します。ナレッジベースに最初のドキュメントを追加するときは必須です。以降は省略するとナレッジベースのインデックス方式を継承します。"
+          },
+          "name": {
+            "description": "ドキュメント名です。",
+            "type": "string"
+          },
+          "original_document_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "置換対象の元ドキュメント ID。"
+          },
+          "process_rule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProcessRule"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンキングの処理ルールです。"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+          },
+          "text": {
+            "description": "ドキュメントのテキスト内容です。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "text"
+        ],
+        "type": "object"
+      },
+      "DocumentTextUpdate": {
+        "anyOf": [
+          {
+            "properties": {
+              "doc_form": {
+                "default": "text_model",
+                "description": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。",
+                "enum": [
+                  "hierarchical_model",
+                  "qa_model",
+                  "text_model"
+                ],
+                "type": "string"
+              },
+              "doc_language": {
+                "default": "English",
+                "description": "処理最適化のためのドキュメント言語です。",
+                "type": "string"
+              },
+              "name": {
+                "default": null,
+                "description": "ドキュメント名です。`text` を指定する場合は必須です。",
+                "type": "string"
+              },
+              "process_rule": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ProcessRule"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "チャンキングの処理ルールです。"
+              },
+              "retrieval_model": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RetrievalModel"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+              },
+              "text": {
+                "default": null,
+                "description": "ドキュメントのテキスト内容です。",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "text"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "doc_form": {
+                "default": "text_model",
+                "description": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。",
+                "enum": [
+                  "hierarchical_model",
+                  "qa_model",
+                  "text_model"
+                ],
+                "type": "string"
+              },
+              "doc_language": {
+                "default": "English",
+                "description": "処理最適化のためのドキュメント言語です。",
+                "type": "string"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "ドキュメント名です。`text` を指定する場合は必須です。"
+              },
+              "process_rule": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ProcessRule"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "チャンキングの処理ルールです。"
+              },
+              "retrieval_model": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RetrievalModel"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+              },
+              "text": {
+                "description": "ドキュメントのテキスト内容です。",
+                "type": "null"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "doc_form": {
+            "default": "text_model",
+            "description": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。",
+            "enum": [
+              "hierarchical_model",
+              "qa_model",
+              "text_model"
+            ],
+            "type": "string"
+          },
+          "doc_language": {
+            "default": "English",
+            "description": "処理最適化のためのドキュメント言語です。",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメント名です。`text` を指定する場合は必須です。"
+          },
+          "process_rule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProcessRule"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンキングの処理ルールです。"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントのテキスト内容です。"
           }
         },
         "type": "object"
@@ -16152,6 +19216,14 @@
           }
         },
         "type": "object"
+      },
+      "FetchFrom": {
+        "description": "ユーザー識別子の取得元を表す列挙型。",
+        "enum": [
+          "customizable-model",
+          "predefined-model"
+        ],
+        "type": "string"
       },
       "FileInputConfig": {
         "properties": {
@@ -16463,6 +19535,469 @@
           }
         ]
       },
+      "HitTestingChildChunk": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "子チャンクのテキスト内容です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "子チャンクの一意識別子です。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "親チャンク内の子チャンクの位置です。"
+          },
+          "score": {
+            "type": "number",
+            "description": "子チャンクの関連性スコアです。"
+          }
+        },
+        "required": [
+          "content",
+          "id",
+          "position",
+          "score"
+        ],
+        "type": "object"
+      },
+      "HitTestingDocument": {
+        "properties": {
+          "data_source_type": {
+            "type": "string",
+            "description": "ドキュメントの作成方法です。"
+          },
+          "doc_metadata": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ドキュメントのメタデータ値です。メタデータが設定されていない場合は `null` です。"
+          },
+          "doc_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ドキュメントタイプの分類です。未設定の場合は `null` です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "ドキュメントの一意識別子です。"
+          },
+          "name": {
+            "type": "string",
+            "description": "ドキュメント名です。"
+          }
+        },
+        "required": [
+          "data_source_type",
+          "doc_metadata",
+          "doc_type",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "HitTestingFile": {
+        "properties": {
+          "extension": {
+            "type": "string",
+            "description": "ファイル拡張子。"
+          },
+          "id": {
+            "type": "string",
+            "description": "添付ファイルの識別子です。"
+          },
+          "mime_type": {
+            "type": "string",
+            "description": "ファイルの MIME タイプ。"
+          },
+          "name": {
+            "type": "string",
+            "description": "元のファイル名です。"
+          },
+          "size": {
+            "type": "integer",
+            "description": "ファイルサイズ（バイト）。"
+          },
+          "source_url": {
+            "type": "string",
+            "description": "添付ファイルにアクセスする URL です。"
+          }
+        },
+        "required": [
+          "extension",
+          "id",
+          "mime_type",
+          "name",
+          "size",
+          "source_url"
+        ],
+        "type": "object"
+      },
+      "HitTestingPayload": {
+        "properties": {
+          "attachment_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ナレッジベースのチャンクに添付済みの画像ファイル ID です。Dify コンソールでチャンク添付をアップロードまたは作成した際の戻り値から取得し、マルチモーダル検索テストに画像コンテキストを追加します。"
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "properties": {
+                  "score_threshold": {
+                    "description": "結果を絞り込む最小類似度スコアのしきい値。",
+                    "type": "number"
+                  },
+                  "score_threshold_enabled": {
+                    "description": "スコアしきい値によるフィルタリングを有効にするかどうか。",
+                    "type": "boolean"
+                  },
+                  "top_k": {
+                    "description": "返す結果の最大数です。",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部ナレッジベースの検索設定です。"
+          },
+          "query": {
+            "description": "検索クエリテキストです。",
+            "maxLength": 250,
+            "type": "string"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "HitTestingQuery": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "検索テストに使用するクエリテキスト。"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "HitTestingRecord": {
+        "properties": {
+          "child_chunks": {
+            "items": {
+              "$ref": "#/components/schemas/HitTestingChildChunk"
+            },
+            "type": "array",
+            "description": "階層インデックスを使用している場合、チャンク内でマッチした子チャンクです。"
+          },
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/HitTestingFile"
+            },
+            "type": "array",
+            "description": "このチャンクに添付されたファイルです。"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "関連性スコアです。"
+          },
+          "segment": {
+            "$ref": "#/components/schemas/HitTestingSegment",
+            "description": "ナレッジベースから一致したチャンクです。"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "要約インデックス経由で取得された場合の要約コンテンツです。"
+          },
+          "tsne_position": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "description": "t-SNE 可視化の位置です。"
+          }
+        },
+        "required": [
+          "child_chunks",
+          "files",
+          "score",
+          "segment",
+          "summary",
+          "tsne_position"
+        ],
+        "type": "object"
+      },
+      "HitTestingResponse": {
+        "properties": {
+          "query": {
+            "$ref": "#/components/schemas/HitTestingQuery",
+            "description": "元のクエリオブジェクトです。"
+          },
+          "records": {
+            "items": {
+              "$ref": "#/components/schemas/HitTestingRecord"
+            },
+            "type": "array",
+            "description": "一致した検索レコードのリスト。"
+          }
+        },
+        "required": [
+          "query",
+          "records"
+        ],
+        "type": "object"
+      },
+      "HitTestingSegment": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "回答コンテンツです。Q&A モードのドキュメントで使用されます。"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "完了時刻（Unix 秒タイムスタンプ）。未完了の場合は `null`。"
+          },
+          "content": {
+            "type": "string",
+            "description": "チャンクのテキスト内容です。"
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "チャンクを作成したユーザーの ID です。"
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "無効化時刻（Unix 秒タイムスタンプ）。有効な場合は `null`。"
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "チャンクを無効化したユーザーの ID です。有効な場合は `null` です。"
+          },
+          "document": {
+            "$ref": "#/components/schemas/HitTestingDocument",
+            "description": "マッチしたチャンクの親ドキュメント情報です。"
+          },
+          "document_id": {
+            "type": "string",
+            "description": "このチャンクが属するドキュメントの ID です。"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "このチャンクが検索に対して有効かどうかです。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス作成が失敗した場合のエラーメッセージです。エラーなしの場合は `null` です。"
+          },
+          "hit_count": {
+            "type": "integer",
+            "description": "このチャンクが検索クエリでマッチした回数です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "チャンクの一意識別子です。"
+          },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックスされたコンテンツのハッシュです。変更の検出に使用されます。"
+          },
+          "index_node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ベクトルストア内のインデックスノードの ID です。"
+          },
+          "indexing_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス開始時刻（Unix 秒タイムスタンプ）。未開始の場合は `null`。"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "キーワードベースの検索のためにこのチャンクに関連付けられたキーワードです。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "ドキュメント内のチャンクの位置。"
+          },
+          "sign_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "整合性検証用の署名付きコンテンツハッシュです。"
+          },
+          "status": {
+            "type": "string",
+            "description": "チャンクのインデックスステータスです。"
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス停止時刻（Unix 秒タイムスタンプ）。停止していない場合は `null`。"
+          },
+          "tokens": {
+            "type": "integer",
+            "description": "チャンク内容のトークン数です。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "チャンク内容の単語数です。"
+          }
+        },
+        "required": [
+          "answer",
+          "completed_at",
+          "content",
+          "created_at",
+          "created_by",
+          "disabled_at",
+          "disabled_by",
+          "document",
+          "document_id",
+          "enabled",
+          "error",
+          "hit_count",
+          "id",
+          "index_node_hash",
+          "index_node_id",
+          "indexing_at",
+          "keywords",
+          "position",
+          "sign_content",
+          "status",
+          "stopped_at",
+          "tokens",
+          "word_count"
+        ],
+        "type": "object"
+      },
       "HumanInputContent": {
         "properties": {
           "form_definition": {
@@ -16770,6 +20305,31 @@
         "properties": {},
         "type": "object"
       },
+      "I18nObject": {
+        "description": "国際化オブジェクトのモデル。",
+        "properties": {
+          "en_US": {
+            "type": "string",
+            "description": "英語（米国）のテキスト。"
+          },
+          "zh_Hans": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "簡体字中国語のテキスト。"
+          }
+        },
+        "required": [
+          "en_US"
+        ],
+        "type": "object"
+      },
       "IndexInfoResponse": {
         "properties": {
           "api_version": {
@@ -16799,6 +20359,46 @@
       "JSONValue": {},
       "JSONValueType": {},
       "JsonValue": {},
+      "KnowledgeTagListResponse": {
+        "items": {
+          "$ref": "#/components/schemas/KnowledgeTagResponse"
+        },
+        "type": "array"
+      },
+      "KnowledgeTagResponse": {
+        "properties": {
+          "binding_count": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "このタグにバインドされたナレッジベースの数です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "タグ識別子です。"
+          },
+          "name": {
+            "type": "string",
+            "description": "タグの表示名です。"
+          },
+          "type": {
+            "type": "string",
+            "description": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
       "MessageFeedbackPayload": {
         "properties": {
           "content": {
@@ -17188,6 +20788,187 @@
           "conversation_id"
         ],
         "type": "object"
+      },
+      "MetadataArgs": {
+        "properties": {
+          "name": {
+            "description": "メタデータフィールド名です。",
+            "type": "string"
+          },
+          "type": {
+            "description": "`string` はテキスト値、`number` は数値、`time` は日付/時刻値です。",
+            "enum": [
+              "number",
+              "string",
+              "time"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "MetadataDetail": {
+        "properties": {
+          "id": {
+            "description": "メタデータフィールド ID。",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "メタデータフィールド名です。",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "メタデータ値。文字列、数値、または `null` を指定できます。"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "MetadataFilteringCondition": {
+        "description": "メタデータのフィルタリング条件。",
+        "properties": {
+          "conditions": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Condition"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "deprecated": true,
+            "description": "評価するメタデータ条件のリストです。"
+          },
+          "logical_operator": {
+            "anyOf": [
+              {
+                "enum": [
+                  "and",
+                  "or"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "and",
+            "description": "複数の条件を組み合わせる方法です。"
+          }
+        },
+        "type": "object"
+      },
+      "MetadataOperationData": {
+        "description": "メタデータ操作データ。",
+        "properties": {
+          "operation_data": {
+            "description": "ドキュメントメタデータ更新操作の配列。各エントリはドキュメント ID をそのメタデータ値に対応付けます。",
+            "items": {
+              "$ref": "#/components/schemas/DocumentMetadataOperation"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "operation_data"
+        ],
+        "type": "object"
+      },
+      "MetadataUpdatePayload": {
+        "properties": {
+          "name": {
+            "description": "新しいメタデータフィールド名。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "ModelFeature": {
+        "description": "LLM 機能の列挙型。",
+        "enum": [
+          "agent-thought",
+          "audio",
+          "document",
+          "multi-tool-call",
+          "polling",
+          "stream-tool-call",
+          "structured-output",
+          "tool-call",
+          "video",
+          "vision"
+        ],
+        "type": "string"
+      },
+      "ModelPropertyKey": {
+        "description": "モデルプロパティキーの列挙型。",
+        "enum": [
+          "audio_type",
+          "context_size",
+          "default_voice",
+          "file_upload_limit",
+          "max_characters_per_chunk",
+          "max_chunks",
+          "max_workers",
+          "mode",
+          "supported_file_extensions",
+          "voices",
+          "word_limit"
+        ],
+        "type": "string"
+      },
+      "ModelStatus": {
+        "description": "モデル状態の列挙型。",
+        "enum": [
+          "active",
+          "credential-removed",
+          "disabled",
+          "no-configure",
+          "no-permission",
+          "quota-exceeded"
+        ],
+        "type": "string"
+      },
+      "ModelType": {
+        "description": "モデルタイプの列挙型。",
+        "enum": [
+          "llm",
+          "moderation",
+          "rerank",
+          "speech2text",
+          "text-embedding",
+          "tts"
+        ],
+        "type": "string"
       },
       "OptionalServiceApiUserPayload": {
         "properties": {
@@ -18638,6 +22419,557 @@
         ],
         "type": "object"
       },
+      "PermissionEnum": {
+        "description": "リソース（ナレッジベース、認証情報など）の共有権限レベル。",
+        "enum": [
+          "all_team_members",
+          "only_me",
+          "partial_members"
+        ],
+        "type": "string"
+      },
+      "PipelineDataset": {
+        "properties": {
+          "chunk_structure": {
+            "type": "string",
+            "description": "ナレッジベースに設定されたチャンク構造。"
+          },
+          "description": {
+            "default": "",
+            "description": "ナレッジベースの説明。",
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "リソース ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "リソース名。"
+          }
+        },
+        "required": [
+          "chunk_structure",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "PipelineDocument": {
+        "properties": {
+          "data_source_info": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "データソース固有のメタデータ（存在する場合）。"
+          },
+          "data_source_type": {
+            "type": "string",
+            "description": "データソースの種類。"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "ドキュメントが検索に使用できるかどうか。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "インデックス作成エラー。エラーがない場合は `null`。"
+          },
+          "id": {
+            "type": "string",
+            "description": "リソース ID。"
+          },
+          "indexing_status": {
+            "type": "string",
+            "description": "キューに入ったドキュメントの現在のインデックス状態です。レスポンスの `batch` を使って[ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status)を呼び出し、段階ごとの進捗を確認します。`completed` と `error` は終端状態で、`paused` の場合は再開後にポーリングを続けます。"
+          },
+          "name": {
+            "type": "string",
+            "description": "リソース名。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "バッチ内でのドキュメントの位置。"
+          }
+        },
+        "required": [
+          "data_source_type",
+          "enabled",
+          "id",
+          "indexing_status",
+          "name",
+          "position"
+        ],
+        "type": "object"
+      },
+      "PipelineRunApiEntity": {
+        "properties": {
+          "datasource_info_list": {
+            "description": "処理するデータソースオブジェクトの一覧です。`datasource_type` により項目の形が決まります。`local_file` は `reference`、`online_document` は `workspace_id` と `page`、`online_drive` は `id` と `type`（必要に応じて `bucket`）、`website_crawl` は `url` を使用します。生成された `oneOf` の順序は、ローカルファイル、オンラインドキュメント、Web クロール、オンラインドライブです。",
+            "items": {
+              "oneOf": [
+                {
+                  "properties": {
+                    "name": {
+                      "description": "ドキュメントタイトル。デフォルトは `untitled`。",
+                      "type": "string"
+                    },
+                    "reference": {
+                      "description": "[ナレッジパイプラインファイルをアップロード](/ja/api-reference/knowledge-pipeline/upload-pipeline-file)エンドポイントで返される `id` を使用します。`related_id` も別名として使用できます。",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "reference"
+                  ],
+                  "title": "ローカルファイル",
+                  "type": "object",
+                  "description": "ローカルファイルの参照。"
+                },
+                {
+                  "properties": {
+                    "credential_id": {
+                      "description": "外部プラットフォームの認証に使用する認証情報。省略するとプロバイダーのデフォルト認証情報を使用します。",
+                      "type": "string"
+                    },
+                    "page": {
+                      "description": "ページの詳細です。",
+                      "properties": {
+                        "page_id": {
+                          "description": "Dify で設定済みオンラインドキュメントプロバイダーのワークスペースまたはデータベースを参照した際に、プロバイダーから返されるページ ID。",
+                          "type": "string"
+                        },
+                        "page_name": {
+                          "description": "表示名。デフォルトは `untitled`。",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "データソースプラグインが定義するページタイプ。",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "page_id",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    "workspace_id": {
+                      "description": "設定済みオンラインドキュメントプロバイダー内のワークスペースまたはデータベース ID。Dify でプロバイダーを選択または参照した際に取得します。Dify ワークスペース ID ではなく、プロバイダー側のリソース ID です。",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "page",
+                    "workspace_id"
+                  ],
+                  "title": "オンラインドキュメント",
+                  "type": "object",
+                  "description": "オンラインドキュメントプロバイダー内のページ。"
+                },
+                {
+                  "properties": {
+                    "title": {
+                      "description": "ドキュメント名として使用します。デフォルトは `untitled`。",
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "クロールする URL。",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ],
+                  "title": "Web クロール",
+                  "type": "object",
+                  "description": "クロールする Web サイト URL。"
+                },
+                {
+                  "properties": {
+                    "bucket": {
+                      "description": "ストレージバケット名。S3 互換ストアなど一部のドライブプロバイダーでは必須です。プロバイダーがバケットを使用しない場合は省略します。",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "Dify で設定済みオンラインドライブプロバイダーを参照した際に、プロバイダーから返されるファイルまたはフォルダー ID。",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "ファイル名。デフォルトは `untitled`。",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "この項目が単一ファイルか、展開対象のフォルダかを指定します。",
+                      "enum": [
+                        "file",
+                        "folder"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "type"
+                  ],
+                  "title": "オンラインドライブ",
+                  "type": "object",
+                  "description": "オンラインドライブプロバイダー内のファイルまたはフォルダー。"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "datasource_type": {
+            "description": "データソースのタイプ。`datasource_info_list` の各項目に必要なフィールドを決定します。",
+            "enum": [
+              "local_file",
+              "online_document",
+              "online_drive",
+              "website_crawl"
+            ],
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "パイプライン入力変数のキーと値のペア。ワークフローで定義されたパイプライン変数に対応します。入力変数がない場合は `{}` を渡してください。",
+            "type": "object"
+          },
+          "is_published": {
+            "description": "ナレッジパイプラインの公開済みまたはドラフトバージョンを実行するかどうか。`true` は最新の公開済みバージョン、`false` は現在のドラフトを実行します。後者は未公開の変更のテストに便利です。",
+            "type": "boolean"
+          },
+          "response_mode": {
+            "description": "ドラフト実行のレスポンスモード。SSE には `streaming`、JSON には `blocking` を使用します。公開済みバージョンの実行はキューに入り、常にバッチメタデータを JSON で返します。",
+            "enum": [
+              "blocking",
+              "streaming"
+            ],
+            "type": "string"
+          },
+          "start_node_id": {
+            "description": "実行を開始するデータソースノード ID。データソースノードは、ファイル、プロバイダーページ、ドライブ、URL を読み込むナレッジパイプラインの入口ステップです。[データソースプラグインを一覧表示](/ja/api-reference/knowledge-pipeline/list-datasource-plugins)が返す `node_id` を使用します。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "datasource_info_list",
+          "datasource_type",
+          "inputs",
+          "is_published",
+          "response_mode",
+          "start_node_id"
+        ],
+        "type": "object"
+      },
+      "PipelineRunJsonResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PublishedPipelineRunResponse"
+          },
+          {
+            "$ref": "#/components/schemas/WorkflowBlockingResponse"
+          }
+        ]
+      },
+      "PipelineUploadFileResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "アップロードのタイムスタンプ（ISO 8601 形式）です。レコード作成中は `null` となることがあります。"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "ファイルをアップロードしたユーザーの ID。"
+          },
+          "extension": {
+            "type": "string",
+            "description": "ファイル拡張子。"
+          },
+          "id": {
+            "type": "string",
+            "description": "アップロードされたファイルの一意識別子です。"
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ファイルの MIME タイプです。アップロードに MIME タイプが含まれない場合、`null` となることがあります。"
+          },
+          "name": {
+            "type": "string",
+            "description": "元のファイル名です。"
+          },
+          "size": {
+            "type": "integer",
+            "description": "ファイルサイズ（バイト）。"
+          }
+        },
+        "required": [
+          "created_by",
+          "extension",
+          "id",
+          "name",
+          "size"
+        ],
+        "type": "object"
+      },
+      "PreProcessingRule": {
+        "properties": {
+          "enabled": {
+            "description": "この前処理ルールが有効かどうかです。",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "ルール識別子です。",
+            "enum": [
+              "remove_extra_spaces",
+              "remove_stopwords",
+              "remove_urls_emails"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "enabled",
+          "id"
+        ],
+        "type": "object"
+      },
+      "ProcessRule": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/ProcessRuleMode",
+            "description": "処理モード。`automatic` は組み込みルール、`custom` は手動設定を使用し、`hierarchical` は `doc_form: hierarchical_model` の親子チャンク構造を有効にします。"
+          },
+          "rules": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Rule"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "カスタム処理ルール。"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "ProcessRuleMode": {
+        "description": "ナレッジベース処理ルールモード。",
+        "enum": [
+          "automatic",
+          "custom",
+          "hierarchical"
+        ],
+        "type": "string"
+      },
+      "ProviderModelWithStatusEntity": {
+        "description": "モデルレスポンスのデータモデル。",
+        "properties": {
+          "deprecated": {
+            "default": false,
+            "type": "boolean",
+            "description": "モデルが非推奨かどうか。"
+          },
+          "features": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ModelFeature"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "モデルがサポートする機能です。なしの場合は `null` です。"
+          },
+          "fetch_from": {
+            "$ref": "#/components/schemas/FetchFrom",
+            "description": "モデル定義の取得元です。`predefined-model` は組み込みモデル、`customizable-model` はユーザー設定モデルを示します。"
+          },
+          "has_invalid_load_balancing_configs": {
+            "default": false,
+            "type": "boolean",
+            "description": "モデルに無効なロードバランシング設定があるかどうか。"
+          },
+          "label": {
+            "$ref": "#/components/schemas/I18nObject",
+            "description": "モデルのローカライズ表示名です。"
+          },
+          "load_balancing_enabled": {
+            "default": false,
+            "type": "boolean",
+            "description": "モデルのロードバランシングが有効かどうか。"
+          },
+          "model": {
+            "type": "string",
+            "description": "モデル識別子です。ナレッジベースの作成または更新時に `embedding_model` の値として使用します。"
+          },
+          "model_properties": {
+            "additionalProperties": true,
+            "propertyNames": {
+              "$ref": "#/components/schemas/ModelPropertyKey"
+            },
+            "type": "object",
+            "description": "`context_size` などのモデル固有のプロパティです。"
+          },
+          "model_type": {
+            "$ref": "#/components/schemas/ModelType",
+            "description": "モデルのタイプです。`model_type` パスパラメータと一致します。"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ModelStatus",
+            "description": "モデルの利用可能ステータスです。使用可能な場合は `active` です。"
+          }
+        },
+        "required": [
+          "fetch_from",
+          "label",
+          "model",
+          "model_properties",
+          "model_type",
+          "status"
+        ],
+        "type": "object"
+      },
+      "ProviderWithModelsListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ProviderWithModelsResponse"
+            },
+            "type": "array",
+            "description": "モデルプロバイダーと利用可能なモデル。"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ProviderWithModelsResponse": {
+        "description": "モデル一覧を含むプロバイダーレスポンスのデータモデル。",
+        "properties": {
+          "icon_small": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/I18nObject"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "プロバイダーの小アイコンの URL です。"
+          },
+          "icon_small_dark": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/I18nObject"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ダークモード用アイコンの URL。プロバイダーにない場合は `null`。"
+          },
+          "label": {
+            "$ref": "#/components/schemas/I18nObject",
+            "description": "プロバイダーのローカライズ表示名です。"
+          },
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/ProviderModelWithStatusEntity"
+            },
+            "type": "array",
+            "description": "このプロバイダーから利用可能なモデルのリストです。"
+          },
+          "provider": {
+            "type": "string",
+            "description": "モデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。以前のプロバイダーでは短縮形（例：`openai`）が返される場合があります。"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CustomConfigurationStatus",
+            "description": "プロバイダーのステータスです。認証情報が設定済みで有効な場合は `active` です。"
+          },
+          "tenant_id": {
+            "type": "string",
+            "description": "このプロバイダー設定が属するワークスペース ID。"
+          }
+        },
+        "required": [
+          "label",
+          "models",
+          "provider",
+          "status",
+          "tenant_id"
+        ],
+        "type": "object"
+      },
+      "PublishedPipelineRunResponse": {
+        "properties": {
+          "batch": {
+            "type": "string",
+            "description": "キューに入った公開済み実行のバッチ ID。[ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) の `batch` として渡し、すべてのドキュメントが完了、失敗、または一時停止になるまでポーリングしてください。"
+          },
+          "dataset": {
+            "$ref": "#/components/schemas/PipelineDataset",
+            "description": "生成されたドキュメントを受け取るナレッジベース。"
+          },
+          "documents": {
+            "items": {
+              "$ref": "#/components/schemas/PipelineDocument"
+            },
+            "type": "array",
+            "description": "作成され、インデックス作成待ちのキューに追加されたドキュメント。"
+          }
+        },
+        "required": [
+          "batch",
+          "dataset",
+          "documents"
+        ],
+        "type": "object"
+      },
       "RequiredServiceApiUserPayload": {
         "properties": {
           "user": {
@@ -18648,6 +22980,35 @@
         "required": [
           "user"
         ],
+        "type": "object"
+      },
+      "RerankingModel": {
+        "properties": {
+          "reranking_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "リランキングモデル名です。"
+          },
+          "reranking_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "再ランキングモデルのプロバイダー名。"
+          }
+        },
         "type": "object"
       },
       "ResultResponse": {
@@ -18662,187 +23023,105 @@
         ],
         "type": "object"
       },
-      "RetrievalModel": {
-        "type": "object",
-        "required": [
-          "search_method",
-          "reranking_enable",
-          "top_k",
-          "score_threshold_enabled"
+      "RetrievalMethod": {
+        "enum": [
+          "full_text_search",
+          "hybrid_search",
+          "keyword_search",
+          "semantic_search"
         ],
+        "type": "string"
+      },
+      "RetrievalModel": {
         "properties": {
-          "search_method": {
-            "type": "string",
-            "description": "検索に使用される検索メソッドです。",
-            "enum": [
-              "keyword_search",
-              "semantic_search",
-              "full_text_search",
-              "hybrid_search"
-            ]
+          "metadata_filtering_conditions": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MetadataFilteringCondition"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ドキュメントのメタデータが指定した条件に一致するチャンクのみを取得対象に絞り込みます。条件はサーバーサイドで評価されます。"
           },
           "reranking_enable": {
-            "type": "boolean",
-            "description": "リランキングが有効かどうかです。"
-          },
-          "reranking_model": {
-            "type": "object",
-            "description": "リランキングモデルの設定です。",
-            "properties": {
-              "reranking_provider_name": {
-                "type": "string",
-                "description": "リランクモデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/cohere/cohere`）。`cohere` のような短縮名は `langgenius/<name>/<name>` に展開され、langgenius が公開したプラグインでのみ機能します。\n\n有効な値は [利用可能なモデルを取得](/ja/api-reference/models/get-available-models) で `model_type=rerank` を指定した際の `provider` フィールドから取得します。"
-              },
-              "reranking_model_name": {
-                "type": "string",
-                "description": "リランキングモデル名です。"
-              }
-            }
+            "description": "リランキングが有効かどうかです。",
+            "type": "boolean"
           },
           "reranking_mode": {
-            "type": "string",
-            "enum": [
-              "reranking_model",
-              "weighted_score"
+            "anyOf": [
+              {
+                "enum": [
+                  "reranking_model",
+                  "weighted_score"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "nullable": true,
+            "default": null,
             "description": "リランキングモードです。`reranking_enable` が `true` の場合は必須です。"
           },
-          "top_k": {
-            "type": "integer",
-            "description": "返す結果の最大数です。"
-          },
-          "score_threshold_enabled": {
-            "type": "boolean",
-            "description": "スコア閾値フィルタリングが有効かどうかです。"
+          "reranking_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RerankingModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "リランキングモデルの設定です。"
           },
           "score_threshold": {
-            "type": "number",
-            "nullable": true,
-            "description": "結果の最小関連性スコアです。`score_threshold_enabled` が `true` の場合にのみ有効です。"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "最小類似度スコア（0〜1）。`score_threshold_enabled` が `true` の場合のみ有効です。"
+          },
+          "score_threshold_enabled": {
+            "description": "スコア閾値フィルタリングが有効かどうかです。",
+            "type": "boolean"
+          },
+          "search_method": {
+            "$ref": "#/components/schemas/RetrievalMethod",
+            "description": "検索に使用される検索メソッドです。"
+          },
+          "top_k": {
+            "description": "返す結果の最大数です。",
+            "type": "integer"
           },
           "weights": {
-            "type": "object",
-            "nullable": true,
-            "description": "ハイブリッド検索の重み設定です。",
-            "properties": {
-              "weight_type": {
-                "type": "string",
-                "description": "セマンティック検索とキーワード検索の重みを調整するための戦略です。",
-                "enum": [
-                  "semantic_first",
-                  "keyword_first",
-                  "customized"
-                ]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WeightModel"
               },
-              "vector_setting": {
-                "type": "object",
-                "description": "セマンティック検索の重み設定です。",
-                "properties": {
-                  "vector_weight": {
-                    "type": "number",
-                    "description": "セマンティック（ベクトル）検索結果に割り当てられた重みです。"
-                  },
-                  "embedding_provider_name": {
-                    "type": "string",
-                    "description": "ベクトル検索に使用される埋め込みモデルのプロバイダーです。"
-                  },
-                  "embedding_model_name": {
-                    "type": "string",
-                    "description": "ベクトル検索に使用される埋め込みモデルの名前です。"
-                  }
-                }
-              },
-              "keyword_setting": {
-                "type": "object",
-                "description": "キーワード検索の重み設定です。",
-                "properties": {
-                  "keyword_weight": {
-                    "type": "number",
-                    "description": "キーワード検索結果に割り当てられた重みです。"
-                  }
-                }
+              {
+                "type": "null"
               }
-            }
-          },
-          "metadata_filtering_conditions": {
-            "type": "object",
-            "nullable": true,
-            "description": "ドキュメントのメタデータが指定した条件に一致するチャンクのみを取得対象に絞り込みます。条件はサーバーサイドで評価されます。",
-            "properties": {
-              "logical_operator": {
-                "type": "string",
-                "enum": [
-                  "and",
-                  "or"
-                ],
-                "default": "and",
-                "nullable": true,
-                "description": "複数の条件を組み合わせる方法です。"
-              },
-              "conditions": {
-                "type": "array",
-                "nullable": true,
-                "description": "評価するメタデータ条件のリストです。",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "name",
-                    "comparison_operator"
-                  ],
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "比較対象とするメタデータフィールド名です。"
-                    },
-                    "comparison_operator": {
-                      "type": "string",
-                      "description": "適用する比較方法です。メタデータのタイプ別：\n\n- 文字列または配列のメタデータ：`contains`、`not contains`、`start with`、`end with`、`is`、`is not`、`empty`、`not empty`、`in`、`not in`\n- 数値メタデータ：`=`、`≠`、`>`、`<`、`≥`、`≤`\n- 時刻メタデータ：`before`、`after`",
-                      "enum": [
-                        "contains",
-                        "not contains",
-                        "start with",
-                        "end with",
-                        "is",
-                        "is not",
-                        "empty",
-                        "not empty",
-                        "in",
-                        "not in",
-                        "=",
-                        "≠",
-                        ">",
-                        "<",
-                        "≥",
-                        "≤",
-                        "before",
-                        "after"
-                      ]
-                    },
-                    "value": {
-                      "nullable": true,
-                      "description": "比較対象の値です。型は `comparison_operator` によって異なります。ほとんどの文字列演算子では文字列、`in` および `not in` では文字列配列、数値演算子では数値、`empty` および `not empty` では省略します。",
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        {
-                          "type": "number"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
+            ],
+            "default": null,
+            "description": "ハイブリッド検索の重み設定です。"
           }
-        }
+        },
+        "required": [
+          "reranking_enable",
+          "score_threshold_enabled",
+          "search_method",
+          "top_k"
+        ],
+        "type": "object"
       },
       "RetrieverResource": {
         "properties": {
@@ -19040,6 +23319,218 @@
         "type": "object",
         "description": "検索リソースの引用および帰属情報です。"
       },
+      "Rule": {
+        "properties": {
+          "parent_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "full-doc",
+                  "paragraph"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "親子セグメンテーションモード。"
+          },
+          "pre_processing_rules": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PreProcessingRule"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンク分割前に適用する前処理ルール。"
+          },
+          "segmentation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Segmentation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "親チャンクの分割設定。"
+          },
+          "subchunk_segmentation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Segmentation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "子チャンクのセグメンテーション設定。"
+          }
+        },
+        "type": "object"
+      },
+      "SegmentAttachmentResponse": {
+        "properties": {
+          "extension": {
+            "type": "string",
+            "description": "ファイル拡張子。"
+          },
+          "id": {
+            "type": "string",
+            "description": "添付ファイルの識別子です。"
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ファイルの MIME タイプ。"
+          },
+          "name": {
+            "type": "string",
+            "description": "元のファイル名です。"
+          },
+          "size": {
+            "type": "integer",
+            "description": "ファイルサイズ（バイト）。"
+          },
+          "source_url": {
+            "type": "string",
+            "description": "添付ファイルにアクセスする URL です。"
+          }
+        },
+        "required": [
+          "extension",
+          "id",
+          "mime_type",
+          "name",
+          "size",
+          "source_url"
+        ],
+        "type": "object"
+      },
+      "SegmentCreateItemPayload": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "QA モードの回答内容。"
+          },
+          "attachment_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "添付ファイル ID です。"
+          },
+          "content": {
+            "description": "チャンクのテキスト内容です。",
+            "minLength": 1,
+            "type": "string"
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンクのキーワードです。"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "SegmentCreateListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SegmentResponse"
+            },
+            "type": "array",
+            "description": "作成されたチャンクのリスト。"
+          },
+          "doc_form": {
+            "type": "string",
+            "description": "このドキュメントが使用するドキュメントチャンキングモードです。"
+          }
+        },
+        "required": [
+          "data",
+          "doc_form"
+        ],
+        "type": "object"
+      },
+      "SegmentCreatePayload": {
+        "properties": {
+          "segments": {
+            "description": "作成するチャンクオブジェクトの配列です。",
+            "items": {
+              "$ref": "#/components/schemas/SegmentCreateItemPayload"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "segments"
+        ],
+        "type": "object"
+      },
+      "SegmentDetailResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SegmentResponse",
+            "description": "作成されたチャンクのリスト。"
+          },
+          "doc_form": {
+            "type": "string",
+            "description": "このドキュメントが使用するドキュメントチャンキングモードです。"
+          }
+        },
+        "required": [
+          "data",
+          "doc_form"
+        ],
+        "type": "object"
+      },
       "SegmentListQuery": {
         "properties": {
           "keyword": {
@@ -19074,6 +23565,403 @@
             "type": "array"
           }
         },
+        "type": "object"
+      },
+      "SegmentListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SegmentResponse"
+            },
+            "type": "array",
+            "description": "チャンクのリスト。"
+          },
+          "doc_form": {
+            "type": "string",
+            "description": "このドキュメントが使用するドキュメントチャンキングモードです。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "次のページにさらに項目が存在するかどうかです。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "1 ページあたりの件数です。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "現在のページ番号です。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "一致するチャンクの合計数です。"
+          }
+        },
+        "required": [
+          "data",
+          "doc_form",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "SegmentResponse": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "回答コンテンツです。Q&A モードのドキュメントで使用されます。"
+          },
+          "attachments": {
+            "items": {
+              "$ref": "#/components/schemas/SegmentAttachmentResponse"
+            },
+            "type": "array",
+            "description": "このチャンクに添付されたファイルです。"
+          },
+          "child_chunks": {
+            "items": {
+              "$ref": "#/components/schemas/ChildChunkResponse"
+            },
+            "type": "array",
+            "description": "このチャンクに属する子チャンクです。階層モードのドキュメントにのみ存在します。"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "完了時刻（Unix 秒タイムスタンプ）。未完了の場合は `null`。"
+          },
+          "content": {
+            "type": "string",
+            "description": "チャンクのテキスト内容です。"
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "チャンクを作成したユーザーの ID です。"
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "無効化時刻（Unix 秒タイムスタンプ）。有効な場合は `null`。"
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "チャンクを無効化したユーザーの ID です。有効な場合は `null` です。"
+          },
+          "document_id": {
+            "type": "string",
+            "description": "このチャンクが属するドキュメントの ID です。"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "このチャンクが検索に対して有効かどうかです。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス作成が失敗した場合のエラーメッセージです。エラーなしの場合は `null` です。"
+          },
+          "hit_count": {
+            "type": "integer",
+            "description": "このチャンクが検索クエリでマッチした回数です。"
+          },
+          "id": {
+            "type": "string",
+            "description": "チャンクの一意識別子です。"
+          },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックスされたコンテンツのハッシュです。変更の検出に使用されます。"
+          },
+          "index_node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ベクトルストア内のインデックスノードの ID です。"
+          },
+          "indexing_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス開始時刻（Unix 秒タイムスタンプ）。未開始の場合は `null`。"
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "キーワードベースの検索のためにこのチャンクに関連付けられたキーワードです。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "ドキュメント内のチャンクの位置。"
+          },
+          "sign_content": {
+            "type": "string",
+            "description": "整合性検証用の署名付きコンテンツハッシュです。"
+          },
+          "status": {
+            "type": "string",
+            "description": "チャンクの現在のインデックスステータスです（例：`completed`、`indexing`、`error`）。"
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "インデックス停止時刻（Unix 秒タイムスタンプ）。停止していない場合は `null`。"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "AI が生成したチャンクコンテンツの要約です。要約インデックスが有効でない場合は `null` です。"
+          },
+          "tokens": {
+            "type": "integer",
+            "description": "チャンク内容のトークン数です。"
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "最終更新タイムスタンプ（Unix エポック、秒単位）です。"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "このチャンクを最後に更新したユーザーの ID です。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "チャンク内容の単語数です。"
+          }
+        },
+        "required": [
+          "answer",
+          "attachments",
+          "child_chunks",
+          "completed_at",
+          "content",
+          "created_at",
+          "created_by",
+          "disabled_at",
+          "disabled_by",
+          "document_id",
+          "enabled",
+          "error",
+          "hit_count",
+          "id",
+          "index_node_hash",
+          "index_node_id",
+          "indexing_at",
+          "keywords",
+          "position",
+          "sign_content",
+          "status",
+          "stopped_at",
+          "summary",
+          "tokens",
+          "updated_at",
+          "updated_by",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "SegmentUpdateArgs": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "QA モードの更新後の回答内容。"
+          },
+          "attachment_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "添付ファイル ID です。"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "更新後のチャンクテキスト内容。"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "チャンクが有効かどうかです。"
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "更新後のチャンクキーワード。"
+          },
+          "regenerate_child_chunks": {
+            "default": false,
+            "description": "親チャンクの更新後に子チャンクを再生成するかどうか。",
+            "type": "boolean"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "サマリーインデックスのサマリー内容です。"
+          }
+        },
+        "type": "object"
+      },
+      "SegmentUpdatePayload": {
+        "properties": {
+          "segment": {
+            "$ref": "#/components/schemas/SegmentUpdateArgs",
+            "description": "チャンク更新ペイロード。"
+          }
+        },
+        "required": [
+          "segment"
+        ],
+        "type": "object"
+      },
+      "Segmentation": {
+        "properties": {
+          "chunk_overlap": {
+            "default": 0,
+            "description": "チャンク間のトークンオーバーラップです。",
+            "type": "integer"
+          },
+          "max_tokens": {
+            "description": "チャンクあたりの最大トークン数です。",
+            "type": "integer"
+          },
+          "separator": {
+            "default": "\n",
+            "description": "テキスト分割用のカスタムセパレーターです。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "max_tokens"
+        ],
         "type": "object"
       },
       "SelectInputConfig": {
@@ -19510,6 +24398,136 @@
         ],
         "type": "object"
       },
+      "TagBindingPayload": {
+        "properties": {
+          "tag_ids": {
+            "description": "バインドするタグ ID。",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "target_id": {
+            "description": "タグをバインドするナレッジベース ID。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag_ids",
+          "target_id"
+        ],
+        "type": "object"
+      },
+      "TagCreatePayload": {
+        "properties": {
+          "name": {
+            "description": "タグ名。",
+            "maxLength": 50,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "TagDeletePayload": {
+        "properties": {
+          "tag_id": {
+            "description": "削除するタグ ID。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag_id"
+        ],
+        "type": "object"
+      },
+      "TagUnbindingPayload": {
+        "anyOf": [
+          {
+            "properties": {
+              "tag_id": {
+                "deprecated": true,
+                "description": "Service API が受け付ける従来の単一タグ ID。",
+                "type": "string"
+              },
+              "tag_ids": {
+                "description": "バインドを解除するタグ ID。新しい連携ではこのフィールドを使用します。",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "target_id": {
+                "description": "ナレッジベース ID。",
+                "type": "string"
+              }
+            },
+            "required": [
+              "tag_id",
+              "target_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "tag_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "deprecated": true,
+                "description": "Service API が受け付ける従来の単一タグ ID。"
+              },
+              "tag_ids": {
+                "description": "バインドを解除するタグ ID。新しい連携ではこのフィールドを使用します。",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "target_id": {
+                "description": "ナレッジベース ID。",
+                "type": "string"
+              }
+            },
+            "required": [
+              "tag_ids",
+              "target_id"
+            ],
+            "type": "object"
+          }
+        ],
+        "description": "従来の `tag_id` ペイロードまたは正規化された `tag_ids` ペイロードを受け付けます。"
+      },
+      "TagUpdatePayload": {
+        "properties": {
+          "name": {
+            "description": "タグ名。",
+            "maxLength": 50,
+            "minLength": 1,
+            "type": "string"
+          },
+          "tag_id": {
+            "description": "更新するタグ ID。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "tag_id"
+        ],
+        "type": "object"
+      },
       "TextToAudioPayload": {
         "properties": {
           "message_id": {
@@ -19639,6 +24657,18 @@
         ],
         "type": "object"
       },
+      "UrlResponse": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "元のアップロードファイルをダウンロードするための署名付き URL です。"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
       "UserActionConfig": {
         "description": "ユーザーアクション設定。",
         "properties": {
@@ -19672,6 +24702,86 @@
           "variable"
         ],
         "type": "string"
+      },
+      "WeightKeywordSetting": {
+        "properties": {
+          "keyword_weight": {
+            "description": "キーワード検索の重み（0〜1）。`customized` では `vector_weight` との合計を 1 にしてください。",
+            "type": "number"
+          }
+        },
+        "required": [
+          "keyword_weight"
+        ],
+        "type": "object"
+      },
+      "WeightModel": {
+        "properties": {
+          "keyword_setting": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WeightKeywordSetting"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "キーワード検索の重み設定です。"
+          },
+          "vector_setting": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WeightVectorSetting"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "セマンティック検索の重み設定です。"
+          },
+          "weight_type": {
+            "anyOf": [
+              {
+                "enum": [
+                  "customized",
+                  "keyword_first",
+                  "semantic_first"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "セマンティック検索とキーワード検索の重みを調整するための戦略です。"
+          }
+        },
+        "type": "object"
+      },
+      "WeightVectorSetting": {
+        "properties": {
+          "embedding_model_name": {
+            "description": "ベクトル検索に使用される埋め込みモデルの名前です。",
+            "type": "string"
+          },
+          "embedding_provider_name": {
+            "description": "ベクトル検索に使用される埋め込みモデルのプロバイダーです。",
+            "type": "string"
+          },
+          "vector_weight": {
+            "description": "セマンティックベクトル検索の重み（0〜1）。`customized` では `keyword_weight` との合計を 1 にしてください。",
+            "type": "number"
+          }
+        },
+        "required": [
+          "embedding_model_name",
+          "embedding_provider_name",
+          "vector_weight"
+        ],
+        "type": "object"
       },
       "WorkflowAppLogPaginationResponse": {
         "properties": {

--- a/tools/api-pipeline/service_api_overlays/en.json
+++ b/tools/api-pipeline/service_api_overlays/en.json
@@ -1663,6 +1663,26 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/ChildChunkCreatePayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkCreatePayload/title",
+      "source_sha256": "63545ce8324fb96303684989379acf8bb56616431c2d7d2f2ee57aa798bebaf5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkDetailResponse/properties/data/description",
+      "value": "Child chunk details."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkDetailResponse/title",
+      "source_sha256": "72326278aa33e7dda0521892ceb9f2a9912539cbc389704eb117ce9d7c7faaaa"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/ChildChunkListQuery/properties/keyword/title",
       "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
     },
@@ -1680,6 +1700,156 @@
       "op": "remove",
       "path": "/components/schemas/ChildChunkListQuery/title",
       "source_sha256": "b1c6a7020550b6caf74316c4f6f0d9a79bb59b5fe961a3d65331855b2e4fa238"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/data/description",
+      "value": "List of child chunks."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/limit/description",
+      "value": "Number of items per page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/page/description",
+      "value": "Current page number."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total/description",
+      "value": "Total number of child chunks."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total_pages/description",
+      "value": "Total number of pages."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total_pages/title",
+      "source_sha256": "c03585d62e7e0882cfed2ce3ffadcf457b534f19db1ffd398904f4b4c52b5968"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/title",
+      "source_sha256": "7b68d427a9281bbf65f91ec8e00ba8cd0661c8453a3df5f5df8ddba3a2be88bc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/content/description",
+      "value": "Text content of the child chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/created_at/description",
+      "value": "Creation timestamp (Unix epoch in seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/id/description",
+      "value": "Unique identifier of the child chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/position/description",
+      "value": "Position of the child chunk within the parent chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/segment_id/description",
+      "value": "ID of the parent chunk this child chunk belongs to."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/segment_id/title",
+      "source_sha256": "7290170777560d41462deb95fa0c1a27884f2e487befa6820e24cf1acedb6131"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/type/description",
+      "value": "How the child chunk was created. Child chunks created or updated through the API are always `customized`. System-generated child chunks are `automatic`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/updated_at/description",
+      "value": "Last update timestamp (Unix epoch in seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/word_count/description",
+      "value": "Word count of the child chunk content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/title",
+      "source_sha256": "94b6c59461791bd7058253d2f17269c2f89aec959082b91763ec8ba4ac115e08"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkUpdatePayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkUpdatePayload/title",
+      "source_sha256": "f34d01f7a5ac4cb28c70bf838fd8e8b61e215925e3bf5af6aebc939ae29966dc"
     },
     {
       "op": "add",
@@ -1962,6 +2132,26 @@
       "op": "remove",
       "path": "/components/schemas/CompletionRequestPayloadWithUser/title",
       "source_sha256": "af0367558fbca9f02fe0c6614e89b0fbaddd2d5462f4aa34f224f2cdf7e90469"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/properties/comparison_operator/title",
+      "source_sha256": "01a4c1663da6b258d5d69743ddaf9f446b7fb8dee538d679a015632cae854a28"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/title",
+      "source_sha256": "418c09a9d05967071c8370af38aa90aa2d0a6d3d13fc29f24e3cfd3a5072c903"
     },
     {
       "op": "add",
@@ -2270,6 +2460,1008 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/CustomConfigurationStatus/title",
+      "source_sha256": "3bae16102634941742ef8cad684cb2c401e1a6f58d28512171907a70e3ba001e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/data/description",
+      "value": "List of tags bound to this knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/total/description",
+      "value": "Total number of tags bound to this knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagListResponse/title",
+      "source_sha256": "de75c865a92dbd9a6c18ec22dff029362c605134dac75b2b1524393d4cd47d68"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/id/description",
+      "value": "Tag identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/name/description",
+      "value": "Tag display name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagResponse/title",
+      "source_sha256": "5411684822d2302289f08f32442c0d2bdd62c8b7255759cd1bfd65c071141727"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model/description",
+      "source_sha256": "a57676abae00b587600f25027f744a24863f5a9c56780647ccaa7efe6422cdb5",
+      "value": "Embedding model name. Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model_provider/description",
+      "source_sha256": "fbc8249d511185eedbe6c1e9ee65c5f0d7e75d5b2fa2cc1b0ff71ea4ea22e403",
+      "value": "Embedding model provider. Use the `provider` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/external_knowledge_api_id/title",
+      "source_sha256": "e2dcf725ee077104f9442be1880b13f8247bc7a88800a43f8c816c9fd9d3a103"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/external_knowledge_id/title",
+      "source_sha256": "579ead72f48e7a70e00c88363de59534661ce4d149e6aad38a4dfc7d16b1a18c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/title",
+      "source_sha256": "73071309e0ecc3a2e4d5fb7b899a4d2cca1754749b85f5f8f11cf336d15950fc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/title",
+      "source_sha256": "479456528114cc52c4e9464416aee5791234ca861ab8c03096a5d7729cf567fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/app_count/description",
+      "value": "Number of applications currently using this knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/app_count/title",
+      "source_sha256": "f2ebc0260c1ba325417509c378782eb056a1d42309a8bf94f240177008a3bfc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/author_name/description",
+      "value": "Display name of the creator."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/author_name/title",
+      "source_sha256": "184bab624ca3534f57b76d065cf11c51a641c53cceed8e6b5f7909a253e49313"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/built_in_field_enabled/description",
+      "value": "Whether built-in metadata fields (e.g., `document_name`, `uploader`) are enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/built_in_field_enabled/title",
+      "source_sha256": "60f3d06b21a1179f5971124c3333c5ffe7798e4371795f20f99bd634a01ba7a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/chunk_structure/description",
+      "value": "Chunk structure configuration."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/chunk_structure/title",
+      "source_sha256": "b6a62f5f409a72d8767489993f9615846dbae82c4f90a4707c872820c63fce60"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_at/description",
+      "value": "Creation timestamp (Unix epoch in seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_by/description",
+      "value": "ID of the user who created the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/data_source_type/description",
+      "value": "Data source type of the documents, `null` if not yet configured."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/description/description",
+      "value": "Optional text describing the purpose or contents of the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_form/description",
+      "value": "Document chunking mode. `text_model` for standard text chunking, `hierarchical_model` for parent-child structure, `qa_model` for QA pair extraction."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_metadata/description",
+      "value": "Metadata field definitions for the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/document_count/description",
+      "value": "Total number of documents in the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/document_count/title",
+      "source_sha256": "cff5b204c719e8f553af52bb13ff9c6caadba08aa6829be7eaed2a4650606693"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_available/description",
+      "value": "Whether the configured embedding model is currently available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_available/title",
+      "source_sha256": "c44b36a0f326462ba7c2c3167cd518c6030452fe525d726b472f292877fcd89f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model/description",
+      "value": "Name of the embedding model used for indexing."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model_provider/description",
+      "value": "Embedding model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). Legacy knowledge bases may return the bare short form (e.g. `openai`)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/enable_api/description",
+      "value": "Whether API access is enabled for this knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/enable_api/title",
+      "source_sha256": "65555b2eb75a2490bacdb1d58b89c6adfc5ae0eb4fda9e608512a48d21ccd5ee"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/external_knowledge_info/description",
+      "value": "Connection details for external knowledge bases. Present when `provider` is `external`."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/external_retrieval_model/description",
+      "value": "Retrieval settings for external knowledge bases. `null` for internal knowledge bases."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/icon_info/description",
+      "value": "Icon display configuration for the knowledge base."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/id/description",
+      "value": "Unique identifier of the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/indexing_technique/description",
+      "value": "`high_quality` uses embedding models for precise search; `economy` uses keyword-based indexing."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_multimodal/description",
+      "value": "Whether multimodal content processing is enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_multimodal/title",
+      "source_sha256": "b112c0ee183ed23fc1cc424141a495e358651addcec0d222c1813d1955e479ca"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_published/description",
+      "value": "Whether the knowledge base is published."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/maintainer/description",
+      "value": "Display name of the knowledge base maintainer. `null` if not set."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/maintainer/title",
+      "source_sha256": "adb42886fe6fc2303496997ccbad46ef2368b62efd170c13234d110e1212e653"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/name/description",
+      "value": "Display name of the knowledge base. Unique within the workspace."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission/description",
+      "value": "Controls who can access this knowledge base. Possible values: `only_me`, `all_team_members`, `partial_members`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission/title",
+      "source_sha256": "75723d503a92ba27c175213c3ad840a7d22eed24be167a8dc77d6a9084cd2bb3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission_keys/description",
+      "value": "Permission identifiers granted to the current caller."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission_keys/title",
+      "source_sha256": "409bf340be15ca6cefbc9bd5df37bbdbbf6d293db607b6ced17849e0e393988a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/pipeline_id/description",
+      "value": "Pipeline ID, if a custom processing pipeline is configured."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/pipeline_id/title",
+      "source_sha256": "d01d3715d91c35f794d5bf05d4196cd3aa8a4ac64785d6c15a16a75e2884ea18"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/provider/description",
+      "value": "Provider type. `vendor` for internally managed, `external` for external knowledge base connections."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/retrieval_model_dict/description",
+      "value": "Retrieval configuration for the knowledge base."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/runtime_mode/description",
+      "value": "Runtime processing mode."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/runtime_mode/title",
+      "source_sha256": "b04a8dd4ab04780b7d2b0f193b72314937c29e61442c3fb340ad52c611087494"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/summary_index_setting/description",
+      "value": "Summary index configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/tags/description",
+      "value": "Tags associated with this knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/tags/title",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_available_documents/description",
+      "value": "Number of documents that are enabled and available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_available_documents/title",
+      "source_sha256": "9354b71ade36bbbde5a486b117577d8ed19d3220bb3f0308b7ab1e396930e36f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_documents/description",
+      "value": "Total number of documents."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_documents/title",
+      "source_sha256": "7e154d8fa98b2d20c75a1fbb7b46e5821f8be6fd37f9ee73733c7e91cbd730e0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_at/description",
+      "value": "Last update timestamp (Unix epoch in seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_by/description",
+      "value": "ID of the user who last updated the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_by/title",
+      "source_sha256": "6b595a302a4b98836b4b277762776908278d6090a198a6ae17e592b71b68abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/word_count/description",
+      "value": "Total word count across all documents."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/title",
+      "source_sha256": "ba6ffb167022ed5355326584c7caee0cda68d61adcb226234cc43526e21533e0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/app_count/description",
+      "value": "Number of applications currently using this knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/app_count/title",
+      "source_sha256": "f2ebc0260c1ba325417509c378782eb056a1d42309a8bf94f240177008a3bfc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/author_name/description",
+      "value": "Display name of the creator."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/author_name/title",
+      "source_sha256": "184bab624ca3534f57b76d065cf11c51a641c53cceed8e6b5f7909a253e49313"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/built_in_field_enabled/description",
+      "value": "Whether built-in metadata fields (e.g., `document_name`, `uploader`) are enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/built_in_field_enabled/title",
+      "source_sha256": "60f3d06b21a1179f5971124c3333c5ffe7798e4371795f20f99bd634a01ba7a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/chunk_structure/description",
+      "value": "Chunk structure configuration."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/chunk_structure/title",
+      "source_sha256": "b6a62f5f409a72d8767489993f9615846dbae82c4f90a4707c872820c63fce60"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_at/description",
+      "value": "Creation timestamp (Unix epoch in seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_by/description",
+      "value": "ID of the user who created the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/data_source_type/description",
+      "value": "Data source type of the documents, `null` if not yet configured."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/description/description",
+      "value": "Optional text describing the purpose or contents of the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_form/description",
+      "value": "Document chunking mode. `text_model` for standard text chunking, `hierarchical_model` for parent-child structure, `qa_model` for QA pair extraction."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_metadata/description",
+      "value": "Metadata field definitions for the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/document_count/description",
+      "value": "Total number of documents in the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/document_count/title",
+      "source_sha256": "cff5b204c719e8f553af52bb13ff9c6caadba08aa6829be7eaed2a4650606693"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_available/description",
+      "value": "Whether the configured embedding model is currently available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_available/title",
+      "source_sha256": "c44b36a0f326462ba7c2c3167cd518c6030452fe525d726b472f292877fcd89f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model/description",
+      "value": "Name of the embedding model used for indexing."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model_provider/description",
+      "value": "Embedding model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). Legacy knowledge bases may return the bare short form (e.g. `openai`)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/enable_api/description",
+      "value": "Whether API access is enabled for this knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/enable_api/title",
+      "source_sha256": "65555b2eb75a2490bacdb1d58b89c6adfc5ae0eb4fda9e608512a48d21ccd5ee"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/external_knowledge_info/description",
+      "value": "Connection details for external knowledge bases. Present when `provider` is `external`."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/external_retrieval_model/description",
+      "value": "Retrieval settings for external knowledge bases. `null` for internal knowledge bases."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/icon_info/description",
+      "value": "Icon display configuration for the knowledge base."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/id/description",
+      "value": "Unique identifier of the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/indexing_technique/description",
+      "value": "`high_quality` uses embedding models for precise search; `economy` uses keyword-based indexing."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_multimodal/description",
+      "value": "Whether multimodal content processing is enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_multimodal/title",
+      "source_sha256": "b112c0ee183ed23fc1cc424141a495e358651addcec0d222c1813d1955e479ca"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_published/description",
+      "value": "Whether the knowledge base is published."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/maintainer/description",
+      "value": "Display name of the knowledge base maintainer. `null` if not set."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/maintainer/title",
+      "source_sha256": "adb42886fe6fc2303496997ccbad46ef2368b62efd170c13234d110e1212e653"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/name/description",
+      "value": "Display name of the knowledge base. Unique within the workspace."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/partial_member_list/description",
+      "value": "Account IDs of members granted access when `permission` is `partial_members`. Always present on the update response; on the detail response, present only when `permission` is `partial_members`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/partial_member_list/title",
+      "source_sha256": "b7497e9ca926924b443c8190d5c56b19295545ce67ea435097982fea0d0b97c8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission/description",
+      "value": "Controls who can access this knowledge base. Possible values: `only_me`, `all_team_members`, `partial_members`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission/title",
+      "source_sha256": "75723d503a92ba27c175213c3ad840a7d22eed24be167a8dc77d6a9084cd2bb3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission_keys/description",
+      "value": "Permission identifiers granted to the current caller."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission_keys/title",
+      "source_sha256": "409bf340be15ca6cefbc9bd5df37bbdbbf6d293db607b6ced17849e0e393988a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/pipeline_id/description",
+      "value": "Pipeline ID, if a custom processing pipeline is configured."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/pipeline_id/title",
+      "source_sha256": "d01d3715d91c35f794d5bf05d4196cd3aa8a4ac64785d6c15a16a75e2884ea18"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/provider/description",
+      "value": "Provider type. `vendor` for internally managed, `external` for external knowledge base connections."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/retrieval_model_dict/description",
+      "value": "Retrieval configuration for the knowledge base."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/runtime_mode/description",
+      "value": "Runtime processing mode."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/runtime_mode/title",
+      "source_sha256": "b04a8dd4ab04780b7d2b0f193b72314937c29e61442c3fb340ad52c611087494"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/summary_index_setting/description",
+      "value": "Summary index configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/tags/description",
+      "value": "Tags associated with this knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/tags/title",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_available_documents/description",
+      "value": "Number of documents that are enabled and available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_available_documents/title",
+      "source_sha256": "9354b71ade36bbbde5a486b117577d8ed19d3220bb3f0308b7ab1e396930e36f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_documents/description",
+      "value": "Total number of documents."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_documents/title",
+      "source_sha256": "7e154d8fa98b2d20c75a1fbb7b46e5821f8be6fd37f9ee73733c7e91cbd730e0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_at/description",
+      "value": "Last update timestamp (Unix epoch in seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_by/description",
+      "value": "ID of the user who last updated the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_by/title",
+      "source_sha256": "6b595a302a4b98836b4b277762776908278d6090a198a6ae17e592b71b68abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/word_count/description",
+      "value": "Total word count across all documents."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/title",
+      "source_sha256": "120511150e6d03ea4d60dd9815a2c45e71051bc59c102cdbd092af3031b0f1c2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/id/description",
+      "value": "Metadata field ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/name/description",
+      "value": "Metadata field name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/type/description",
+      "value": "Metadata value type."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/title",
+      "source_sha256": "e51fee287704b0e9cf4008142fb394e284e0d4937f08dad8ec917e1cb0bec0fe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_endpoint/description",
+      "value": "Endpoint URL of the external knowledge API."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_endpoint/title",
+      "source_sha256": "e27ae06d6dd9320dcafb7f6b9180869c764e5ed409c4802b5923c634c78eeef3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_id/description",
+      "value": "ID of the external knowledge API connection."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_id/title",
+      "source_sha256": "e2dcf725ee077104f9442be1880b13f8247bc7a88800a43f8c816c9fd9d3a103"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_name/description",
+      "value": "Display name of the external knowledge API."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_name/title",
+      "source_sha256": "ef4ab335626277134a4538efb6061eb32a11d8c1d0c53f1e39b258f875ca45a2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_id/description",
+      "value": "ID of the external knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_id/title",
+      "source_sha256": "579ead72f48e7a70e00c88363de59534661ce4d149e6aad38a4dfc7d16b1a18c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/title",
+      "source_sha256": "76c321b297c352e17ff1d92c2b7ffcbc3b496886ddbce569f5f9524befcbcf83"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold/description",
+      "value": "Minimum score required for a retrieval result."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold_enabled/description",
+      "value": "Whether score threshold filtering is enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold_enabled/title",
+      "source_sha256": "33e7b2a6e80860238254ee394cff0875c97ba3ba486bd89f1919f34dfe77abc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/top_k/description",
+      "value": "Maximum number of retrieval results."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/top_k/title",
+      "source_sha256": "08cf18c91d1b734279713b3783ef3a997cda93cc0aab4059885a3dfc3159c81c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/title",
+      "source_sha256": "c1d5e899db040acf563ce5efea0320fba15cde42bc2c3c1febebbc68c9abfab6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon/description",
+      "value": "Icon identifier or emoji."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon/title",
+      "source_sha256": "a4c7282e026e9c0eb1fc174c7d813fb7e1fc644829b38d12c28db5f9b9514330"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_background/description",
+      "value": "Background color for the icon."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_background/title",
+      "source_sha256": "15067379b68b825a8c24c73dca876adf650c51636467e4209270fac5b87c6dda"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_type/description",
+      "value": "Type of icon."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_type/title",
+      "source_sha256": "285323907b457c9b9afe39555fbc8def3298246940561fc8587bfb6e657e3170"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_url/description",
+      "value": "URL of a custom icon image."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_url/title",
+      "source_sha256": "2002ea73f523b651e2e6f4c79f87fcd5231a172d575ec276ef2bbcee3d338405"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/title",
+      "source_sha256": "b9c742e98a7d10591464bedf3c7f1fa5a5719f4d5ce7987776b7b9ffca373e70"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetKeywordSettingResponse/properties/keyword_weight/description",
+      "value": "Weight assigned to keyword search results."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetKeywordSettingResponse/properties/keyword_weight/title",
+      "source_sha256": "577b14638d81d6d6c18433bcef87546069492150025ba80645a9ef107e8f9eb0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetKeywordSettingResponse/title",
+      "source_sha256": "a676998f43edd7113f5cd12cda4d9f4604b80c3b5a4b53144ec546bd639f89ae"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/DatasetListQuery/properties/include_all/title",
       "source_sha256": "0ed407edf20b9a0cd51edb26d336b83ab00e4b98009f3bd0c0b98c6c5aa670ee"
     },
@@ -2299,6 +3491,673 @@
       "source_sha256": "fc0d9565af1ad1839448481672b9f23de466a6299631b453b5d8e7e2739696fa"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/data/description",
+      "value": "Knowledge bases on the current page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/has_more/description",
+      "value": "Whether more knowledge bases are available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/limit/description",
+      "value": "Number of items per page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/page/description",
+      "value": "Current page number."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/total/description",
+      "value": "Total number of matching knowledge bases."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/title",
+      "source_sha256": "b27970249561883526cc142777c7a15ada9823a94261ade0caed3899167ba66a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataActionResponse/properties/result/description",
+      "value": "Result of the metadata action."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataActionResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataActionResponse/title",
+      "source_sha256": "bb6d438cd416c2d5855dab3174a12afbeaa6dde88a76c610a2df7e9d6dfc7cab"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/name/description",
+      "value": "Built-in metadata field name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/type/description",
+      "value": "Built-in metadata value type."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/title",
+      "source_sha256": "c3d8af8888f05da403256335d33cd62c21a51caa95216be03c5e8318bc087bae"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldsResponse/properties/fields/description",
+      "value": "List of system-provided metadata fields."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldsResponse/properties/fields/title",
+      "source_sha256": "150e2a17d78790e48f1973e0c4a2e32f724f8b820b1e65408839ac69a44d0ccb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldsResponse/title",
+      "source_sha256": "cc4cafdf6f466ddcc365b39ad1db3d2c8461f15945919fa0053ad60df042446a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/count/description",
+      "value": "Number of documents using this metadata field."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/count/title",
+      "source_sha256": "8a4beb9a57edc26e6a3c411c6ba603e9dba4e821f8e4244e826a7db1f64c1051"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/id/description",
+      "value": "Metadata field identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/name/description",
+      "value": "Metadata field name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/type/description",
+      "value": "Metadata field type."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/title",
+      "source_sha256": "11ffbfd3754323d98ef086412d09df0e68b5ec4ffbb1acb6a31f7e6f3c08cac7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/built_in_field_enabled/description",
+      "value": "Whether built-in metadata fields are enabled for this knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/built_in_field_enabled/title",
+      "source_sha256": "60f3d06b21a1179f5971124c3333c5ffe7798e4371795f20f99bd634a01ba7a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/doc_metadata/description",
+      "value": "List of metadata field definitions."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListResponse/title",
+      "source_sha256": "975c6bdb3d471d8eccefb635980149f6bebee325856d2fd0af03d860cf6e0ec0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/id/description",
+      "value": "Metadata field ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/name/description",
+      "value": "Metadata field name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/type/description",
+      "value": "Metadata value type."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/title",
+      "source_sha256": "0a214240d8a1f0936bf587059a13ca79732abeac3384930f10ef944e194d96ce"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_model_name/description",
+      "value": "Name of the reranking model."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_model_name/title",
+      "source_sha256": "84c57945febff99bd6d302f456cc0c67177d5564c52716407f118e8f2e8fc041"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_provider_name/description",
+      "value": "Provider of the reranking model."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_provider_name/title",
+      "source_sha256": "60b41a32b54ab0b9acf6ad2d6c68ee0ff1e2ad26650e94e289f4265e71a59581"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRerankingModelResponse/title",
+      "source_sha256": "40008ca2d608ce08030c342e753190b7612ea0b1f7c873fc70f01bddfdc1d0f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_enable/description",
+      "value": "Whether reranking is enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_enable/title",
+      "source_sha256": "cc1894711ba2670a7ad95df9cb248ff4496427dc4e61eefde0f555ebdaeec218"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_mode/description",
+      "value": "Reranking mode. `reranking_model` for model-based reranking, `weighted_score` for score-based weighting. `null` if reranking is disabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_mode/title",
+      "source_sha256": "f5301c9027acd776f86cf98e696814c2b9404bfe29ccf772a75b020694c93dd5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_model/description",
+      "value": "Reranking model configuration."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold/description",
+      "value": "Minimum similarity score for results. Only effective when `score_threshold_enabled` is `true`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold_enabled/description",
+      "value": "Whether score threshold filtering is enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold_enabled/title",
+      "source_sha256": "33e7b2a6e80860238254ee394cff0875c97ba3ba486bd89f1919f34dfe77abc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/search_method/description",
+      "value": "Search method used for retrieval. `keyword_search` for keyword matching, `semantic_search` for embedding-based similarity, `full_text_search` for full-text indexing, `hybrid_search` for a combination of semantic and keyword approaches."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/search_method/title",
+      "source_sha256": "1b3a6e09048c1873ec9bf86eda6798c0654e1fd48edce3c148e31783353badbc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/top_k/description",
+      "value": "Maximum number of results to return."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/top_k/title",
+      "source_sha256": "08cf18c91d1b734279713b3783ef3a997cda93cc0aab4059885a3dfc3159c81c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/weights/description",
+      "value": "Weight configuration for hybrid search."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/title",
+      "source_sha256": "6aaf327c2cc64329c0397dfca30ef31db0b9c270e5287b82fa664ce7a05c2210"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/enable/description",
+      "value": "Whether summary indexing is enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/enable/title",
+      "source_sha256": "992e91e5c8cdb4be1ba11d9ba0ead16ecc43ba3231652481845b26d9e71fb5e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_name/description",
+      "value": "Name of the model used for generating summaries."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_name/title",
+      "source_sha256": "34c44e6c7f885e0aa41e55418f39ac0e3199d9023a1ce834595fc14e58529df7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_provider_name/description",
+      "value": "Provider of the summary generation model."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_provider_name/title",
+      "source_sha256": "d23d50574b82636f866334d72f5c4b3967f61223f3651d409311d7c8d12f3df7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/summary_prompt/description",
+      "value": "Prompt used to generate document summaries."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/summary_prompt/title",
+      "source_sha256": "c12c46aae2806b7ebd252b7dd20ca574299a3024a053ea630184c2d7d4e2c012"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/title",
+      "source_sha256": "d70e583cd54c31f5ddd76d706e3a37aa20a53c92ba1a257159a50c5d5e4dfa05"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetTagResponse/properties/id/description",
+      "value": "Tag ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetTagResponse/properties/name/description",
+      "value": "Tag name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetTagResponse/properties/type/description",
+      "value": "Tag type."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/title",
+      "source_sha256": "58b36e80c267af2940ebfd8c8c26eafc0aa273eb5383759267412049d939bc10"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model/description",
+      "source_sha256": "a57676abae00b587600f25027f744a24863f5a9c56780647ccaa7efe6422cdb5",
+      "value": "Embedding model name. Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model_provider/description",
+      "source_sha256": "fbc8249d511185eedbe6c1e9ee65c5f0d7e75d5b2fa2cc1b0ff71ea4ea22e403",
+      "value": "Embedding model provider. Use the `provider` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_knowledge_api_id/title",
+      "source_sha256": "e2dcf725ee077104f9442be1880b13f8247bc7a88800a43f8c816c9fd9d3a103"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_knowledge_id/title",
+      "source_sha256": "579ead72f48e7a70e00c88363de59534661ce4d149e6aad38a4dfc7d16b1a18c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/title",
+      "source_sha256": "d03fc29219971b95e45ea314fa45f7195207bd25b5275c364b5fc398b8a4a2c0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/partial_member_list/title",
+      "source_sha256": "b7497e9ca926924b443c8190d5c56b19295545ce67ea435097982fea0d0b97c8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/title",
+      "source_sha256": "6f40b26ba5761d0bef97beea667093c20b23e8fbdc9224c664c30ca4e3ccd46f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_model_name/description",
+      "value": "Name of the embedding model used for vector search."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_model_name/title",
+      "source_sha256": "4d79d966137d5bf514424da3770d0535ef6289a20ce67d7d5be6038198ccd6bf"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_provider_name/description",
+      "value": "Provider of the embedding model used for vector search."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_provider_name/title",
+      "source_sha256": "4e0310d84c92f0465d3c1184754fbd60864f0d6925435fa6eff884947966e073"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/vector_weight/description",
+      "value": "Weight assigned to semantic (vector) search results."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/vector_weight/title",
+      "source_sha256": "6a405f1ff0999e072f0178b60240aecf12ebe66f212fc2c78450e2876050f29d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/title",
+      "source_sha256": "c2905945c9f349af23c6f1c154922af8d37b2be5a1fb7bf657521fbd7dfb415b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/keyword_setting/description",
+      "value": "Keyword search weight settings."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/vector_setting/description",
+      "value": "Semantic search weight settings."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/weight_type/description",
+      "value": "Strategy for balancing semantic and keyword search weights."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/weight_type/title",
+      "source_sha256": "2e0fc6f3749fdbeac0065d9c56f1ce8fcdd30d133b1a8c00b5f42eda78ce8b2a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/title",
+      "source_sha256": "f230dd59f57c357aa0fc146b9c1bc4112edda596bd7e1f59f370b352e5de2f78"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/id/description",
+      "value": "Credential ID. Pass this as `credential_id` to [Run Datasource Node](/en/api-reference/knowledge-pipeline/run-datasource-node) or in per-item `credential_id` fields of [Run Pipeline](/en/api-reference/knowledge-pipeline/run-pipeline)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/is_default/description",
+      "value": "Whether this credential is the default for the provider."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/is_default/title",
+      "source_sha256": "3677617520e227631859c6715a99229221a19d3f4ade215934607bc716ee1991"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/name/description",
+      "value": "Display name of the credential."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/type/description",
+      "value": "Credential type defined by the datasource plugin."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/title",
+      "source_sha256": "984e4f1a417a9283c66e4d11fe3f6a11fc76eb59343cdea6e00eb054340ad536"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/credential_id/title",
+      "source_sha256": "d637e68184a5e5e808af8ab9a5673857a63e64d82e30e47529405518805d0983"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/datasource_type/title",
+      "source_sha256": "1ddade5ac920148720355e512eb186d05c2511471941c47e4307d239b1f03f83"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/title",
+      "source_sha256": "dbde50e1a779b6c90ba30e96a5c8bda78717a8799badbc614d9c13675f32c2cd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginListResponse/title",
+      "source_sha256": "27a91134481f05acc93398cd9865f2fe6f8a1aa17cb7e6d58ccb7a6b8c286a1e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/credentials/description",
+      "value": "Credentials available for authenticating with this datasource."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/credentials/title",
+      "source_sha256": "28d24da580aa5c063887d5508597035026c7caf82a9598a5a01fb70e955463fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/datasource_type/description",
+      "value": "Type of datasource. One of `local_file`, `online_document`, `online_drive`, `website_crawl`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/datasource_type/title",
+      "source_sha256": "1ddade5ac920148720355e512eb186d05c2511471941c47e4307d239b1f03f83"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/node_id/description",
+      "value": "ID of the datasource node in the pipeline workflow. Pass this as `node_id` to [Run Datasource Node](/en/api-reference/knowledge-pipeline/run-datasource-node), or as `start_node_id` to [Run Pipeline](/en/api-reference/knowledge-pipeline/run-pipeline)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/plugin_id/description",
+      "value": "ID of the datasource plugin providing this node."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/plugin_id/title",
+      "source_sha256": "1cbd2f6573f6512c5db14a93d59ddc4b09a591546d66cc51bc0d881a92de08f4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/provider_name/description",
+      "value": "Provider name registered by the datasource plugin."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/provider_name/title",
+      "source_sha256": "3610e3d454ff9d1c255e9ec61ce6cedc89589d47026d8e113168c41a8859a700"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/title/description",
+      "value": "Plugin display title."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/title/title",
+      "source_sha256": "4be9d4f1daabdb03afb07253382b19d77501261a6106d734746734605436aa77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/user_input_variables/description",
+      "value": "Pipeline input variables the caller must supply for this datasource, derived from `{{#...#}}` references in the node's datasource parameters. Each item follows the pipeline variable schema used by the workflow."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/user_input_variables/title",
+      "source_sha256": "56a7fdabc079363149486cd0f29e9c7461d8d91f8cd2b9f70e03a3f346d0711f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/title",
+      "source_sha256": "bed82dfa465fa00a84ab21411d01eff1e458f1d0e5978173250857f5609fbf4d"
+    },
+    {
       "op": "remove",
       "path": "/components/schemas/DatasourcePluginsQuery/properties/is_published/title",
       "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
@@ -2307,6 +4166,351 @@
       "op": "remove",
       "path": "/components/schemas/DatasourcePluginsQuery/title",
       "source_sha256": "63246588db3edc622fc9aeef4dc8cdfe80ccee0f8e90d4df88b85d9b5a09db16"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentAndBatchResponse/properties/batch/description",
+      "value": "Batch ID for tracking indexing progress."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentAndBatchResponse/properties/batch/title",
+      "source_sha256": "026b89e52976b2603339b009c7e7547467948fb0753001d02deaa79180427305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentAndBatchResponse/properties/document/description",
+      "value": "Parent document information for the matched chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentAndBatchResponse/title",
+      "source_sha256": "3504d6ad4554dcb3ac5a6e7307b16c222db259229109883bf903a5c6bfbd860d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentBatchDownloadZipPayload/properties/document_ids/title",
+      "source_sha256": "dc2a6757bb082f1cd12d85478d340d6d79013f1f3c382be5c6ffc4faee398176"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentBatchDownloadZipPayload/title",
+      "source_sha256": "8530113fc7b84b60536923586316ab99e0419aef64f256f2f105b1ee004e9ecd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/archived/description",
+      "value": "Whether the document is archived."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/archived/title",
+      "source_sha256": "8541102da5d25ddd0f39f05c975618421519547c67475c4a73cfafac24accec1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/average_segment_length/description",
+      "value": "Average character length of chunks."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/average_segment_length/title",
+      "source_sha256": "a01c272dd964ca429ab71ab2ceafae0782202a241e8b34e63c86ed79f10cd4ff"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/completed_at/description",
+      "value": "Completion time as a Unix timestamp in seconds; `null` if not completed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_at/description",
+      "value": "Creation time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_by/description",
+      "value": "ID of the user who created the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_from/description",
+      "value": "Origin of the document. `api` for API creation, `web` for UI creation."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_from/title",
+      "source_sha256": "ac7605d36b5da31a00bcf6692a557183ddce029a6ca4c5fb5cc911c9e9fd1495"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_info/description",
+      "value": "Data source details. For file uploads, this detail endpoint returns the full file object under `upload_file` (the list endpoint returns only `upload_file_id`)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_info/title",
+      "source_sha256": "04fc73b8bbb0b1fd1a8bcb259069d7a0107de9f8eb895eaee40b81077b977e8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_type/description",
+      "value": "How the document was uploaded. `upload_file` for file uploads, `notion_import` for Notion imports."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule/description",
+      "value": "Knowledge-base-level processing rule configuration."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule/title",
+      "source_sha256": "ba53a68d3795b4649956a33af1310f064cf6dad79057bc158e4934bcefab4c1e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule_id/description",
+      "value": "ID of the processing rule applied to this document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule_id/title",
+      "source_sha256": "7fe87b64e27b7605197b76399c4f820ed867d9acb75bbdb744928f5414822bcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_at/description",
+      "value": "Disable time as a Unix timestamp in seconds; `null` if enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_by/description",
+      "value": "ID of the user who disabled the document, `null` if enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/display_status/description",
+      "value": "Display-friendly indexing status for the UI."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/display_status/title",
+      "source_sha256": "f3d19acfd660ecbc3ef3e75c51ad2e1cc29b57881a0c8fee1a3228186d8919f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_form/description",
+      "value": "Document chunking mode. `text_model` for standard text, `hierarchical_model` for parent-child, `qa_model` for QA pairs."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_language/description",
+      "value": "Language of the document content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_metadata/description",
+      "value": "Custom metadata key-value pairs for this document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_type/description",
+      "value": "Document type classification, `null` if not set."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_type/title",
+      "source_sha256": "9df74ed42d3a2e6f946ce0af273666dc30fef00ebd133970e773dd1e27428fcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/document_process_rule/description",
+      "value": "Document-level processing rule configuration."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/document_process_rule/title",
+      "source_sha256": "721a63f3f15e5d8aaedcfa99cd9835272aacbd8655b261323855d5632891eeb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/enabled/description",
+      "value": "Whether the document is enabled for retrieval."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/error/description",
+      "value": "Error message if indexing failed, `null` otherwise."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/hit_count/description",
+      "value": "Number of times this document has been retrieved."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/id/description",
+      "value": "Document identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_latency/description",
+      "value": "Time taken for indexing in seconds, `null` if not completed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_latency/title",
+      "source_sha256": "9958606e45e1f84a90bf2b35cc6f1da7667f177f05f2e6507a09465d31b91b6f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_status/description",
+      "value": "Current indexing status, e.g. `waiting`, `parsing`, `cleaning`, `splitting`, `indexing`, `completed`, `error`, `paused`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/name/description",
+      "value": "Document name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/need_summary/description",
+      "value": "Whether the document needs summary generation."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/need_summary/title",
+      "source_sha256": "f86a97523001d39eb483e5eb409dd41314bec44581f7537da8356eddca7a3209"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/position/description",
+      "value": "Position index within the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/segment_count/description",
+      "value": "Number of chunks in the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/segment_count/title",
+      "source_sha256": "b00632c029a06236c07045f50ea4c8d7d1be5eee01bdb2a0066f043c170f93d8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/summary_index_status/description",
+      "value": "Status of summary indexing, `null` if summary index is not enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/summary_index_status/title",
+      "source_sha256": "f071851825f1aef8746a503d9c35eb84d025616f0cea1088f7865b510f2c180a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/tokens/description",
+      "value": "Number of tokens in the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/updated_at/description",
+      "value": "Last update time as a Unix timestamp in seconds."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/title",
+      "source_sha256": "47de58693b044c133c8524b3999a1a724a401e536b8c79b59df0d47f5d13676c"
     },
     {
       "op": "remove",
@@ -2342,6 +4546,688 @@
       "op": "remove",
       "path": "/components/schemas/DocumentListQuery/title",
       "source_sha256": "ed2db5c64b168833d59052e05d0a006c0c7f1f83ada31a1dbf4c7a06e48fceda"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/data/description",
+      "value": "Documents on the current page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/has_more/description",
+      "value": "Whether more documents are available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/limit/description",
+      "value": "Number of items per page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/page/description",
+      "value": "Current page number."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/total/description",
+      "value": "Total number of matching documents."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/title",
+      "source_sha256": "8435a09d11cdbd474fd5cc16e3e85f1166bf99947fb83e96d9274d7aa3702c71"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/metadata_list/title",
+      "source_sha256": "74c1bd3c93da31006af3e9fbbc2185f56659a934ca930979b912d78f9f7ab349"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/partial_update/title",
+      "source_sha256": "f5248201347a7ebfbe3b073bc563cfc799d2c792f4890d2a3923e5c60fe812fc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/title",
+      "source_sha256": "6a94e1b7a5668ef785a2a8c18edf4b1d7d09678f163cb754d0a30a6ca7694b0d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/id/description",
+      "value": "Metadata field identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/name/description",
+      "value": "Metadata field name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/type/description",
+      "value": "Metadata field value type."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/value/description",
+      "value": "Metadata value for this document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/title",
+      "source_sha256": "4c1c189d5bef8cc41bc0d17b17b3c918042c851d9e45db8ba4840f8def43abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/archived/description",
+      "value": "Whether the document is archived."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/archived/title",
+      "source_sha256": "8541102da5d25ddd0f39f05c975618421519547c67475c4a73cfafac24accec1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/created_at/description",
+      "value": "Creation timestamp (Unix epoch in seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/created_by/description",
+      "value": "ID of the user who created the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/created_from/description",
+      "value": "Origin of the document. `api` for API creation, `web` for UI creation."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/created_from/title",
+      "source_sha256": "ac7605d36b5da31a00bcf6692a557183ddce029a6ca4c5fb5cc911c9e9fd1495"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_detail_dict/description",
+      "value": "Detailed data source information including file details."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_detail_dict/title",
+      "source_sha256": "28dd9da99ba5d7bc55120227afe601c8b503ab708a5fca4e3d14c0d72d0c25a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_info/description",
+      "value": "Raw data source information, varies by `data_source_type`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_info/title",
+      "source_sha256": "04fc73b8bbb0b1fd1a8bcb259069d7a0107de9f8eb895eaee40b81077b977e8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_type/description",
+      "value": "How the document was created. `upload_file` for file uploads, `notion_import` for Notion imports."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/dataset_process_rule_id/description",
+      "value": "ID of the processing rule applied to this document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/dataset_process_rule_id/title",
+      "source_sha256": "7fe87b64e27b7605197b76399c4f820ed867d9acb75bbdb744928f5414822bcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_at/description",
+      "value": "Disable time as a Unix timestamp in seconds; `null` if enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_by/description",
+      "value": "ID of the user who disabled the document. `null` if enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/display_status/description",
+      "value": "User-facing display status derived from `indexing_status` and `enabled` state."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/display_status/title",
+      "source_sha256": "f3d19acfd660ecbc3ef3e75c51ad2e1cc29b57881a0c8fee1a3228186d8919f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/doc_form/description",
+      "value": "Document chunking mode. `text_model` for standard text chunking, `hierarchical_model` for parent-child structure, `qa_model` for QA pair extraction."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/doc_metadata/description",
+      "value": "Metadata values assigned to this document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/enabled/description",
+      "value": "Whether the document is enabled for retrieval."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/error/description",
+      "value": "Error message if indexing failed. `null` when no error."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/hit_count/description",
+      "value": "Number of times the document has been matched in retrieval queries."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/id/description",
+      "value": "Unique identifier of the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/indexing_status/description",
+      "value": "Current indexing status. `waiting` for queued, `parsing` while extracting content, `cleaning` while removing noise, `splitting` while chunking, `indexing` while building vectors, `completed` when ready, `error` if failed, `paused` if manually paused."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/name/description",
+      "value": "Document name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/need_summary/description",
+      "value": "Whether a summary needs to be generated for this document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/need_summary/title",
+      "source_sha256": "f86a97523001d39eb483e5eb409dd41314bec44581f7537da8356eddca7a3209"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/position/description",
+      "value": "Display position of the document in the list."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/summary_index_status/description",
+      "value": "Status of the summary index for this document. `null` if summary indexing is not configured."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/summary_index_status/title",
+      "source_sha256": "f071851825f1aef8746a503d9c35eb84d025616f0cea1088f7865b510f2c180a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/tokens/description",
+      "value": "Total number of tokens in the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/word_count/description",
+      "value": "Total word count of the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/title",
+      "source_sha256": "2e21f14477b9e62a64922ef5d3614928ef4f390217977f08f6be9b13274ce35e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusListResponse/properties/data/description",
+      "value": "Document processing status records."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusListResponse/title",
+      "source_sha256": "271dc90dcdf630dcd05ce6d196274faf721b3cbd2d12c414ca29d86cc4ed8c0f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentStatusPayload/properties/document_ids/description",
+      "source_sha256": "234a2deb218eaa9bc74cf0ee5cc26b0c06b9208488238e5c44e31d17794012d6",
+      "value": "List of document IDs to update. This field is optional for compatibility; when omitted or empty, the request succeeds without updating any documents."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusPayload/properties/document_ids/title",
+      "source_sha256": "dc2a6757bb082f1cd12d85478d340d6d79013f1f3c382be5c6ffc4faee398176"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusPayload/title",
+      "source_sha256": "8bf178b15f72df177fae4f9df12a004fec21f4c2caac21200fe65f7d29002933"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/cleaning_completed_at/description",
+      "value": "Unix timestamp in seconds when cleaning completed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/cleaning_completed_at/title",
+      "source_sha256": "03b3cb7786f7423ca24280558a8d4899cc3f4ff6698c3a0354f52c6ffb2610b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_at/description",
+      "value": "Unix timestamp in seconds when indexing completed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_segments/description",
+      "value": "Number of chunks that have been indexed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_segments/title",
+      "source_sha256": "2a63a79f7927e11e90fa30a49344e987f1f8faf74ec78bb42ce6ad1780ee4ce4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error/description",
+      "value": "Error message if indexing failed. `null` if no error."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error_code/description",
+      "value": "Processing error code, or `null` when no error occurred."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error_code/title",
+      "source_sha256": "0a784f3f0dd812c0bf04ba86b7aaf4027aae79d0cd98b06385701ca56fc33779"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/estimated_vector_space_mb/description",
+      "value": "Estimated vector storage usage in megabytes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/estimated_vector_space_mb/title",
+      "source_sha256": "82883eedce2c8a2f1d7ba55145c838481d4636f533b617c0e4250ec3f349a573"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/id/description",
+      "value": "Document identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/indexing_status/description",
+      "value": "Current indexing status: `waiting`, `parsing`, `cleaning`, `splitting`, `indexing`, `completed`, `error`, or `paused`. Treat `completed` and `error` as terminal. The Service API cannot resume `paused` documents; resume them in the Dify knowledge-base console before polling again."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/parsing_completed_at/description",
+      "value": "Unix timestamp in seconds when parsing completed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/parsing_completed_at/title",
+      "source_sha256": "6f4040a53d17dc6d300f8b3db316043775bdf5c62902620c9b7ebe5a5f887743"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/paused_at/description",
+      "value": "Unix timestamp in seconds when indexing was paused. `null` if not paused."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/paused_at/title",
+      "source_sha256": "27f9211f8d20297ee4ae52683191e77dbc1f685480025ec7b6b38674b31bd26f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/processing_started_at/description",
+      "value": "Unix timestamp in seconds when processing started."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/processing_started_at/title",
+      "source_sha256": "c23858653858bb7fc7237d3033b5588ac1e694381bb2915531d6bb9d00f7448e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/splitting_completed_at/description",
+      "value": "Unix timestamp in seconds when splitting completed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/splitting_completed_at/title",
+      "source_sha256": "a3218648896dd8e1534da12e88b1b3b380369b751d514a22ed361d210f1699dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/stopped_at/description",
+      "value": "Unix timestamp in seconds when indexing was stopped. `null` if not stopped."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/stopped_at/title",
+      "source_sha256": "e6760f92f5dde2261be331d6fdc428cb187032976d9229b4171e068dc69a82d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/total_segments/description",
+      "value": "Total number of chunks to be indexed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/total_segments/title",
+      "source_sha256": "09fe63bdbc83b98d9e40b93ddae803e779caa1c7ab674a0b9bb53b74207c332f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/vector_space_limit_mb/description",
+      "value": "Vector storage limit in megabytes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/vector_space_limit_mb/title",
+      "source_sha256": "9028c6208cbdb28fbe3137f15278a86807d70f7a9c437e782ac95693836e20f8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/title",
+      "source_sha256": "3e7be7a8546ebb1e58a75fd5ceb1b6c450d9ef02799db20c2a4d6a7c87f7f7b8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model/description",
+      "source_sha256": "a57676abae00b587600f25027f744a24863f5a9c56780647ccaa7efe6422cdb5",
+      "value": "Embedding model name. Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model_provider/description",
+      "source_sha256": "fbc8249d511185eedbe6c1e9ee65c5f0d7e75d5b2fa2cc1b0ff71ea4ea22e403",
+      "value": "Embedding model provider. Use the `provider` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/original_document_id/title",
+      "source_sha256": "912e375455228dc2bf425df1398caef3a87b188a983848b6a659052d401055bd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/title",
+      "source_sha256": "f5a7947e48de74109f6c499cae88124d8dc10511463ecae5e716b4b917d633bb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/title",
+      "source_sha256": "8ff01b234dd66b682db99e9c3b7e5afdb96764fea3d8437b131d439771ba7ef0"
     },
     {
       "op": "remove",
@@ -2477,6 +5363,11 @@
       "op": "remove",
       "path": "/components/schemas/FeedbackListQuery/title",
       "source_sha256": "2ee2ef5a0b8833947992d468c455c3ec9722d91f0512455ef418a2ca9fa97e89"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FetchFrom/title",
+      "source_sha256": "acb0dd729bd3571f3c6e9f9d7f2f02ef818bca9ba75204ba8debbaa023a9126d"
     },
     {
       "op": "add",
@@ -2772,6 +5663,522 @@
       "op": "remove",
       "path": "/components/schemas/FileType/title",
       "source_sha256": "1146fdf89b9afd90dd54e7a8a49cc084960dbe6ab3cb3c9ddb13494be2676ed7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/content/description",
+      "value": "Text content of the child chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/id/description",
+      "value": "Unique identifier of the child chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/position/description",
+      "value": "Position of the child chunk within the parent chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/score/description",
+      "value": "Similarity score of the child chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/title",
+      "source_sha256": "04a4b8972b5517ed1952fc67fc2ac7d057647bc0a9e530692dba6de71583680f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/data_source_type/description",
+      "value": "How the document was created."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_metadata/description",
+      "value": "Metadata values for the document. `null` if no metadata is configured."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_type/description",
+      "value": "Document type classification. `null` if not set."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_type/title",
+      "source_sha256": "9df74ed42d3a2e6f946ce0af273666dc30fef00ebd133970e773dd1e27428fcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/id/description",
+      "value": "Unique identifier of the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/name/description",
+      "value": "Document name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/title",
+      "source_sha256": "5e94cace3967519065fce6e26f98e585eed1a2c48f3d9bdb4aab9f96ea192fea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/extension/description",
+      "value": "File extension."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/id/description",
+      "value": "Attachment file identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/mime_type/description",
+      "value": "MIME type of the file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/name/description",
+      "value": "Original file name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/size/description",
+      "value": "File size in bytes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/source_url/description",
+      "value": "URL to access the attachment."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/source_url/title",
+      "source_sha256": "3d48f2577f877973dd0a3ab85975e367b5a9ab1964eb533d2cb3dd317134d453"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/title",
+      "source_sha256": "39b9e374e8c486ac5f02f9c571c6632befb800130e8a706987a0b429a360f42c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/attachment_ids/description",
+      "source_sha256": "bf7f542822d8864ea08a8b221abb9edb06a05cce58548f1bfe4aae4ca316a9c8",
+      "value": "IDs of image files already attached to knowledge-base chunks, as returned when those chunk attachments are uploaded or created in the Dify console. They add image context to multimodal retrieval testing."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/properties/attachment_ids/title",
+      "source_sha256": "477c1e5aa9f364630218d09c7e51bb851e632ef1f297ec491ef9e34c725bbcbd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/title",
+      "source_sha256": "d03fc29219971b95e45ea314fa45f7195207bd25b5275c364b5fc398b8a4a2c0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/title",
+      "source_sha256": "ce553fcd151500efc39b4f765e849170d57d90a6492f4de009c7f1c52dad61be"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingQuery/properties/content/description",
+      "value": "Query text used for retrieval testing."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingQuery/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingQuery/title",
+      "source_sha256": "76dfb654101204d869e2eb0e611e02f148acd3ee6e6aa1746d6e5653c1a4ff50"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/child_chunks/description",
+      "value": "Matched child chunks within the chunk, if using hierarchical indexing."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/child_chunks/title",
+      "source_sha256": "bd2ab3b4c807f0086a23c8bcf021f57f9516f43bc3b3577bf84f78237dd361e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/files/description",
+      "value": "Files attached to this chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/score/description",
+      "value": "Similarity score."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/segment/description",
+      "value": "Matched chunk from the knowledge base."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/summary/description",
+      "value": "Summary content if retrieved via summary index."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/tsne_position/description",
+      "value": "t-SNE visualization position."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/tsne_position/title",
+      "source_sha256": "bab0091eada78f67bd15e07cbef0b8871d8fac48c0f71ecbd1b796da402d0c3d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/title",
+      "source_sha256": "9598ca2914a61e78b5ec68296ecd78c1b28a1c2857459b03da6390504f970d94"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingResponse/properties/query/description",
+      "value": "The original query object."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingResponse/properties/records/description",
+      "value": "List of matched retrieval records."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingResponse/properties/records/title",
+      "source_sha256": "079b962f34b8d3d57508383c9b5669e6818b1c65dc9beeaf43609f12a46d34b9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingResponse/title",
+      "source_sha256": "e4214278c7f114e4f04ecfc01a54df155fce3d3011412a40439969be5c2ae862"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/answer/description",
+      "value": "Answer content, used in Q&A mode documents."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/completed_at/description",
+      "value": "Completion time as a Unix timestamp in seconds; `null` if not completed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/content/description",
+      "value": "Text content of the chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/created_at/description",
+      "value": "Creation timestamp (Unix epoch in seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/created_by/description",
+      "value": "ID of the user who created the chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_at/description",
+      "value": "Disable time as a Unix timestamp in seconds; `null` if enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_by/description",
+      "value": "ID of the user who disabled the chunk. `null` if enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/document/description",
+      "value": "Parent document information for the matched chunk."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/document_id/description",
+      "value": "ID of the document this chunk belongs to."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/enabled/description",
+      "value": "Whether the chunk is enabled for retrieval."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/error/description",
+      "value": "Error message if indexing failed. `null` when no error."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/hit_count/description",
+      "value": "Number of times this chunk has been matched in retrieval queries."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/id/description",
+      "value": "Unique identifier of the chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_hash/description",
+      "value": "Hash of the indexed content, used to detect changes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_id/description",
+      "value": "ID of the index node in the vector store."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_id/title",
+      "source_sha256": "0d45b0d6da2c05390b91146a6cd5de5845c26e58431ba1174c3e3c0793192b42"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/indexing_at/description",
+      "value": "Indexing start time as a Unix timestamp in seconds; `null` if not started."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/indexing_at/title",
+      "source_sha256": "3d4b6de81308d36e9b8544959f48c914d42c529120fa60ad2e08922d6b60fa8a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/keywords/description",
+      "value": "Keywords associated with this chunk for keyword-based retrieval."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/position/description",
+      "value": "Position of the chunk within the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/sign_content/description",
+      "value": "Signed content hash for integrity verification."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/sign_content/title",
+      "source_sha256": "0b01a836c72cea937f5dc68e84213e59c3dc45e8a385ac28588608ab9c00bea4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/status/description",
+      "value": "Indexing status of the chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/stopped_at/description",
+      "value": "Indexing stop time as a Unix timestamp in seconds; `null` if not stopped."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/stopped_at/title",
+      "source_sha256": "e6760f92f5dde2261be331d6fdc428cb187032976d9229b4171e068dc69a82d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/tokens/description",
+      "value": "Token count of the chunk content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/word_count/description",
+      "value": "Word count of the chunk content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/title",
+      "source_sha256": "f3c4398d148dc323df829715bfcd57aec3fea754cb2b6fa1c52ee9f7dab03cbe"
     },
     {
       "op": "add",
@@ -3090,6 +6497,31 @@
     },
     {
       "op": "add",
+      "path": "/components/schemas/I18nObject/properties/en_US/description",
+      "value": "English (United States) text."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/I18nObject/properties/en_US/title",
+      "source_sha256": "91730468013580d2ca81b9ec9f7f7c2d035aafd4e02e18dca3f7414a2255876c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/I18nObject/properties/zh_Hans/description",
+      "value": "Simplified Chinese text."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/I18nObject/properties/zh_Hans/title",
+      "source_sha256": "3303c331ae7406cb2ff6ebf0ea89c214a8b77ffe90bfca224f24dcc8d65205a0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/I18nObject/title",
+      "source_sha256": "a8261231c196264130c3255d0b00818e884a251f90142bdc9128a4f7a54a5a2d"
+    },
+    {
+      "op": "add",
       "path": "/components/schemas/IndexInfoResponse/properties/api_version/description",
       "value": "Service API version."
     },
@@ -3122,6 +6554,56 @@
       "op": "remove",
       "path": "/components/schemas/IndexInfoResponse/title",
       "source_sha256": "39bae08b9ff59cac2e8753bfc4a2e27ee7493eb5d4f6402c2f1c354436048e6e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagListResponse/title",
+      "source_sha256": "7ea66a71f438538cc91dc4a3c8f5b1f1ac45a9eec520618f4d86759a873d58bd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/binding_count/description",
+      "value": "Number of knowledge bases bound to this tag."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/binding_count/title",
+      "source_sha256": "6744d2c8f3469e6d93b9054f200888a7f83c5434fada4fab7da8c497fee9334a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/id/description",
+      "value": "Tag identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/name/description",
+      "value": "Tag display name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/type/description",
+      "value": "Tag type. Always `knowledge` for knowledge base tags."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/title",
+      "source_sha256": "5d35b5b2ca17ef8d8b9e46e07f786fd8d5868bc644495e9452b64cfb52bcbafd"
     },
     {
       "op": "remove",
@@ -3502,6 +6984,96 @@
       "op": "remove",
       "path": "/components/schemas/MessageListQuery/title",
       "source_sha256": "17997d5395df2c93391badf0ba144f4ca86426f5b37ae14fd35d9c873a56e906"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataArgs/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataArgs/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataArgs/title",
+      "source_sha256": "5010db9c5b96a550c36c36195662f267ede43500911e35fb0c94e6ab88dc578a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/title",
+      "source_sha256": "302664e69b302538fbbb457b69ed4b30cbcbefe70237d9c4c4a99709535d424b"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataFilteringCondition/properties/conditions/title",
+      "source_sha256": "4859ee3a5984f46db2a7ccfa66d09ea46ad9df847d6cb8397511e787f067b808"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataFilteringCondition/properties/logical_operator/title",
+      "source_sha256": "bd84f30aea6a169e867e9db93128823bc7d81fb1dfda548b082b0bcc781fd9b1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataFilteringCondition/title",
+      "source_sha256": "b06ffd3e4965d76123abf4cd03de62125ac92beb783b60945b7ab06bb5c102b1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataOperationData/properties/operation_data/title",
+      "source_sha256": "02b7dc37f55b2fbb29b6e3c7924c7784cedbddae06d7ee78f1bac1d440a2d75a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataOperationData/title",
+      "source_sha256": "ee06ed81dc74e00e43985d26fa6ff24cc18e77b8459bd788db8a6ba34799d3eb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataUpdatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataUpdatePayload/title",
+      "source_sha256": "aabaef1791ea8fbdc2dfeb00d411b65852b6c403ce271039db738a89968c3ecd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelFeature/title",
+      "source_sha256": "5780e7c733374436c449054dd03e6033a0b8938701761eaad659da105cdb5e79"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelPropertyKey/title",
+      "source_sha256": "706b1321efa56929cbfaa83d1701bb1f2cca7139978811df4128553dc9579da1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelStatus/title",
+      "source_sha256": "46314ebd42525f4675cfa3644685b6f21f98f94fba835afd047311dd9bb248ac"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelType/title",
+      "source_sha256": "79143b74dca244e14369c3408a772220b8cf93187a1cbe2eb2986adc393920ba"
     },
     {
       "op": "remove",
@@ -4665,8 +8237,593 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/PermissionEnum/title",
+      "source_sha256": "570f985d8678a60eaabf80571396764eb068de6b7de35b398747f22978fe60f6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDataset/properties/chunk_structure/description",
+      "value": "Chunking structure configured for the knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/chunk_structure/title",
+      "source_sha256": "b6a62f5f409a72d8767489993f9615846dbae82c4f90a4707c872820c63fce60"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineDataset/properties/description/description",
+      "source_sha256": "c261ff1298c1bfa9af71a5c603225f66da3a638a59c71bfd7148722976e2c7f9",
+      "value": "Knowledge base description."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDataset/properties/id/description",
+      "value": "Resource ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDataset/properties/name/description",
+      "value": "Resource name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/title",
+      "source_sha256": "6023a9c1af11b9c6aac41e09a8e47dd6114740f717eba442d22e64601159cf54"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_info/description",
+      "value": "Datasource-specific metadata, when available."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_info/title",
+      "source_sha256": "04fc73b8bbb0b1fd1a8bcb259069d7a0107de9f8eb895eaee40b81077b977e8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_type/description",
+      "value": "Datasource type."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/enabled/description",
+      "value": "Whether the document is enabled for retrieval."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/error/description",
+      "value": "Indexing error, or `null` when no error has occurred."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/id/description",
+      "value": "Resource ID."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/indexing_status/description",
+      "value": "Current indexing status for the queued document. Use the response `batch` with [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status) for stage-by-stage progress; `completed` and `error` are terminal, while `paused` requires a resume before polling continues."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/name/description",
+      "value": "Resource name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/position/description",
+      "value": "Document position within the batch."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/title",
+      "source_sha256": "fb0c2514b90b55b30c22e1c2c9bbc92941d52d1228aaffa3af0dcfa12aa84cf2"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/description",
+      "source_sha256": "e720357c655f0d8504f094ad48e40eaf5b907a615b2568ae86b34333504f9173",
+      "value": "List of datasource objects to process. `datasource_type` selects the item shape: `local_file` uses `reference`; `online_document` uses `workspace_id` and `page`; `online_drive` uses `id` and `type` (plus optional `bucket`); `website_crawl` uses `url`. The `oneOf` branches are emitted in local-file, online-document, website-crawl, online-drive order."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/description",
+      "value": "Local file reference.",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/properties/reference/description",
+      "source_sha256": "5e091d8d1c537316b3e11a5452de5d966eac0a2490c76b53fe5baca8ecc576dc",
+      "value": "Use the `id` returned by the [Upload Pipeline File](/en/api-reference/knowledge-pipeline/upload-pipeline-file) endpoint. `related_id` is accepted as an alias.",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/title",
+      "source_sha256": "688ebe6107db26f7618180df8437c03891bceb34944c4c01be2ced16c5c3534b",
+      "value": "Local file",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/description",
+      "value": "Page in an online document provider.",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/page/properties/page_id/description",
+      "source_sha256": "7442a8bf6acbcdc7e39ad20cbd468d77e9017f75382782b2a05a117d954cf22a",
+      "value": "Page ID returned by the configured online-document provider when its workspace or database is browsed in Dify.",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/workspace_id/description",
+      "source_sha256": "fe7985f91af3a78660419f2c00283978050d7045f952805d0195ba9374f218f8",
+      "value": "Workspace or database ID from the configured online-document provider. Obtain it while selecting or browsing the provider in Dify; it is the provider's own resource ID, not a Dify workspace ID.",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/title",
+      "source_sha256": "b898200bc602b877c67fa42231265b54672cb38b8ae2b269fa10857ac7cee12b",
+      "value": "Online document",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2/description",
+      "value": "Website URL to crawl.",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2",
+      "context_sha256": "d1752d06316336af94c7d7bbb791a0f2be173d0acb6cad363268ef51b4d574a6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2/title",
+      "source_sha256": "63874e0a6751f26e7c1cdfd57fbaed4a1d0013723ea7bb783f14df82758f5050",
+      "value": "Website crawl",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2",
+      "context_sha256": "d1752d06316336af94c7d7bbb791a0f2be173d0acb6cad363268ef51b4d574a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/description",
+      "value": "File or folder in an online drive provider.",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/properties/id/description",
+      "source_sha256": "e3d026c55577010814ff70c81e11a81451d20d5ea2eae3ac14df44326cf81b6b",
+      "value": "File or folder ID returned by the configured online-drive provider when the drive is browsed in Dify.",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/title",
+      "source_sha256": "c35dacddac4d0a24d2a4f2d15a259a6b81aac87735652096552cac21400016be",
+      "value": "Online drive",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/title",
+      "source_sha256": "cd6d7537c927eb684756966236a5a1f5e0d2f5e55ebba093c75138182989f1b8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_type/title",
+      "source_sha256": "1ddade5ac920148720355e512eb186d05c2511471941c47e4307d239b1f03f83"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/start_node_id/description",
+      "source_sha256": "4e4adb169d322a57c9af1f1f6f630bb1e40f5422ed67300405dac45f73efcc8d",
+      "value": "Datasource node ID where the run starts. A datasource node is the knowledge pipeline's entry step that reads files, provider pages, drives, or URLs. Use `node_id` from [List Datasource Plugins](/en/api-reference/knowledge-pipeline/list-datasource-plugins)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/start_node_id/title",
+      "source_sha256": "db0a024b6472164f8f45fec7ee5b253de6284fa29e07f81859047dc90c100b9a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/title",
+      "source_sha256": "955e3596c1f8c89af4ddb61252a1c88f86872727d08b1aebc4b292e8f3a2325a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunJsonResponse/description",
+      "source_sha256": "28ff911df5f8eb8b5478e307e1006d5679ed9a267e0ceef0201048dd0593683c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunJsonResponse/title",
+      "source_sha256": "185e74bfde554c3700e0ab00bf434e6fd36ac0b4b44686ad3da95d65416e140b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_at/description",
+      "value": "Upload timestamp in ISO 8601 format. May be `null` while the record is being created."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_by/description",
+      "value": "ID of the user who uploaded the file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/extension/description",
+      "value": "File extension."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/id/description",
+      "value": "Unique identifier of the uploaded file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/mime_type/description",
+      "value": "MIME type of the file. May be `null` if the upload did not include one."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/name/description",
+      "value": "Original file name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/size/description",
+      "value": "File size in bytes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/title",
+      "source_sha256": "bb113da90addfc75f941e3b9bf244282e60f799dbd26ea9b80c9c5382c8a5f8b"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PreProcessingRule/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PreProcessingRule/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PreProcessingRule/title",
+      "source_sha256": "b47661a7f70c18c954a02974b77463a163376487ee6eeb8af10a2a27533f5e2a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProcessRule/title",
+      "source_sha256": "db324a07cd05b37002bb411f1e0343864d8b699abca97ce06b54d79e38f206ab"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProcessRuleMode/title",
+      "source_sha256": "f7358171c8ee1b08f0e4d52870e721480d33b88cf4cb44f0d1aba51a48a94945"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/deprecated/description",
+      "value": "Whether the model is deprecated."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/deprecated/title",
+      "source_sha256": "80f6e3262ddc9dbae4b5543d8cf1ab8d4f3111645716a73c9db7c288ae591d8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/features/description",
+      "value": "Supported features of the model, `null` if none."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/features/title",
+      "source_sha256": "5ba7137beafc546fd1f158261c26eb856fc806b187977a07566494355e9e4e9b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/fetch_from/description",
+      "value": "Where the model definition comes from. `predefined-model` for built-in models, `customizable-model` for user-configured models."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/has_invalid_load_balancing_configs/description",
+      "value": "Whether the model has invalid load-balancing configurations."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/has_invalid_load_balancing_configs/title",
+      "source_sha256": "7944103f90c86b8d1aa059b20991fcdc85dcbd16bea56e1f1f72944059551055"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/label/description",
+      "value": "Localized display name of the model."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/load_balancing_enabled/description",
+      "value": "Whether load balancing is enabled for the model."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/load_balancing_enabled/title",
+      "source_sha256": "19d609f1ad9452998e7a4548bb2dc9b68ae73367a62fef6eaff1a7893ea0023d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model/description",
+      "value": "Model identifier. Use this as the `embedding_model` value when creating or updating a knowledge base."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model/title",
+      "source_sha256": "9c16c09f0c180580bcc75cd99dc16eb9764abe7902e6a19ba4d7adbd28d66b22"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model_properties/description",
+      "value": "Model-specific properties such as `context_size`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model_properties/title",
+      "source_sha256": "a32671a4e6f39b5933657bb99b6017c623de24878be588c6c92333f03358fdb0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model_type/description",
+      "value": "Type of the model, matching the `model_type` path parameter."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/status/description",
+      "value": "Model availability status. `active` when ready to use."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/title",
+      "source_sha256": "4846d901d44580e734dbead0b947dcd6321d9be04ad58e95a872a204a06801c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsListResponse/properties/data/description",
+      "value": "Model providers and their available models."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsListResponse/title",
+      "source_sha256": "2039f710e47e27c0a7fdab1fa3984269c5c5a108e9e1ca86691f8ae79fbc9dfc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/icon_small/description",
+      "value": "URL of the provider's small icon."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/icon_small_dark/description",
+      "value": "Dark-mode icon URLs; `null` when the provider has none."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/label/description",
+      "value": "Localized display name of the provider."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/models/description",
+      "value": "List of available models from this provider."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/models/title",
+      "source_sha256": "527919df30e60438b9999d570aca82ff0214c59755ad69ea14a15900b5b06c26"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/provider/description",
+      "value": "Model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). Legacy providers may return the bare short form (e.g. `openai`)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/status/description",
+      "value": "Provider status. `active` when credentials are configured and valid."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/tenant_id/description",
+      "value": "Workspace ID the provider configuration belongs to."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/tenant_id/title",
+      "source_sha256": "ae18aae49d3ccc237cd61077f9e1235aa293a131da760623f83eab7b5e51d944"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/title",
+      "source_sha256": "74970e98a1a9d36c34558a5528dd394784820e4d57c0d69d26e6d51629ad66d5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/batch/description",
+      "value": "Batch ID for the queued published run. Pass it as `batch` to [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status) and poll until every document is completed, failed, or paused."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/batch/title",
+      "source_sha256": "026b89e52976b2603339b009c7e7547467948fb0753001d02deaa79180427305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/dataset/description",
+      "value": "Knowledge base receiving the generated documents."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/documents/description",
+      "value": "Documents created and queued for indexing."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/documents/title",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PublishedPipelineRunResponse/title",
+      "source_sha256": "54d7f59fdb352a4ea87c5ea8cb76db25797e51ea2335cc3fe0059db53302f455"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/RequiredServiceApiUserPayload/title",
       "source_sha256": "a1269019db4ddc7c919d3b0447ea781251fcad5e3c189d0d8214785fae80891d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RerankingModel/properties/reranking_model_name/title",
+      "source_sha256": "84c57945febff99bd6d302f456cc0c67177d5564c52716407f118e8f2e8fc041"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RerankingModel/properties/reranking_provider_name/title",
+      "source_sha256": "60b41a32b54ab0b9acf6ad2d6c68ee0ff1e2ad26650e94e289f4265e71a59581"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RerankingModel/title",
+      "source_sha256": "6fb75a747a4a0129024d0e632a601000492365b2046eaac090c6f52ed37e038e"
     },
     {
       "op": "add",
@@ -4682,6 +8839,47 @@
       "op": "remove",
       "path": "/components/schemas/ResultResponse/title",
       "source_sha256": "01088850b9c319d53d821afeaed65bffdaeb842f51b877c8b03a85f6877dc8da"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalMethod/title",
+      "source_sha256": "8dc47bb74955cfa3a214f19059c03082323843025859295239a41a0b06bc93a4"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_enable/title",
+      "source_sha256": "cc1894711ba2670a7ad95df9cb248ff4496427dc4e61eefde0f555ebdaeec218"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_mode/title",
+      "source_sha256": "f5301c9027acd776f86cf98e696814c2b9404bfe29ccf772a75b020694c93dd5"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold/description",
+      "source_sha256": "9226e3718348835b029623af75bfa41d9b2cb610ebbaea42858a3ac7420971af",
+      "value": "Minimum similarity score from 0 to 1. Only effective when `score_threshold_enabled` is `true`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold_enabled/title",
+      "source_sha256": "33e7b2a6e80860238254ee394cff0875c97ba3ba486bd89f1919f34dfe77abc9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/top_k/title",
+      "source_sha256": "08cf18c91d1b734279713b3783ef3a997cda93cc0aab4059885a3dfc3159c81c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/title",
+      "source_sha256": "666a988293a7f6ae869835747dcd92b2bd1a79f3b04646f6f12c185760fa6a03"
     },
     {
       "op": "add",
@@ -4865,6 +9063,166 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/Rule/properties/parent_mode/title",
+      "source_sha256": "7a3e4b03c8e473c363780e217ac31d5296d3f1648ce487f28f4dd3adad1fd479"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Rule/properties/pre_processing_rules/title",
+      "source_sha256": "7d3e0cda2e0c21c0badc4a3b16dc3dfbcf035b66e7f855204ec0c1caf94463e9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Rule/title",
+      "source_sha256": "37b145ea2f8c75d011310872a13d8691600428522327e9fa756408228cf0a916"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/extension/description",
+      "value": "File extension."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/id/description",
+      "value": "Attachment file identifier."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/mime_type/description",
+      "value": "MIME type of the file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/name/description",
+      "value": "Original file name."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/size/description",
+      "value": "File size in bytes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/source_url/description",
+      "value": "URL to access the attachment."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/source_url/title",
+      "source_sha256": "3d48f2577f877973dd0a3ab85975e367b5a9ab1964eb533d2cb3dd317134d453"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/title",
+      "source_sha256": "265200114ec0ead4db2faf6278176361627bebcfabd2e0e399427f0c83132bc2"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/attachment_ids/title",
+      "source_sha256": "477c1e5aa9f364630218d09c7e51bb851e632ef1f297ec491ef9e34c725bbcbd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/title",
+      "source_sha256": "794a619a5d9edb158a3ad415c72c23e2a276867117a567944f304eda604f25de"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/data/description",
+      "value": "List of created chunks."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/doc_form/description",
+      "value": "Document chunking mode used by this document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateListResponse/title",
+      "source_sha256": "dddf326520ef179531d516395a20cdbc4f559439373f3d4caeaaf49e0daa8cc5"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreatePayload/properties/segments/title",
+      "source_sha256": "505d8419cf4cc5e1048ae6b568b094d437dfbcb7e2beaa3ef069b7453ae04453"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreatePayload/title",
+      "source_sha256": "fb73672ae57c80d6fa43473e94455557ad048ea74aff2ede203d05216feb6bf0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentDetailResponse/properties/data/description",
+      "value": "List of created chunks."
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentDetailResponse/properties/doc_form/description",
+      "value": "Document chunking mode used by this document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentDetailResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentDetailResponse/title",
+      "source_sha256": "0de38d68419929d7e241177982f8f3ed9101460431e000c55ae2a36b3cbfc25f"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/SegmentListQuery/properties/keyword/title",
       "source_sha256": "93c32bb02ba173239554ca823a4549a0b740a1bed566ba8edb386c8cd655fc94"
     },
@@ -4887,6 +9245,411 @@
       "op": "remove",
       "path": "/components/schemas/SegmentListQuery/title",
       "source_sha256": "0cd59385c6acbfa47454f1681728f3753d5b551e24e8ca993624fd336f64d154"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/data/description",
+      "value": "List of chunks."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/doc_form/description",
+      "value": "Document chunking mode used by this document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/has_more/description",
+      "value": "Whether more items exist on the next page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/limit/description",
+      "value": "Number of items per page."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/page/description",
+      "value": "Current page number."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/total/description",
+      "value": "Total number of matching chunks."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/title",
+      "source_sha256": "baab7d72cdb208fbaca82b5d478ffc03ce2e8e05fdaca092bf5723f62cb924ef"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/answer/description",
+      "value": "Answer content, used in Q&A mode documents."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/attachments/description",
+      "value": "Files attached to this chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/attachments/title",
+      "source_sha256": "7598bc1dde680e28fe88f4627a34b7dc34e02c54caa57e6df303af05e73856a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/child_chunks/description",
+      "value": "Child chunks belonging to this chunk. Only present for hierarchical mode documents."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/child_chunks/title",
+      "source_sha256": "bd2ab3b4c807f0086a23c8bcf021f57f9516f43bc3b3577bf84f78237dd361e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/completed_at/description",
+      "value": "Completion time as a Unix timestamp in seconds; `null` if not completed."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/content/description",
+      "value": "Text content of the chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/created_at/description",
+      "value": "Creation timestamp (Unix epoch in seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/created_by/description",
+      "value": "ID of the user who created the chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_at/description",
+      "value": "Disable time as a Unix timestamp in seconds; `null` if enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_by/description",
+      "value": "ID of the user who disabled the chunk. `null` if enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/document_id/description",
+      "value": "ID of the document this chunk belongs to."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/enabled/description",
+      "value": "Whether the chunk is enabled for retrieval."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/error/description",
+      "value": "Error message if indexing failed. `null` when no error."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/hit_count/description",
+      "value": "Number of times this chunk has been matched in retrieval queries."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/id/description",
+      "value": "Unique identifier of the chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_hash/description",
+      "value": "Hash of the indexed content, used to detect changes."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_id/description",
+      "value": "ID of the index node in the vector store."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_id/title",
+      "source_sha256": "0d45b0d6da2c05390b91146a6cd5de5845c26e58431ba1174c3e3c0793192b42"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/indexing_at/description",
+      "value": "Indexing start time as a Unix timestamp in seconds; `null` if not started."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/indexing_at/title",
+      "source_sha256": "3d4b6de81308d36e9b8544959f48c914d42c529120fa60ad2e08922d6b60fa8a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/keywords/description",
+      "value": "Keywords associated with this chunk for keyword-based retrieval."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/position/description",
+      "value": "Position of the chunk within the document."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/sign_content/description",
+      "value": "Signed content hash for integrity verification."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/sign_content/title",
+      "source_sha256": "0b01a836c72cea937f5dc68e84213e59c3dc45e8a385ac28588608ab9c00bea4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/status/description",
+      "value": "Current indexing status of the chunk, e.g. `completed`, `indexing`, `error`."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/stopped_at/description",
+      "value": "Indexing stop time as a Unix timestamp in seconds; `null` if not stopped."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/stopped_at/title",
+      "source_sha256": "e6760f92f5dde2261be331d6fdc428cb187032976d9229b4171e068dc69a82d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/summary/description",
+      "value": "AI-generated summary of the chunk content. `null` if summary indexing is not enabled."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/tokens/description",
+      "value": "Token count of the chunk content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/updated_at/description",
+      "value": "Last update timestamp (Unix epoch in seconds)."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/updated_by/description",
+      "value": "ID of the user who last updated the chunk."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/updated_by/title",
+      "source_sha256": "6b595a302a4b98836b4b277762776908278d6090a198a6ae17e592b71b68abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/word_count/description",
+      "value": "Word count of the chunk content."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/title",
+      "source_sha256": "6404bd1128525d136b6a45e73b2694505f049c8e1e75ea00de143fd3e1b7fd0d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/attachment_ids/title",
+      "source_sha256": "477c1e5aa9f364630218d09c7e51bb851e632ef1f297ec491ef9e34c725bbcbd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/regenerate_child_chunks/title",
+      "source_sha256": "ec2820d3e42e3b34773484ca6c60e83ca7f205079caee9687775965d359aeb16"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/title",
+      "source_sha256": "55d5ccff6c4f6d836ca1e8f0f130b687b3230266fdd5f69979908c39497cef9f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdatePayload/title",
+      "source_sha256": "83e2265607c3090491856b9685849cb09461ed67bd933e662bf5e63e09685e42"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/properties/chunk_overlap/title",
+      "source_sha256": "1258b5681185c4c7c54b1eb931d232bc406095510421aff6ce0402837bbc0b12"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/properties/max_tokens/title",
+      "source_sha256": "c61948210aa9aa4ef842ff5b6e9beeb2f03177494459a33b35ef16a9bf64d175"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/properties/separator/title",
+      "source_sha256": "acb8cb92b3674b508ab3d2eeebb1d7be4c00ce16dcbf8a973c743d57ad98bb17"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/title",
+      "source_sha256": "bd314aba55c9dbea14be93c16834e7dca8525f07640c58453b0f3f1766ac66a1"
     },
     {
       "op": "add",
@@ -5400,6 +10163,75 @@
     },
     {
       "op": "remove",
+      "path": "/components/schemas/TagBindingPayload/properties/tag_ids/title",
+      "source_sha256": "185b1bbb86d24865700f4807ef17e5b4cfb00f26b994b81ed2961a16a08296b8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagBindingPayload/properties/target_id/title",
+      "source_sha256": "18bb786a77f9223c415b1aa4070c075e937065392d6775984cb969cc55b2245f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagBindingPayload/title",
+      "source_sha256": "6912ed857c175a6876a684bbae51d94fd6ffbcec215e8f4acc34d6caf5348b8d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagCreatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagCreatePayload/title",
+      "source_sha256": "1ec17ce70ed4907e7fce6cb288629467e2459c357751367caff686a329ec0745"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagDeletePayload/properties/tag_id/title",
+      "source_sha256": "298f8188e097a31d884ebc26e9900e5733bf6392046442e14d2993fe56b386f8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagDeletePayload/title",
+      "source_sha256": "c01697f6d6ef0b466cd8423bf40254e1fa3ca4da7266c35895b3fba0dd469022"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/0/properties/target_id/title",
+      "source_sha256": "18bb786a77f9223c415b1aa4070c075e937065392d6775984cb969cc55b2245f",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/0",
+      "context_sha256": "8a2c4bf85948b5affc685aab7be95e8daf35d62ec20349da5e4c4789dd7f4372"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/1/properties/target_id/title",
+      "source_sha256": "18bb786a77f9223c415b1aa4070c075e937065392d6775984cb969cc55b2245f",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/1",
+      "context_sha256": "daed8c26e0d1721cb98aa92cb51810ea4f811864ce0f7da2dd1583fca56fd134"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUnbindingPayload/title",
+      "source_sha256": "4ed4b86ecca9595c8a2175f84db1d7d728c92ca7caf1df789acd8a33f5bf7efe"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUpdatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUpdatePayload/properties/tag_id/title",
+      "source_sha256": "298f8188e097a31d884ebc26e9900e5733bf6392046442e14d2993fe56b386f8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUpdatePayload/title",
+      "source_sha256": "1f28aef19bd0c3355b03284bf1367133e716e2f8897e283387a3faac4b1f7ccb"
+    },
+    {
+      "op": "remove",
       "path": "/components/schemas/TextToAudioPayload/properties/message_id/title",
       "source_sha256": "dbe4016a2565becdbbf4d71a007d54d9c206c647ccb6b213e05884f1e91b66ed"
     },
@@ -5487,6 +10319,21 @@
     },
     {
       "op": "add",
+      "path": "/components/schemas/UrlResponse/properties/url/description",
+      "value": "Signed URL to download the original uploaded file."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UrlResponse/properties/url/title",
+      "source_sha256": "0146bf069164386d9cbddfbb77eed14df29c3fbf0326244f5676fc1c06a30963"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UrlResponse/title",
+      "source_sha256": "2dc437c1ca3d8756e3cf32966ba1e41fa5528de46dfec816612b0dba45e2bfc3"
+    },
+    {
+      "op": "add",
       "path": "/components/schemas/UserActionConfig/properties/button_style/description",
       "value": "Visual style of the button. Available values: `primary`, `default`, `accent`, `ghost`."
     },
@@ -5519,6 +10366,58 @@
       "op": "remove",
       "path": "/components/schemas/ValueSourceType/title",
       "source_sha256": "b27082732c38a38ed5997a127490a1121fdd96ed9079027df4ac09ff3e557856"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightKeywordSetting/properties/keyword_weight/description",
+      "source_sha256": "21c5fa00a0b4389101d5b387dec82085ec9797951766458bc2a5e0cea339dce2",
+      "value": "Keyword-search weight from 0 to 1. For `customized` weighting, use it with `vector_weight` so the two weights total 1."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightKeywordSetting/properties/keyword_weight/title",
+      "source_sha256": "577b14638d81d6d6c18433bcef87546069492150025ba80645a9ef107e8f9eb0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightKeywordSetting/title",
+      "source_sha256": "4caae01e8644e200975766b29aa75b4669b97927984b55c555d483fe6956c374"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightModel/properties/weight_type/title",
+      "source_sha256": "2e0fc6f3749fdbeac0065d9c56f1ce8fcdd30d133b1a8c00b5f42eda78ce8b2a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightModel/title",
+      "source_sha256": "a0018f00973cb6f88d2cf5e2d013ea57b3bcb0f83d02e574b9010d1bfbebfce2"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/properties/embedding_model_name/title",
+      "source_sha256": "4d79d966137d5bf514424da3770d0535ef6289a20ce67d7d5be6038198ccd6bf"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/properties/embedding_provider_name/title",
+      "source_sha256": "4e0310d84c92f0465d3c1184754fbd60864f0d6925435fa6eff884947966e073"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightVectorSetting/properties/vector_weight/description",
+      "source_sha256": "6c8623f8fde54ee57da16439061574fd8817dcf88817051669eec0e577ce87b9",
+      "value": "Semantic vector-search weight from 0 to 1. For `customized` weighting, use it with `keyword_weight` so the two weights total 1."
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/properties/vector_weight/title",
+      "source_sha256": "6a405f1ff0999e072f0178b60240aecf12ebe66f212fc2c78450e2876050f29d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/title",
+      "source_sha256": "5eb9d2cbdaac4147eb845112796b9d81aa66dd837756402b7df0f0f6bb21a282"
     },
     {
       "op": "add",

--- a/tools/api-pipeline/service_api_overlays/ja.json
+++ b/tools/api-pipeline/service_api_overlays/ja.json
@@ -1999,6 +1999,32 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/ChildChunkCreatePayload/properties/content/description",
+      "source_sha256": "4e8d8ddc4b6dfba3289f1235ed4afc3c2cf1b52b2099f96484ee10ccdc370f44",
+      "value": "子チャンクのテキスト内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkCreatePayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkCreatePayload/title",
+      "source_sha256": "63545ce8324fb96303684989379acf8bb56616431c2d7d2f2ee57aa798bebaf5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkDetailResponse/properties/data/description",
+      "value": "子チャンクの詳細。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkDetailResponse/title",
+      "source_sha256": "72326278aa33e7dda0521892ceb9f2a9912539cbc389704eb117ce9d7c7faaaa"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/ChildChunkListQuery/properties/keyword/description",
       "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
       "value": "検索キーワードです。"
@@ -2034,6 +2060,162 @@
       "op": "remove",
       "path": "/components/schemas/ChildChunkListQuery/title",
       "source_sha256": "b1c6a7020550b6caf74316c4f6f0d9a79bb59b5fe961a3d65331855b2e4fa238"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/data/description",
+      "value": "子チャンクのリスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/limit/description",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/page/description",
+      "value": "現在のページ番号です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total/description",
+      "value": "子チャンクの合計数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total_pages/description",
+      "value": "合計ページ数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total_pages/title",
+      "source_sha256": "c03585d62e7e0882cfed2ce3ffadcf457b534f19db1ffd398904f4b4c52b5968"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/title",
+      "source_sha256": "7b68d427a9281bbf65f91ec8e00ba8cd0661c8453a3df5f5df8ddba3a2be88bc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/content/description",
+      "value": "子チャンクのテキスト内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/created_at/description",
+      "value": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/id/description",
+      "value": "子チャンクの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/position/description",
+      "value": "親チャンク内の子チャンクの位置です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/segment_id/description",
+      "value": "この子チャンクが属する親チャンクの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/segment_id/title",
+      "source_sha256": "7290170777560d41462deb95fa0c1a27884f2e487befa6820e24cf1acedb6131"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/type/description",
+      "value": "子チャンクの作成方法です。API から作成または更新された子チャンクは常に `customized` です。システム生成の子チャンクは `automatic` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/updated_at/description",
+      "value": "最終更新タイムスタンプ（Unix エポック、秒単位）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/word_count/description",
+      "value": "子チャンク内容の単語数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/title",
+      "source_sha256": "94b6c59461791bd7058253d2f17269c2f89aec959082b91763ec8ba4ac115e08"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChildChunkUpdatePayload/properties/content/description",
+      "source_sha256": "4e8d8ddc4b6dfba3289f1235ed4afc3c2cf1b52b2099f96484ee10ccdc370f44",
+      "value": "子チャンクのテキスト内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkUpdatePayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkUpdatePayload/title",
+      "source_sha256": "f34d01f7a5ac4cb28c70bf838fd8e8b61e215925e3bf5af6aebc939ae29966dc"
     },
     {
       "op": "add",
@@ -2540,6 +2722,50 @@
       "source_sha256": "af0367558fbca9f02fe0c6614e89b0fbaddd2d5462f4aa34f224f2cdf7e90469"
     },
     {
+      "op": "replace",
+      "path": "/components/schemas/Condition/description",
+      "source_sha256": "dd9560e76248d366ee7b4738e26f2e16fd7eb11c34e1296e4351be2096a8954b",
+      "value": "条件の詳細。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Condition/properties/comparison_operator/description",
+      "source_sha256": "8df6a8a633f9fc4370705819585e6c05b2ebbfe88e943d2c5f6bd063a63343da",
+      "value": "適用する比較方法。文字列演算子（`contains`、`not contains`、`start with`、`end with`、`is`、`is not`、`empty`、`not empty`、`in`、`not in`）は文字列または配列メタデータ、数値演算子（`=`、`≠`、`>`、`<`、`≥`、`≤`）は数値メタデータ、時間演算子（`before`、`after`）は時間メタデータに適用されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/properties/comparison_operator/title",
+      "source_sha256": "01a4c1663da6b258d5d69743ddaf9f446b7fb8dee538d679a015632cae854a28"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Condition/properties/name/description",
+      "source_sha256": "e152c45805bce6777a48b1fee038117de12539b2a9ecccf199f665029b383e77",
+      "value": "比較対象とするメタデータフィールド名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Condition/properties/value/description",
+      "source_sha256": "002af1b12c03b27cc2e83a68729a097b9d3b127a82992c5cd12f30b7e217eb4d",
+      "value": "比較する値。型は `comparison_operator` によって異なります。ほとんどの文字列演算子は文字列、`in` と `not in` は文字列配列、数値演算子は数値を使用し、`empty` と `not empty` では省略するか `null` を使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/title",
+      "source_sha256": "418c09a9d05967071c8370af38aa90aa2d0a6d3d13fc29f24e3cfd3a5072c903"
+    },
+    {
       "op": "add",
       "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/data/description",
       "value": "このページの会話一覧。"
@@ -2994,6 +3220,1100 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/CustomConfigurationStatus/description",
+      "source_sha256": "d440d08c73af711607dcb80bdc29b0fe683f0726fc83a791171731bc145a0d7f",
+      "value": "カスタム設定状態の列挙型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CustomConfigurationStatus/title",
+      "source_sha256": "3bae16102634941742ef8cad684cb2c401e1a6f58d28512171907a70e3ba001e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/data/description",
+      "value": "このナレッジベースにバインドされたタグのリスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/total/description",
+      "value": "このナレッジベースにバインドされたタグの合計数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagListResponse/title",
+      "source_sha256": "de75c865a92dbd9a6c18ec22dff029362c605134dac75b2b1524393d4cd47d68"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/id/description",
+      "value": "タグ識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/name/description",
+      "value": "タグの表示名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagResponse/title",
+      "source_sha256": "5411684822d2302289f08f32442c0d2bdd62c8b7255759cd1bfd65c071141727"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/description/description",
+      "source_sha256": "55776608955dfaabd609a7e59ac5f005a65589da9f0e01a73d306437cc124da7",
+      "value": "ナレッジベースの説明です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model/description",
+      "source_sha256": "a57676abae00b587600f25027f744a24863f5a9c56780647ccaa7efe6422cdb5",
+      "value": "埋め込みモデル名。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `model` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model_provider/description",
+      "source_sha256": "fbc8249d511185eedbe6c1e9ee65c5f0d7e75d5b2fa2cc1b0ff71ea4ea22e403",
+      "value": "埋め込みモデルプロバイダー。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `provider` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/external_knowledge_api_id/description",
+      "source_sha256": "30f3fea37c7166d49cc69781ebb7d612a6d3d52cce766e7428dd3e2e1c4cf90c",
+      "value": "外部ナレッジ API の ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/external_knowledge_api_id/title",
+      "source_sha256": "e2dcf725ee077104f9442be1880b13f8247bc7a88800a43f8c816c9fd9d3a103"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/external_knowledge_id/description",
+      "source_sha256": "e63af9fd8e5a851202889f38c61fe7abbe296538866962d22d948e0fb6764b72",
+      "value": "外部ナレッジベースの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/external_knowledge_id/title",
+      "source_sha256": "579ead72f48e7a70e00c88363de59534661ce4d149e6aad38a4dfc7d16b1a18c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/indexing_technique/description",
+      "source_sha256": "a933b20c1aaec91450173dd832d27b424c525f85dc9b2ab702b57fcd3a8a8bad",
+      "value": "`high_quality` は埋め込みモデルを使用した精密検索、`economy` はキーワードベースのインデキシングです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/name/description",
+      "source_sha256": "b756a6eb4f379851befe6a770ca22095058fb204a003f89e3043903a33296fb2",
+      "value": "ナレッジベース名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/permission/description",
+      "source_sha256": "1eb98a26104557e4a9e5ef8d9354fc78a1652e76668c95a32b95422f814d98f7",
+      "value": "このナレッジベースにアクセスできるユーザーを制御します。`only_me` は作成者のみ、`all_team_members` はワークスペース全体、`partial_members` は指定したメンバーにアクセスを許可します。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/provider/description",
+      "source_sha256": "ecfbc2eaab876d0db888ca3c091705424d06300da1d35925a8c551fb0157b6b7",
+      "value": "ナレッジベースのプロバイダー。内部ナレッジベースは `vendor`、外部ナレッジベースは `external`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0/properties/enable/description",
+      "source_sha256": "51d854f11aedecf6dc57681f719075be0742fe2a5b75acc250a6ce24d35a8867",
+      "value": "サマリーインデックスを有効にするかどうかです。",
+      "context_path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0",
+      "context_sha256": "2d7c55668d62e0d85a1b036d4165f60ccaed1ffa53f9c3bedfe3e1c1c071215c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0/properties/model_name/description",
+      "source_sha256": "85c684e30a883f2dd0bfa5b90a698202d229539cecc4bf6a717d6fad02c682d2",
+      "value": "要約生成に使用されるモデルの名前です。",
+      "context_path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0",
+      "context_sha256": "2d7c55668d62e0d85a1b036d4165f60ccaed1ffa53f9c3bedfe3e1c1c071215c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0/properties/model_provider_name/description",
+      "source_sha256": "910400771c19c1ef0781f3b13afae297e0e91ba4c7936c40a35eab6a8f26c235",
+      "value": "要約生成モデルのプロバイダーです。",
+      "context_path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0",
+      "context_sha256": "2d7c55668d62e0d85a1b036d4165f60ccaed1ffa53f9c3bedfe3e1c1c071215c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0/properties/summary_prompt/description",
+      "source_sha256": "08665ea50f1dfdf35bb831e6143c6bcd9067a582b0fba3af0f727dd26470f208",
+      "value": "要約生成用のカスタムプロンプトテンプレートです。",
+      "context_path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0",
+      "context_sha256": "2d7c55668d62e0d85a1b036d4165f60ccaed1ffa53f9c3bedfe3e1c1c071215c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/description",
+      "source_sha256": "8f0d4c377ccc7bbb2b01886dcac46849e5640a21e812435913fbdd56608d6aae",
+      "value": "サマリーインデックスの設定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/title",
+      "source_sha256": "73071309e0ecc3a2e4d5fb7b899a4d2cca1754749b85f5f8f11cf336d15950fc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/title",
+      "source_sha256": "479456528114cc52c4e9464416aee5791234ca861ab8c03096a5d7729cf567fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/app_count/description",
+      "value": "現在このナレッジベースを使用しているアプリケーションの数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/app_count/title",
+      "source_sha256": "f2ebc0260c1ba325417509c378782eb056a1d42309a8bf94f240177008a3bfc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/author_name/description",
+      "value": "作成者の表示名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/author_name/title",
+      "source_sha256": "184bab624ca3534f57b76d065cf11c51a641c53cceed8e6b5f7909a253e49313"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/built_in_field_enabled/description",
+      "value": "組み込みメタデータフィールド（例：`document_name`、`uploader`）が有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/built_in_field_enabled/title",
+      "source_sha256": "60f3d06b21a1179f5971124c3333c5ffe7798e4371795f20f99bd634a01ba7a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/chunk_structure/description",
+      "value": "チャンク構造の設定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/chunk_structure/title",
+      "source_sha256": "b6a62f5f409a72d8767489993f9615846dbae82c4f90a4707c872820c63fce60"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_at/description",
+      "value": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_by/description",
+      "value": "ナレッジベースを作成したユーザーの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/data_source_type/description",
+      "value": "ドキュメントのデータソースタイプです。まだ設定されていない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/description/description",
+      "value": "ナレッジベースの目的または内容を説明するオプションのテキストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_form/description",
+      "value": "ドキュメントのチャンキングモードです。`text_model` は標準テキストチャンキング、`hierarchical_model` は親子構造、`qa_model` は QA ペア抽出を示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_metadata/description",
+      "value": "ナレッジベースのメタデータフィールド定義です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/document_count/description",
+      "value": "ナレッジベース内のドキュメント総数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/document_count/title",
+      "source_sha256": "cff5b204c719e8f553af52bb13ff9c6caadba08aa6829be7eaed2a4650606693"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_available/description",
+      "value": "設定された埋め込みモデルが現在利用可能かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_available/title",
+      "source_sha256": "c44b36a0f326462ba7c2c3167cd518c6030452fe525d726b472f292877fcd89f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model/description",
+      "value": "インデックス作成に使用される埋め込みモデルの名前です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model_provider/description",
+      "value": "埋め込みモデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。以前のナレッジベースでは短縮形（例：`openai`）が返される場合があります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/enable_api/description",
+      "value": "このナレッジベースで API アクセスが有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/enable_api/title",
+      "source_sha256": "65555b2eb75a2490bacdb1d58b89c6adfc5ae0eb4fda9e608512a48d21ccd5ee"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/external_knowledge_info/description",
+      "value": "外部ナレッジベースの接続詳細です。`provider` が `external` の場合に存在します。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/external_retrieval_model/description",
+      "value": "外部ナレッジベースの検索設定です。内部ナレッジベースの場合は `null` です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/icon_info/description",
+      "value": "ナレッジベースのアイコン表示設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/id/description",
+      "value": "ナレッジベースの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/indexing_technique/description",
+      "value": "`high_quality` は埋め込みモデルを使用した精密検索、`economy` はキーワードベースのインデキシングです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_multimodal/description",
+      "value": "マルチモーダルコンテンツ処理が有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_multimodal/title",
+      "source_sha256": "b112c0ee183ed23fc1cc424141a495e358651addcec0d222c1813d1955e479ca"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_published/description",
+      "value": "ナレッジベースが公開済みかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/maintainer/description",
+      "value": "ナレッジベースのメンテナーの表示名です。設定されていない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/maintainer/title",
+      "source_sha256": "adb42886fe6fc2303496997ccbad46ef2368b62efd170c13234d110e1212e653"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/name/description",
+      "value": "ナレッジベースの表示名です。ワークスペース内で一意です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission/description",
+      "value": "このナレッジベースにアクセスできるユーザーを制御します。指定可能な値：`only_me`、`all_team_members`、`partial_members`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission/title",
+      "source_sha256": "75723d503a92ba27c175213c3ad840a7d22eed24be167a8dc77d6a9084cd2bb3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission_keys/description",
+      "value": "現在の呼び出し元に付与された権限識別子。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission_keys/title",
+      "source_sha256": "409bf340be15ca6cefbc9bd5df37bbdbbf6d293db607b6ced17849e0e393988a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/pipeline_id/description",
+      "value": "カスタム処理パイプラインが設定されている場合のパイプライン ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/pipeline_id/title",
+      "source_sha256": "d01d3715d91c35f794d5bf05d4196cd3aa8a4ac64785d6c15a16a75e2884ea18"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/provider/description",
+      "value": "プロバイダータイプです。内部管理の場合は `vendor`、外部ナレッジベース接続の場合は `external` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/retrieval_model_dict/description",
+      "value": "ナレッジベースの検索設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/runtime_mode/description",
+      "value": "ランタイム処理モードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/runtime_mode/title",
+      "source_sha256": "b04a8dd4ab04780b7d2b0f193b72314937c29e61442c3fb340ad52c611087494"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/summary_index_setting/description",
+      "value": "サマリーインデックスの設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/tags/description",
+      "value": "このナレッジベースに関連付けられたタグです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/tags/title",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_available_documents/description",
+      "value": "有効で利用可能なドキュメントの数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_available_documents/title",
+      "source_sha256": "9354b71ade36bbbde5a486b117577d8ed19d3220bb3f0308b7ab1e396930e36f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_documents/description",
+      "value": "ドキュメントの合計数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_documents/title",
+      "source_sha256": "7e154d8fa98b2d20c75a1fbb7b46e5821f8be6fd37f9ee73733c7e91cbd730e0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_at/description",
+      "value": "最終更新タイムスタンプ（Unix エポック、秒単位）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_by/description",
+      "value": "ナレッジベースを最後に更新したユーザーの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_by/title",
+      "source_sha256": "6b595a302a4b98836b4b277762776908278d6090a198a6ae17e592b71b68abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/word_count/description",
+      "value": "全ドキュメントの合計単語数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/title",
+      "source_sha256": "ba6ffb167022ed5355326584c7caee0cda68d61adcb226234cc43526e21533e0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/app_count/description",
+      "value": "現在このナレッジベースを使用しているアプリケーションの数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/app_count/title",
+      "source_sha256": "f2ebc0260c1ba325417509c378782eb056a1d42309a8bf94f240177008a3bfc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/author_name/description",
+      "value": "作成者の表示名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/author_name/title",
+      "source_sha256": "184bab624ca3534f57b76d065cf11c51a641c53cceed8e6b5f7909a253e49313"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/built_in_field_enabled/description",
+      "value": "組み込みメタデータフィールド（例：`document_name`、`uploader`）が有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/built_in_field_enabled/title",
+      "source_sha256": "60f3d06b21a1179f5971124c3333c5ffe7798e4371795f20f99bd634a01ba7a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/chunk_structure/description",
+      "value": "チャンク構造の設定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/chunk_structure/title",
+      "source_sha256": "b6a62f5f409a72d8767489993f9615846dbae82c4f90a4707c872820c63fce60"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_at/description",
+      "value": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_by/description",
+      "value": "ナレッジベースを作成したユーザーの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/data_source_type/description",
+      "value": "ドキュメントのデータソースタイプです。まだ設定されていない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/description/description",
+      "value": "ナレッジベースの目的または内容を説明するオプションのテキストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_form/description",
+      "value": "ドキュメントのチャンキングモードです。`text_model` は標準テキストチャンキング、`hierarchical_model` は親子構造、`qa_model` は QA ペア抽出を示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_metadata/description",
+      "value": "ナレッジベースのメタデータフィールド定義です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/document_count/description",
+      "value": "ナレッジベース内のドキュメント総数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/document_count/title",
+      "source_sha256": "cff5b204c719e8f553af52bb13ff9c6caadba08aa6829be7eaed2a4650606693"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_available/description",
+      "value": "設定された埋め込みモデルが現在利用可能かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_available/title",
+      "source_sha256": "c44b36a0f326462ba7c2c3167cd518c6030452fe525d726b472f292877fcd89f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model/description",
+      "value": "インデックス作成に使用される埋め込みモデルの名前です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model_provider/description",
+      "value": "埋め込みモデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。以前のナレッジベースでは短縮形（例：`openai`）が返される場合があります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/enable_api/description",
+      "value": "このナレッジベースで API アクセスが有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/enable_api/title",
+      "source_sha256": "65555b2eb75a2490bacdb1d58b89c6adfc5ae0eb4fda9e608512a48d21ccd5ee"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/external_knowledge_info/description",
+      "value": "外部ナレッジベースの接続詳細です。`provider` が `external` の場合に存在します。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/external_retrieval_model/description",
+      "value": "外部ナレッジベースの検索設定です。内部ナレッジベースの場合は `null` です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/icon_info/description",
+      "value": "ナレッジベースのアイコン表示設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/id/description",
+      "value": "ナレッジベースの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/indexing_technique/description",
+      "value": "`high_quality` は埋め込みモデルを使用した精密検索、`economy` はキーワードベースのインデキシングです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_multimodal/description",
+      "value": "マルチモーダルコンテンツ処理が有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_multimodal/title",
+      "source_sha256": "b112c0ee183ed23fc1cc424141a495e358651addcec0d222c1813d1955e479ca"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_published/description",
+      "value": "ナレッジベースが公開済みかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/maintainer/description",
+      "value": "ナレッジベースのメンテナーの表示名です。設定されていない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/maintainer/title",
+      "source_sha256": "adb42886fe6fc2303496997ccbad46ef2368b62efd170c13234d110e1212e653"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/name/description",
+      "value": "ナレッジベースの表示名です。ワークスペース内で一意です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/partial_member_list/description",
+      "value": "`permission` が `partial_members` の場合にアクセスを許可されたメンバーのアカウント ID です。更新レスポンスでは常に含まれ、詳細レスポンスでは `permission` が `partial_members` の場合にのみ含まれます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/partial_member_list/title",
+      "source_sha256": "b7497e9ca926924b443c8190d5c56b19295545ce67ea435097982fea0d0b97c8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission/description",
+      "value": "このナレッジベースにアクセスできるユーザーを制御します。指定可能な値：`only_me`、`all_team_members`、`partial_members`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission/title",
+      "source_sha256": "75723d503a92ba27c175213c3ad840a7d22eed24be167a8dc77d6a9084cd2bb3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission_keys/description",
+      "value": "現在の呼び出し元に付与された権限識別子。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission_keys/title",
+      "source_sha256": "409bf340be15ca6cefbc9bd5df37bbdbbf6d293db607b6ced17849e0e393988a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/pipeline_id/description",
+      "value": "カスタム処理パイプラインが設定されている場合のパイプライン ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/pipeline_id/title",
+      "source_sha256": "d01d3715d91c35f794d5bf05d4196cd3aa8a4ac64785d6c15a16a75e2884ea18"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/provider/description",
+      "value": "プロバイダータイプです。内部管理の場合は `vendor`、外部ナレッジベース接続の場合は `external` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/retrieval_model_dict/description",
+      "value": "ナレッジベースの検索設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/runtime_mode/description",
+      "value": "ランタイム処理モードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/runtime_mode/title",
+      "source_sha256": "b04a8dd4ab04780b7d2b0f193b72314937c29e61442c3fb340ad52c611087494"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/summary_index_setting/description",
+      "value": "サマリーインデックスの設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/tags/description",
+      "value": "このナレッジベースに関連付けられたタグです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/tags/title",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_available_documents/description",
+      "value": "有効で利用可能なドキュメントの数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_available_documents/title",
+      "source_sha256": "9354b71ade36bbbde5a486b117577d8ed19d3220bb3f0308b7ab1e396930e36f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_documents/description",
+      "value": "ドキュメントの合計数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_documents/title",
+      "source_sha256": "7e154d8fa98b2d20c75a1fbb7b46e5821f8be6fd37f9ee73733c7e91cbd730e0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_at/description",
+      "value": "最終更新タイムスタンプ（Unix エポック、秒単位）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_by/description",
+      "value": "ナレッジベースを最後に更新したユーザーの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_by/title",
+      "source_sha256": "6b595a302a4b98836b4b277762776908278d6090a198a6ae17e592b71b68abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/word_count/description",
+      "value": "全ドキュメントの合計単語数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/title",
+      "source_sha256": "120511150e6d03ea4d60dd9815a2c45e71051bc59c102cdbd092af3031b0f1c2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/id/description",
+      "value": "メタデータフィールド ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/name/description",
+      "value": "メタデータフィールド名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/type/description",
+      "value": "メタデータ値の型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/title",
+      "source_sha256": "e51fee287704b0e9cf4008142fb394e284e0d4937f08dad8ec917e1cb0bec0fe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_endpoint/description",
+      "value": "外部ナレッジ API のエンドポイント URL です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_endpoint/title",
+      "source_sha256": "e27ae06d6dd9320dcafb7f6b9180869c764e5ed409c4802b5923c634c78eeef3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_id/description",
+      "value": "外部ナレッジ API 接続の ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_id/title",
+      "source_sha256": "e2dcf725ee077104f9442be1880b13f8247bc7a88800a43f8c816c9fd9d3a103"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_name/description",
+      "value": "外部ナレッジ API の表示名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_name/title",
+      "source_sha256": "ef4ab335626277134a4538efb6061eb32a11d8c1d0c53f1e39b258f875ca45a2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_id/description",
+      "value": "外部ナレッジベースの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_id/title",
+      "source_sha256": "579ead72f48e7a70e00c88363de59534661ce4d149e6aad38a4dfc7d16b1a18c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/title",
+      "source_sha256": "76c321b297c352e17ff1d92c2b7ffcbc3b496886ddbce569f5f9524befcbcf83"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold/description",
+      "value": "検索結果に必要な最小スコア。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold_enabled/description",
+      "value": "スコアしきい値によるフィルタリングを有効にするかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold_enabled/title",
+      "source_sha256": "33e7b2a6e80860238254ee394cff0875c97ba3ba486bd89f1919f34dfe77abc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/top_k/description",
+      "value": "検索結果の最大数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/top_k/title",
+      "source_sha256": "08cf18c91d1b734279713b3783ef3a997cda93cc0aab4059885a3dfc3159c81c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/title",
+      "source_sha256": "c1d5e899db040acf563ce5efea0320fba15cde42bc2c3c1febebbc68c9abfab6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon/description",
+      "value": "アイコン識別子または絵文字です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon/title",
+      "source_sha256": "a4c7282e026e9c0eb1fc174c7d813fb7e1fc644829b38d12c28db5f9b9514330"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_background/description",
+      "value": "アイコンの背景色です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_background/title",
+      "source_sha256": "15067379b68b825a8c24c73dca876adf650c51636467e4209270fac5b87c6dda"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_type/description",
+      "value": "アイコンの種類です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_type/title",
+      "source_sha256": "285323907b457c9b9afe39555fbc8def3298246940561fc8587bfb6e657e3170"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_url/description",
+      "value": "カスタムアイコン画像の URL です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_url/title",
+      "source_sha256": "2002ea73f523b651e2e6f4c79f87fcd5231a172d575ec276ef2bbcee3d338405"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/title",
+      "source_sha256": "b9c742e98a7d10591464bedf3c7f1fa5a5719f4d5ce7987776b7b9ffca373e70"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetKeywordSettingResponse/properties/keyword_weight/description",
+      "value": "キーワード検索結果に割り当てられた重みです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetKeywordSettingResponse/properties/keyword_weight/title",
+      "source_sha256": "577b14638d81d6d6c18433bcef87546069492150025ba80645a9ef107e8f9eb0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetKeywordSettingResponse/title",
+      "source_sha256": "a676998f43edd7113f5cd12cda4d9f4604b80c3b5a4b53144ec546bd639f89ae"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/DatasetListQuery/properties/include_all/description",
       "source_sha256": "42ec0cfe0d70ab1439e6efd97eab8ed04b3723cf7eaa967a9ea50082c82f8ecc",
       "value": "権限に関係なくすべてのナレッジベースを含めるかどうかです。"
@@ -3053,6 +4373,783 @@
       "source_sha256": "fc0d9565af1ad1839448481672b9f23de466a6299631b453b5d8e7e2739696fa"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/data/description",
+      "value": "現在のページのナレッジベース一覧。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/has_more/description",
+      "value": "さらにナレッジベースがあるかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/limit/description",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/page/description",
+      "value": "現在のページ番号です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/total/description",
+      "value": "一致するナレッジベースの総数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/title",
+      "source_sha256": "b27970249561883526cc142777c7a15ada9823a94261ade0caed3899167ba66a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataActionResponse/properties/result/description",
+      "value": "メタデータ操作の結果。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataActionResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataActionResponse/title",
+      "source_sha256": "bb6d438cd416c2d5855dab3174a12afbeaa6dde88a76c610a2df7e9d6dfc7cab"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/name/description",
+      "value": "組み込みメタデータフィールド名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/type/description",
+      "value": "組み込みメタデータ値の型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/title",
+      "source_sha256": "c3d8af8888f05da403256335d33cd62c21a51caa95216be03c5e8318bc087bae"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldsResponse/properties/fields/description",
+      "value": "システム提供のメタデータフィールドのリストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldsResponse/properties/fields/title",
+      "source_sha256": "150e2a17d78790e48f1973e0c4a2e32f724f8b820b1e65408839ac69a44d0ccb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldsResponse/title",
+      "source_sha256": "cc4cafdf6f466ddcc365b39ad1db3d2c8461f15945919fa0053ad60df042446a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/count/description",
+      "value": "このメタデータフィールドを使用しているドキュメント数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/count/title",
+      "source_sha256": "8a4beb9a57edc26e6a3c411c6ba603e9dba4e821f8e4244e826a7db1f64c1051"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/id/description",
+      "value": "メタデータフィールドの識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/name/description",
+      "value": "メタデータフィールド名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/type/description",
+      "value": "メタデータフィールドの種類です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/title",
+      "source_sha256": "11ffbfd3754323d98ef086412d09df0e68b5ec4ffbb1acb6a31f7e6f3c08cac7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/built_in_field_enabled/description",
+      "value": "このナレッジベースで組み込みメタデータフィールドが有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/built_in_field_enabled/title",
+      "source_sha256": "60f3d06b21a1179f5971124c3333c5ffe7798e4371795f20f99bd634a01ba7a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/doc_metadata/description",
+      "value": "メタデータフィールド定義のリスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListResponse/title",
+      "source_sha256": "975c6bdb3d471d8eccefb635980149f6bebee325856d2fd0af03d860cf6e0ec0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/id/description",
+      "value": "メタデータフィールド ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/name/description",
+      "value": "メタデータフィールド名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/type/description",
+      "value": "メタデータ値の型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/title",
+      "source_sha256": "0a214240d8a1f0936bf587059a13ca79732abeac3384930f10ef944e194d96ce"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_model_name/description",
+      "value": "リランキングモデル名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_model_name/title",
+      "source_sha256": "84c57945febff99bd6d302f456cc0c67177d5564c52716407f118e8f2e8fc041"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_provider_name/description",
+      "value": "再ランキングモデルのプロバイダー。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_provider_name/title",
+      "source_sha256": "60b41a32b54ab0b9acf6ad2d6c68ee0ff1e2ad26650e94e289f4265e71a59581"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRerankingModelResponse/title",
+      "source_sha256": "40008ca2d608ce08030c342e753190b7612ea0b1f7c873fc70f01bddfdc1d0f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_enable/description",
+      "value": "リランキングが有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_enable/title",
+      "source_sha256": "cc1894711ba2670a7ad95df9cb248ff4496427dc4e61eefde0f555ebdaeec218"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_mode/description",
+      "value": "リランキングモードです。`reranking_model` はモデルベースのリランキング、`weighted_score` はスコアベースの重み付けを示します。リランキングが無効の場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_mode/title",
+      "source_sha256": "f5301c9027acd776f86cf98e696814c2b9404bfe29ccf772a75b020694c93dd5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_model/description",
+      "value": "リランキングモデルの設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold/description",
+      "value": "結果の最小関連性スコアです。`score_threshold_enabled` が `true` の場合にのみ有効です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold_enabled/description",
+      "value": "スコア閾値フィルタリングが有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold_enabled/title",
+      "source_sha256": "33e7b2a6e80860238254ee394cff0875c97ba3ba486bd89f1919f34dfe77abc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/search_method/description",
+      "value": "検索に使用する検索方法です。`keyword_search` はキーワードマッチング、`semantic_search` は埋め込みベースの類似度検索、`full_text_search` は全文インデックス検索、`hybrid_search` はセマンティックとキーワードの組み合わせ検索を示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/search_method/title",
+      "source_sha256": "1b3a6e09048c1873ec9bf86eda6798c0654e1fd48edce3c148e31783353badbc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/top_k/description",
+      "value": "返す結果の最大数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/top_k/title",
+      "source_sha256": "08cf18c91d1b734279713b3783ef3a997cda93cc0aab4059885a3dfc3159c81c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/weights/description",
+      "value": "ハイブリッド検索の重み設定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/title",
+      "source_sha256": "6aaf327c2cc64329c0397dfca30ef31db0b9c270e5287b82fa664ce7a05c2210"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/enable/description",
+      "value": "要約インデックスを有効にするかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/enable/title",
+      "source_sha256": "992e91e5c8cdb4be1ba11d9ba0ead16ecc43ba3231652481845b26d9e71fb5e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_name/description",
+      "value": "要約生成に使用されるモデルの名前です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_name/title",
+      "source_sha256": "34c44e6c7f885e0aa41e55418f39ac0e3199d9023a1ce834595fc14e58529df7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_provider_name/description",
+      "value": "要約生成モデルのプロバイダーです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_provider_name/title",
+      "source_sha256": "d23d50574b82636f866334d72f5c4b3967f61223f3651d409311d7c8d12f3df7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/summary_prompt/description",
+      "value": "ドキュメント要約の生成に使用するプロンプト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/summary_prompt/title",
+      "source_sha256": "c12c46aae2806b7ebd252b7dd20ca574299a3024a053ea630184c2d7d4e2c012"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/title",
+      "source_sha256": "d70e583cd54c31f5ddd76d706e3a37aa20a53c92ba1a257159a50c5d5e4dfa05"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetTagResponse/properties/id/description",
+      "value": "タグ ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetTagResponse/properties/name/description",
+      "value": "タグ名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetTagResponse/properties/type/description",
+      "value": "タグの種類。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/title",
+      "source_sha256": "58b36e80c267af2940ebfd8c8c26eafc0aa273eb5383759267412049d939bc10"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/description/description",
+      "source_sha256": "55776608955dfaabd609a7e59ac5f005a65589da9f0e01a73d306437cc124da7",
+      "value": "ナレッジベースの説明です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model/description",
+      "source_sha256": "a57676abae00b587600f25027f744a24863f5a9c56780647ccaa7efe6422cdb5",
+      "value": "埋め込みモデル名。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `model` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model_provider/description",
+      "source_sha256": "fbc8249d511185eedbe6c1e9ee65c5f0d7e75d5b2fa2cc1b0ff71ea4ea22e403",
+      "value": "埋め込みモデルプロバイダー。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `provider` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_knowledge_api_id/description",
+      "source_sha256": "30f3fea37c7166d49cc69781ebb7d612a6d3d52cce766e7428dd3e2e1c4cf90c",
+      "value": "外部ナレッジ API の ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_knowledge_api_id/title",
+      "source_sha256": "e2dcf725ee077104f9442be1880b13f8247bc7a88800a43f8c816c9fd9d3a103"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_knowledge_id/description",
+      "source_sha256": "e63af9fd8e5a851202889f38c61fe7abbe296538866962d22d948e0fb6764b72",
+      "value": "外部ナレッジベースの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_knowledge_id/title",
+      "source_sha256": "579ead72f48e7a70e00c88363de59534661ce4d149e6aad38a4dfc7d16b1a18c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0/properties/score_threshold/description",
+      "source_sha256": "e08ce098a3e4e7a50685993b4260a6d398fca9c01d4925cb388cec520c40adb0",
+      "value": "結果を絞り込む最小類似度スコアのしきい値。",
+      "context_path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0/properties/score_threshold_enabled/description",
+      "source_sha256": "a07d7e9732d41dda023d175736f5f250a7d8640eac5a2ccebfd5131382895752",
+      "value": "スコアしきい値によるフィルタリングを有効にするかどうか。",
+      "context_path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0/properties/top_k/description",
+      "source_sha256": "e1c44a06a752a0b9f03931c5962fc46ebf9f68f6a80f8195cff1853a9276c2d8",
+      "value": "返す結果の最大数です。",
+      "context_path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/description",
+      "source_sha256": "044fa8bdc78ee71858f1e7e5f1c7834c31d639314e24a2c73eec62c126cb3638",
+      "value": "外部ナレッジベースの検索設定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/title",
+      "source_sha256": "d03fc29219971b95e45ea314fa45f7195207bd25b5275c364b5fc398b8a4a2c0"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/indexing_technique/description",
+      "source_sha256": "a933b20c1aaec91450173dd832d27b424c525f85dc9b2ab702b57fcd3a8a8bad",
+      "value": "`high_quality` は埋め込みモデルを使用した精密検索、`economy` はキーワードベースのインデキシングです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/name/description",
+      "source_sha256": "b756a6eb4f379851befe6a770ca22095058fb204a003f89e3043903a33296fb2",
+      "value": "ナレッジベース名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/partial_member_list/anyOf/0/items/properties/user_id/description",
+      "source_sha256": "ddfe67bac1cd071b589609143c44d06fb0323535f91bc870469a78ca10ade51d",
+      "value": "アクセス権を付与するチームメンバーの ID です。",
+      "context_path": "/components/schemas/DatasetUpdatePayload/properties/partial_member_list/anyOf/0",
+      "context_sha256": "41ff189492695517378d8a1dc6a370ba80267bd050bae9928bc2546d27737e67"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/partial_member_list/description",
+      "source_sha256": "ac0f3d28718e20cc585730104901429408b1239c84d6e36359ca98387725efc5",
+      "value": "`permission` が `partial_members` の場合にアクセス権を持つチームメンバーのリストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/partial_member_list/title",
+      "source_sha256": "b7497e9ca926924b443c8190d5c56b19295545ce67ea435097982fea0d0b97c8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/permission/description",
+      "source_sha256": "1eb98a26104557e4a9e5ef8d9354fc78a1652e76668c95a32b95422f814d98f7",
+      "value": "このナレッジベースにアクセスできるユーザーを制御します。`only_me` は作成者のみ、`all_team_members` はワークスペース全体、`partial_members` は指定したメンバーにアクセスを許可します。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/title",
+      "source_sha256": "6f40b26ba5761d0bef97beea667093c20b23e8fbdc9224c664c30ca4e3ccd46f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_model_name/description",
+      "value": "ベクトル検索に使用される埋め込みモデルの名前です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_model_name/title",
+      "source_sha256": "4d79d966137d5bf514424da3770d0535ef6289a20ce67d7d5be6038198ccd6bf"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_provider_name/description",
+      "value": "ベクトル検索に使用される埋め込みモデルのプロバイダーです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_provider_name/title",
+      "source_sha256": "4e0310d84c92f0465d3c1184754fbd60864f0d6925435fa6eff884947966e073"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/vector_weight/description",
+      "value": "セマンティック（ベクトル）検索結果に割り当てられた重みです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/vector_weight/title",
+      "source_sha256": "6a405f1ff0999e072f0178b60240aecf12ebe66f212fc2c78450e2876050f29d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/title",
+      "source_sha256": "c2905945c9f349af23c6f1c154922af8d37b2be5a1fb7bf657521fbd7dfb415b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/keyword_setting/description",
+      "value": "キーワード検索の重み設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/vector_setting/description",
+      "value": "セマンティック検索の重み設定です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/weight_type/description",
+      "value": "セマンティック検索とキーワード検索の重みを調整するための戦略です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/weight_type/title",
+      "source_sha256": "2e0fc6f3749fdbeac0065d9c56f1ce8fcdd30d133b1a8c00b5f42eda78ce8b2a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/title",
+      "source_sha256": "f230dd59f57c357aa0fc146b9c1bc4112edda596bd7e1f59f370b352e5de2f78"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/id/description",
+      "value": "資格情報の ID です。 [データソースノードを実行](/ja/api-reference/knowledge-pipeline/run-datasource-node) では `credential_id` として、 [パイプラインを実行](/ja/api-reference/knowledge-pipeline/run-pipeline) の各データソース項目の `credential_id` フィールドとして渡します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/is_default/description",
+      "value": "この資格情報がプロバイダーのデフォルトかどうかを示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/is_default/title",
+      "source_sha256": "3677617520e227631859c6715a99229221a19d3f4ade215934607bc716ee1991"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/name/description",
+      "value": "資格情報の表示名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/type/description",
+      "value": "データソースプラグインが定義する資格情報のタイプです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/title",
+      "source_sha256": "984e4f1a417a9283c66e4d11fe3f6a11fc76eb59343cdea6e00eb054340ad536"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/credential_id/description",
+      "source_sha256": "38c895b73126328657683df03c1266c0605720c3185acc46f7b336c6f4e75e46",
+      "value": "データソース認証情報 ID。省略するとデフォルトを使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/credential_id/title",
+      "source_sha256": "d637e68184a5e5e808af8ab9a5673857a63e64d82e30e47529405518805d0983"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/datasource_type/description",
+      "source_sha256": "926dea22865422c8a048020ab1317176f99f93ba6766a3ff2fc3148a1e3ce760",
+      "value": "データソースの種類です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/datasource_type/title",
+      "source_sha256": "1ddade5ac920148720355e512eb186d05c2511471941c47e4307d239b1f03f83"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/inputs/description",
+      "source_sha256": "894176ed12d27db6f60099d76e1adc355ba91b589c9e892cd2637fbbca471447",
+      "value": "データソースノードの入力変数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/is_published/description",
+      "source_sha256": "75f2844acbf5ef4975420f6914605e063581ba51b9206a39be7e991b3369d9b0",
+      "value": "ノードの公開済みまたはドラフトバージョンを実行するかどうか。`true` は公開済み、`false` はドラフトを実行します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/title",
+      "source_sha256": "dbde50e1a779b6c90ba30e96a5c8bda78717a8799badbc614d9c13675f32c2cd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginListResponse/title",
+      "source_sha256": "27a91134481f05acc93398cd9865f2fe6f8a1aa17cb7e6d58ccb7a6b8c286a1e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/credentials/description",
+      "value": "このデータソースの認証に利用できる資格情報のリストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/credentials/title",
+      "source_sha256": "28d24da580aa5c063887d5508597035026c7caf82a9598a5a01fb70e955463fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/datasource_type/description",
+      "value": "データソースのタイプです。`local_file`、`online_document`、`online_drive`、`website_crawl` のいずれかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/datasource_type/title",
+      "source_sha256": "1ddade5ac920148720355e512eb186d05c2511471941c47e4307d239b1f03f83"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/node_id/description",
+      "value": "パイプラインワークフロー内のデータソースノードの ID です。 [データソースノードを実行](/ja/api-reference/knowledge-pipeline/run-datasource-node) では `node_id` として、 [パイプラインを実行](/ja/api-reference/knowledge-pipeline/run-pipeline) では `start_node_id` として渡します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/plugin_id/description",
+      "value": "このノードを提供するデータソースプラグインの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/plugin_id/title",
+      "source_sha256": "1cbd2f6573f6512c5db14a93d59ddc4b09a591546d66cc51bc0d881a92de08f4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/provider_name/description",
+      "value": "データソースプラグインが登録するプロバイダー名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/provider_name/title",
+      "source_sha256": "3610e3d454ff9d1c255e9ec61ce6cedc89589d47026d8e113168c41a8859a700"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/title/description",
+      "value": "プラグインの表示タイトル。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/title/title",
+      "source_sha256": "4be9d4f1daabdb03afb07253382b19d77501261a6106d734746734605436aa77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/user_input_variables/description",
+      "value": "このデータソースに対して呼び出し元が指定するパイプライン入力変数です。ノードのデータソースパラメータ内の `{{#...#}}` 参照から導出されます。各要素はワークフローが使用するパイプライン変数のスキーマに従います。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/user_input_variables/title",
+      "source_sha256": "56a7fdabc079363149486cd0f29e9c7461d8d91f8cd2b9f70e03a3f346d0711f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/title",
+      "source_sha256": "bed82dfa465fa00a84ab21411d01eff1e458f1d0e5978173250857f5609fbf4d"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/DatasourcePluginsQuery/properties/is_published/description",
       "source_sha256": "5c48d3437a279f6bd9bde8071f0c9482a5fc24366e0d244247f80f4d668dc02d",
@@ -3067,6 +5164,363 @@
       "op": "remove",
       "path": "/components/schemas/DatasourcePluginsQuery/title",
       "source_sha256": "63246588db3edc622fc9aeef4dc8cdfe80ccee0f8e90d4df88b85d9b5a09db16"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentAndBatchResponse/properties/batch/description",
+      "value": "インデックス進捗を追跡するためのバッチ ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentAndBatchResponse/properties/batch/title",
+      "source_sha256": "026b89e52976b2603339b009c7e7547467948fb0753001d02deaa79180427305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentAndBatchResponse/properties/document/description",
+      "value": "マッチしたチャンクの親ドキュメント情報です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentAndBatchResponse/title",
+      "source_sha256": "3504d6ad4554dcb3ac5a6e7307b16c222db259229109883bf903a5c6bfbd860d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentBatchDownloadZipPayload/description",
+      "source_sha256": "a19b258c7ab87015cee5612a45057218cf36cb9e50f0bcf8d66dd2c1df7fb2aa",
+      "value": "ドキュメントを ZIP アーカイブとして一括ダウンロードするリクエストペイロード。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentBatchDownloadZipPayload/properties/document_ids/description",
+      "source_sha256": "61013a5dc68cb391d76f62e702bb37a33b52b085947be5acfdf071b5f29448f6",
+      "value": "ZIP ダウンロードに含めるドキュメント ID のリスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentBatchDownloadZipPayload/properties/document_ids/title",
+      "source_sha256": "dc2a6757bb082f1cd12d85478d340d6d79013f1f3c382be5c6ffc4faee398176"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentBatchDownloadZipPayload/title",
+      "source_sha256": "8530113fc7b84b60536923586316ab99e0419aef64f256f2f105b1ee004e9ecd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/archived/description",
+      "value": "ドキュメントがアーカイブ済みかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/archived/title",
+      "source_sha256": "8541102da5d25ddd0f39f05c975618421519547c67475c4a73cfafac24accec1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/average_segment_length/description",
+      "value": "チャンクの平均文字長です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/average_segment_length/title",
+      "source_sha256": "a01c272dd964ca429ab71ab2ceafae0782202a241e8b34e63c86ed79f10cd4ff"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/completed_at/description",
+      "value": "完了時刻（Unix 秒タイムスタンプ）。未完了の場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_at/description",
+      "value": "作成時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_by/description",
+      "value": "ドキュメントを作成したユーザーの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_from/description",
+      "value": "ドキュメントの作成元です。API で作成した場合は `api`、UI で作成した場合は `web` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_from/title",
+      "source_sha256": "ac7605d36b5da31a00bcf6692a557183ddce029a6ca4c5fb5cc911c9e9fd1495"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_info/description",
+      "value": "データソースの詳細です。ファイルアップロードの場合、この詳細エンドポイントは `upload_file` 配下に完全なファイルオブジェクトを返します（リストエンドポイントは `upload_file_id` のみを返します）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_info/title",
+      "source_sha256": "04fc73b8bbb0b1fd1a8bcb259069d7a0107de9f8eb895eaee40b81077b977e8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_type/description",
+      "value": "ドキュメントのアップロード方法です。ファイルアップロードの場合は `upload_file`、Notion インポートの場合は `notion_import` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule/description",
+      "value": "ナレッジベースレベルの処理ルール設定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule/title",
+      "source_sha256": "ba53a68d3795b4649956a33af1310f064cf6dad79057bc158e4934bcefab4c1e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule_id/description",
+      "value": "このドキュメントに適用された処理ルールの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule_id/title",
+      "source_sha256": "7fe87b64e27b7605197b76399c4f820ed867d9acb75bbdb744928f5414822bcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_at/description",
+      "value": "無効化時刻（Unix 秒タイムスタンプ）。有効な場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_by/description",
+      "value": "ドキュメントを無効化したユーザーの ID です。有効な場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/display_status/description",
+      "value": "UI 向けの表示用インデックスステータスです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/display_status/title",
+      "source_sha256": "f3d19acfd660ecbc3ef3e75c51ad2e1cc29b57881a0c8fee1a3228186d8919f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_form/description",
+      "value": "ドキュメントのチャンキングモードです。`text_model` は標準テキスト、`hierarchical_model` は親子構造、`qa_model` は QA ペアを示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_language/description",
+      "value": "ドキュメント内容の言語です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_metadata/description",
+      "value": "このドキュメントのカスタムメタデータキーバリューペア。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_type/description",
+      "value": "ドキュメントタイプの分類です。未設定の場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_type/title",
+      "source_sha256": "9df74ed42d3a2e6f946ce0af273666dc30fef00ebd133970e773dd1e27428fcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/document_process_rule/description",
+      "value": "ドキュメントレベルの処理ルール設定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/document_process_rule/title",
+      "source_sha256": "721a63f3f15e5d8aaedcfa99cd9835272aacbd8655b261323855d5632891eeb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/enabled/description",
+      "value": "このドキュメントが検索に対して有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/error/description",
+      "value": "インデックス作成が失敗した場合のエラーメッセージです。それ以外は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/hit_count/description",
+      "value": "このドキュメントが検索された回数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/id/description",
+      "value": "ドキュメント識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_latency/description",
+      "value": "インデックス作成にかかった時間（秒）です。未完了の場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_latency/title",
+      "source_sha256": "9958606e45e1f84a90bf2b35cc6f1da7667f177f05f2e6507a09465d31b91b6f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_status/description",
+      "value": "現在のインデックスステータスです（例：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、`error`、`paused`）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/name/description",
+      "value": "ドキュメント名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/need_summary/description",
+      "value": "このドキュメントが要約生成を必要とするかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/need_summary/title",
+      "source_sha256": "f86a97523001d39eb483e5eb409dd41314bec44581f7537da8356eddca7a3209"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/position/description",
+      "value": "ナレッジベース内の位置インデックスです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/segment_count/description",
+      "value": "ドキュメント内のチャンク数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/segment_count/title",
+      "source_sha256": "b00632c029a06236c07045f50ea4c8d7d1be5eee01bdb2a0066f043c170f93d8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/summary_index_status/description",
+      "value": "要約インデックスのステータスです。要約インデックスが有効でない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/summary_index_status/title",
+      "source_sha256": "f071851825f1aef8746a503d9c35eb84d025616f0cea1088f7865b510f2c180a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/tokens/description",
+      "value": "ドキュメント内のトークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/updated_at/description",
+      "value": "最終更新時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/title",
+      "source_sha256": "47de58693b044c133c8524b3999a1a724a401e536b8c79b59df0d47f5d13676c"
     },
     {
       "op": "replace",
@@ -3132,6 +5586,886 @@
       "op": "remove",
       "path": "/components/schemas/DocumentListQuery/title",
       "source_sha256": "ed2db5c64b168833d59052e05d0a006c0c7f1f83ada31a1dbf4c7a06e48fceda"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/data/description",
+      "value": "現在のページのドキュメント一覧。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/has_more/description",
+      "value": "さらにドキュメントがあるかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/limit/description",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/page/description",
+      "value": "現在のページ番号です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/total/description",
+      "value": "一致するドキュメントの総数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/title",
+      "source_sha256": "8435a09d11cdbd474fd5cc16e3e85f1166bf99947fb83e96d9274d7aa3702c71"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/document_id/description",
+      "source_sha256": "c2ce292785657305de2476937376065ce2c8846d6ba99f9d45cd633e963302fe",
+      "value": "メタデータを更新するドキュメント ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/metadata_list/description",
+      "source_sha256": "8ff5f5cfb3d991ddb4d8c8a01657864ccaf926ba43af15410214d99e5aa94095",
+      "value": "更新するメタデータフィールド。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/metadata_list/title",
+      "source_sha256": "74c1bd3c93da31006af3e9fbbc2185f56659a934ca930979b912d78f9f7ab349"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/partial_update/description",
+      "source_sha256": "fcff191800ab973d5987419b5e02de0127399516fea2d3e62c52560afec3cae2",
+      "value": "メタデータを部分的に更新し、未指定フィールドの既存の値を保持するかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/partial_update/title",
+      "source_sha256": "f5248201347a7ebfbe3b073bc563cfc799d2c792f4890d2a3923e5c60fe812fc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/title",
+      "source_sha256": "6a94e1b7a5668ef785a2a8c18edf4b1d7d09678f163cb754d0a30a6ca7694b0d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/id/description",
+      "value": "メタデータフィールドの識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/name/description",
+      "value": "メタデータフィールド名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/type/description",
+      "value": "メタデータフィールドの値の種類です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/value/description",
+      "value": "このドキュメントのメタデータ値。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/title",
+      "source_sha256": "4c1c189d5bef8cc41bc0d17b17b3c918042c851d9e45db8ba4840f8def43abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/archived/description",
+      "value": "ドキュメントがアーカイブ済みかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/archived/title",
+      "source_sha256": "8541102da5d25ddd0f39f05c975618421519547c67475c4a73cfafac24accec1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/created_at/description",
+      "value": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/created_by/description",
+      "value": "ドキュメントを作成したユーザーの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/created_from/description",
+      "value": "ドキュメントの作成元です。API で作成した場合は `api`、UI で作成した場合は `web` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/created_from/title",
+      "source_sha256": "ac7605d36b5da31a00bcf6692a557183ddce029a6ca4c5fb5cc911c9e9fd1495"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_detail_dict/description",
+      "value": "ファイル詳細を含む詳細なデータソース情報です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_detail_dict/title",
+      "source_sha256": "28dd9da99ba5d7bc55120227afe601c8b503ab708a5fca4e3d14c0d72d0c25a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_info/description",
+      "value": "生のデータソース情報です。`data_source_type` によって異なります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_info/title",
+      "source_sha256": "04fc73b8bbb0b1fd1a8bcb259069d7a0107de9f8eb895eaee40b81077b977e8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_type/description",
+      "value": "ドキュメントの作成方法です。ファイルアップロードの場合は `upload_file`、Notion インポートの場合は `notion_import` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/dataset_process_rule_id/description",
+      "value": "このドキュメントに適用された処理ルールの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/dataset_process_rule_id/title",
+      "source_sha256": "7fe87b64e27b7605197b76399c4f820ed867d9acb75bbdb744928f5414822bcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_at/description",
+      "value": "無効化時刻（Unix 秒タイムスタンプ）。有効な場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_by/description",
+      "value": "ドキュメントを無効化したユーザーの ID です。有効な場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/display_status/description",
+      "value": "`indexing_status` と `enabled` 状態から導出されたユーザー向け表示ステータスです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/display_status/title",
+      "source_sha256": "f3d19acfd660ecbc3ef3e75c51ad2e1cc29b57881a0c8fee1a3228186d8919f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/doc_form/description",
+      "value": "ドキュメントのチャンキングモードです。`text_model` は標準テキストチャンキング、`hierarchical_model` は親子構造、`qa_model` は QA ペア抽出を示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/doc_metadata/description",
+      "value": "このドキュメントに割り当てられたメタデータ値です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/enabled/description",
+      "value": "このドキュメントが検索に対して有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/error/description",
+      "value": "インデックス作成が失敗した場合のエラーメッセージです。エラーなしの場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/hit_count/description",
+      "value": "ドキュメントが検索クエリでマッチした回数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/id/description",
+      "value": "ドキュメントの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/indexing_status/description",
+      "value": "現在のインデックスステータスです。`waiting` はキュー待ち、`parsing` はコンテンツ抽出中、`cleaning` はノイズ除去中、`splitting` はチャンキング中、`indexing` はベクトル構築中、`completed` は準備完了、`error` は失敗、`paused` は手動一時停止を示します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/name/description",
+      "value": "ドキュメント名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/need_summary/description",
+      "value": "このドキュメントに要約を生成する必要があるかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/need_summary/title",
+      "source_sha256": "f86a97523001d39eb483e5eb409dd41314bec44581f7537da8356eddca7a3209"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/position/description",
+      "value": "リスト内のドキュメントの表示位置です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/summary_index_status/description",
+      "value": "このドキュメントの要約インデックスのステータスです。要約インデックスが設定されていない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/summary_index_status/title",
+      "source_sha256": "f071851825f1aef8746a503d9c35eb84d025616f0cea1088f7865b510f2c180a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/tokens/description",
+      "value": "ドキュメント内の合計トークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/word_count/description",
+      "value": "ドキュメントの合計単語数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/title",
+      "source_sha256": "2e21f14477b9e62a64922ef5d3614928ef4f390217977f08f6be9b13274ce35e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusListResponse/properties/data/description",
+      "value": "ドキュメント処理状態のレコード。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusListResponse/title",
+      "source_sha256": "271dc90dcdf630dcd05ce6d196274faf721b3cbd2d12c414ca29d86cc4ed8c0f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentStatusPayload/properties/document_ids/description",
+      "source_sha256": "234a2deb218eaa9bc74cf0ee5cc26b0c06b9208488238e5c44e31d17794012d6",
+      "value": "更新するドキュメント ID のリストです。互換性のため任意です。省略するか空配列を渡すと、リクエストは成功しますがドキュメントは更新されません。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusPayload/properties/document_ids/title",
+      "source_sha256": "dc2a6757bb082f1cd12d85478d340d6d79013f1f3c382be5c6ffc4faee398176"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusPayload/title",
+      "source_sha256": "8bf178b15f72df177fae4f9df12a004fec21f4c2caac21200fe65f7d29002933"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/cleaning_completed_at/description",
+      "value": "クリーニング完了時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/cleaning_completed_at/title",
+      "source_sha256": "03b3cb7786f7423ca24280558a8d4899cc3f4ff6698c3a0354f52c6ffb2610b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_at/description",
+      "value": "インデックス完了時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_segments/description",
+      "value": "インデックス済みのチャンク数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_segments/title",
+      "source_sha256": "2a63a79f7927e11e90fa30a49344e987f1f8faf74ec78bb42ce6ad1780ee4ce4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error/description",
+      "value": "インデキシングが失敗した場合のエラーメッセージ。エラーがない場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error_code/description",
+      "value": "処理エラーコード。エラーがない場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error_code/title",
+      "source_sha256": "0a784f3f0dd812c0bf04ba86b7aaf4027aae79d0cd98b06385701ca56fc33779"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/estimated_vector_space_mb/description",
+      "value": "推定ベクトルストレージ使用量（MB）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/estimated_vector_space_mb/title",
+      "source_sha256": "82883eedce2c8a2f1d7ba55145c838481d4636f533b617c0e4250ec3f349a573"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/id/description",
+      "value": "ドキュメント識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/indexing_status/description",
+      "value": "現在のインデックス状態：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、`error`、または `paused`。`completed` と `error` は終端状態です。Service API では `paused` のドキュメントを再開できません。Dify のナレッジベース画面で再開してからポーリングを続けてください。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/parsing_completed_at/description",
+      "value": "解析完了時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/parsing_completed_at/title",
+      "source_sha256": "6f4040a53d17dc6d300f8b3db316043775bdf5c62902620c9b7ebe5a5f887743"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/paused_at/description",
+      "value": "インデックス一時停止時刻（Unix 秒タイムスタンプ）。一時停止していない場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/paused_at/title",
+      "source_sha256": "27f9211f8d20297ee4ae52683191e77dbc1f685480025ec7b6b38674b31bd26f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/processing_started_at/description",
+      "value": "処理開始時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/processing_started_at/title",
+      "source_sha256": "c23858653858bb7fc7237d3033b5588ac1e694381bb2915531d6bb9d00f7448e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/splitting_completed_at/description",
+      "value": "分割完了時刻（Unix 秒タイムスタンプ）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/splitting_completed_at/title",
+      "source_sha256": "a3218648896dd8e1534da12e88b1b3b380369b751d514a22ed361d210f1699dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/stopped_at/description",
+      "value": "インデックス停止時刻（Unix 秒タイムスタンプ）。停止していない場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/stopped_at/title",
+      "source_sha256": "e6760f92f5dde2261be331d6fdc428cb187032976d9229b4171e068dc69a82d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/total_segments/description",
+      "value": "インデックス対象のチャンクの合計数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/total_segments/title",
+      "source_sha256": "09fe63bdbc83b98d9e40b93ddae803e779caa1c7ab674a0b9bb53b74207c332f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/vector_space_limit_mb/description",
+      "value": "ベクトルストレージ上限（MB）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/vector_space_limit_mb/title",
+      "source_sha256": "9028c6208cbdb28fbe3137f15278a86807d70f7a9c437e782ac95693836e20f8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/title",
+      "source_sha256": "3e7be7a8546ebb1e58a75fd5ceb1b6c450d9ef02799db20c2a4d6a7c87f7f7b8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/doc_form/description",
+      "source_sha256": "19683e8d31c731b01fa05ed424b3e190e75b65c0fc85184bfb09335c6b91b742",
+      "value": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/doc_language/description",
+      "source_sha256": "efb6f3721270f3dfb8b787bba1f0d6a2f1165295da61025d63e34a1d09ec5b04",
+      "value": "処理最適化のためのドキュメント言語です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model/description",
+      "source_sha256": "a57676abae00b587600f25027f744a24863f5a9c56780647ccaa7efe6422cdb5",
+      "value": "埋め込みモデル名。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `model` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model_provider/description",
+      "source_sha256": "fbc8249d511185eedbe6c1e9ee65c5f0d7e75d5b2fa2cc1b0ff71ea4ea22e403",
+      "value": "埋め込みモデルプロバイダー。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models)で返される `provider` フィールドを使用し、`model_type` を `text-embedding` に設定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/indexing_technique/description",
+      "source_sha256": "5cd15c86131f0495c2100b3e96f89919de8758cf6aca8bb75aedb705f359d019",
+      "value": "`high_quality` は埋め込みモデルによる高精度検索、`economy` はキーワードベースのインデックスを使用します。ナレッジベースに最初のドキュメントを追加するときは必須です。以降は省略するとナレッジベースのインデックス方式を継承します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/name/description",
+      "source_sha256": "be05790374a007475abc7dcb1915fbd594aaaf3e9ddbab4905848dc944ff2654",
+      "value": "ドキュメント名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/original_document_id/description",
+      "source_sha256": "60073b60b17f220ab0be0933ae61c6343b9e0e3f06384af4fde769a1ffb8568d",
+      "value": "置換対象の元ドキュメント ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/original_document_id/title",
+      "source_sha256": "912e375455228dc2bf425df1398caef3a87b188a983848b6a659052d401055bd"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/process_rule/description",
+      "source_sha256": "64d646df43acecf87aa51d272bf053bf69ffb0db981f6bd5b324abdafc3efd3f",
+      "value": "チャンキングの処理ルールです。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/text/description",
+      "source_sha256": "15d1cf90d8b4e25fe0d172442df7017c6df810fa6f95fe40ae9b60ccc97384e4",
+      "value": "ドキュメントのテキスト内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/title",
+      "source_sha256": "f5a7947e48de74109f6c499cae88124d8dc10511463ecae5e716b4b917d633bb"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/doc_form/description",
+      "source_sha256": "19683e8d31c731b01fa05ed424b3e190e75b65c0fc85184bfb09335c6b91b742",
+      "value": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/doc_language/description",
+      "source_sha256": "efb6f3721270f3dfb8b787bba1f0d6a2f1165295da61025d63e34a1d09ec5b04",
+      "value": "処理最適化のためのドキュメント言語です。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/name/description",
+      "source_sha256": "0a8346b229609f3d8fa39b64da94d1d46e42856d98b6b9f9f6b7863925574b1a",
+      "value": "ドキュメント名です。`text` を指定する場合は必須です。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/process_rule/description",
+      "source_sha256": "64d646df43acecf87aa51d272bf053bf69ffb0db981f6bd5b324abdafc3efd3f",
+      "value": "チャンキングの処理ルールです。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "チャンクの検索方法と順位付けを制御する検索モデル設定。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/text/description",
+      "source_sha256": "15d1cf90d8b4e25fe0d172442df7017c6df810fa6f95fe40ae9b60ccc97384e4",
+      "value": "ドキュメントのテキスト内容です。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/doc_form/description",
+      "source_sha256": "19683e8d31c731b01fa05ed424b3e190e75b65c0fc85184bfb09335c6b91b742",
+      "value": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/doc_language/description",
+      "source_sha256": "efb6f3721270f3dfb8b787bba1f0d6a2f1165295da61025d63e34a1d09ec5b04",
+      "value": "処理最適化のためのドキュメント言語です。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/name/description",
+      "source_sha256": "0a8346b229609f3d8fa39b64da94d1d46e42856d98b6b9f9f6b7863925574b1a",
+      "value": "ドキュメント名です。`text` を指定する場合は必須です。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/process_rule/description",
+      "source_sha256": "64d646df43acecf87aa51d272bf053bf69ffb0db981f6bd5b324abdafc3efd3f",
+      "value": "チャンキングの処理ルールです。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "チャンクの検索方法と順位付けを制御する検索モデル設定。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/text/description",
+      "source_sha256": "15d1cf90d8b4e25fe0d172442df7017c6df810fa6f95fe40ae9b60ccc97384e4",
+      "value": "ドキュメントのテキスト内容です。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/doc_form/description",
+      "source_sha256": "19683e8d31c731b01fa05ed424b3e190e75b65c0fc85184bfb09335c6b91b742",
+      "value": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/doc_language/description",
+      "source_sha256": "efb6f3721270f3dfb8b787bba1f0d6a2f1165295da61025d63e34a1d09ec5b04",
+      "value": "処理最適化のためのドキュメント言語です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/name/description",
+      "source_sha256": "0a8346b229609f3d8fa39b64da94d1d46e42856d98b6b9f9f6b7863925574b1a",
+      "value": "ドキュメント名です。`text` を指定する場合は必須です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/process_rule/description",
+      "source_sha256": "64d646df43acecf87aa51d272bf053bf69ffb0db981f6bd5b324abdafc3efd3f",
+      "value": "チャンキングの処理ルールです。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/text/description",
+      "source_sha256": "15d1cf90d8b4e25fe0d172442df7017c6df810fa6f95fe40ae9b60ccc97384e4",
+      "value": "ドキュメントのテキスト内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/title",
+      "source_sha256": "8ff01b234dd66b682db99e9c3b7e5afdb96764fea3d8437b131d439771ba7ef0"
     },
     {
       "op": "remove",
@@ -3279,6 +6613,17 @@
       "op": "remove",
       "path": "/components/schemas/FeedbackListQuery/title",
       "source_sha256": "2ee2ef5a0b8833947992d468c455c3ec9722d91f0512455ef418a2ca9fa97e89"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/FetchFrom/description",
+      "source_sha256": "93b013d10f7d415ee23f10d2da2177911d3910daa1cbc898c34b362affe74317",
+      "value": "ユーザー識別子の取得元を表す列挙型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FetchFrom/title",
+      "source_sha256": "acb0dd729bd3571f3c6e9f9d7f2f02ef818bca9ba75204ba8debbaa023a9126d"
     },
     {
       "op": "add",
@@ -3580,6 +6925,564 @@
       "op": "remove",
       "path": "/components/schemas/FileType/title",
       "source_sha256": "1146fdf89b9afd90dd54e7a8a49cc084960dbe6ab3cb3c9ddb13494be2676ed7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/content/description",
+      "value": "子チャンクのテキスト内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/id/description",
+      "value": "子チャンクの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/position/description",
+      "value": "親チャンク内の子チャンクの位置です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/score/description",
+      "value": "子チャンクの関連性スコアです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/title",
+      "source_sha256": "04a4b8972b5517ed1952fc67fc2ac7d057647bc0a9e530692dba6de71583680f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/data_source_type/description",
+      "value": "ドキュメントの作成方法です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_metadata/description",
+      "value": "ドキュメントのメタデータ値です。メタデータが設定されていない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_type/description",
+      "value": "ドキュメントタイプの分類です。未設定の場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_type/title",
+      "source_sha256": "9df74ed42d3a2e6f946ce0af273666dc30fef00ebd133970e773dd1e27428fcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/id/description",
+      "value": "ドキュメントの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/name/description",
+      "value": "ドキュメント名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/title",
+      "source_sha256": "5e94cace3967519065fce6e26f98e585eed1a2c48f3d9bdb4aab9f96ea192fea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/extension/description",
+      "value": "ファイル拡張子。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/id/description",
+      "value": "添付ファイルの識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/mime_type/description",
+      "value": "ファイルの MIME タイプ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/name/description",
+      "value": "元のファイル名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/size/description",
+      "value": "ファイルサイズ（バイト）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/source_url/description",
+      "value": "添付ファイルにアクセスする URL です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/source_url/title",
+      "source_sha256": "3d48f2577f877973dd0a3ab85975e367b5a9ab1964eb533d2cb3dd317134d453"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/title",
+      "source_sha256": "39b9e374e8c486ac5f02f9c571c6632befb800130e8a706987a0b429a360f42c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/attachment_ids/description",
+      "source_sha256": "bf7f542822d8864ea08a8b221abb9edb06a05cce58548f1bfe4aae4ca316a9c8",
+      "value": "ナレッジベースのチャンクに添付済みの画像ファイル ID です。Dify コンソールでチャンク添付をアップロードまたは作成した際の戻り値から取得し、マルチモーダル検索テストに画像コンテキストを追加します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/properties/attachment_ids/title",
+      "source_sha256": "477c1e5aa9f364630218d09c7e51bb851e632ef1f297ec491ef9e34c725bbcbd"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0/properties/score_threshold/description",
+      "source_sha256": "e08ce098a3e4e7a50685993b4260a6d398fca9c01d4925cb388cec520c40adb0",
+      "value": "結果を絞り込む最小類似度スコアのしきい値。",
+      "context_path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0/properties/score_threshold_enabled/description",
+      "source_sha256": "a07d7e9732d41dda023d175736f5f250a7d8640eac5a2ccebfd5131382895752",
+      "value": "スコアしきい値によるフィルタリングを有効にするかどうか。",
+      "context_path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0/properties/top_k/description",
+      "source_sha256": "e1c44a06a752a0b9f03931c5962fc46ebf9f68f6a80f8195cff1853a9276c2d8",
+      "value": "返す結果の最大数です。",
+      "context_path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/description",
+      "source_sha256": "044fa8bdc78ee71858f1e7e5f1c7834c31d639314e24a2c73eec62c126cb3638",
+      "value": "外部ナレッジベースの検索設定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/title",
+      "source_sha256": "d03fc29219971b95e45ea314fa45f7195207bd25b5275c364b5fc398b8a4a2c0"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/query/description",
+      "source_sha256": "c10a718bfe74e7f83b03055ae36933b87ddbc233243a9b2b18da5a9ad3b5107e",
+      "value": "検索クエリテキストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "チャンクの検索方法と順位付けを制御する検索モデル設定。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/title",
+      "source_sha256": "ce553fcd151500efc39b4f765e849170d57d90a6492f4de009c7f1c52dad61be"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingQuery/properties/content/description",
+      "value": "検索テストに使用するクエリテキスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingQuery/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingQuery/title",
+      "source_sha256": "76dfb654101204d869e2eb0e611e02f148acd3ee6e6aa1746d6e5653c1a4ff50"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/child_chunks/description",
+      "value": "階層インデックスを使用している場合、チャンク内でマッチした子チャンクです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/child_chunks/title",
+      "source_sha256": "bd2ab3b4c807f0086a23c8bcf021f57f9516f43bc3b3577bf84f78237dd361e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/files/description",
+      "value": "このチャンクに添付されたファイルです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/score/description",
+      "value": "関連性スコアです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/segment/description",
+      "value": "ナレッジベースから一致したチャンクです。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/summary/description",
+      "value": "要約インデックス経由で取得された場合の要約コンテンツです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/tsne_position/description",
+      "value": "t-SNE 可視化の位置です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/tsne_position/title",
+      "source_sha256": "bab0091eada78f67bd15e07cbef0b8871d8fac48c0f71ecbd1b796da402d0c3d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/title",
+      "source_sha256": "9598ca2914a61e78b5ec68296ecd78c1b28a1c2857459b03da6390504f970d94"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingResponse/properties/query/description",
+      "value": "元のクエリオブジェクトです。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingResponse/properties/records/description",
+      "value": "一致した検索レコードのリスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingResponse/properties/records/title",
+      "source_sha256": "079b962f34b8d3d57508383c9b5669e6818b1c65dc9beeaf43609f12a46d34b9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingResponse/title",
+      "source_sha256": "e4214278c7f114e4f04ecfc01a54df155fce3d3011412a40439969be5c2ae862"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/answer/description",
+      "value": "回答コンテンツです。Q&A モードのドキュメントで使用されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/completed_at/description",
+      "value": "完了時刻（Unix 秒タイムスタンプ）。未完了の場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/content/description",
+      "value": "チャンクのテキスト内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/created_at/description",
+      "value": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/created_by/description",
+      "value": "チャンクを作成したユーザーの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_at/description",
+      "value": "無効化時刻（Unix 秒タイムスタンプ）。有効な場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_by/description",
+      "value": "チャンクを無効化したユーザーの ID です。有効な場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/document/description",
+      "value": "マッチしたチャンクの親ドキュメント情報です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/document_id/description",
+      "value": "このチャンクが属するドキュメントの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/enabled/description",
+      "value": "このチャンクが検索に対して有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/error/description",
+      "value": "インデックス作成が失敗した場合のエラーメッセージです。エラーなしの場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/hit_count/description",
+      "value": "このチャンクが検索クエリでマッチした回数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/id/description",
+      "value": "チャンクの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_hash/description",
+      "value": "インデックスされたコンテンツのハッシュです。変更の検出に使用されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_id/description",
+      "value": "ベクトルストア内のインデックスノードの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_id/title",
+      "source_sha256": "0d45b0d6da2c05390b91146a6cd5de5845c26e58431ba1174c3e3c0793192b42"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/indexing_at/description",
+      "value": "インデックス開始時刻（Unix 秒タイムスタンプ）。未開始の場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/indexing_at/title",
+      "source_sha256": "3d4b6de81308d36e9b8544959f48c914d42c529120fa60ad2e08922d6b60fa8a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/keywords/description",
+      "value": "キーワードベースの検索のためにこのチャンクに関連付けられたキーワードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/position/description",
+      "value": "ドキュメント内のチャンクの位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/sign_content/description",
+      "value": "整合性検証用の署名付きコンテンツハッシュです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/sign_content/title",
+      "source_sha256": "0b01a836c72cea937f5dc68e84213e59c3dc45e8a385ac28588608ab9c00bea4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/status/description",
+      "value": "チャンクのインデックスステータスです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/stopped_at/description",
+      "value": "インデックス停止時刻（Unix 秒タイムスタンプ）。停止していない場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/stopped_at/title",
+      "source_sha256": "e6760f92f5dde2261be331d6fdc428cb187032976d9229b4171e068dc69a82d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/tokens/description",
+      "value": "チャンク内容のトークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/word_count/description",
+      "value": "チャンク内容の単語数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/title",
+      "source_sha256": "f3c4398d148dc323df829715bfcd57aec3fea754cb2b6fa1c52ee9f7dab03cbe"
     },
     {
       "op": "add",
@@ -3927,6 +7830,37 @@
       "source_sha256": "aa2f56fbcc6b021221b64c92e880abaccf77304d4960f15e77f766fae9e7c1e1"
     },
     {
+      "op": "replace",
+      "path": "/components/schemas/I18nObject/description",
+      "source_sha256": "7a1384fbe0312d8e0f1aa3709672e486da30d49840af1f8bf7720f9f69cb5ece",
+      "value": "国際化オブジェクトのモデル。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/I18nObject/properties/en_US/description",
+      "value": "英語（米国）のテキスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/I18nObject/properties/en_US/title",
+      "source_sha256": "91730468013580d2ca81b9ec9f7f7c2d035aafd4e02e18dca3f7414a2255876c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/I18nObject/properties/zh_Hans/description",
+      "value": "簡体字中国語のテキスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/I18nObject/properties/zh_Hans/title",
+      "source_sha256": "3303c331ae7406cb2ff6ebf0ea89c214a8b77ffe90bfca224f24dcc8d65205a0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/I18nObject/title",
+      "source_sha256": "a8261231c196264130c3255d0b00818e884a251f90142bdc9128a4f7a54a5a2d"
+    },
+    {
       "op": "add",
       "path": "/components/schemas/IndexInfoResponse/properties/api_version/description",
       "value": "Service API のバージョン。"
@@ -3960,6 +7894,56 @@
       "op": "remove",
       "path": "/components/schemas/IndexInfoResponse/title",
       "source_sha256": "39bae08b9ff59cac2e8753bfc4a2e27ee7493eb5d4f6402c2f1c354436048e6e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagListResponse/title",
+      "source_sha256": "7ea66a71f438538cc91dc4a3c8f5b1f1ac45a9eec520618f4d86759a873d58bd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/binding_count/description",
+      "value": "このタグにバインドされたナレッジベースの数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/binding_count/title",
+      "source_sha256": "6744d2c8f3469e6d93b9054f200888a7f83c5434fada4fab7da8c497fee9334a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/id/description",
+      "value": "タグ識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/name/description",
+      "value": "タグの表示名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/type/description",
+      "value": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/title",
+      "source_sha256": "5d35b5b2ca17ef8d8b9e46e07f786fd8d5868bc644495e9452b64cfb52bcbafd"
     },
     {
       "op": "replace",
@@ -4388,6 +8372,186 @@
       "op": "remove",
       "path": "/components/schemas/MessageListQuery/title",
       "source_sha256": "17997d5395df2c93391badf0ba144f4ca86426f5b37ae14fd35d9c873a56e906"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataArgs/properties/name/description",
+      "source_sha256": "3f2e55a969f40b27ef2783ba0161dafc53961bc1aa30523fa3651dd788c71300",
+      "value": "メタデータフィールド名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataArgs/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataArgs/properties/type/description",
+      "source_sha256": "c7cf93e24c0c66483dcbd9fafdd30d8f18b5e4b7f611044c441211a2a1c687ba",
+      "value": "`string` はテキスト値、`number` は数値、`time` は日付/時刻値です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataArgs/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataArgs/title",
+      "source_sha256": "5010db9c5b96a550c36c36195662f267ede43500911e35fb0c94e6ab88dc578a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataDetail/properties/id/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "メタデータフィールド ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataDetail/properties/name/description",
+      "source_sha256": "3f2e55a969f40b27ef2783ba0161dafc53961bc1aa30523fa3651dd788c71300",
+      "value": "メタデータフィールド名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataDetail/properties/value/description",
+      "source_sha256": "3fdf277a590661a66052c2250e1f219173b294e12db31667b0f0f335a9ef1046",
+      "value": "メタデータ値。文字列、数値、または `null` を指定できます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/title",
+      "source_sha256": "302664e69b302538fbbb457b69ed4b30cbcbefe70237d9c4c4a99709535d424b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataFilteringCondition/description",
+      "source_sha256": "619bb3c72d6a1df26bf70c18a4b5dee89a44fa039cb8fa5f7363c3f2625c03d5",
+      "value": "メタデータのフィルタリング条件。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataFilteringCondition/properties/conditions/description",
+      "source_sha256": "0cee17456cfb5acb30302205498035132fda78a3e80485460246606bd72a3296",
+      "value": "評価するメタデータ条件のリストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataFilteringCondition/properties/conditions/title",
+      "source_sha256": "4859ee3a5984f46db2a7ccfa66d09ea46ad9df847d6cb8397511e787f067b808"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataFilteringCondition/properties/logical_operator/description",
+      "source_sha256": "4607effbd3a2afc71a74d145faa8548e26f148c22d8ef7463003c9421f94e55b",
+      "value": "複数の条件を組み合わせる方法です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataFilteringCondition/properties/logical_operator/title",
+      "source_sha256": "bd84f30aea6a169e867e9db93128823bc7d81fb1dfda548b082b0bcc781fd9b1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataFilteringCondition/title",
+      "source_sha256": "b06ffd3e4965d76123abf4cd03de62125ac92beb783b60945b7ab06bb5c102b1"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataOperationData/description",
+      "source_sha256": "be6bd52b9115554d18edb75b0f8636420d176d1f6f856425ed4e199648640e39",
+      "value": "メタデータ操作データ。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataOperationData/properties/operation_data/description",
+      "source_sha256": "05188a756294c069f170be44b9dcff59f3a0244fd0069ffc2ece50491bcffdf8",
+      "value": "ドキュメントメタデータ更新操作の配列。各エントリはドキュメント ID をそのメタデータ値に対応付けます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataOperationData/properties/operation_data/title",
+      "source_sha256": "02b7dc37f55b2fbb29b6e3c7924c7784cedbddae06d7ee78f1bac1d440a2d75a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataOperationData/title",
+      "source_sha256": "ee06ed81dc74e00e43985d26fa6ff24cc18e77b8459bd788db8a6ba34799d3eb"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataUpdatePayload/properties/name/description",
+      "source_sha256": "d8626bc15656aac057165159c4558b0ded5dafcbebcdade61c5a09e3eba3b151",
+      "value": "新しいメタデータフィールド名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataUpdatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataUpdatePayload/title",
+      "source_sha256": "aabaef1791ea8fbdc2dfeb00d411b65852b6c403ce271039db738a89968c3ecd"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ModelFeature/description",
+      "source_sha256": "4a271a6b3e6fece160c11be74b83b914934b6b2b42589b4b36548a1cfe9d1ed5",
+      "value": "LLM 機能の列挙型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelFeature/title",
+      "source_sha256": "5780e7c733374436c449054dd03e6033a0b8938701761eaad659da105cdb5e79"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ModelPropertyKey/description",
+      "source_sha256": "587be277cf74fa2137f2f63f53a031c7e21313474af385e4afaae906f7c3640b",
+      "value": "モデルプロパティキーの列挙型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelPropertyKey/title",
+      "source_sha256": "706b1321efa56929cbfaa83d1701bb1f2cca7139978811df4128553dc9579da1"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ModelStatus/description",
+      "source_sha256": "ceb92b86549966f60990db6a356bffa119873e4ad66dd7d5b28d0ac942a98b72",
+      "value": "モデル状態の列挙型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelStatus/title",
+      "source_sha256": "46314ebd42525f4675cfa3644685b6f21f98f94fba835afd047311dd9bb248ac"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ModelType/description",
+      "source_sha256": "19db1c5faa088d8d3d7a1aed47801e9ef0e18559a23f9acb3136a06368714d19",
+      "value": "モデルタイプの列挙型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelType/title",
+      "source_sha256": "79143b74dca244e14369c3408a772220b8cf93187a1cbe2eb2986adc393920ba"
     },
     {
       "op": "replace",
@@ -5563,6 +9727,728 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/PermissionEnum/description",
+      "source_sha256": "8ad7ecdb1a053a94b2d8ef792b8ab9414af671d2af0bf4d99da1ad0e89af66e4",
+      "value": "リソース（ナレッジベース、認証情報など）の共有権限レベル。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PermissionEnum/title",
+      "source_sha256": "570f985d8678a60eaabf80571396764eb068de6b7de35b398747f22978fe60f6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDataset/properties/chunk_structure/description",
+      "value": "ナレッジベースに設定されたチャンク構造。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/chunk_structure/title",
+      "source_sha256": "b6a62f5f409a72d8767489993f9615846dbae82c4f90a4707c872820c63fce60"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineDataset/properties/description/description",
+      "source_sha256": "c261ff1298c1bfa9af71a5c603225f66da3a638a59c71bfd7148722976e2c7f9",
+      "value": "ナレッジベースの説明。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDataset/properties/id/description",
+      "value": "リソース ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDataset/properties/name/description",
+      "value": "リソース名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/title",
+      "source_sha256": "6023a9c1af11b9c6aac41e09a8e47dd6114740f717eba442d22e64601159cf54"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_info/description",
+      "value": "データソース固有のメタデータ（存在する場合）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_info/title",
+      "source_sha256": "04fc73b8bbb0b1fd1a8bcb259069d7a0107de9f8eb895eaee40b81077b977e8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_type/description",
+      "value": "データソースの種類。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/enabled/description",
+      "value": "ドキュメントが検索に使用できるかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/error/description",
+      "value": "インデックス作成エラー。エラーがない場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/id/description",
+      "value": "リソース ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/indexing_status/description",
+      "value": "キューに入ったドキュメントの現在のインデックス状態です。レスポンスの `batch` を使って[ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status)を呼び出し、段階ごとの進捗を確認します。`completed` と `error` は終端状態で、`paused` の場合は再開後にポーリングを続けます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/name/description",
+      "value": "リソース名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/position/description",
+      "value": "バッチ内でのドキュメントの位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/title",
+      "source_sha256": "fb0c2514b90b55b30c22e1c2c9bbc92941d52d1228aaffa3af0dcfa12aa84cf2"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/description",
+      "source_sha256": "e720357c655f0d8504f094ad48e40eaf5b907a615b2568ae86b34333504f9173",
+      "value": "処理するデータソースオブジェクトの一覧です。`datasource_type` により項目の形が決まります。`local_file` は `reference`、`online_document` は `workspace_id` と `page`、`online_drive` は `id` と `type`（必要に応じて `bucket`）、`website_crawl` は `url` を使用します。生成された `oneOf` の順序は、ローカルファイル、オンラインドキュメント、Web クロール、オンラインドライブです。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/description",
+      "value": "ローカルファイルの参照。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/properties/name/description",
+      "source_sha256": "bdba5238eae9e70a589c72ce1d90cd6895f8a411a8a24340bb8fcb15e39d5911",
+      "value": "ドキュメントタイトル。デフォルトは `untitled`。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/properties/reference/description",
+      "source_sha256": "5e091d8d1c537316b3e11a5452de5d966eac0a2490c76b53fe5baca8ecc576dc",
+      "value": "[ナレッジパイプラインファイルをアップロード](/ja/api-reference/knowledge-pipeline/upload-pipeline-file)エンドポイントで返される `id` を使用します。`related_id` も別名として使用できます。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/title",
+      "source_sha256": "688ebe6107db26f7618180df8437c03891bceb34944c4c01be2ced16c5c3534b",
+      "value": "ローカルファイル",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/description",
+      "value": "オンラインドキュメントプロバイダー内のページ。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/credential_id/description",
+      "source_sha256": "400d744d30b3265e671530e329787eb5acb431bfea91549a033afff3f0df5661",
+      "value": "外部プラットフォームの認証に使用する認証情報。省略するとプロバイダーのデフォルト認証情報を使用します。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/page/description",
+      "source_sha256": "e655a6dafe66ca8c3b0c943aa1443d4bcd2548ea6acbc907ea8e8ff1f944f759",
+      "value": "ページの詳細です。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/page/properties/page_id/description",
+      "source_sha256": "7442a8bf6acbcdc7e39ad20cbd468d77e9017f75382782b2a05a117d954cf22a",
+      "value": "Dify で設定済みオンラインドキュメントプロバイダーのワークスペースまたはデータベースを参照した際に、プロバイダーから返されるページ ID。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/page/properties/page_name/description",
+      "source_sha256": "04e23f39724084ed122c84c93bc85b208f82961e51b0d82c649bc9163ef6b6cd",
+      "value": "表示名。デフォルトは `untitled`。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/page/properties/type/description",
+      "source_sha256": "e079791a74f171de31164b8e8ab36bc5b75b1ff8bb94b6c0a25f97b17041ee29",
+      "value": "データソースプラグインが定義するページタイプ。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/workspace_id/description",
+      "source_sha256": "fe7985f91af3a78660419f2c00283978050d7045f952805d0195ba9374f218f8",
+      "value": "設定済みオンラインドキュメントプロバイダー内のワークスペースまたはデータベース ID。Dify でプロバイダーを選択または参照した際に取得します。Dify ワークスペース ID ではなく、プロバイダー側のリソース ID です。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/title",
+      "source_sha256": "b898200bc602b877c67fa42231265b54672cb38b8ae2b269fa10857ac7cee12b",
+      "value": "オンラインドキュメント",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2/description",
+      "value": "クロールする Web サイト URL。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2",
+      "context_sha256": "d1752d06316336af94c7d7bbb791a0f2be173d0acb6cad363268ef51b4d574a6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2/properties/title/description",
+      "source_sha256": "82a82aacba90f778862e58193523ee5b10a02fa8e2cf9d3f7a8f163a293a0cef",
+      "value": "ドキュメント名として使用します。デフォルトは `untitled`。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2",
+      "context_sha256": "d1752d06316336af94c7d7bbb791a0f2be173d0acb6cad363268ef51b4d574a6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2/properties/url/description",
+      "source_sha256": "bf2f71ec2efab5bb740cd24a4b1db5883f188e5a9cde5c9574316e3e70c104de",
+      "value": "クロールする URL。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2",
+      "context_sha256": "d1752d06316336af94c7d7bbb791a0f2be173d0acb6cad363268ef51b4d574a6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2/title",
+      "source_sha256": "63874e0a6751f26e7c1cdfd57fbaed4a1d0013723ea7bb783f14df82758f5050",
+      "value": "Web クロール",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2",
+      "context_sha256": "d1752d06316336af94c7d7bbb791a0f2be173d0acb6cad363268ef51b4d574a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/description",
+      "value": "オンラインドライブプロバイダー内のファイルまたはフォルダー。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/properties/bucket/description",
+      "source_sha256": "bb738428f6a8ca74729e9617a69c07e63b26dae1b7b2fca5ea44ca3ad4c96ac9",
+      "value": "ストレージバケット名。S3 互換ストアなど一部のドライブプロバイダーでは必須です。プロバイダーがバケットを使用しない場合は省略します。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/properties/id/description",
+      "source_sha256": "e3d026c55577010814ff70c81e11a81451d20d5ea2eae3ac14df44326cf81b6b",
+      "value": "Dify で設定済みオンラインドライブプロバイダーを参照した際に、プロバイダーから返されるファイルまたはフォルダー ID。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/properties/name/description",
+      "source_sha256": "e95f87d5b92c5d63e99d9c9877bf2e5d5d1de82a905acb83542241c46769d548",
+      "value": "ファイル名。デフォルトは `untitled`。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/properties/type/description",
+      "source_sha256": "07097d1144f0f71c4956d4b5ccc7643f611fa3b70737bd842eabaa4774766b43",
+      "value": "この項目が単一ファイルか、展開対象のフォルダかを指定します。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/title",
+      "source_sha256": "c35dacddac4d0a24d2a4f2d15a259a6b81aac87735652096552cac21400016be",
+      "value": "オンラインドライブ",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/title",
+      "source_sha256": "cd6d7537c927eb684756966236a5a1f5e0d2f5e55ebba093c75138182989f1b8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_type/description",
+      "source_sha256": "ffb9a08b2ee5438665b6281a13e258280b75dcae3e03773223361eb458226731",
+      "value": "データソースのタイプ。`datasource_info_list` の各項目に必要なフィールドを決定します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_type/title",
+      "source_sha256": "1ddade5ac920148720355e512eb186d05c2511471941c47e4307d239b1f03f83"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/inputs/description",
+      "source_sha256": "fd26ef396b034063bce2847a15f605509722c15b765c769d871d2d71e989b4bc",
+      "value": "パイプライン入力変数のキーと値のペア。ワークフローで定義されたパイプライン変数に対応します。入力変数がない場合は `{}` を渡してください。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/is_published/description",
+      "source_sha256": "01dec585a5646788d17d8a662c199da00ce4d07ddd84461a8907e9226dd7a8cc",
+      "value": "ナレッジパイプラインの公開済みまたはドラフトバージョンを実行するかどうか。`true` は最新の公開済みバージョン、`false` は現在のドラフトを実行します。後者は未公開の変更のテストに便利です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/response_mode/description",
+      "source_sha256": "d0db0208fa573cafc24d176b8feeb80b45c37d88f047a74abd2fca7bf8c82fd6",
+      "value": "ドラフト実行のレスポンスモード。SSE には `streaming`、JSON には `blocking` を使用します。公開済みバージョンの実行はキューに入り、常にバッチメタデータを JSON で返します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/start_node_id/description",
+      "source_sha256": "4e4adb169d322a57c9af1f1f6f630bb1e40f5422ed67300405dac45f73efcc8d",
+      "value": "実行を開始するデータソースノード ID。データソースノードは、ファイル、プロバイダーページ、ドライブ、URL を読み込むナレッジパイプラインの入口ステップです。[データソースプラグインを一覧表示](/ja/api-reference/knowledge-pipeline/list-datasource-plugins)が返す `node_id` を使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/start_node_id/title",
+      "source_sha256": "db0a024b6472164f8f45fec7ee5b253de6284fa29e07f81859047dc90c100b9a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/title",
+      "source_sha256": "955e3596c1f8c89af4ddb61252a1c88f86872727d08b1aebc4b292e8f3a2325a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunJsonResponse/description",
+      "source_sha256": "28ff911df5f8eb8b5478e307e1006d5679ed9a267e0ceef0201048dd0593683c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunJsonResponse/title",
+      "source_sha256": "185e74bfde554c3700e0ab00bf434e6fd36ac0b4b44686ad3da95d65416e140b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_at/description",
+      "value": "アップロードのタイムスタンプ（ISO 8601 形式）です。レコード作成中は `null` となることがあります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_by/description",
+      "value": "ファイルをアップロードしたユーザーの ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/extension/description",
+      "value": "ファイル拡張子。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/id/description",
+      "value": "アップロードされたファイルの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/mime_type/description",
+      "value": "ファイルの MIME タイプです。アップロードに MIME タイプが含まれない場合、`null` となることがあります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/name/description",
+      "value": "元のファイル名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/size/description",
+      "value": "ファイルサイズ（バイト）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/title",
+      "source_sha256": "bb113da90addfc75f941e3b9bf244282e60f799dbd26ea9b80c9c5382c8a5f8b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PreProcessingRule/properties/enabled/description",
+      "source_sha256": "0c6591752d35c3cffc5b32de08298a6574363d88234675d703b320df9ca7938a",
+      "value": "この前処理ルールが有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PreProcessingRule/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PreProcessingRule/properties/id/description",
+      "source_sha256": "cf07210fbf1d45fdb43d7b62c207cd4d8e259e1468587085c8c320acf6de0295",
+      "value": "ルール識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PreProcessingRule/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PreProcessingRule/title",
+      "source_sha256": "b47661a7f70c18c954a02974b77463a163376487ee6eeb8af10a2a27533f5e2a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ProcessRule/properties/mode/description",
+      "source_sha256": "c44a2118d2b146d7beee0819a314a1a89d17112dc4bc2d727da2c3ffae3dc8c0",
+      "value": "処理モード。`automatic` は組み込みルール、`custom` は手動設定を使用し、`hierarchical` は `doc_form: hierarchical_model` の親子チャンク構造を有効にします。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ProcessRule/properties/rules/description",
+      "source_sha256": "0f3d18211c81a669a4579d0b293bf94ddcc0848fbe09bddfb42a18d77dfe093f",
+      "value": "カスタム処理ルール。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProcessRule/title",
+      "source_sha256": "db324a07cd05b37002bb411f1e0343864d8b699abca97ce06b54d79e38f206ab"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ProcessRuleMode/description",
+      "source_sha256": "181d70e1dafe300a8a07da29dee3247636f0c284d2ba40aa2e8ad46be605c13c",
+      "value": "ナレッジベース処理ルールモード。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProcessRuleMode/title",
+      "source_sha256": "f7358171c8ee1b08f0e4d52870e721480d33b88cf4cb44f0d1aba51a48a94945"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/description",
+      "source_sha256": "3d2823aa3f3eebcb83c6ea80680a0166bf2edf32d9704ebd8770c18a7e25ce95",
+      "value": "モデルレスポンスのデータモデル。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/deprecated/description",
+      "value": "モデルが非推奨かどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/deprecated/title",
+      "source_sha256": "80f6e3262ddc9dbae4b5543d8cf1ab8d4f3111645716a73c9db7c288ae591d8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/features/description",
+      "value": "モデルがサポートする機能です。なしの場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/features/title",
+      "source_sha256": "5ba7137beafc546fd1f158261c26eb856fc806b187977a07566494355e9e4e9b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/fetch_from/description",
+      "value": "モデル定義の取得元です。`predefined-model` は組み込みモデル、`customizable-model` はユーザー設定モデルを示します。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/has_invalid_load_balancing_configs/description",
+      "value": "モデルに無効なロードバランシング設定があるかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/has_invalid_load_balancing_configs/title",
+      "source_sha256": "7944103f90c86b8d1aa059b20991fcdc85dcbd16bea56e1f1f72944059551055"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/label/description",
+      "value": "モデルのローカライズ表示名です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/load_balancing_enabled/description",
+      "value": "モデルのロードバランシングが有効かどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/load_balancing_enabled/title",
+      "source_sha256": "19d609f1ad9452998e7a4548bb2dc9b68ae73367a62fef6eaff1a7893ea0023d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model/description",
+      "value": "モデル識別子です。ナレッジベースの作成または更新時に `embedding_model` の値として使用します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model/title",
+      "source_sha256": "9c16c09f0c180580bcc75cd99dc16eb9764abe7902e6a19ba4d7adbd28d66b22"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model_properties/description",
+      "value": "`context_size` などのモデル固有のプロパティです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model_properties/title",
+      "source_sha256": "a32671a4e6f39b5933657bb99b6017c623de24878be588c6c92333f03358fdb0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model_type/description",
+      "value": "モデルのタイプです。`model_type` パスパラメータと一致します。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/status/description",
+      "value": "モデルの利用可能ステータスです。使用可能な場合は `active` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/title",
+      "source_sha256": "4846d901d44580e734dbead0b947dcd6321d9be04ad58e95a872a204a06801c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsListResponse/properties/data/description",
+      "value": "モデルプロバイダーと利用可能なモデル。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsListResponse/title",
+      "source_sha256": "2039f710e47e27c0a7fdab1fa3984269c5c5a108e9e1ca86691f8ae79fbc9dfc"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ProviderWithModelsResponse/description",
+      "source_sha256": "1017c70595c87071231c967363412e90d34bd0e308519a92d8b1521f9197d818",
+      "value": "モデル一覧を含むプロバイダーレスポンスのデータモデル。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/icon_small/description",
+      "value": "プロバイダーの小アイコンの URL です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/icon_small_dark/description",
+      "value": "ダークモード用アイコンの URL。プロバイダーにない場合は `null`。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/label/description",
+      "value": "プロバイダーのローカライズ表示名です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/models/description",
+      "value": "このプロバイダーから利用可能なモデルのリストです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/models/title",
+      "source_sha256": "527919df30e60438b9999d570aca82ff0214c59755ad69ea14a15900b5b06c26"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/provider/description",
+      "value": "モデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。以前のプロバイダーでは短縮形（例：`openai`）が返される場合があります。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/status/description",
+      "value": "プロバイダーのステータスです。認証情報が設定済みで有効な場合は `active` です。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/tenant_id/description",
+      "value": "このプロバイダー設定が属するワークスペース ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/tenant_id/title",
+      "source_sha256": "ae18aae49d3ccc237cd61077f9e1235aa293a131da760623f83eab7b5e51d944"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/title",
+      "source_sha256": "74970e98a1a9d36c34558a5528dd394784820e4d57c0d69d26e6d51629ad66d5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/batch/description",
+      "value": "キューに入った公開済み実行のバッチ ID。[ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) の `batch` として渡し、すべてのドキュメントが完了、失敗、または一時停止になるまでポーリングしてください。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/batch/title",
+      "source_sha256": "026b89e52976b2603339b009c7e7547467948fb0753001d02deaa79180427305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/dataset/description",
+      "value": "生成されたドキュメントを受け取るナレッジベース。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/documents/description",
+      "value": "作成され、インデックス作成待ちのキューに追加されたドキュメント。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/documents/title",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PublishedPipelineRunResponse/title",
+      "source_sha256": "54d7f59fdb352a4ea87c5ea8cb76db25797e51ea2335cc3fe0059db53302f455"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/RequiredServiceApiUserPayload/properties/user/description",
       "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
       "value": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。"
@@ -5571,6 +10457,33 @@
       "op": "remove",
       "path": "/components/schemas/RequiredServiceApiUserPayload/title",
       "source_sha256": "a1269019db4ddc7c919d3b0447ea781251fcad5e3c189d0d8214785fae80891d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RerankingModel/properties/reranking_model_name/description",
+      "source_sha256": "ee6fe6577ff8467ec5541d84b9d253b1f0de6352fe81751a1223c2764fd9238b",
+      "value": "リランキングモデル名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RerankingModel/properties/reranking_model_name/title",
+      "source_sha256": "84c57945febff99bd6d302f456cc0c67177d5564c52716407f118e8f2e8fc041"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RerankingModel/properties/reranking_provider_name/description",
+      "source_sha256": "95f6e1128a6b5d7341df3c940361ff1f505f29d5e9eeedc0d4abae744c96ebc5",
+      "value": "再ランキングモデルのプロバイダー名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RerankingModel/properties/reranking_provider_name/title",
+      "source_sha256": "60b41a32b54ab0b9acf6ad2d6c68ee0ff1e2ad26650e94e289f4265e71a59581"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RerankingModel/title",
+      "source_sha256": "6fb75a747a4a0129024d0e632a601000492365b2046eaac090c6f52ed37e038e"
     },
     {
       "op": "add",
@@ -5586,6 +10499,95 @@
       "op": "remove",
       "path": "/components/schemas/ResultResponse/title",
       "source_sha256": "01088850b9c319d53d821afeaed65bffdaeb842f51b877c8b03a85f6877dc8da"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalMethod/title",
+      "source_sha256": "8dc47bb74955cfa3a214f19059c03082323843025859295239a41a0b06bc93a4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/metadata_filtering_conditions/description",
+      "source_sha256": "abf53f9c3f2b2c7614317ea23626504a844350664358776674d4064ca116d991",
+      "value": "ドキュメントのメタデータが指定した条件に一致するチャンクのみを取得対象に絞り込みます。条件はサーバーサイドで評価されます。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_enable/description",
+      "source_sha256": "b6b8e3bc6134f3ffb903b2ac00f11480b0ae9ae497ffbf706adbfd7bca94738b",
+      "value": "リランキングが有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_enable/title",
+      "source_sha256": "cc1894711ba2670a7ad95df9cb248ff4496427dc4e61eefde0f555ebdaeec218"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_mode/description",
+      "source_sha256": "3b53822617108def0a31fd3ce6ce083d305208583c1df3e3e53124024ec1a2e5",
+      "value": "リランキングモードです。`reranking_enable` が `true` の場合は必須です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_mode/title",
+      "source_sha256": "f5301c9027acd776f86cf98e696814c2b9404bfe29ccf772a75b020694c93dd5"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_model/description",
+      "source_sha256": "7c347c0c4a61c16b067204d5853cb812c02a0f2d4c5193480c1043c8009ec89c",
+      "value": "リランキングモデルの設定です。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold/description",
+      "source_sha256": "9226e3718348835b029623af75bfa41d9b2cb610ebbaea42858a3ac7420971af",
+      "value": "最小類似度スコア（0〜1）。`score_threshold_enabled` が `true` の場合のみ有効です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold_enabled/description",
+      "source_sha256": "a07d7e9732d41dda023d175736f5f250a7d8640eac5a2ccebfd5131382895752",
+      "value": "スコア閾値フィルタリングが有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold_enabled/title",
+      "source_sha256": "33e7b2a6e80860238254ee394cff0875c97ba3ba486bd89f1919f34dfe77abc9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/search_method/description",
+      "source_sha256": "c6d6f6ede9f6643c63563e09f8f5046070feff52b418770d7ea60ca86f4e027e",
+      "value": "検索に使用される検索メソッドです。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/top_k/description",
+      "source_sha256": "e1c44a06a752a0b9f03931c5962fc46ebf9f68f6a80f8195cff1853a9276c2d8",
+      "value": "返す結果の最大数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/top_k/title",
+      "source_sha256": "08cf18c91d1b734279713b3783ef3a997cda93cc0aab4059885a3dfc3159c81c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/weights/description",
+      "source_sha256": "4f8272c508c50c30ddeb5218ab8d62b31d3a3fe5fe689f2407409d06e541a348",
+      "value": "ハイブリッド検索の重み設定です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/title",
+      "source_sha256": "666a988293a7f6ae869835747dcd92b2bd1a79f3b04646f6f12c185760fa6a03"
     },
     {
       "op": "add",
@@ -5769,6 +10771,220 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/Rule/properties/parent_mode/description",
+      "source_sha256": "47817b6deed2493ccac0bcf385f8767c5c54a96ff1f8c8e8ff571e2b59027504",
+      "value": "親子セグメンテーションモード。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Rule/properties/parent_mode/title",
+      "source_sha256": "7a3e4b03c8e473c363780e217ac31d5296d3f1648ce487f28f4dd3adad1fd479"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Rule/properties/pre_processing_rules/description",
+      "source_sha256": "29779ba7f198b5d81b88fe1aaf2bd82a131ea50a205862e4d34a5dac6f8b5e99",
+      "value": "チャンク分割前に適用する前処理ルール。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Rule/properties/pre_processing_rules/title",
+      "source_sha256": "7d3e0cda2e0c21c0badc4a3b16dc3dfbcf035b66e7f855204ec0c1caf94463e9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Rule/properties/segmentation/description",
+      "source_sha256": "10b372c1699c661c4a26dddb73d0e96a7d72e5a00ce239dbe5aa1f5cd8ea35f7",
+      "value": "親チャンクの分割設定。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Rule/properties/subchunk_segmentation/description",
+      "source_sha256": "fd1399c5cc8fec7d2e030b2b88f42ad58f897d997f2741135d5f6b78163d6e04",
+      "value": "子チャンクのセグメンテーション設定。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Rule/title",
+      "source_sha256": "37b145ea2f8c75d011310872a13d8691600428522327e9fa756408228cf0a916"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/extension/description",
+      "value": "ファイル拡張子。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/id/description",
+      "value": "添付ファイルの識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/mime_type/description",
+      "value": "ファイルの MIME タイプ。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/name/description",
+      "value": "元のファイル名です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/size/description",
+      "value": "ファイルサイズ（バイト）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/source_url/description",
+      "value": "添付ファイルにアクセスする URL です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/source_url/title",
+      "source_sha256": "3d48f2577f877973dd0a3ab85975e367b5a9ab1964eb533d2cb3dd317134d453"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/title",
+      "source_sha256": "265200114ec0ead4db2faf6278176361627bebcfabd2e0e399427f0c83132bc2"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/answer/description",
+      "source_sha256": "1c8774c8bb747a52e3cda74e99ac6d8915c11bbe47a7852a894e8a01f38aafe2",
+      "value": "QA モードの回答内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/attachment_ids/description",
+      "source_sha256": "146aa83a6e739feddb11f5165b492a60423ceb0d5b3254f84eec28fb6b4ddefa",
+      "value": "添付ファイル ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/attachment_ids/title",
+      "source_sha256": "477c1e5aa9f364630218d09c7e51bb851e632ef1f297ec491ef9e34c725bbcbd"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/content/description",
+      "source_sha256": "71ea7409b90e3003086ef8b0e331d337221966b33bcbe9f925927943ed8b4d5e",
+      "value": "チャンクのテキスト内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/keywords/description",
+      "source_sha256": "e228361b7e8dacce7abb9f2a574065bc3e05f422294da5df3f4e5477da2b93d5",
+      "value": "チャンクのキーワードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/title",
+      "source_sha256": "794a619a5d9edb158a3ad415c72c23e2a276867117a567944f304eda604f25de"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/data/description",
+      "value": "作成されたチャンクのリスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/doc_form/description",
+      "value": "このドキュメントが使用するドキュメントチャンキングモードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateListResponse/title",
+      "source_sha256": "dddf326520ef179531d516395a20cdbc4f559439373f3d4caeaaf49e0daa8cc5"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentCreatePayload/properties/segments/description",
+      "source_sha256": "2d20feba674600400168bc8afcf74569c1b96c94ab0c1076c5c4e4690c8eb08e",
+      "value": "作成するチャンクオブジェクトの配列です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreatePayload/properties/segments/title",
+      "source_sha256": "505d8419cf4cc5e1048ae6b568b094d437dfbcb7e2beaa3ef069b7453ae04453"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreatePayload/title",
+      "source_sha256": "fb73672ae57c80d6fa43473e94455557ad048ea74aff2ede203d05216feb6bf0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentDetailResponse/properties/data/description",
+      "value": "作成されたチャンクのリスト。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentDetailResponse/properties/doc_form/description",
+      "value": "このドキュメントが使用するドキュメントチャンキングモードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentDetailResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentDetailResponse/title",
+      "source_sha256": "0de38d68419929d7e241177982f8f3ed9101460431e000c55ae2a36b3cbfc25f"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/SegmentListQuery/properties/keyword/description",
       "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
       "value": "検索キーワードです。"
@@ -5815,6 +11031,477 @@
       "op": "remove",
       "path": "/components/schemas/SegmentListQuery/title",
       "source_sha256": "0cd59385c6acbfa47454f1681728f3753d5b551e24e8ca993624fd336f64d154"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/data/description",
+      "value": "チャンクのリスト。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/doc_form/description",
+      "value": "このドキュメントが使用するドキュメントチャンキングモードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/has_more/description",
+      "value": "次のページにさらに項目が存在するかどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/limit/description",
+      "value": "1 ページあたりの件数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/page/description",
+      "value": "現在のページ番号です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/total/description",
+      "value": "一致するチャンクの合計数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/title",
+      "source_sha256": "baab7d72cdb208fbaca82b5d478ffc03ce2e8e05fdaca092bf5723f62cb924ef"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/answer/description",
+      "value": "回答コンテンツです。Q&A モードのドキュメントで使用されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/attachments/description",
+      "value": "このチャンクに添付されたファイルです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/attachments/title",
+      "source_sha256": "7598bc1dde680e28fe88f4627a34b7dc34e02c54caa57e6df303af05e73856a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/child_chunks/description",
+      "value": "このチャンクに属する子チャンクです。階層モードのドキュメントにのみ存在します。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/child_chunks/title",
+      "source_sha256": "bd2ab3b4c807f0086a23c8bcf021f57f9516f43bc3b3577bf84f78237dd361e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/completed_at/description",
+      "value": "完了時刻（Unix 秒タイムスタンプ）。未完了の場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/content/description",
+      "value": "チャンクのテキスト内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/created_at/description",
+      "value": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/created_by/description",
+      "value": "チャンクを作成したユーザーの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_at/description",
+      "value": "無効化時刻（Unix 秒タイムスタンプ）。有効な場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_by/description",
+      "value": "チャンクを無効化したユーザーの ID です。有効な場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/document_id/description",
+      "value": "このチャンクが属するドキュメントの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/enabled/description",
+      "value": "このチャンクが検索に対して有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/error/description",
+      "value": "インデックス作成が失敗した場合のエラーメッセージです。エラーなしの場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/hit_count/description",
+      "value": "このチャンクが検索クエリでマッチした回数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/id/description",
+      "value": "チャンクの一意識別子です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_hash/description",
+      "value": "インデックスされたコンテンツのハッシュです。変更の検出に使用されます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_id/description",
+      "value": "ベクトルストア内のインデックスノードの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_id/title",
+      "source_sha256": "0d45b0d6da2c05390b91146a6cd5de5845c26e58431ba1174c3e3c0793192b42"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/indexing_at/description",
+      "value": "インデックス開始時刻（Unix 秒タイムスタンプ）。未開始の場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/indexing_at/title",
+      "source_sha256": "3d4b6de81308d36e9b8544959f48c914d42c529120fa60ad2e08922d6b60fa8a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/keywords/description",
+      "value": "キーワードベースの検索のためにこのチャンクに関連付けられたキーワードです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/position/description",
+      "value": "ドキュメント内のチャンクの位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/sign_content/description",
+      "value": "整合性検証用の署名付きコンテンツハッシュです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/sign_content/title",
+      "source_sha256": "0b01a836c72cea937f5dc68e84213e59c3dc45e8a385ac28588608ab9c00bea4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/status/description",
+      "value": "チャンクの現在のインデックスステータスです（例：`completed`、`indexing`、`error`）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/stopped_at/description",
+      "value": "インデックス停止時刻（Unix 秒タイムスタンプ）。停止していない場合は `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/stopped_at/title",
+      "source_sha256": "e6760f92f5dde2261be331d6fdc428cb187032976d9229b4171e068dc69a82d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/summary/description",
+      "value": "AI が生成したチャンクコンテンツの要約です。要約インデックスが有効でない場合は `null` です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/tokens/description",
+      "value": "チャンク内容のトークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/updated_at/description",
+      "value": "最終更新タイムスタンプ（Unix エポック、秒単位）です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/updated_by/description",
+      "value": "このチャンクを最後に更新したユーザーの ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/updated_by/title",
+      "source_sha256": "6b595a302a4b98836b4b277762776908278d6090a198a6ae17e592b71b68abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/word_count/description",
+      "value": "チャンク内容の単語数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/title",
+      "source_sha256": "6404bd1128525d136b6a45e73b2694505f049c8e1e75ea00de143fd3e1b7fd0d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/answer/description",
+      "source_sha256": "ac824f4dcddbab22f3ce9dc7e3d6c13381d6320494435a7d45541c01cdce650c",
+      "value": "QA モードの更新後の回答内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/attachment_ids/description",
+      "source_sha256": "146aa83a6e739feddb11f5165b492a60423ceb0d5b3254f84eec28fb6b4ddefa",
+      "value": "添付ファイル ID です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/attachment_ids/title",
+      "source_sha256": "477c1e5aa9f364630218d09c7e51bb851e632ef1f297ec491ef9e34c725bbcbd"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/content/description",
+      "source_sha256": "a6fed04d64a04b5e81e04b54f9f44784d8d951fcaae249943e2e50b90fda2d7b",
+      "value": "更新後のチャンクテキスト内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/enabled/description",
+      "source_sha256": "653a843fd539b8f89e946e500768ea941b52485c19de704ccbaf43686ddc3b40",
+      "value": "チャンクが有効かどうかです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/keywords/description",
+      "source_sha256": "765dbfdf86518f438f476e0e8fb37f019d873f0db584bd0c80b53117b2a2a6e9",
+      "value": "更新後のチャンクキーワード。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/regenerate_child_chunks/description",
+      "source_sha256": "17bb6ad58368cf7dea1246c975d2bb9fe29d556712ba97758999cb650fcb8d1f",
+      "value": "親チャンクの更新後に子チャンクを再生成するかどうか。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/regenerate_child_chunks/title",
+      "source_sha256": "ec2820d3e42e3b34773484ca6c60e83ca7f205079caee9687775965d359aeb16"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/summary/description",
+      "source_sha256": "9b15e7c8c612b713dc47e670fb607972b6795f86d1c6c84e3aeaadb7ce777a99",
+      "value": "サマリーインデックスのサマリー内容です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/title",
+      "source_sha256": "55d5ccff6c4f6d836ca1e8f0f130b687b3230266fdd5f69979908c39497cef9f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdatePayload/properties/segment/description",
+      "source_sha256": "2f13c057f9e5d3e9a30dba43c8c80f9e5daae7378098cf14b4da7b89f38f0868",
+      "value": "チャンク更新ペイロード。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdatePayload/title",
+      "source_sha256": "83e2265607c3090491856b9685849cb09461ed67bd933e662bf5e63e09685e42"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Segmentation/properties/chunk_overlap/description",
+      "source_sha256": "3971f5487af563a9fd717f1e6071497e03f2ab7ee852542be9a5dc513b458ff2",
+      "value": "チャンク間のトークンオーバーラップです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/properties/chunk_overlap/title",
+      "source_sha256": "1258b5681185c4c7c54b1eb931d232bc406095510421aff6ce0402837bbc0b12"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Segmentation/properties/max_tokens/description",
+      "source_sha256": "224e44872fb822ec84993241fcfd7777819f15c0eb3f0c0f6daf9f215d17e318",
+      "value": "チャンクあたりの最大トークン数です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/properties/max_tokens/title",
+      "source_sha256": "c61948210aa9aa4ef842ff5b6e9beeb2f03177494459a33b35ef16a9bf64d175"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Segmentation/properties/separator/description",
+      "source_sha256": "716e4b8d3f2cf08942737d72c44913ea805d4601e5349c0a0029a88b78a57146",
+      "value": "テキスト分割用のカスタムセパレーターです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/properties/separator/title",
+      "source_sha256": "acb8cb92b3674b508ab3d2eeebb1d7be4c00ce16dcbf8a973c743d57ad98bb17"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/title",
+      "source_sha256": "bd314aba55c9dbea14be93c16834e7dca8525f07640c58453b0f3f1766ac66a1"
     },
     {
       "op": "add",
@@ -6334,6 +12021,165 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/TagBindingPayload/properties/tag_ids/description",
+      "source_sha256": "7cd1d6356651bdbafde8e8a450e4b972aa782fdeadeb6ea365e87f156a9f290f",
+      "value": "バインドするタグ ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagBindingPayload/properties/tag_ids/title",
+      "source_sha256": "185b1bbb86d24865700f4807ef17e5b4cfb00f26b994b81ed2961a16a08296b8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagBindingPayload/properties/target_id/description",
+      "source_sha256": "4195040703f5cc998c6bf1fa04d556a88d3039b1f3e27ddfcccfd26d7ed0f250",
+      "value": "タグをバインドするナレッジベース ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagBindingPayload/properties/target_id/title",
+      "source_sha256": "18bb786a77f9223c415b1aa4070c075e937065392d6775984cb969cc55b2245f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagBindingPayload/title",
+      "source_sha256": "6912ed857c175a6876a684bbae51d94fd6ffbcec215e8f4acc34d6caf5348b8d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagCreatePayload/properties/name/description",
+      "source_sha256": "56553c9544fcd74c2fa01c28faaf5387d82fc12d0d01ef5f07a7b2068b7e5128",
+      "value": "タグ名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagCreatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagCreatePayload/title",
+      "source_sha256": "1ec17ce70ed4907e7fce6cb288629467e2459c357751367caff686a329ec0745"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagDeletePayload/properties/tag_id/description",
+      "source_sha256": "bc6d6da389505431b0818ecf8630fcd5bbbab380894977bad77e21fd290acbb7",
+      "value": "削除するタグ ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagDeletePayload/properties/tag_id/title",
+      "source_sha256": "298f8188e097a31d884ebc26e9900e5733bf6392046442e14d2993fe56b386f8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagDeletePayload/title",
+      "source_sha256": "c01697f6d6ef0b466cd8423bf40254e1fa3ca4da7266c35895b3fba0dd469022"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/0/properties/tag_id/description",
+      "source_sha256": "d2e8a9ade687a80f23be1d30e149ce88015f2c3b99e0b05ad0cc717de73f28bd",
+      "value": "Service API が受け付ける従来の単一タグ ID。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/0",
+      "context_sha256": "8a2c4bf85948b5affc685aab7be95e8daf35d62ec20349da5e4c4789dd7f4372"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/0/properties/tag_ids/description",
+      "source_sha256": "f411ff70b5e6411aa8d211f0927cd25e3ef73e56a3faa3027237512e7303e6b5",
+      "value": "バインドを解除するタグ ID。新しい連携ではこのフィールドを使用します。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/0",
+      "context_sha256": "8a2c4bf85948b5affc685aab7be95e8daf35d62ec20349da5e4c4789dd7f4372"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/0/properties/target_id/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/0",
+      "context_sha256": "8a2c4bf85948b5affc685aab7be95e8daf35d62ec20349da5e4c4789dd7f4372"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/0/properties/target_id/title",
+      "source_sha256": "18bb786a77f9223c415b1aa4070c075e937065392d6775984cb969cc55b2245f",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/0",
+      "context_sha256": "8a2c4bf85948b5affc685aab7be95e8daf35d62ec20349da5e4c4789dd7f4372"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/1/properties/tag_id/description",
+      "source_sha256": "d2e8a9ade687a80f23be1d30e149ce88015f2c3b99e0b05ad0cc717de73f28bd",
+      "value": "Service API が受け付ける従来の単一タグ ID。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/1",
+      "context_sha256": "daed8c26e0d1721cb98aa92cb51810ea4f811864ce0f7da2dd1583fca56fd134"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/1/properties/tag_ids/description",
+      "source_sha256": "f411ff70b5e6411aa8d211f0927cd25e3ef73e56a3faa3027237512e7303e6b5",
+      "value": "バインドを解除するタグ ID。新しい連携ではこのフィールドを使用します。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/1",
+      "context_sha256": "daed8c26e0d1721cb98aa92cb51810ea4f811864ce0f7da2dd1583fca56fd134"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/1/properties/target_id/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/1",
+      "context_sha256": "daed8c26e0d1721cb98aa92cb51810ea4f811864ce0f7da2dd1583fca56fd134"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/1/properties/target_id/title",
+      "source_sha256": "18bb786a77f9223c415b1aa4070c075e937065392d6775984cb969cc55b2245f",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/1",
+      "context_sha256": "daed8c26e0d1721cb98aa92cb51810ea4f811864ce0f7da2dd1583fca56fd134"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/description",
+      "source_sha256": "017aca34d2c926dddc2bdece7a08b6c8584e8dd0c4055c321b240e53d3499dcd",
+      "value": "従来の `tag_id` ペイロードまたは正規化された `tag_ids` ペイロードを受け付けます。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUnbindingPayload/title",
+      "source_sha256": "4ed4b86ecca9595c8a2175f84db1d7d728c92ca7caf1df789acd8a33f5bf7efe"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUpdatePayload/properties/name/description",
+      "source_sha256": "56553c9544fcd74c2fa01c28faaf5387d82fc12d0d01ef5f07a7b2068b7e5128",
+      "value": "タグ名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUpdatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUpdatePayload/properties/tag_id/description",
+      "source_sha256": "c6bd4fb363813f0336a41316afd5bb58c08e8b6fd14e8bf5be044550e97fedb4",
+      "value": "更新するタグ ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUpdatePayload/properties/tag_id/title",
+      "source_sha256": "298f8188e097a31d884ebc26e9900e5733bf6392046442e14d2993fe56b386f8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUpdatePayload/title",
+      "source_sha256": "1f28aef19bd0c3355b03284bf1367133e716e2f8897e283387a3faac4b1f7ccb"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/TextToAudioPayload/properties/message_id/description",
       "source_sha256": "47f5efd48161cf7478427652060c2fbe41c0ffd3adea29c80a7e92824fb6f704",
       "value": "メッセージ ID。両方を指定した場合は `text` より優先されます。"
@@ -6462,6 +12308,21 @@
       "source_sha256": "25ff44cb5514b1148a3243ce18e6135333123c6a437c924be3bd88f8be03028f"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/UrlResponse/properties/url/description",
+      "value": "元のアップロードファイルをダウンロードするための署名付き URL です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UrlResponse/properties/url/title",
+      "source_sha256": "0146bf069164386d9cbddfbb77eed14df29c3fbf0326244f5676fc1c06a30963"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UrlResponse/title",
+      "source_sha256": "2dc437c1ca3d8756e3cf32966ba1e41fa5528de46dfec816612b0dba45e2bfc3"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/UserActionConfig/description",
       "source_sha256": "8335dbe54deb6d63d84583f2441b28057935bc5a7df092b6bb344bfd813b5f78",
@@ -6507,6 +12368,88 @@
       "op": "remove",
       "path": "/components/schemas/ValueSourceType/title",
       "source_sha256": "b27082732c38a38ed5997a127490a1121fdd96ed9079027df4ac09ff3e557856"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightKeywordSetting/properties/keyword_weight/description",
+      "source_sha256": "21c5fa00a0b4389101d5b387dec82085ec9797951766458bc2a5e0cea339dce2",
+      "value": "キーワード検索の重み（0〜1）。`customized` では `vector_weight` との合計を 1 にしてください。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightKeywordSetting/properties/keyword_weight/title",
+      "source_sha256": "577b14638d81d6d6c18433bcef87546069492150025ba80645a9ef107e8f9eb0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightKeywordSetting/title",
+      "source_sha256": "4caae01e8644e200975766b29aa75b4669b97927984b55c555d483fe6956c374"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightModel/properties/keyword_setting/description",
+      "source_sha256": "a7d7742c1f5e3084d4e14da7cfecbd060e8d3331688081d096612f8bb11e370d",
+      "value": "キーワード検索の重み設定です。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightModel/properties/vector_setting/description",
+      "source_sha256": "67ac9f655ef66fccfd7cd13935099a6370a25994044620628e1a296af07d9159",
+      "value": "セマンティック検索の重み設定です。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightModel/properties/weight_type/description",
+      "source_sha256": "274fb7d9ca59b2d9b3b90159e951c3edbcb6c0b2847b6ff71f4b687f87c80034",
+      "value": "セマンティック検索とキーワード検索の重みを調整するための戦略です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightModel/properties/weight_type/title",
+      "source_sha256": "2e0fc6f3749fdbeac0065d9c56f1ce8fcdd30d133b1a8c00b5f42eda78ce8b2a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightModel/title",
+      "source_sha256": "a0018f00973cb6f88d2cf5e2d013ea57b3bcb0f83d02e574b9010d1bfbebfce2"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightVectorSetting/properties/embedding_model_name/description",
+      "source_sha256": "b5a2b85a16a67eb58acc836bd6ca6e8d2f11c1fdec476de0c1c9b77293c26002",
+      "value": "ベクトル検索に使用される埋め込みモデルの名前です。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/properties/embedding_model_name/title",
+      "source_sha256": "4d79d966137d5bf514424da3770d0535ef6289a20ce67d7d5be6038198ccd6bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightVectorSetting/properties/embedding_provider_name/description",
+      "source_sha256": "d0ed4932ead6cc30dffb91ac47acf5c952514e2a461259841468e0f5f45eb2ba",
+      "value": "ベクトル検索に使用される埋め込みモデルのプロバイダーです。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/properties/embedding_provider_name/title",
+      "source_sha256": "4e0310d84c92f0465d3c1184754fbd60864f0d6925435fa6eff884947966e073"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightVectorSetting/properties/vector_weight/description",
+      "source_sha256": "6c8623f8fde54ee57da16439061574fd8817dcf88817051669eec0e577ce87b9",
+      "value": "セマンティックベクトル検索の重み（0〜1）。`customized` では `keyword_weight` との合計を 1 にしてください。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/properties/vector_weight/title",
+      "source_sha256": "6a405f1ff0999e072f0178b60240aecf12ebe66f212fc2c78450e2876050f29d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/title",
+      "source_sha256": "5eb9d2cbdaac4147eb845112796b9d81aa66dd837756402b7df0f0f6bb21a282"
     },
     {
       "op": "add",

--- a/tools/api-pipeline/service_api_overlays/zh.json
+++ b/tools/api-pipeline/service_api_overlays/zh.json
@@ -1999,6 +1999,32 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/ChildChunkCreatePayload/properties/content/description",
+      "source_sha256": "4e8d8ddc4b6dfba3289f1235ed4afc3c2cf1b52b2099f96484ee10ccdc370f44",
+      "value": "子分段文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkCreatePayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkCreatePayload/title",
+      "source_sha256": "63545ce8324fb96303684989379acf8bb56616431c2d7d2f2ee57aa798bebaf5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkDetailResponse/properties/data/description",
+      "value": "子分段详情。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkDetailResponse/title",
+      "source_sha256": "72326278aa33e7dda0521892ceb9f2a9912539cbc389704eb117ce9d7c7faaaa"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/ChildChunkListQuery/properties/keyword/description",
       "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
       "value": "搜索关键词。"
@@ -2034,6 +2060,162 @@
       "op": "remove",
       "path": "/components/schemas/ChildChunkListQuery/title",
       "source_sha256": "b1c6a7020550b6caf74316c4f6f0d9a79bb59b5fe961a3d65331855b2e4fa238"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/data/description",
+      "value": "子分段列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/limit/description",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/page/description",
+      "value": "当前页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total/description",
+      "value": "子分段总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total_pages/description",
+      "value": "总页数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/properties/total_pages/title",
+      "source_sha256": "c03585d62e7e0882cfed2ce3ffadcf457b534f19db1ffd398904f4b4c52b5968"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkListResponse/title",
+      "source_sha256": "7b68d427a9281bbf65f91ec8e00ba8cd0661c8453a3df5f5df8ddba3a2be88bc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/content/description",
+      "value": "子分段的文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/created_at/description",
+      "value": "创建时间戳（Unix 纪元，单位为秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/id/description",
+      "value": "子分段的唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/position/description",
+      "value": "子分段在父分段中的位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/segment_id/description",
+      "value": "该子分段所属的父分段 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/segment_id/title",
+      "source_sha256": "7290170777560d41462deb95fa0c1a27884f2e487befa6820e24cf1acedb6131"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/type/description",
+      "value": "子分段的创建方式。通过 API 创建或更新的子分段始终为 `customized`。系统生成的子分段为 `automatic`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/updated_at/description",
+      "value": "最后更新时间戳（Unix 纪元，单位为秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ChildChunkResponse/properties/word_count/description",
+      "value": "子分段内容的字数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkResponse/title",
+      "source_sha256": "94b6c59461791bd7058253d2f17269c2f89aec959082b91763ec8ba4ac115e08"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ChildChunkUpdatePayload/properties/content/description",
+      "source_sha256": "4e8d8ddc4b6dfba3289f1235ed4afc3c2cf1b52b2099f96484ee10ccdc370f44",
+      "value": "子分段文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkUpdatePayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ChildChunkUpdatePayload/title",
+      "source_sha256": "f34d01f7a5ac4cb28c70bf838fd8e8b61e215925e3bf5af6aebc939ae29966dc"
     },
     {
       "op": "add",
@@ -2540,6 +2722,50 @@
       "source_sha256": "af0367558fbca9f02fe0c6614e89b0fbaddd2d5462f4aa34f224f2cdf7e90469"
     },
     {
+      "op": "replace",
+      "path": "/components/schemas/Condition/description",
+      "source_sha256": "dd9560e76248d366ee7b4738e26f2e16fd7eb11c34e1296e4351be2096a8954b",
+      "value": "条件详情。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Condition/properties/comparison_operator/description",
+      "source_sha256": "8df6a8a633f9fc4370705819585e6c05b2ebbfe88e943d2c5f6bd063a63343da",
+      "value": "要应用的比较方式。字符串运算符（`contains`、`not contains`、`start with`、`end with`、`is`、`is not`、`empty`、`not empty`、`in`、`not in`）用于字符串或数组元数据；数值运算符（`=`、`≠`、`>`、`<`、`≥`、`≤`）用于数值元数据；时间运算符（`before`、`after`）用于时间元数据。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/properties/comparison_operator/title",
+      "source_sha256": "01a4c1663da6b258d5d69743ddaf9f446b7fb8dee538d679a015632cae854a28"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Condition/properties/name/description",
+      "source_sha256": "e152c45805bce6777a48b1fee038117de12539b2a9ecccf199f665029b383e77",
+      "value": "用于比较的元数据字段名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Condition/properties/value/description",
+      "source_sha256": "002af1b12c03b27cc2e83a68729a097b9d3b127a82992c5cd12f30b7e217eb4d",
+      "value": "用于比较的值。类型取决于 `comparison_operator`：大多数字符串运算符使用字符串，`in` 和 `not in` 使用字符串数组，数值运算符使用数字，`empty` 和 `not empty` 应省略此值或使用 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Condition/title",
+      "source_sha256": "418c09a9d05967071c8370af38aa90aa2d0a6d3d13fc29f24e3cfd3a5072c903"
+    },
+    {
       "op": "add",
       "path": "/components/schemas/ConversationInfiniteScrollPagination/properties/data/description",
       "value": "当前页的会话列表。"
@@ -2994,6 +3220,1100 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/CustomConfigurationStatus/description",
+      "source_sha256": "d440d08c73af711607dcb80bdc29b0fe683f0726fc83a791171731bc145a0d7f",
+      "value": "自定义配置状态的枚举。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/CustomConfigurationStatus/title",
+      "source_sha256": "3bae16102634941742ef8cad684cb2c401e1a6f58d28512171907a70e3ba001e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/data/description",
+      "value": "绑定到此知识库的标签列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/total/description",
+      "value": "绑定到该知识库的标签总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagListResponse/title",
+      "source_sha256": "de75c865a92dbd9a6c18ec22dff029362c605134dac75b2b1524393d4cd47d68"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/id/description",
+      "value": "标签标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/name/description",
+      "value": "标签显示名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetBoundTagResponse/title",
+      "source_sha256": "5411684822d2302289f08f32442c0d2bdd62c8b7255759cd1bfd65c071141727"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/description/description",
+      "source_sha256": "55776608955dfaabd609a7e59ac5f005a65589da9f0e01a73d306437cc124da7",
+      "value": "知识库描述。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model/description",
+      "source_sha256": "a57676abae00b587600f25027f744a24863f5a9c56780647ccaa7efe6422cdb5",
+      "value": "嵌入模型名称。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `model` 字段，并将 `model_type` 设置为 `text-embedding`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model_provider/description",
+      "source_sha256": "fbc8249d511185eedbe6c1e9ee65c5f0d7e75d5b2fa2cc1b0ff71ea4ea22e403",
+      "value": "嵌入模型提供商。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `provider` 字段，并将 `model_type` 设置为 `text-embedding`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/external_knowledge_api_id/description",
+      "source_sha256": "30f3fea37c7166d49cc69781ebb7d612a6d3d52cce766e7428dd3e2e1c4cf90c",
+      "value": "外部知识 API 的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/external_knowledge_api_id/title",
+      "source_sha256": "e2dcf725ee077104f9442be1880b13f8247bc7a88800a43f8c816c9fd9d3a103"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/external_knowledge_id/description",
+      "source_sha256": "e63af9fd8e5a851202889f38c61fe7abbe296538866962d22d948e0fb6764b72",
+      "value": "外部知识库的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/external_knowledge_id/title",
+      "source_sha256": "579ead72f48e7a70e00c88363de59534661ce4d149e6aad38a4dfc7d16b1a18c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/indexing_technique/description",
+      "source_sha256": "a933b20c1aaec91450173dd832d27b424c525f85dc9b2ab702b57fcd3a8a8bad",
+      "value": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/name/description",
+      "source_sha256": "b756a6eb4f379851befe6a770ca22095058fb204a003f89e3043903a33296fb2",
+      "value": "知识库名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/permission/description",
+      "source_sha256": "1eb98a26104557e4a9e5ef8d9354fc78a1652e76668c95a32b95422f814d98f7",
+      "value": "控制谁可以访问此知识库。`only_me` 仅允许创建者访问，`all_team_members` 允许整个工作区访问，`partial_members` 仅允许指定成员访问。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/provider/description",
+      "source_sha256": "ecfbc2eaab876d0db888ca3c091705424d06300da1d35925a8c551fb0157b6b7",
+      "value": "知识库提供方：内部知识库使用 `vendor`，外部知识库使用 `external`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "检索模型配置，用于控制分段的搜索和排序方式。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0/properties/enable/description",
+      "source_sha256": "51d854f11aedecf6dc57681f719075be0742fe2a5b75acc250a6ce24d35a8867",
+      "value": "是否启用摘要索引。",
+      "context_path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0",
+      "context_sha256": "2d7c55668d62e0d85a1b036d4165f60ccaed1ffa53f9c3bedfe3e1c1c071215c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0/properties/model_name/description",
+      "source_sha256": "85c684e30a883f2dd0bfa5b90a698202d229539cecc4bf6a717d6fad02c682d2",
+      "value": "用于生成摘要的模型名称。",
+      "context_path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0",
+      "context_sha256": "2d7c55668d62e0d85a1b036d4165f60ccaed1ffa53f9c3bedfe3e1c1c071215c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0/properties/model_provider_name/description",
+      "source_sha256": "910400771c19c1ef0781f3b13afae297e0e91ba4c7936c40a35eab6a8f26c235",
+      "value": "摘要生成模型的供应商。",
+      "context_path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0",
+      "context_sha256": "2d7c55668d62e0d85a1b036d4165f60ccaed1ffa53f9c3bedfe3e1c1c071215c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0/properties/summary_prompt/description",
+      "source_sha256": "08665ea50f1dfdf35bb831e6143c6bcd9067a582b0fba3af0f727dd26470f208",
+      "value": "用于摘要生成的自定义提示词模板。",
+      "context_path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/anyOf/0",
+      "context_sha256": "2d7c55668d62e0d85a1b036d4165f60ccaed1ffa53f9c3bedfe3e1c1c071215c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/description",
+      "source_sha256": "8f0d4c377ccc7bbb2b01886dcac46849e5640a21e812435913fbdd56608d6aae",
+      "value": "摘要索引配置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/properties/summary_index_setting/title",
+      "source_sha256": "73071309e0ecc3a2e4d5fb7b899a4d2cca1754749b85f5f8f11cf336d15950fc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetCreatePayload/title",
+      "source_sha256": "479456528114cc52c4e9464416aee5791234ca861ab8c03096a5d7729cf567fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/app_count/description",
+      "value": "当前使用该知识库的应用数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/app_count/title",
+      "source_sha256": "f2ebc0260c1ba325417509c378782eb056a1d42309a8bf94f240177008a3bfc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/author_name/description",
+      "value": "创建者的显示名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/author_name/title",
+      "source_sha256": "184bab624ca3534f57b76d065cf11c51a641c53cceed8e6b5f7909a253e49313"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/built_in_field_enabled/description",
+      "value": "是否启用内置元数据字段（例如 `document_name`、`uploader`）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/built_in_field_enabled/title",
+      "source_sha256": "60f3d06b21a1179f5971124c3333c5ffe7798e4371795f20f99bd634a01ba7a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/chunk_structure/description",
+      "value": "分段结构配置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/chunk_structure/title",
+      "source_sha256": "b6a62f5f409a72d8767489993f9615846dbae82c4f90a4707c872820c63fce60"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_at/description",
+      "value": "创建时间戳（Unix 纪元，单位为秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_by/description",
+      "value": "创建该知识库的用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/data_source_type/description",
+      "value": "文档的数据源类型，尚未配置时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/description/description",
+      "value": "描述知识库用途或内容的可选文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_form/description",
+      "value": "文档分块模式。`text_model` 表示标准文本分块，`hierarchical_model` 表示父子结构，`qa_model` 表示问答对提取。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_metadata/description",
+      "value": "知识库的元数据字段定义。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/document_count/description",
+      "value": "知识库中的文档总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/document_count/title",
+      "source_sha256": "cff5b204c719e8f553af52bb13ff9c6caadba08aa6829be7eaed2a4650606693"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_available/description",
+      "value": "配置的嵌入模型当前是否可用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_available/title",
+      "source_sha256": "c44b36a0f326462ba7c2c3167cd518c6030452fe525d726b472f292877fcd89f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model/description",
+      "value": "用于索引的嵌入模型名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model_provider/description",
+      "value": "嵌入模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。旧版知识库可能返回简写形式（例如 `openai`）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/enable_api/description",
+      "value": "该知识库是否启用 API 访问。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/enable_api/title",
+      "source_sha256": "65555b2eb75a2490bacdb1d58b89c6adfc5ae0eb4fda9e608512a48d21ccd5ee"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/external_knowledge_info/description",
+      "value": "外部知识库的连接详情。当 `provider` 为 `external` 时存在。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/external_retrieval_model/description",
+      "value": "外部知识库的检索设置。内部知识库时为 `null`。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/icon_info/description",
+      "value": "知识库的图标显示配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/id/description",
+      "value": "知识库的唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/indexing_technique/description",
+      "value": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_multimodal/description",
+      "value": "是否启用多模态内容处理。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_multimodal/title",
+      "source_sha256": "b112c0ee183ed23fc1cc424141a495e358651addcec0d222c1813d1955e479ca"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_published/description",
+      "value": "知识库是否已发布。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/maintainer/description",
+      "value": "知识库维护者的显示名称。未设置时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/maintainer/title",
+      "source_sha256": "adb42886fe6fc2303496997ccbad46ef2368b62efd170c13234d110e1212e653"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/name/description",
+      "value": "知识库的显示名称。在工作区内唯一。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission/description",
+      "value": "控制谁可以访问此知识库。可选值：`only_me`、`all_team_members`、`partial_members`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission/title",
+      "source_sha256": "75723d503a92ba27c175213c3ad840a7d22eed24be167a8dc77d6a9084cd2bb3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission_keys/description",
+      "value": "授予当前调用方的权限标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/permission_keys/title",
+      "source_sha256": "409bf340be15ca6cefbc9bd5df37bbdbbf6d293db607b6ced17849e0e393988a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/pipeline_id/description",
+      "value": "自定义处理流水线的 ID（如果已配置）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/pipeline_id/title",
+      "source_sha256": "d01d3715d91c35f794d5bf05d4196cd3aa8a4ac64785d6c15a16a75e2884ea18"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/provider/description",
+      "value": "供应商类型。内部管理为 `vendor`，外部知识库连接为 `external`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/retrieval_model_dict/description",
+      "value": "知识库的检索配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/runtime_mode/description",
+      "value": "运行时处理模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/runtime_mode/title",
+      "source_sha256": "b04a8dd4ab04780b7d2b0f193b72314937c29e61442c3fb340ad52c611087494"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/summary_index_setting/description",
+      "value": "摘要索引配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/tags/description",
+      "value": "与该知识库关联的标签。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/tags/title",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_available_documents/description",
+      "value": "已启用且可用的文档数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_available_documents/title",
+      "source_sha256": "9354b71ade36bbbde5a486b117577d8ed19d3220bb3f0308b7ab1e396930e36f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_documents/description",
+      "value": "文档总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/total_documents/title",
+      "source_sha256": "7e154d8fa98b2d20c75a1fbb7b46e5821f8be6fd37f9ee73733c7e91cbd730e0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_at/description",
+      "value": "最后更新时间戳（Unix 纪元，单位为秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_by/description",
+      "value": "最后更新该知识库的用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/updated_by/title",
+      "source_sha256": "6b595a302a4b98836b4b277762776908278d6090a198a6ae17e592b71b68abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailResponse/properties/word_count/description",
+      "value": "所有文档的总字数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailResponse/title",
+      "source_sha256": "ba6ffb167022ed5355326584c7caee0cda68d61adcb226234cc43526e21533e0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/app_count/description",
+      "value": "当前使用该知识库的应用数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/app_count/title",
+      "source_sha256": "f2ebc0260c1ba325417509c378782eb056a1d42309a8bf94f240177008a3bfc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/author_name/description",
+      "value": "创建者的显示名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/author_name/title",
+      "source_sha256": "184bab624ca3534f57b76d065cf11c51a641c53cceed8e6b5f7909a253e49313"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/built_in_field_enabled/description",
+      "value": "是否启用内置元数据字段（例如 `document_name`、`uploader`）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/built_in_field_enabled/title",
+      "source_sha256": "60f3d06b21a1179f5971124c3333c5ffe7798e4371795f20f99bd634a01ba7a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/chunk_structure/description",
+      "value": "分段结构配置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/chunk_structure/title",
+      "source_sha256": "b6a62f5f409a72d8767489993f9615846dbae82c4f90a4707c872820c63fce60"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_at/description",
+      "value": "创建时间戳（Unix 纪元，单位为秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_by/description",
+      "value": "创建该知识库的用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/data_source_type/description",
+      "value": "文档的数据源类型，尚未配置时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/description/description",
+      "value": "描述知识库用途或内容的可选文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_form/description",
+      "value": "文档分块模式。`text_model` 表示标准文本分块，`hierarchical_model` 表示父子结构，`qa_model` 表示问答对提取。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_metadata/description",
+      "value": "知识库的元数据字段定义。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/document_count/description",
+      "value": "知识库中的文档总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/document_count/title",
+      "source_sha256": "cff5b204c719e8f553af52bb13ff9c6caadba08aa6829be7eaed2a4650606693"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_available/description",
+      "value": "配置的嵌入模型当前是否可用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_available/title",
+      "source_sha256": "c44b36a0f326462ba7c2c3167cd518c6030452fe525d726b472f292877fcd89f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model/description",
+      "value": "用于索引的嵌入模型名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model_provider/description",
+      "value": "嵌入模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。旧版知识库可能返回简写形式（例如 `openai`）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/enable_api/description",
+      "value": "该知识库是否启用 API 访问。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/enable_api/title",
+      "source_sha256": "65555b2eb75a2490bacdb1d58b89c6adfc5ae0eb4fda9e608512a48d21ccd5ee"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/external_knowledge_info/description",
+      "value": "外部知识库的连接详情。当 `provider` 为 `external` 时存在。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/external_retrieval_model/description",
+      "value": "外部知识库的检索设置。内部知识库时为 `null`。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/icon_info/description",
+      "value": "知识库的图标显示配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/id/description",
+      "value": "知识库的唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/indexing_technique/description",
+      "value": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_multimodal/description",
+      "value": "是否启用多模态内容处理。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_multimodal/title",
+      "source_sha256": "b112c0ee183ed23fc1cc424141a495e358651addcec0d222c1813d1955e479ca"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_published/description",
+      "value": "知识库是否已发布。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/maintainer/description",
+      "value": "知识库维护者的显示名称。未设置时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/maintainer/title",
+      "source_sha256": "adb42886fe6fc2303496997ccbad46ef2368b62efd170c13234d110e1212e653"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/name/description",
+      "value": "知识库的显示名称。在工作区内唯一。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/partial_member_list/description",
+      "value": "当 `permission` 为 `partial_members` 时被授予访问权限的成员账户 ID。更新响应中始终返回；详情响应中仅当 `permission` 为 `partial_members` 时返回。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/partial_member_list/title",
+      "source_sha256": "b7497e9ca926924b443c8190d5c56b19295545ce67ea435097982fea0d0b97c8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission/description",
+      "value": "控制谁可以访问此知识库。可选值：`only_me`、`all_team_members`、`partial_members`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission/title",
+      "source_sha256": "75723d503a92ba27c175213c3ad840a7d22eed24be167a8dc77d6a9084cd2bb3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission_keys/description",
+      "value": "授予当前调用方的权限标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/permission_keys/title",
+      "source_sha256": "409bf340be15ca6cefbc9bd5df37bbdbbf6d293db607b6ced17849e0e393988a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/pipeline_id/description",
+      "value": "自定义处理流水线的 ID（如果已配置）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/pipeline_id/title",
+      "source_sha256": "d01d3715d91c35f794d5bf05d4196cd3aa8a4ac64785d6c15a16a75e2884ea18"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/provider/description",
+      "value": "供应商类型。内部管理为 `vendor`，外部知识库连接为 `external`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/retrieval_model_dict/description",
+      "value": "知识库的检索配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/runtime_mode/description",
+      "value": "运行时处理模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/runtime_mode/title",
+      "source_sha256": "b04a8dd4ab04780b7d2b0f193b72314937c29e61442c3fb340ad52c611087494"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/summary_index_setting/description",
+      "value": "摘要索引配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/tags/description",
+      "value": "与该知识库关联的标签。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/tags/title",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_available_documents/description",
+      "value": "已启用且可用的文档数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_available_documents/title",
+      "source_sha256": "9354b71ade36bbbde5a486b117577d8ed19d3220bb3f0308b7ab1e396930e36f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_documents/description",
+      "value": "文档总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/total_documents/title",
+      "source_sha256": "7e154d8fa98b2d20c75a1fbb7b46e5821f8be6fd37f9ee73733c7e91cbd730e0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_at/description",
+      "value": "最后更新时间戳（Unix 纪元，单位为秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_by/description",
+      "value": "最后更新该知识库的用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/updated_by/title",
+      "source_sha256": "6b595a302a4b98836b4b277762776908278d6090a198a6ae17e592b71b68abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/word_count/description",
+      "value": "所有文档的总字数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDetailWithPartialMembersResponse/title",
+      "source_sha256": "120511150e6d03ea4d60dd9815a2c45e71051bc59c102cdbd092af3031b0f1c2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/id/description",
+      "value": "元数据字段 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/name/description",
+      "value": "元数据字段名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/type/description",
+      "value": "元数据值类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetDocMetadataResponse/title",
+      "source_sha256": "e51fee287704b0e9cf4008142fb394e284e0d4937f08dad8ec917e1cb0bec0fe"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_endpoint/description",
+      "value": "外部知识库 API 的端点 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_endpoint/title",
+      "source_sha256": "e27ae06d6dd9320dcafb7f6b9180869c764e5ed409c4802b5923c634c78eeef3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_id/description",
+      "value": "外部知识库 API 连接的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_id/title",
+      "source_sha256": "e2dcf725ee077104f9442be1880b13f8247bc7a88800a43f8c816c9fd9d3a103"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_name/description",
+      "value": "外部知识库 API 的显示名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_api_name/title",
+      "source_sha256": "ef4ab335626277134a4538efb6061eb32a11d8c1d0c53f1e39b258f875ca45a2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_id/description",
+      "value": "外部知识库的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/properties/external_knowledge_id/title",
+      "source_sha256": "579ead72f48e7a70e00c88363de59534661ce4d149e6aad38a4dfc7d16b1a18c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalKnowledgeInfoResponse/title",
+      "source_sha256": "76c321b297c352e17ff1d92c2b7ffcbc3b496886ddbce569f5f9524befcbcf83"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold/description",
+      "value": "检索结果需要达到的最低分数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold_enabled/description",
+      "value": "是否启用分数阈值筛选。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/score_threshold_enabled/title",
+      "source_sha256": "33e7b2a6e80860238254ee394cff0875c97ba3ba486bd89f1919f34dfe77abc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/top_k/description",
+      "value": "检索结果的最大数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/properties/top_k/title",
+      "source_sha256": "08cf18c91d1b734279713b3783ef3a997cda93cc0aab4059885a3dfc3159c81c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetExternalRetrievalModelResponse/title",
+      "source_sha256": "c1d5e899db040acf563ce5efea0320fba15cde42bc2c3c1febebbc68c9abfab6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon/description",
+      "value": "图标标识符或表情符号。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon/title",
+      "source_sha256": "a4c7282e026e9c0eb1fc174c7d813fb7e1fc644829b38d12c28db5f9b9514330"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_background/description",
+      "value": "图标的背景颜色。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_background/title",
+      "source_sha256": "15067379b68b825a8c24c73dca876adf650c51636467e4209270fac5b87c6dda"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_type/description",
+      "value": "图标类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_type/title",
+      "source_sha256": "285323907b457c9b9afe39555fbc8def3298246940561fc8587bfb6e657e3170"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_url/description",
+      "value": "自定义图标图片的 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/properties/icon_url/title",
+      "source_sha256": "2002ea73f523b651e2e6f4c79f87fcd5231a172d575ec276ef2bbcee3d338405"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetIconInfoResponse/title",
+      "source_sha256": "b9c742e98a7d10591464bedf3c7f1fa5a5719f4d5ce7987776b7b9ffca373e70"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetKeywordSettingResponse/properties/keyword_weight/description",
+      "value": "分配给关键词搜索结果的权重。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetKeywordSettingResponse/properties/keyword_weight/title",
+      "source_sha256": "577b14638d81d6d6c18433bcef87546069492150025ba80645a9ef107e8f9eb0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetKeywordSettingResponse/title",
+      "source_sha256": "a676998f43edd7113f5cd12cda4d9f4604b80c3b5a4b53144ec546bd639f89ae"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/DatasetListQuery/properties/include_all/description",
       "source_sha256": "42ec0cfe0d70ab1439e6efd97eab8ed04b3723cf7eaa967a9ea50082c82f8ecc",
       "value": "是否包含所有知识库，无论权限如何。"
@@ -3053,6 +4373,783 @@
       "source_sha256": "fc0d9565af1ad1839448481672b9f23de466a6299631b453b5d8e7e2739696fa"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/data/description",
+      "value": "当前页的知识库列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/has_more/description",
+      "value": "是否还有更多知识库。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/limit/description",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/page/description",
+      "value": "当前页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetListResponse/properties/total/description",
+      "value": "匹配的知识库总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetListResponse/title",
+      "source_sha256": "b27970249561883526cc142777c7a15ada9823a94261ade0caed3899167ba66a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataActionResponse/properties/result/description",
+      "value": "元数据操作结果。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataActionResponse/properties/result/title",
+      "source_sha256": "37d8a40483ed487e2ca2163e9d62b2b8ecdc6287773b240a56da54aa5a851d18"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataActionResponse/title",
+      "source_sha256": "bb6d438cd416c2d5855dab3174a12afbeaa6dde88a76c610a2df7e9d6dfc7cab"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/name/description",
+      "value": "内置元数据字段名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/type/description",
+      "value": "内置元数据值类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldResponse/title",
+      "source_sha256": "c3d8af8888f05da403256335d33cd62c21a51caa95216be03c5e8318bc087bae"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldsResponse/properties/fields/description",
+      "value": "系统提供的元数据字段列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldsResponse/properties/fields/title",
+      "source_sha256": "150e2a17d78790e48f1973e0c4a2e32f724f8b820b1e65408839ac69a44d0ccb"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataBuiltInFieldsResponse/title",
+      "source_sha256": "cc4cafdf6f466ddcc365b39ad1db3d2c8461f15945919fa0053ad60df042446a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/count/description",
+      "value": "使用该元数据字段的文档数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/count/title",
+      "source_sha256": "8a4beb9a57edc26e6a3c411c6ba603e9dba4e821f8e4244e826a7db1f64c1051"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/id/description",
+      "value": "元数据字段标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/name/description",
+      "value": "元数据字段名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/type/description",
+      "value": "元数据字段类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListItemResponse/title",
+      "source_sha256": "11ffbfd3754323d98ef086412d09df0e68b5ec4ffbb1acb6a31f7e6f3c08cac7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/built_in_field_enabled/description",
+      "value": "该知识库是否启用了内置元数据字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/built_in_field_enabled/title",
+      "source_sha256": "60f3d06b21a1179f5971124c3333c5ffe7798e4371795f20f99bd634a01ba7a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/doc_metadata/description",
+      "value": "元数据字段定义列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataListResponse/title",
+      "source_sha256": "975c6bdb3d471d8eccefb635980149f6bebee325856d2fd0af03d860cf6e0ec0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/id/description",
+      "value": "元数据字段 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/name/description",
+      "value": "元数据字段名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/type/description",
+      "value": "元数据值类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetMetadataResponse/title",
+      "source_sha256": "0a214240d8a1f0936bf587059a13ca79732abeac3384930f10ef944e194d96ce"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_model_name/description",
+      "value": "重排序模型名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_model_name/title",
+      "source_sha256": "84c57945febff99bd6d302f456cc0c67177d5564c52716407f118e8f2e8fc041"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_provider_name/description",
+      "value": "重排序模型的提供商。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRerankingModelResponse/properties/reranking_provider_name/title",
+      "source_sha256": "60b41a32b54ab0b9acf6ad2d6c68ee0ff1e2ad26650e94e289f4265e71a59581"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRerankingModelResponse/title",
+      "source_sha256": "40008ca2d608ce08030c342e753190b7612ea0b1f7c873fc70f01bddfdc1d0f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_enable/description",
+      "value": "是否启用重排序。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_enable/title",
+      "source_sha256": "cc1894711ba2670a7ad95df9cb248ff4496427dc4e61eefde0f555ebdaeec218"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_mode/description",
+      "value": "重排序模式。`reranking_model` 表示基于模型的重排序，`weighted_score` 表示基于分数的加权。重排序禁用时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_mode/title",
+      "source_sha256": "f5301c9027acd776f86cf98e696814c2b9404bfe29ccf772a75b020694c93dd5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/reranking_model/description",
+      "value": "重排序模型配置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold/description",
+      "value": "结果的最低相关性分数。仅在 `score_threshold_enabled` 为 `true` 时生效。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold_enabled/description",
+      "value": "是否启用分数阈值过滤。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/score_threshold_enabled/title",
+      "source_sha256": "33e7b2a6e80860238254ee394cff0875c97ba3ba486bd89f1919f34dfe77abc9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/search_method/description",
+      "value": "用于检索的搜索方式。`keyword_search` 表示关键词匹配，`semantic_search` 表示基于嵌入的语义相似度，`full_text_search` 表示全文索引，`hybrid_search` 表示语义和关键词混合搜索。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/search_method/title",
+      "source_sha256": "1b3a6e09048c1873ec9bf86eda6798c0654e1fd48edce3c148e31783353badbc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/top_k/description",
+      "value": "返回的最大结果数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/top_k/title",
+      "source_sha256": "08cf18c91d1b734279713b3783ef3a997cda93cc0aab4059885a3dfc3159c81c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/properties/weights/description",
+      "value": "混合搜索的权重配置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetRetrievalModelResponse/title",
+      "source_sha256": "6aaf327c2cc64329c0397dfca30ef31db0b9c270e5287b82fa664ce7a05c2210"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/enable/description",
+      "value": "是否启用摘要索引。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/enable/title",
+      "source_sha256": "992e91e5c8cdb4be1ba11d9ba0ead16ecc43ba3231652481845b26d9e71fb5e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_name/description",
+      "value": "用于生成摘要的模型名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_name/title",
+      "source_sha256": "34c44e6c7f885e0aa41e55418f39ac0e3199d9023a1ce834595fc14e58529df7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_provider_name/description",
+      "value": "摘要生成模型的供应商。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/model_provider_name/title",
+      "source_sha256": "d23d50574b82636f866334d72f5c4b3967f61223f3651d409311d7c8d12f3df7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/summary_prompt/description",
+      "value": "用于生成文档摘要的提示词。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/properties/summary_prompt/title",
+      "source_sha256": "c12c46aae2806b7ebd252b7dd20ca574299a3024a053ea630184c2d7d4e2c012"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetSummaryIndexSettingResponse/title",
+      "source_sha256": "d70e583cd54c31f5ddd76d706e3a37aa20a53c92ba1a257159a50c5d5e4dfa05"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetTagResponse/properties/id/description",
+      "value": "标签 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetTagResponse/properties/name/description",
+      "value": "标签名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetTagResponse/properties/type/description",
+      "value": "标签类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetTagResponse/title",
+      "source_sha256": "58b36e80c267af2940ebfd8c8c26eafc0aa273eb5383759267412049d939bc10"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/description/description",
+      "source_sha256": "55776608955dfaabd609a7e59ac5f005a65589da9f0e01a73d306437cc124da7",
+      "value": "知识库描述。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model/description",
+      "source_sha256": "a57676abae00b587600f25027f744a24863f5a9c56780647ccaa7efe6422cdb5",
+      "value": "嵌入模型名称。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `model` 字段，并将 `model_type` 设置为 `text-embedding`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model_provider/description",
+      "source_sha256": "fbc8249d511185eedbe6c1e9ee65c5f0d7e75d5b2fa2cc1b0ff71ea4ea22e403",
+      "value": "嵌入模型提供商。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `provider` 字段，并将 `model_type` 设置为 `text-embedding`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_knowledge_api_id/description",
+      "source_sha256": "30f3fea37c7166d49cc69781ebb7d612a6d3d52cce766e7428dd3e2e1c4cf90c",
+      "value": "外部知识 API 的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_knowledge_api_id/title",
+      "source_sha256": "e2dcf725ee077104f9442be1880b13f8247bc7a88800a43f8c816c9fd9d3a103"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_knowledge_id/description",
+      "source_sha256": "e63af9fd8e5a851202889f38c61fe7abbe296538866962d22d948e0fb6764b72",
+      "value": "外部知识库的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_knowledge_id/title",
+      "source_sha256": "579ead72f48e7a70e00c88363de59534661ce4d149e6aad38a4dfc7d16b1a18c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0/properties/score_threshold/description",
+      "source_sha256": "e08ce098a3e4e7a50685993b4260a6d398fca9c01d4925cb388cec520c40adb0",
+      "value": "用于筛选结果的最低相似度阈值。",
+      "context_path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0/properties/score_threshold_enabled/description",
+      "source_sha256": "a07d7e9732d41dda023d175736f5f250a7d8640eac5a2ccebfd5131382895752",
+      "value": "是否启用分数阈值过滤。",
+      "context_path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0/properties/top_k/description",
+      "source_sha256": "e1c44a06a752a0b9f03931c5962fc46ebf9f68f6a80f8195cff1853a9276c2d8",
+      "value": "最多返回的结果数量。",
+      "context_path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/description",
+      "source_sha256": "044fa8bdc78ee71858f1e7e5f1c7834c31d639314e24a2c73eec62c126cb3638",
+      "value": "外部知识库的检索设置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/external_retrieval_model/title",
+      "source_sha256": "d03fc29219971b95e45ea314fa45f7195207bd25b5275c364b5fc398b8a4a2c0"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/indexing_technique/description",
+      "source_sha256": "a933b20c1aaec91450173dd832d27b424c525f85dc9b2ab702b57fcd3a8a8bad",
+      "value": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/name/description",
+      "source_sha256": "b756a6eb4f379851befe6a770ca22095058fb204a003f89e3043903a33296fb2",
+      "value": "知识库名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/partial_member_list/anyOf/0/items/properties/user_id/description",
+      "source_sha256": "ddfe67bac1cd071b589609143c44d06fb0323535f91bc870469a78ca10ade51d",
+      "value": "要授予访问权限的团队成员 ID。",
+      "context_path": "/components/schemas/DatasetUpdatePayload/properties/partial_member_list/anyOf/0",
+      "context_sha256": "41ff189492695517378d8a1dc6a370ba80267bd050bae9928bc2546d27737e67"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/partial_member_list/description",
+      "source_sha256": "ac0f3d28718e20cc585730104901429408b1239c84d6e36359ca98387725efc5",
+      "value": "当 `permission` 为 `partial_members` 时有访问权限的团队成员列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/partial_member_list/title",
+      "source_sha256": "b7497e9ca926924b443c8190d5c56b19295545ce67ea435097982fea0d0b97c8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/permission/description",
+      "source_sha256": "1eb98a26104557e4a9e5ef8d9354fc78a1652e76668c95a32b95422f814d98f7",
+      "value": "控制谁可以访问此知识库。`only_me` 仅允许创建者访问，`all_team_members` 允许整个工作区访问，`partial_members` 仅允许指定成员访问。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasetUpdatePayload/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "检索模型配置，用于控制分段的搜索和排序方式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetUpdatePayload/title",
+      "source_sha256": "6f40b26ba5761d0bef97beea667093c20b23e8fbdc9224c664c30ca4e3ccd46f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_model_name/description",
+      "value": "用于向量搜索的嵌入模型名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_model_name/title",
+      "source_sha256": "4d79d966137d5bf514424da3770d0535ef6289a20ce67d7d5be6038198ccd6bf"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_provider_name/description",
+      "value": "用于向量搜索的嵌入模型供应商。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/embedding_provider_name/title",
+      "source_sha256": "4e0310d84c92f0465d3c1184754fbd60864f0d6925435fa6eff884947966e073"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/vector_weight/description",
+      "value": "分配给语义（向量）搜索结果的权重。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/properties/vector_weight/title",
+      "source_sha256": "6a405f1ff0999e072f0178b60240aecf12ebe66f212fc2c78450e2876050f29d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetVectorSettingResponse/title",
+      "source_sha256": "c2905945c9f349af23c6f1c154922af8d37b2be5a1fb7bf657521fbd7dfb415b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/keyword_setting/description",
+      "value": "关键词搜索权重设置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/vector_setting/description",
+      "value": "语义搜索权重设置。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/weight_type/description",
+      "value": "平衡语义搜索和关键词搜索权重的策略。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/properties/weight_type/title",
+      "source_sha256": "2e0fc6f3749fdbeac0065d9c56f1ce8fcdd30d133b1a8c00b5f42eda78ce8b2a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasetWeightedScoreResponse/title",
+      "source_sha256": "f230dd59f57c357aa0fc146b9c1bc4112edda596bd7e1f59f370b352e5de2f78"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/id/description",
+      "value": "凭证 ID。调用 [执行数据源节点](/zh/api-reference/knowledge-pipeline/run-datasource-node) 时作为 `credential_id` 传入，或作为 [运行流水线](/zh/api-reference/knowledge-pipeline/run-pipeline) 各数据源项中的 `credential_id` 字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/is_default/description",
+      "value": "该凭证是否为提供商的默认凭证。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/is_default/title",
+      "source_sha256": "3677617520e227631859c6715a99229221a19d3f4ade215934607bc716ee1991"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/name/description",
+      "value": "凭证的显示名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/type/description",
+      "value": "数据源插件定义的凭证类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceCredentialInfoResponse/title",
+      "source_sha256": "984e4f1a417a9283c66e4d11fe3f6a11fc76eb59343cdea6e00eb054340ad536"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/credential_id/description",
+      "source_sha256": "38c895b73126328657683df03c1266c0605720c3185acc46f7b336c6f4e75e46",
+      "value": "数据源凭据 ID。省略时使用默认凭据。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/credential_id/title",
+      "source_sha256": "d637e68184a5e5e808af8ab9a5673857a63e64d82e30e47529405518805d0983"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/datasource_type/description",
+      "source_sha256": "926dea22865422c8a048020ab1317176f99f93ba6766a3ff2fc3148a1e3ce760",
+      "value": "数据源类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/datasource_type/title",
+      "source_sha256": "1ddade5ac920148720355e512eb186d05c2511471941c47e4307d239b1f03f83"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/inputs/description",
+      "source_sha256": "894176ed12d27db6f60099d76e1adc355ba91b589c9e892cd2637fbbca471447",
+      "value": "数据源节点的输入变量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/is_published/description",
+      "source_sha256": "75f2844acbf5ef4975420f6914605e063581ba51b9206a39be7e991b3369d9b0",
+      "value": "是否运行节点的已发布版本或草稿版本。`true` 运行已发布版本，`false` 运行草稿版本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourceNodeRunPayload/title",
+      "source_sha256": "dbde50e1a779b6c90ba30e96a5c8bda78717a8799badbc614d9c13675f32c2cd"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginListResponse/title",
+      "source_sha256": "27a91134481f05acc93398cd9865f2fe6f8a1aa17cb7e6d58ccb7a6b8c286a1e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/credentials/description",
+      "value": "可用于对该数据源进行认证的凭证列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/credentials/title",
+      "source_sha256": "28d24da580aa5c063887d5508597035026c7caf82a9598a5a01fb70e955463fa"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/datasource_type/description",
+      "value": "数据源类型。取值为 `local_file`、`online_document`、`online_drive`、`website_crawl` 之一。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/datasource_type/title",
+      "source_sha256": "1ddade5ac920148720355e512eb186d05c2511471941c47e4307d239b1f03f83"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/node_id/description",
+      "value": "流水线工作流中数据源节点的 ID。调用 [执行数据源节点](/zh/api-reference/knowledge-pipeline/run-datasource-node) 时作为 `node_id` 传入，或调用 [运行流水线](/zh/api-reference/knowledge-pipeline/run-pipeline) 时作为 `start_node_id` 传入。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/node_id/title",
+      "source_sha256": "bfe970763ea25b9c36de1760d63fc52d802d039194700df2bb1315d5bf1f4c41"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/plugin_id/description",
+      "value": "提供该节点的数据源插件的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/plugin_id/title",
+      "source_sha256": "1cbd2f6573f6512c5db14a93d59ddc4b09a591546d66cc51bc0d881a92de08f4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/provider_name/description",
+      "value": "数据源插件注册的提供商名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/provider_name/title",
+      "source_sha256": "3610e3d454ff9d1c255e9ec61ce6cedc89589d47026d8e113168c41a8859a700"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/title/description",
+      "value": "插件显示标题。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/title/title",
+      "source_sha256": "4be9d4f1daabdb03afb07253382b19d77501261a6106d734746734605436aa77"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/user_input_variables/description",
+      "value": "调用方需要为该数据源提供的流水线输入变量，来自节点数据源参数中 `{{#...#}}` 引用的变量。每一项遵循工作流使用的流水线变量结构。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/properties/user_input_variables/title",
+      "source_sha256": "56a7fdabc079363149486cd0f29e9c7461d8d91f8cd2b9f70e03a3f346d0711f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DatasourcePluginResponse/title",
+      "source_sha256": "bed82dfa465fa00a84ab21411d01eff1e458f1d0e5978173250857f5609fbf4d"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/DatasourcePluginsQuery/properties/is_published/description",
       "source_sha256": "5c48d3437a279f6bd9bde8071f0c9482a5fc24366e0d244247f80f4d668dc02d",
@@ -3067,6 +5164,363 @@
       "op": "remove",
       "path": "/components/schemas/DatasourcePluginsQuery/title",
       "source_sha256": "63246588db3edc622fc9aeef4dc8cdfe80ccee0f8e90d4df88b85d9b5a09db16"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentAndBatchResponse/properties/batch/description",
+      "value": "用于跟踪索引进度的批次 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentAndBatchResponse/properties/batch/title",
+      "source_sha256": "026b89e52976b2603339b009c7e7547467948fb0753001d02deaa79180427305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentAndBatchResponse/properties/document/description",
+      "value": "匹配分段的父文档信息。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentAndBatchResponse/title",
+      "source_sha256": "3504d6ad4554dcb3ac5a6e7307b16c222db259229109883bf903a5c6bfbd860d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentBatchDownloadZipPayload/description",
+      "source_sha256": "a19b258c7ab87015cee5612a45057218cf36cb9e50f0bcf8d66dd2c1df7fb2aa",
+      "value": "将文档批量下载为 ZIP 压缩包的请求载荷。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentBatchDownloadZipPayload/properties/document_ids/description",
+      "source_sha256": "61013a5dc68cb391d76f62e702bb37a33b52b085947be5acfdf071b5f29448f6",
+      "value": "要包含在 ZIP 下载中的文档 ID 列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentBatchDownloadZipPayload/properties/document_ids/title",
+      "source_sha256": "dc2a6757bb082f1cd12d85478d340d6d79013f1f3c382be5c6ffc4faee398176"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentBatchDownloadZipPayload/title",
+      "source_sha256": "8530113fc7b84b60536923586316ab99e0419aef64f256f2f105b1ee004e9ecd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/archived/description",
+      "value": "文档是否已归档。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/archived/title",
+      "source_sha256": "8541102da5d25ddd0f39f05c975618421519547c67475c4a73cfafac24accec1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/average_segment_length/description",
+      "value": "分段的平均字符长度。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/average_segment_length/title",
+      "source_sha256": "a01c272dd964ca429ab71ab2ceafae0782202a241e8b34e63c86ed79f10cd4ff"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/completed_at/description",
+      "value": "完成时间，Unix 秒级时间戳；未完成时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_at/description",
+      "value": "创建时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_by/description",
+      "value": "创建该文档的用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_from/description",
+      "value": "文档来源。通过 API 创建时为 `api`，通过 UI 创建时为 `web`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/created_from/title",
+      "source_sha256": "ac7605d36b5da31a00bcf6692a557183ddce029a6ca4c5fb5cc911c9e9fd1495"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_info/description",
+      "value": "数据源详情。文件上传时，此详情接口在 `upload_file` 下返回完整的文件对象，而列表接口仅返回 `upload_file_id`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_info/title",
+      "source_sha256": "04fc73b8bbb0b1fd1a8bcb259069d7a0107de9f8eb895eaee40b81077b977e8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_type/description",
+      "value": "文档的上传方式。文件上传为 `upload_file`，Notion 导入为 `notion_import`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule/description",
+      "value": "知识库级别的处理规则配置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule/title",
+      "source_sha256": "ba53a68d3795b4649956a33af1310f064cf6dad79057bc158e4934bcefab4c1e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule_id/description",
+      "value": "应用于该文档的处理规则 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/dataset_process_rule_id/title",
+      "source_sha256": "7fe87b64e27b7605197b76399c4f820ed867d9acb75bbdb744928f5414822bcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_at/description",
+      "value": "停用时间，Unix 秒级时间戳；启用时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_by/description",
+      "value": "禁用该文档的用户 ID，启用时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/display_status/description",
+      "value": "适合 UI 显示的索引状态。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/display_status/title",
+      "source_sha256": "f3d19acfd660ecbc3ef3e75c51ad2e1cc29b57881a0c8fee1a3228186d8919f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_form/description",
+      "value": "文档分块模式。`text_model` 表示标准文本，`hierarchical_model` 表示父子结构，`qa_model` 表示问答对。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_language/description",
+      "value": "文档内容的语言。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_metadata/description",
+      "value": "此文档的自定义元数据键值对。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_type/description",
+      "value": "文档类型分类，未设置时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/doc_type/title",
+      "source_sha256": "9df74ed42d3a2e6f946ce0af273666dc30fef00ebd133970e773dd1e27428fcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/document_process_rule/description",
+      "value": "文档级别的处理规则配置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/document_process_rule/title",
+      "source_sha256": "721a63f3f15e5d8aaedcfa99cd9835272aacbd8655b261323855d5632891eeb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/enabled/description",
+      "value": "该文档是否启用检索。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/error/description",
+      "value": "索引失败时的错误消息，否则为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/hit_count/description",
+      "value": "该文档被检索的次数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/id/description",
+      "value": "文档标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_latency/description",
+      "value": "索引耗时（秒），未完成时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_latency/title",
+      "source_sha256": "9958606e45e1f84a90bf2b35cc6f1da7667f177f05f2e6507a09465d31b91b6f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_status/description",
+      "value": "当前索引状态，例如 `waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、`error`、`paused`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/name/description",
+      "value": "文档名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/need_summary/description",
+      "value": "该文档是否需要生成摘要。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/need_summary/title",
+      "source_sha256": "f86a97523001d39eb483e5eb409dd41314bec44581f7537da8356eddca7a3209"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/position/description",
+      "value": "在知识库中的位置索引。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/segment_count/description",
+      "value": "文档中的分段数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/segment_count/title",
+      "source_sha256": "b00632c029a06236c07045f50ea4c8d7d1be5eee01bdb2a0066f043c170f93d8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/summary_index_status/description",
+      "value": "摘要索引的状态，未启用摘要索引时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/summary_index_status/title",
+      "source_sha256": "f071851825f1aef8746a503d9c35eb84d025616f0cea1088f7865b510f2c180a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/tokens/description",
+      "value": "文档中的令牌数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentDetailResponse/properties/updated_at/description",
+      "value": "最后更新时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentDetailResponse/title",
+      "source_sha256": "47de58693b044c133c8524b3999a1a724a401e536b8c79b59df0d47f5d13676c"
     },
     {
       "op": "replace",
@@ -3132,6 +5586,886 @@
       "op": "remove",
       "path": "/components/schemas/DocumentListQuery/title",
       "source_sha256": "ed2db5c64b168833d59052e05d0a006c0c7f1f83ada31a1dbf4c7a06e48fceda"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/data/description",
+      "value": "当前页的文档列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/has_more/description",
+      "value": "是否还有更多文档。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/limit/description",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/page/description",
+      "value": "当前页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentListResponse/properties/total/description",
+      "value": "匹配的文档总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentListResponse/title",
+      "source_sha256": "8435a09d11cdbd474fd5cc16e3e85f1166bf99947fb83e96d9274d7aa3702c71"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/document_id/description",
+      "source_sha256": "c2ce292785657305de2476937376065ce2c8846d6ba99f9d45cd633e963302fe",
+      "value": "要更新元数据的文档 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/metadata_list/description",
+      "source_sha256": "8ff5f5cfb3d991ddb4d8c8a01657864ccaf926ba43af15410214d99e5aa94095",
+      "value": "要更新的元数据字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/metadata_list/title",
+      "source_sha256": "74c1bd3c93da31006af3e9fbbc2185f56659a934ca930979b912d78f9f7ab349"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/partial_update/description",
+      "source_sha256": "fcff191800ab973d5987419b5e02de0127399516fea2d3e62c52560afec3cae2",
+      "value": "是否部分更新元数据，保留未指定字段的现有值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/properties/partial_update/title",
+      "source_sha256": "f5248201347a7ebfbe3b073bc563cfc799d2c792f4890d2a3923e5c60fe812fc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataOperation/title",
+      "source_sha256": "6a94e1b7a5668ef785a2a8c18edf4b1d7d09678f163cb754d0a30a6ca7694b0d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/id/description",
+      "value": "元数据字段标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/name/description",
+      "value": "元数据字段名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/type/description",
+      "value": "元数据字段值类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/value/description",
+      "value": "此文档的元数据值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentMetadataResponse/title",
+      "source_sha256": "4c1c189d5bef8cc41bc0d17b17b3c918042c851d9e45db8ba4840f8def43abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/archived/description",
+      "value": "文档是否已归档。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/archived/title",
+      "source_sha256": "8541102da5d25ddd0f39f05c975618421519547c67475c4a73cfafac24accec1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/created_at/description",
+      "value": "创建时间戳（Unix 纪元，单位为秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/created_by/description",
+      "value": "创建该文档的用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/created_from/description",
+      "value": "文档来源。通过 API 创建时为 `api`，通过 UI 创建时为 `web`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/created_from/title",
+      "source_sha256": "ac7605d36b5da31a00bcf6692a557183ddce029a6ca4c5fb5cc911c9e9fd1495"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_detail_dict/description",
+      "value": "详细的数据源信息，包括文件详情。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_detail_dict/title",
+      "source_sha256": "28dd9da99ba5d7bc55120227afe601c8b503ab708a5fca4e3d14c0d72d0c25a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_info/description",
+      "value": "原始数据源信息，随 `data_source_type` 而异。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_info/title",
+      "source_sha256": "04fc73b8bbb0b1fd1a8bcb259069d7a0107de9f8eb895eaee40b81077b977e8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_type/description",
+      "value": "文档的创建方式。文件上传为 `upload_file`，Notion 导入为 `notion_import`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/dataset_process_rule_id/description",
+      "value": "应用于该文档的处理规则 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/dataset_process_rule_id/title",
+      "source_sha256": "7fe87b64e27b7605197b76399c4f820ed867d9acb75bbdb744928f5414822bcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_at/description",
+      "value": "停用时间，Unix 秒级时间戳；启用时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_by/description",
+      "value": "禁用该文档的用户 ID。启用时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/display_status/description",
+      "value": "基于 `indexing_status` 和 `enabled` 状态派生的面向用户的显示状态。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/display_status/title",
+      "source_sha256": "f3d19acfd660ecbc3ef3e75c51ad2e1cc29b57881a0c8fee1a3228186d8919f5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/doc_form/description",
+      "value": "文档分块模式。`text_model` 表示标准文本分块，`hierarchical_model` 表示父子结构，`qa_model` 表示问答对提取。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/doc_metadata/description",
+      "value": "分配给该文档的元数据值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/enabled/description",
+      "value": "该文档是否启用检索。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/error/description",
+      "value": "索引失败时的错误消息。无错误时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/hit_count/description",
+      "value": "该文档在检索查询中被匹配的次数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/id/description",
+      "value": "文档的唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/indexing_status/description",
+      "value": "当前索引状态。`waiting` 表示排队中，`parsing` 表示正在提取内容，`cleaning` 表示正在去噪，`splitting` 表示正在分块，`indexing` 表示正在构建向量，`completed` 表示就绪，`error` 表示失败，`paused` 表示手动暂停。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/name/description",
+      "value": "文档名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/need_summary/description",
+      "value": "是否需要为该文档生成摘要。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/need_summary/title",
+      "source_sha256": "f86a97523001d39eb483e5eb409dd41314bec44581f7537da8356eddca7a3209"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/position/description",
+      "value": "文档在列表中的显示位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/summary_index_status/description",
+      "value": "该文档的摘要索引状态。未配置摘要索引时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/summary_index_status/title",
+      "source_sha256": "f071851825f1aef8746a503d9c35eb84d025616f0cea1088f7865b510f2c180a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/tokens/description",
+      "value": "文档中的令牌总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentResponse/properties/word_count/description",
+      "value": "文档的总字数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentResponse/title",
+      "source_sha256": "2e21f14477b9e62a64922ef5d3614928ef4f390217977f08f6be9b13274ce35e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusListResponse/properties/data/description",
+      "value": "文档处理状态记录。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusListResponse/title",
+      "source_sha256": "271dc90dcdf630dcd05ce6d196274faf721b3cbd2d12c414ca29d86cc4ed8c0f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentStatusPayload/properties/document_ids/description",
+      "source_sha256": "234a2deb218eaa9bc74cf0ee5cc26b0c06b9208488238e5c44e31d17794012d6",
+      "value": "要更新的文档 ID 列表。为保持兼容，该字段为可选；省略或传入空数组时，请求成功但不会更新任何文档。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusPayload/properties/document_ids/title",
+      "source_sha256": "dc2a6757bb082f1cd12d85478d340d6d79013f1f3c382be5c6ffc4faee398176"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusPayload/title",
+      "source_sha256": "8bf178b15f72df177fae4f9df12a004fec21f4c2caac21200fe65f7d29002933"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/cleaning_completed_at/description",
+      "value": "清洗完成时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/cleaning_completed_at/title",
+      "source_sha256": "03b3cb7786f7423ca24280558a8d4899cc3f4ff6698c3a0354f52c6ffb2610b2"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_at/description",
+      "value": "索引完成时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_segments/description",
+      "value": "已索引的分段数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/completed_segments/title",
+      "source_sha256": "2a63a79f7927e11e90fa30a49344e987f1f8faf74ec78bb42ce6ad1780ee4ce4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error/description",
+      "value": "索引失败时的错误信息。无错误时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error_code/description",
+      "value": "处理错误代码；未发生错误时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/error_code/title",
+      "source_sha256": "0a784f3f0dd812c0bf04ba86b7aaf4027aae79d0cd98b06385701ca56fc33779"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/estimated_vector_space_mb/description",
+      "value": "预计向量存储用量，单位为 MB。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/estimated_vector_space_mb/title",
+      "source_sha256": "82883eedce2c8a2f1d7ba55145c838481d4636f533b617c0e4250ec3f349a573"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/id/description",
+      "value": "文档标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/indexing_status/description",
+      "value": "当前索引状态：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、`error` 或 `paused`。`completed` 和 `error` 为终态。Service API 无法恢复 `paused` 文档；请在 Dify 知识库控制台恢复后再继续轮询。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/parsing_completed_at/description",
+      "value": "解析完成时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/parsing_completed_at/title",
+      "source_sha256": "6f4040a53d17dc6d300f8b3db316043775bdf5c62902620c9b7ebe5a5f887743"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/paused_at/description",
+      "value": "索引暂停时间，Unix 秒级时间戳；未暂停时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/paused_at/title",
+      "source_sha256": "27f9211f8d20297ee4ae52683191e77dbc1f685480025ec7b6b38674b31bd26f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/processing_started_at/description",
+      "value": "处理开始时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/processing_started_at/title",
+      "source_sha256": "c23858653858bb7fc7237d3033b5588ac1e694381bb2915531d6bb9d00f7448e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/splitting_completed_at/description",
+      "value": "分段完成时间，Unix 秒级时间戳。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/splitting_completed_at/title",
+      "source_sha256": "a3218648896dd8e1534da12e88b1b3b380369b751d514a22ed361d210f1699dd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/stopped_at/description",
+      "value": "索引停止时间，Unix 秒级时间戳；未停止时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/stopped_at/title",
+      "source_sha256": "e6760f92f5dde2261be331d6fdc428cb187032976d9229b4171e068dc69a82d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/total_segments/description",
+      "value": "待索引的分段总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/total_segments/title",
+      "source_sha256": "09fe63bdbc83b98d9e40b93ddae803e779caa1c7ab674a0b9bb53b74207c332f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/DocumentStatusResponse/properties/vector_space_limit_mb/description",
+      "value": "向量存储上限，单位为 MB。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/properties/vector_space_limit_mb/title",
+      "source_sha256": "9028c6208cbdb28fbe3137f15278a86807d70f7a9c437e782ac95693836e20f8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentStatusResponse/title",
+      "source_sha256": "3e7be7a8546ebb1e58a75fd5ceb1b6c450d9ef02799db20c2a4d6a7c87f7f7b8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/doc_form/description",
+      "source_sha256": "19683e8d31c731b01fa05ed424b3e190e75b65c0fc85184bfb09335c6b91b742",
+      "value": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/doc_language/description",
+      "source_sha256": "efb6f3721270f3dfb8b787bba1f0d6a2f1165295da61025d63e34a1d09ec5b04",
+      "value": "用于处理优化的文档语言。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model/description",
+      "source_sha256": "a57676abae00b587600f25027f744a24863f5a9c56780647ccaa7efe6422cdb5",
+      "value": "嵌入模型名称。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `model` 字段，并将 `model_type` 设置为 `text-embedding`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model/title",
+      "source_sha256": "86b825042b7f347b4139010f13a3a280b3a3cdcae30137037d93120d5f6f8980"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model_provider/description",
+      "source_sha256": "fbc8249d511185eedbe6c1e9ee65c5f0d7e75d5b2fa2cc1b0ff71ea4ea22e403",
+      "value": "嵌入模型提供商。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `provider` 字段，并将 `model_type` 设置为 `text-embedding`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/embedding_model_provider/title",
+      "source_sha256": "897c3c817cce9c53d7cbc10f7bcd827418a7f14ca9b4e436cbd26c3c7df0c0ad"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/indexing_technique/description",
+      "source_sha256": "5cd15c86131f0495c2100b3e96f89919de8758cf6aca8bb75aedb705f359d019",
+      "value": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。向知识库添加首个文档时必填；后续文档省略时会继承知识库的索引方式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/indexing_technique/title",
+      "source_sha256": "e47dd8c253e9c4294d64be7ca6c0a383ca8f048ef60f85f4896fd1e07a137aba"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/name/description",
+      "source_sha256": "be05790374a007475abc7dcb1915fbd594aaaf3e9ddbab4905848dc944ff2654",
+      "value": "文档名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/original_document_id/description",
+      "source_sha256": "60073b60b17f220ab0be0933ae61c6343b9e0e3f06384af4fde769a1ffb8568d",
+      "value": "要替换的原始文档 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/original_document_id/title",
+      "source_sha256": "912e375455228dc2bf425df1398caef3a87b188a983848b6a659052d401055bd"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/process_rule/description",
+      "source_sha256": "64d646df43acecf87aa51d272bf053bf69ffb0db981f6bd5b324abdafc3efd3f",
+      "value": "分块处理规则。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "检索模型配置，用于控制分段的搜索和排序方式。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/text/description",
+      "source_sha256": "15d1cf90d8b4e25fe0d172442df7017c6df810fa6f95fe40ae9b60ccc97384e4",
+      "value": "文档文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextCreatePayload/title",
+      "source_sha256": "f5a7947e48de74109f6c499cae88124d8dc10511463ecae5e716b4b917d633bb"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/doc_form/description",
+      "source_sha256": "19683e8d31c731b01fa05ed424b3e190e75b65c0fc85184bfb09335c6b91b742",
+      "value": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/doc_language/description",
+      "source_sha256": "efb6f3721270f3dfb8b787bba1f0d6a2f1165295da61025d63e34a1d09ec5b04",
+      "value": "用于处理优化的文档语言。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/name/description",
+      "source_sha256": "0a8346b229609f3d8fa39b64da94d1d46e42856d98b6b9f9f6b7863925574b1a",
+      "value": "文档名称。当提供 `text` 时必填。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/process_rule/description",
+      "source_sha256": "64d646df43acecf87aa51d272bf053bf69ffb0db981f6bd5b324abdafc3efd3f",
+      "value": "分块处理规则。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "检索模型配置，用于控制分段的搜索和排序方式。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/text/description",
+      "source_sha256": "15d1cf90d8b4e25fe0d172442df7017c6df810fa6f95fe40ae9b60ccc97384e4",
+      "value": "文档文本内容。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/0/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/0",
+      "context_sha256": "3d2d590fb65847c2890c6124cccc19e4bde1ae6cd958c6e0d98b1fd959b5720a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/doc_form/description",
+      "source_sha256": "19683e8d31c731b01fa05ed424b3e190e75b65c0fc85184bfb09335c6b91b742",
+      "value": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/doc_language/description",
+      "source_sha256": "efb6f3721270f3dfb8b787bba1f0d6a2f1165295da61025d63e34a1d09ec5b04",
+      "value": "用于处理优化的文档语言。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/name/description",
+      "source_sha256": "0a8346b229609f3d8fa39b64da94d1d46e42856d98b6b9f9f6b7863925574b1a",
+      "value": "文档名称。当提供 `text` 时必填。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/process_rule/description",
+      "source_sha256": "64d646df43acecf87aa51d272bf053bf69ffb0db981f6bd5b324abdafc3efd3f",
+      "value": "分块处理规则。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "检索模型配置，用于控制分段的搜索和排序方式。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/anyOf/1/properties/text/description",
+      "source_sha256": "15d1cf90d8b4e25fe0d172442df7017c6df810fa6f95fe40ae9b60ccc97384e4",
+      "value": "文档文本内容。",
+      "context_path": "/components/schemas/DocumentTextUpdate/anyOf/1",
+      "context_sha256": "77b08b1b097ff7221666c82645e946c943eefe565f3101dac643e446b1d507d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/doc_form/description",
+      "source_sha256": "19683e8d31c731b01fa05ed424b3e190e75b65c0fc85184bfb09335c6b91b742",
+      "value": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/doc_language/description",
+      "source_sha256": "efb6f3721270f3dfb8b787bba1f0d6a2f1165295da61025d63e34a1d09ec5b04",
+      "value": "用于处理优化的文档语言。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/doc_language/title",
+      "source_sha256": "2a0a23f00c19a047021be15d30681950cfe8f219723704f61e9206f0c1b34fde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/name/description",
+      "source_sha256": "0a8346b229609f3d8fa39b64da94d1d46e42856d98b6b9f9f6b7863925574b1a",
+      "value": "文档名称。当提供 `text` 时必填。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/process_rule/description",
+      "source_sha256": "64d646df43acecf87aa51d272bf053bf69ffb0db981f6bd5b324abdafc3efd3f",
+      "value": "分块处理规则。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "检索模型配置，用于控制分段的搜索和排序方式。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DocumentTextUpdate/properties/text/description",
+      "source_sha256": "15d1cf90d8b4e25fe0d172442df7017c6df810fa6f95fe40ae9b60ccc97384e4",
+      "value": "文档文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/properties/text/title",
+      "source_sha256": "c028d4bda5c6fda7d50332b324fd20992eb78517fc85b8f6a2421f2d3bf68a79"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/DocumentTextUpdate/title",
+      "source_sha256": "8ff01b234dd66b682db99e9c3b7e5afdb96764fea3d8437b131d439771ba7ef0"
     },
     {
       "op": "remove",
@@ -3279,6 +6613,17 @@
       "op": "remove",
       "path": "/components/schemas/FeedbackListQuery/title",
       "source_sha256": "2ee2ef5a0b8833947992d468c455c3ec9722d91f0512455ef418a2ca9fa97e89"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/FetchFrom/description",
+      "source_sha256": "93b013d10f7d415ee23f10d2da2177911d3910daa1cbc898c34b362affe74317",
+      "value": "用户标识符来源的枚举。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/FetchFrom/title",
+      "source_sha256": "acb0dd729bd3571f3c6e9f9d7f2f02ef818bca9ba75204ba8debbaa023a9126d"
     },
     {
       "op": "add",
@@ -3580,6 +6925,564 @@
       "op": "remove",
       "path": "/components/schemas/FileType/title",
       "source_sha256": "1146fdf89b9afd90dd54e7a8a49cc084960dbe6ab3cb3c9ddb13494be2676ed7"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/content/description",
+      "value": "子分段的文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/id/description",
+      "value": "子分段的唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/position/description",
+      "value": "子分段在父分段中的位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingChildChunk/properties/score/description",
+      "value": "子分段的相关性得分。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingChildChunk/title",
+      "source_sha256": "04a4b8972b5517ed1952fc67fc2ac7d057647bc0a9e530692dba6de71583680f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/data_source_type/description",
+      "value": "文档的创建方式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_metadata/description",
+      "value": "文档的元数据值。未配置元数据时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_metadata/title",
+      "source_sha256": "05575d7669d2fcdce56b4279695bd41c3118ce022eb5b6f05a1f0d6edbe1ccb8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_type/description",
+      "value": "文档类型分类。未设置时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/doc_type/title",
+      "source_sha256": "9df74ed42d3a2e6f946ce0af273666dc30fef00ebd133970e773dd1e27428fcb"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/id/description",
+      "value": "文档的唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingDocument/properties/name/description",
+      "value": "文档名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingDocument/title",
+      "source_sha256": "5e94cace3967519065fce6e26f98e585eed1a2c48f3d9bdb4aab9f96ea192fea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/extension/description",
+      "value": "文件扩展名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/id/description",
+      "value": "附件文件标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/mime_type/description",
+      "value": "文件的 MIME 类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/name/description",
+      "value": "原始文件名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/size/description",
+      "value": "文件大小（字节）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingFile/properties/source_url/description",
+      "value": "访问附件的 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/properties/source_url/title",
+      "source_sha256": "3d48f2577f877973dd0a3ab85975e367b5a9ab1964eb533d2cb3dd317134d453"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingFile/title",
+      "source_sha256": "39b9e374e8c486ac5f02f9c571c6632befb800130e8a706987a0b429a360f42c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/attachment_ids/description",
+      "source_sha256": "bf7f542822d8864ea08a8b221abb9edb06a05cce58548f1bfe4aae4ca316a9c8",
+      "value": "已附加到知识库分段的图片文件 ID，可从 Dify 控制台上传或创建这些分段附件后返回的数据中获取。它们为多模态召回测试添加图片上下文。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/properties/attachment_ids/title",
+      "source_sha256": "477c1e5aa9f364630218d09c7e51bb851e632ef1f297ec491ef9e34c725bbcbd"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0/properties/score_threshold/description",
+      "source_sha256": "e08ce098a3e4e7a50685993b4260a6d398fca9c01d4925cb388cec520c40adb0",
+      "value": "用于筛选结果的最低相似度阈值。",
+      "context_path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0/properties/score_threshold_enabled/description",
+      "source_sha256": "a07d7e9732d41dda023d175736f5f250a7d8640eac5a2ccebfd5131382895752",
+      "value": "是否启用分数阈值过滤。",
+      "context_path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0/properties/top_k/description",
+      "source_sha256": "e1c44a06a752a0b9f03931c5962fc46ebf9f68f6a80f8195cff1853a9276c2d8",
+      "value": "最多返回的结果数量。",
+      "context_path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/anyOf/0",
+      "context_sha256": "282db5f1ce87bf09705d8eaa27c9d97d92d50a83ef1aaaf20950804c5f6a017e"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/description",
+      "source_sha256": "044fa8bdc78ee71858f1e7e5f1c7834c31d639314e24a2c73eec62c126cb3638",
+      "value": "外部知识库的检索设置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/properties/external_retrieval_model/title",
+      "source_sha256": "d03fc29219971b95e45ea314fa45f7195207bd25b5275c364b5fc398b8a4a2c0"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/query/description",
+      "source_sha256": "c10a718bfe74e7f83b03055ae36933b87ddbc233243a9b2b18da5a9ad3b5107e",
+      "value": "搜索查询文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/properties/query/title",
+      "source_sha256": "36f58a4bc68841966647ee936a63b27b5f7ca3ee0a12dde6360463a85a270b76"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/HitTestingPayload/properties/retrieval_model/description",
+      "source_sha256": "c09f9deb1e02036ce77df4598024be4e61d4d4386cb1d2a3a435a5af279a12a1",
+      "value": "检索模型配置，用于控制分段的搜索和排序方式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingPayload/title",
+      "source_sha256": "ce553fcd151500efc39b4f765e849170d57d90a6492f4de009c7f1c52dad61be"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingQuery/properties/content/description",
+      "value": "用于检索测试的查询文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingQuery/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingQuery/title",
+      "source_sha256": "76dfb654101204d869e2eb0e611e02f148acd3ee6e6aa1746d6e5653c1a4ff50"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/child_chunks/description",
+      "value": "使用分层索引时，分段内匹配的子分段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/child_chunks/title",
+      "source_sha256": "bd2ab3b4c807f0086a23c8bcf021f57f9516f43bc3b3577bf84f78237dd361e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/files/description",
+      "value": "附加到该分段的文件。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/files/title",
+      "source_sha256": "6e190b061b83b7bf697a1be3963541ff10d3db138305bc3a4bd85547b709ae05"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/score/description",
+      "value": "相关性得分。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/score/title",
+      "source_sha256": "ee6251f853e10e7fb27ede4afb9f240c17ecb0b38e1616539efb062c40fbd792"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/segment/description",
+      "value": "从知识库中匹配的分段。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/summary/description",
+      "value": "通过摘要索引检索到的摘要内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingRecord/properties/tsne_position/description",
+      "value": "t-SNE 可视化位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/properties/tsne_position/title",
+      "source_sha256": "bab0091eada78f67bd15e07cbef0b8871d8fac48c0f71ecbd1b796da402d0c3d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingRecord/title",
+      "source_sha256": "9598ca2914a61e78b5ec68296ecd78c1b28a1c2857459b03da6390504f970d94"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingResponse/properties/query/description",
+      "value": "原始查询对象。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingResponse/properties/records/description",
+      "value": "匹配的检索记录列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingResponse/properties/records/title",
+      "source_sha256": "079b962f34b8d3d57508383c9b5669e6818b1c65dc9beeaf43609f12a46d34b9"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingResponse/title",
+      "source_sha256": "e4214278c7f114e4f04ecfc01a54df155fce3d3011412a40439969be5c2ae862"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/answer/description",
+      "value": "回答内容，用于问答模式文档。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/completed_at/description",
+      "value": "完成时间，Unix 秒级时间戳；未完成时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/content/description",
+      "value": "分段的文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/created_at/description",
+      "value": "创建时间戳（Unix 纪元，单位为秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/created_by/description",
+      "value": "创建该分段的用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_at/description",
+      "value": "停用时间，Unix 秒级时间戳；启用时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_by/description",
+      "value": "禁用该分段的用户 ID。启用时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/document/description",
+      "value": "匹配分段的父文档信息。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/document_id/description",
+      "value": "该分段所属文档的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/enabled/description",
+      "value": "该分段是否启用检索。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/error/description",
+      "value": "索引失败时的错误消息。无错误时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/hit_count/description",
+      "value": "该分段在检索查询中被匹配的次数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/id/description",
+      "value": "分段的唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_hash/description",
+      "value": "索引内容的哈希值，用于检测变更。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_id/description",
+      "value": "向量存储中索引节点的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/index_node_id/title",
+      "source_sha256": "0d45b0d6da2c05390b91146a6cd5de5845c26e58431ba1174c3e3c0793192b42"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/indexing_at/description",
+      "value": "索引开始时间，Unix 秒级时间戳；未开始时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/indexing_at/title",
+      "source_sha256": "3d4b6de81308d36e9b8544959f48c914d42c529120fa60ad2e08922d6b60fa8a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/keywords/description",
+      "value": "与该分段关联的关键词，用于基于关键词的检索。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/position/description",
+      "value": "分段在文档中的位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/sign_content/description",
+      "value": "用于完整性验证的签名内容哈希。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/sign_content/title",
+      "source_sha256": "0b01a836c72cea937f5dc68e84213e59c3dc45e8a385ac28588608ab9c00bea4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/status/description",
+      "value": "分段的索引状态。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/stopped_at/description",
+      "value": "索引停止时间，Unix 秒级时间戳；未停止时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/stopped_at/title",
+      "source_sha256": "e6760f92f5dde2261be331d6fdc428cb187032976d9229b4171e068dc69a82d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/tokens/description",
+      "value": "分段内容的令牌数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/HitTestingSegment/properties/word_count/description",
+      "value": "分段内容的字数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/HitTestingSegment/title",
+      "source_sha256": "f3c4398d148dc323df829715bfcd57aec3fea754cb2b6fa1c52ee9f7dab03cbe"
     },
     {
       "op": "add",
@@ -3927,6 +7830,37 @@
       "source_sha256": "aa2f56fbcc6b021221b64c92e880abaccf77304d4960f15e77f766fae9e7c1e1"
     },
     {
+      "op": "replace",
+      "path": "/components/schemas/I18nObject/description",
+      "source_sha256": "7a1384fbe0312d8e0f1aa3709672e486da30d49840af1f8bf7720f9f69cb5ece",
+      "value": "国际化对象模型。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/I18nObject/properties/en_US/description",
+      "value": "英语（美国）文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/I18nObject/properties/en_US/title",
+      "source_sha256": "91730468013580d2ca81b9ec9f7f7c2d035aafd4e02e18dca3f7414a2255876c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/I18nObject/properties/zh_Hans/description",
+      "value": "简体中文文本。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/I18nObject/properties/zh_Hans/title",
+      "source_sha256": "3303c331ae7406cb2ff6ebf0ea89c214a8b77ffe90bfca224f24dcc8d65205a0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/I18nObject/title",
+      "source_sha256": "a8261231c196264130c3255d0b00818e884a251f90142bdc9128a4f7a54a5a2d"
+    },
+    {
       "op": "add",
       "path": "/components/schemas/IndexInfoResponse/properties/api_version/description",
       "value": "Service API 版本。"
@@ -3960,6 +7894,56 @@
       "op": "remove",
       "path": "/components/schemas/IndexInfoResponse/title",
       "source_sha256": "39bae08b9ff59cac2e8753bfc4a2e27ee7493eb5d4f6402c2f1c354436048e6e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagListResponse/title",
+      "source_sha256": "7ea66a71f438538cc91dc4a3c8f5b1f1ac45a9eec520618f4d86759a873d58bd"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/binding_count/description",
+      "value": "绑定到该标签的知识库数量。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/binding_count/title",
+      "source_sha256": "6744d2c8f3469e6d93b9054f200888a7f83c5434fada4fab7da8c497fee9334a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/id/description",
+      "value": "标签标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/name/description",
+      "value": "标签显示名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/type/description",
+      "value": "标签类型。知识库标签始终为 `knowledge`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/KnowledgeTagResponse/title",
+      "source_sha256": "5d35b5b2ca17ef8d8b9e46e07f786fd8d5868bc644495e9452b64cfb52bcbafd"
     },
     {
       "op": "replace",
@@ -4388,6 +8372,186 @@
       "op": "remove",
       "path": "/components/schemas/MessageListQuery/title",
       "source_sha256": "17997d5395df2c93391badf0ba144f4ca86426f5b37ae14fd35d9c873a56e906"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataArgs/properties/name/description",
+      "source_sha256": "3f2e55a969f40b27ef2783ba0161dafc53961bc1aa30523fa3651dd788c71300",
+      "value": "元数据字段名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataArgs/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataArgs/properties/type/description",
+      "source_sha256": "c7cf93e24c0c66483dcbd9fafdd30d8f18b5e4b7f611044c441211a2a1c687ba",
+      "value": "`string` 为文本值，`number` 为数值，`time` 为日期/时间值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataArgs/properties/type/title",
+      "source_sha256": "c44f7ab8bbd24858d1bd1ab995f21c5f52c6a671907b29ed3a4b094345f70b21"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataArgs/title",
+      "source_sha256": "5010db9c5b96a550c36c36195662f267ede43500911e35fb0c94e6ab88dc578a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataDetail/properties/id/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "元数据字段 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataDetail/properties/name/description",
+      "source_sha256": "3f2e55a969f40b27ef2783ba0161dafc53961bc1aa30523fa3651dd788c71300",
+      "value": "元数据字段名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataDetail/properties/value/description",
+      "source_sha256": "3fdf277a590661a66052c2250e1f219173b294e12db31667b0f0f335a9ef1046",
+      "value": "元数据值。可以是字符串、数字或 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/properties/value/title",
+      "source_sha256": "f951b794a3597650ab31f2b677bc86eff3ad6798860f7caa908a8e202955b8dc"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataDetail/title",
+      "source_sha256": "302664e69b302538fbbb457b69ed4b30cbcbefe70237d9c4c4a99709535d424b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataFilteringCondition/description",
+      "source_sha256": "619bb3c72d6a1df26bf70c18a4b5dee89a44fa039cb8fa5f7363c3f2625c03d5",
+      "value": "元数据筛选条件。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataFilteringCondition/properties/conditions/description",
+      "source_sha256": "0cee17456cfb5acb30302205498035132fda78a3e80485460246606bd72a3296",
+      "value": "要评估的元数据条件列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataFilteringCondition/properties/conditions/title",
+      "source_sha256": "4859ee3a5984f46db2a7ccfa66d09ea46ad9df847d6cb8397511e787f067b808"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataFilteringCondition/properties/logical_operator/description",
+      "source_sha256": "4607effbd3a2afc71a74d145faa8548e26f148c22d8ef7463003c9421f94e55b",
+      "value": "多个条件之间的组合方式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataFilteringCondition/properties/logical_operator/title",
+      "source_sha256": "bd84f30aea6a169e867e9db93128823bc7d81fb1dfda548b082b0bcc781fd9b1"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataFilteringCondition/title",
+      "source_sha256": "b06ffd3e4965d76123abf4cd03de62125ac92beb783b60945b7ab06bb5c102b1"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataOperationData/description",
+      "source_sha256": "be6bd52b9115554d18edb75b0f8636420d176d1f6f856425ed4e199648640e39",
+      "value": "元数据操作数据。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataOperationData/properties/operation_data/description",
+      "source_sha256": "05188a756294c069f170be44b9dcff59f3a0244fd0069ffc2ece50491bcffdf8",
+      "value": "文档元数据更新操作数组。每个条目将一个文档 ID 映射到其元数据值。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataOperationData/properties/operation_data/title",
+      "source_sha256": "02b7dc37f55b2fbb29b6e3c7924c7784cedbddae06d7ee78f1bac1d440a2d75a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataOperationData/title",
+      "source_sha256": "ee06ed81dc74e00e43985d26fa6ff24cc18e77b8459bd788db8a6ba34799d3eb"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/MetadataUpdatePayload/properties/name/description",
+      "source_sha256": "d8626bc15656aac057165159c4558b0ded5dafcbebcdade61c5a09e3eba3b151",
+      "value": "新的元数据字段名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataUpdatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/MetadataUpdatePayload/title",
+      "source_sha256": "aabaef1791ea8fbdc2dfeb00d411b65852b6c403ce271039db738a89968c3ecd"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ModelFeature/description",
+      "source_sha256": "4a271a6b3e6fece160c11be74b83b914934b6b2b42589b4b36548a1cfe9d1ed5",
+      "value": "大语言模型功能的枚举。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelFeature/title",
+      "source_sha256": "5780e7c733374436c449054dd03e6033a0b8938701761eaad659da105cdb5e79"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ModelPropertyKey/description",
+      "source_sha256": "587be277cf74fa2137f2f63f53a031c7e21313474af385e4afaae906f7c3640b",
+      "value": "模型属性键的枚举。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelPropertyKey/title",
+      "source_sha256": "706b1321efa56929cbfaa83d1701bb1f2cca7139978811df4128553dc9579da1"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ModelStatus/description",
+      "source_sha256": "ceb92b86549966f60990db6a356bffa119873e4ad66dd7d5b28d0ac942a98b72",
+      "value": "模型状态的枚举。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelStatus/title",
+      "source_sha256": "46314ebd42525f4675cfa3644685b6f21f98f94fba835afd047311dd9bb248ac"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ModelType/description",
+      "source_sha256": "19db1c5faa088d8d3d7a1aed47801e9ef0e18559a23f9acb3136a06368714d19",
+      "value": "模型类型的枚举。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ModelType/title",
+      "source_sha256": "79143b74dca244e14369c3408a772220b8cf93187a1cbe2eb2986adc393920ba"
     },
     {
       "op": "replace",
@@ -5563,6 +9727,728 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/PermissionEnum/description",
+      "source_sha256": "8ad7ecdb1a053a94b2d8ef792b8ab9414af671d2af0bf4d99da1ad0e89af66e4",
+      "value": "资源（知识库、凭据等）的共享权限级别。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PermissionEnum/title",
+      "source_sha256": "570f985d8678a60eaabf80571396764eb068de6b7de35b398747f22978fe60f6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDataset/properties/chunk_structure/description",
+      "value": "知识库配置的分段结构。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/chunk_structure/title",
+      "source_sha256": "b6a62f5f409a72d8767489993f9615846dbae82c4f90a4707c872820c63fce60"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineDataset/properties/description/description",
+      "source_sha256": "c261ff1298c1bfa9af71a5c603225f66da3a638a59c71bfd7148722976e2c7f9",
+      "value": "知识库描述。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/description/title",
+      "source_sha256": "6e0d190c847ecfe3c49229dcfd9caa90444cb1565c1459b736142822a647f963"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDataset/properties/id/description",
+      "value": "资源 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDataset/properties/name/description",
+      "value": "资源名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDataset/title",
+      "source_sha256": "6023a9c1af11b9c6aac41e09a8e47dd6114740f717eba442d22e64601159cf54"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_info/description",
+      "value": "数据源特定的元数据（如有）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_info/title",
+      "source_sha256": "04fc73b8bbb0b1fd1a8bcb259069d7a0107de9f8eb895eaee40b81077b977e8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_type/description",
+      "value": "数据源类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/data_source_type/title",
+      "source_sha256": "33b74328b9f236ef6812c5cff5ecef84f1183c8d16b6eef355f0893874f1740f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/enabled/description",
+      "value": "文档是否已启用检索。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/error/description",
+      "value": "索引错误；未发生错误时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/id/description",
+      "value": "资源 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/indexing_status/description",
+      "value": "排队文档的当前索引状态。使用响应中的 `batch` 调用[获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 查看各阶段进度；`completed` 和 `error` 为终态，`paused` 则需恢复后再继续轮询。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/indexing_status/title",
+      "source_sha256": "0e9f9e56beae96cbf001f47cbf57e75a00161f2a64189cc9a925e2fcfee2ac23"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/name/description",
+      "value": "资源名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineDocument/properties/position/description",
+      "value": "文档在批次中的位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineDocument/title",
+      "source_sha256": "fb0c2514b90b55b30c22e1c2c9bbc92941d52d1228aaffa3af0dcfa12aa84cf2"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/description",
+      "source_sha256": "e720357c655f0d8504f094ad48e40eaf5b907a615b2568ae86b34333504f9173",
+      "value": "要处理的数据源对象列表。`datasource_type` 决定条目结构：`local_file` 使用 `reference`；`online_document` 使用 `workspace_id` 和 `page`；`online_drive` 使用 `id` 和 `type`（可选 `bucket`）；`website_crawl` 使用 `url`。生成的 `oneOf` 分支顺序为本地文件、在线文档、网页抓取、在线云盘。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/description",
+      "value": "本地文件引用。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/properties/name/description",
+      "source_sha256": "bdba5238eae9e70a589c72ce1d90cd6895f8a411a8a24340bb8fcb15e39d5911",
+      "value": "文档标题。默认为 `untitled`。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/properties/reference/description",
+      "source_sha256": "5e091d8d1c537316b3e11a5452de5d966eac0a2490c76b53fe5baca8ecc576dc",
+      "value": "使用[上传知识流水线文件](/zh/api-reference/knowledge-pipeline/upload-pipeline-file)接口返回的 `id`。也接受 `related_id` 作为别名。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0/title",
+      "source_sha256": "688ebe6107db26f7618180df8437c03891bceb34944c4c01be2ced16c5c3534b",
+      "value": "本地文件",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/0",
+      "context_sha256": "0e2f602c7d62a412f8b454270fe416bcab16e1608f4c3361c5f3c5a6eb0577d6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/description",
+      "value": "在线文档供应商中的页面。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/credential_id/description",
+      "source_sha256": "400d744d30b3265e671530e329787eb5acb431bfea91549a033afff3f0df5661",
+      "value": "用于向外部平台进行身份验证的凭据。省略时使用提供商的默认凭据。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/page/description",
+      "source_sha256": "e655a6dafe66ca8c3b0c943aa1443d4bcd2548ea6acbc907ea8e8ff1f944f759",
+      "value": "页面详情。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/page/properties/page_id/description",
+      "source_sha256": "7442a8bf6acbcdc7e39ad20cbd468d77e9017f75382782b2a05a117d954cf22a",
+      "value": "在 Dify 中浏览已配置在线文档供应商的工作空间或数据库时，由供应商返回的页面 ID。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/page/properties/page_name/description",
+      "source_sha256": "04e23f39724084ed122c84c93bc85b208f82961e51b0d82c649bc9163ef6b6cd",
+      "value": "显示名称。默认为 `untitled`。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/page/properties/type/description",
+      "source_sha256": "e079791a74f171de31164b8e8ab36bc5b75b1ff8bb94b6c0a25f97b17041ee29",
+      "value": "数据源插件定义的页面类型。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/properties/workspace_id/description",
+      "source_sha256": "fe7985f91af3a78660419f2c00283978050d7045f952805d0195ba9374f218f8",
+      "value": "已配置在线文档供应商中的工作空间或数据库 ID。在 Dify 中选择或浏览该供应商时获取；这是供应商自己的资源 ID，不是 Dify 工作区 ID。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1/title",
+      "source_sha256": "b898200bc602b877c67fa42231265b54672cb38b8ae2b269fa10857ac7cee12b",
+      "value": "在线文档",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/1",
+      "context_sha256": "be9fe1b3a85ae1a924e70db06d79821d18f6e193206c329fa41f5644f0b2c66d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2/description",
+      "value": "要抓取的网站 URL。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2",
+      "context_sha256": "d1752d06316336af94c7d7bbb791a0f2be173d0acb6cad363268ef51b4d574a6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2/properties/title/description",
+      "source_sha256": "82a82aacba90f778862e58193523ee5b10a02fa8e2cf9d3f7a8f163a293a0cef",
+      "value": "用作文档名称。默认为 `untitled`。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2",
+      "context_sha256": "d1752d06316336af94c7d7bbb791a0f2be173d0acb6cad363268ef51b4d574a6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2/properties/url/description",
+      "source_sha256": "bf2f71ec2efab5bb740cd24a4b1db5883f188e5a9cde5c9574316e3e70c104de",
+      "value": "要抓取的 URL。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2",
+      "context_sha256": "d1752d06316336af94c7d7bbb791a0f2be173d0acb6cad363268ef51b4d574a6"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2/title",
+      "source_sha256": "63874e0a6751f26e7c1cdfd57fbaed4a1d0013723ea7bb783f14df82758f5050",
+      "value": "网页抓取",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/2",
+      "context_sha256": "d1752d06316336af94c7d7bbb791a0f2be173d0acb6cad363268ef51b4d574a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/description",
+      "value": "在线云盘供应商中的文件或文件夹。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/properties/bucket/description",
+      "source_sha256": "bb738428f6a8ca74729e9617a69c07e63b26dae1b7b2fca5ea44ca3ad4c96ac9",
+      "value": "存储桶名称。某些驱动器提供商（如兼容 S3 的存储）需要此字段；若提供商不使用存储桶则省略。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/properties/id/description",
+      "source_sha256": "e3d026c55577010814ff70c81e11a81451d20d5ea2eae3ac14df44326cf81b6b",
+      "value": "在 Dify 中浏览已配置在线云盘供应商时，由供应商返回的文件或文件夹 ID。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/properties/name/description",
+      "source_sha256": "e95f87d5b92c5d63e99d9c9877bf2e5d5d1de82a905acb83542241c46769d548",
+      "value": "文件名。默认为 `untitled`。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/properties/type/description",
+      "source_sha256": "07097d1144f0f71c4956d4b5ccc7643f611fa3b70737bd842eabaa4774766b43",
+      "value": "该条目是单个文件还是待展开的文件夹。",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3/title",
+      "source_sha256": "c35dacddac4d0a24d2a4f2d15a259a6b81aac87735652096552cac21400016be",
+      "value": "在线云盘",
+      "context_path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/items/oneOf/3",
+      "context_sha256": "394401fba045bc233b833d427853b68e5b8132bf65d249871d96d06e89a1d54b"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_info_list/title",
+      "source_sha256": "cd6d7537c927eb684756966236a5a1f5e0d2f5e55ebba093c75138182989f1b8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_type/description",
+      "source_sha256": "ffb9a08b2ee5438665b6281a13e258280b75dcae3e03773223361eb458226731",
+      "value": "数据源类型。决定 `datasource_info_list` 中条目所需的字段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/datasource_type/title",
+      "source_sha256": "1ddade5ac920148720355e512eb186d05c2511471941c47e4307d239b1f03f83"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/inputs/description",
+      "source_sha256": "fd26ef396b034063bce2847a15f605509722c15b765c769d871d2d71e989b4bc",
+      "value": "流水线输入变量的键值对，对应工作流中定义的流水线变量。如果流水线没有输入变量，传 `{}`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/inputs/title",
+      "source_sha256": "01b6ddb25b6f2d18d787b9d4f23ca4f1f6f3dfd22019c3259ac84f8b38f6c2d4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/is_published/description",
+      "source_sha256": "01dec585a5646788d17d8a662c199da00ce4d07ddd84461a8907e9226dd7a8cc",
+      "value": "是否运行知识流水线的已发布版本或草稿版本。`true` 运行最新已发布版本；`false` 运行当前草稿，适合测试未发布的更改。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/is_published/title",
+      "source_sha256": "395b36ad465f986da5892fd6e9406814b2759565c5d1f779fe60cd8e0822778a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/response_mode/description",
+      "source_sha256": "d0db0208fa573cafc24d176b8feeb80b45c37d88f047a74abd2fca7bf8c82fd6",
+      "value": "草稿运行的响应模式。SSE 使用 `streaming`，JSON 使用 `blocking`。已发布版本的运行会进入队列，并始终以 JSON 返回批次元数据。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/response_mode/title",
+      "source_sha256": "5d984affe6c3068760c69d7c9ed3a59a1754f0067ff13b5b96d79b27d69b08f9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/start_node_id/description",
+      "source_sha256": "4e4adb169d322a57c9af1f1f6f630bb1e40f5422ed67300405dac45f73efcc8d",
+      "value": "流水线起始数据源节点的 ID。数据源节点是知识流水线读取文件、供应商页面、云盘或 URL 的入口步骤。使用[获取数据源插件列表](/zh/api-reference/knowledge-pipeline/list-datasource-plugins)返回的 `node_id`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/properties/start_node_id/title",
+      "source_sha256": "db0a024b6472164f8f45fec7ee5b253de6284fa29e07f81859047dc90c100b9a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunApiEntity/title",
+      "source_sha256": "955e3596c1f8c89af4ddb61252a1c88f86872727d08b1aebc4b292e8f3a2325a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunJsonResponse/description",
+      "source_sha256": "28ff911df5f8eb8b5478e307e1006d5679ed9a267e0ceef0201048dd0593683c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineRunJsonResponse/title",
+      "source_sha256": "185e74bfde554c3700e0ab00bf434e6fd36ac0b4b44686ad3da95d65416e140b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_at/description",
+      "value": "上传时间戳（ISO 8601 格式）。在记录创建过程中可能为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_by/description",
+      "value": "上传文件的用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/extension/description",
+      "value": "文件扩展名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/id/description",
+      "value": "已上传文件的唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/mime_type/description",
+      "value": "文件的 MIME 类型。若上传未包含 MIME 类型则可能为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/name/description",
+      "value": "原始文件名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/size/description",
+      "value": "文件大小（字节）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PipelineUploadFileResponse/title",
+      "source_sha256": "bb113da90addfc75f941e3b9bf244282e60f799dbd26ea9b80c9c5382c8a5f8b"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PreProcessingRule/properties/enabled/description",
+      "source_sha256": "0c6591752d35c3cffc5b32de08298a6574363d88234675d703b320df9ca7938a",
+      "value": "该预处理规则是否启用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PreProcessingRule/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/PreProcessingRule/properties/id/description",
+      "source_sha256": "cf07210fbf1d45fdb43d7b62c207cd4d8e259e1468587085c8c320acf6de0295",
+      "value": "规则标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PreProcessingRule/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PreProcessingRule/title",
+      "source_sha256": "b47661a7f70c18c954a02974b77463a163376487ee6eeb8af10a2a27533f5e2a"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ProcessRule/properties/mode/description",
+      "source_sha256": "c44a2118d2b146d7beee0819a314a1a89d17112dc4bc2d727da2c3ffae3dc8c0",
+      "value": "处理模式。`automatic` 使用内置规则，`custom` 允许手动配置，`hierarchical` 为 `doc_form: hierarchical_model` 启用父子分段结构。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ProcessRule/properties/rules/description",
+      "source_sha256": "0f3d18211c81a669a4579d0b293bf94ddcc0848fbe09bddfb42a18d77dfe093f",
+      "value": "自定义处理规则。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProcessRule/title",
+      "source_sha256": "db324a07cd05b37002bb411f1e0343864d8b699abca97ce06b54d79e38f206ab"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ProcessRuleMode/description",
+      "source_sha256": "181d70e1dafe300a8a07da29dee3247636f0c284d2ba40aa2e8ad46be605c13c",
+      "value": "知识库处理规则模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProcessRuleMode/title",
+      "source_sha256": "f7358171c8ee1b08f0e4d52870e721480d33b88cf4cb44f0d1aba51a48a94945"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/description",
+      "source_sha256": "3d2823aa3f3eebcb83c6ea80680a0166bf2edf32d9704ebd8770c18a7e25ce95",
+      "value": "模型响应的数据模型。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/deprecated/description",
+      "value": "模型是否已弃用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/deprecated/title",
+      "source_sha256": "80f6e3262ddc9dbae4b5543d8cf1ab8d4f3111645716a73c9db7c288ae591d8e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/features/description",
+      "value": "模型支持的功能，无功能时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/features/title",
+      "source_sha256": "5ba7137beafc546fd1f158261c26eb856fc806b187977a07566494355e9e4e9b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/fetch_from/description",
+      "value": "模型定义的来源。`predefined-model` 表示内置模型，`customizable-model` 表示用户自配置的模型。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/has_invalid_load_balancing_configs/description",
+      "value": "模型是否存在无效的负载均衡配置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/has_invalid_load_balancing_configs/title",
+      "source_sha256": "7944103f90c86b8d1aa059b20991fcdc85dcbd16bea56e1f1f72944059551055"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/label/description",
+      "value": "模型的本地化显示名称。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/load_balancing_enabled/description",
+      "value": "模型是否启用负载均衡。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/load_balancing_enabled/title",
+      "source_sha256": "19d609f1ad9452998e7a4548bb2dc9b68ae73367a62fef6eaff1a7893ea0023d"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model/description",
+      "value": "模型标识符。创建或更新知识库时，将此值作为 `embedding_model` 参数使用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model/title",
+      "source_sha256": "9c16c09f0c180580bcc75cd99dc16eb9764abe7902e6a19ba4d7adbd28d66b22"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model_properties/description",
+      "value": "模型特定的属性，例如 `context_size`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model_properties/title",
+      "source_sha256": "a32671a4e6f39b5933657bb99b6017c623de24878be588c6c92333f03358fdb0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/model_type/description",
+      "value": "模型类型，与 `model_type` 路径参数匹配。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/properties/status/description",
+      "value": "模型可用状态。就绪时为 `active`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderModelWithStatusEntity/title",
+      "source_sha256": "4846d901d44580e734dbead0b947dcd6321d9be04ad58e95a872a204a06801c9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsListResponse/properties/data/description",
+      "value": "模型提供商及其可用模型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsListResponse/title",
+      "source_sha256": "2039f710e47e27c0a7fdab1fa3984269c5c5a108e9e1ca86691f8ae79fbc9dfc"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/ProviderWithModelsResponse/description",
+      "source_sha256": "1017c70595c87071231c967363412e90d34bd0e308519a92d8b1521f9197d818",
+      "value": "包含模型列表的提供商响应数据模型。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/icon_small/description",
+      "value": "供应商小图标的 URL。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/icon_small_dark/description",
+      "value": "深色模式图标 URL；供应商没有时为 `null`。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/label/description",
+      "value": "供应商的本地化显示名称。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/models/description",
+      "value": "该供应商的可用模型列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/models/title",
+      "source_sha256": "527919df30e60438b9999d570aca82ff0214c59755ad69ea14a15900b5b06c26"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/provider/description",
+      "value": "模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。旧版供应商可能返回简写形式（例如 `openai`）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/provider/title",
+      "source_sha256": "33f9a30399fa52a1648f4bd30220cddb2f45eda8b95b8908bdd06a5d74a1733f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/status/description",
+      "value": "供应商状态。凭证已配置且有效时为 `active`。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/tenant_id/description",
+      "value": "该供应商配置所属的工作空间 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/properties/tenant_id/title",
+      "source_sha256": "ae18aae49d3ccc237cd61077f9e1235aa293a131da760623f83eab7b5e51d944"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/ProviderWithModelsResponse/title",
+      "source_sha256": "74970e98a1a9d36c34558a5528dd394784820e4d57c0d69d26e6d51629ad66d5"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/batch/description",
+      "value": "已排队发布运行的批次 ID。将其作为 `batch` 传给[获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status)，轮询直到所有文档完成、失败或暂停。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/batch/title",
+      "source_sha256": "026b89e52976b2603339b009c7e7547467948fb0753001d02deaa79180427305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/dataset/description",
+      "value": "接收生成文档的知识库。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/documents/description",
+      "value": "已创建并排队等待索引的文档。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PublishedPipelineRunResponse/properties/documents/title",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/PublishedPipelineRunResponse/title",
+      "source_sha256": "54d7f59fdb352a4ea87c5ea8cb76db25797e51ea2335cc3fe0059db53302f455"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/RequiredServiceApiUserPayload/properties/user/description",
       "source_sha256": "ab923e235359aec4f9d0287a1218b216126bb2a35f676e6b747057372ae740d1",
       "value": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。"
@@ -5571,6 +10457,33 @@
       "op": "remove",
       "path": "/components/schemas/RequiredServiceApiUserPayload/title",
       "source_sha256": "a1269019db4ddc7c919d3b0447ea781251fcad5e3c189d0d8214785fae80891d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RerankingModel/properties/reranking_model_name/description",
+      "source_sha256": "ee6fe6577ff8467ec5541d84b9d253b1f0de6352fe81751a1223c2764fd9238b",
+      "value": "重排序模型名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RerankingModel/properties/reranking_model_name/title",
+      "source_sha256": "84c57945febff99bd6d302f456cc0c67177d5564c52716407f118e8f2e8fc041"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RerankingModel/properties/reranking_provider_name/description",
+      "source_sha256": "95f6e1128a6b5d7341df3c940361ff1f505f29d5e9eeedc0d4abae744c96ebc5",
+      "value": "重排序模型的提供商名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RerankingModel/properties/reranking_provider_name/title",
+      "source_sha256": "60b41a32b54ab0b9acf6ad2d6c68ee0ff1e2ad26650e94e289f4265e71a59581"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RerankingModel/title",
+      "source_sha256": "6fb75a747a4a0129024d0e632a601000492365b2046eaac090c6f52ed37e038e"
     },
     {
       "op": "add",
@@ -5586,6 +10499,95 @@
       "op": "remove",
       "path": "/components/schemas/ResultResponse/title",
       "source_sha256": "01088850b9c319d53d821afeaed65bffdaeb842f51b877c8b03a85f6877dc8da"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalMethod/title",
+      "source_sha256": "8dc47bb74955cfa3a214f19059c03082323843025859295239a41a0b06bc93a4"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/metadata_filtering_conditions/description",
+      "source_sha256": "abf53f9c3f2b2c7614317ea23626504a844350664358776674d4064ca116d991",
+      "value": "仅检索文档元数据匹配指定条件的分段。条件由服务端基于文档元数据字段评估。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_enable/description",
+      "source_sha256": "b6b8e3bc6134f3ffb903b2ac00f11480b0ae9ae497ffbf706adbfd7bca94738b",
+      "value": "是否启用重排序。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_enable/title",
+      "source_sha256": "cc1894711ba2670a7ad95df9cb248ff4496427dc4e61eefde0f555ebdaeec218"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_mode/description",
+      "source_sha256": "3b53822617108def0a31fd3ce6ce083d305208583c1df3e3e53124024ec1a2e5",
+      "value": "重排序模式。当 `reranking_enable` 为 `true` 时必填。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_mode/title",
+      "source_sha256": "f5301c9027acd776f86cf98e696814c2b9404bfe29ccf772a75b020694c93dd5"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/reranking_model/description",
+      "source_sha256": "7c347c0c4a61c16b067204d5853cb812c02a0f2d4c5193480c1043c8009ec89c",
+      "value": "重排序模型配置。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold/description",
+      "source_sha256": "9226e3718348835b029623af75bfa41d9b2cb610ebbaea42858a3ac7420971af",
+      "value": "最低相似度分数，取值范围为 0 到 1。仅在 `score_threshold_enabled` 为 `true` 时生效。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold/title",
+      "source_sha256": "f7d49f37ed945025c5f9027ac1cb7f3e3bf65dcf54d73990dc6c9bf06bcac452"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold_enabled/description",
+      "source_sha256": "a07d7e9732d41dda023d175736f5f250a7d8640eac5a2ccebfd5131382895752",
+      "value": "是否启用分数阈值过滤。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/score_threshold_enabled/title",
+      "source_sha256": "33e7b2a6e80860238254ee394cff0875c97ba3ba486bd89f1919f34dfe77abc9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/search_method/description",
+      "source_sha256": "c6d6f6ede9f6643c63563e09f8f5046070feff52b418770d7ea60ca86f4e027e",
+      "value": "用于检索的搜索方法。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/top_k/description",
+      "source_sha256": "e1c44a06a752a0b9f03931c5962fc46ebf9f68f6a80f8195cff1853a9276c2d8",
+      "value": "返回的最大结果数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/properties/top_k/title",
+      "source_sha256": "08cf18c91d1b734279713b3783ef3a997cda93cc0aab4059885a3dfc3159c81c"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/RetrievalModel/properties/weights/description",
+      "source_sha256": "4f8272c508c50c30ddeb5218ab8d62b31d3a3fe5fe689f2407409d06e541a348",
+      "value": "混合搜索的权重配置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/RetrievalModel/title",
+      "source_sha256": "666a988293a7f6ae869835747dcd92b2bd1a79f3b04646f6f12c185760fa6a03"
     },
     {
       "op": "add",
@@ -5769,6 +10771,220 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/Rule/properties/parent_mode/description",
+      "source_sha256": "47817b6deed2493ccac0bcf385f8767c5c54a96ff1f8c8e8ff571e2b59027504",
+      "value": "父子分段模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Rule/properties/parent_mode/title",
+      "source_sha256": "7a3e4b03c8e473c363780e217ac31d5296d3f1648ce487f28f4dd3adad1fd479"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Rule/properties/pre_processing_rules/description",
+      "source_sha256": "29779ba7f198b5d81b88fe1aaf2bd82a131ea50a205862e4d34a5dac6f8b5e99",
+      "value": "分段前应用的预处理规则。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Rule/properties/pre_processing_rules/title",
+      "source_sha256": "7d3e0cda2e0c21c0badc4a3b16dc3dfbcf035b66e7f855204ec0c1caf94463e9"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Rule/properties/segmentation/description",
+      "source_sha256": "10b372c1699c661c4a26dddb73d0e96a7d72e5a00ce239dbe5aa1f5cd8ea35f7",
+      "value": "父分段设置。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Rule/properties/subchunk_segmentation/description",
+      "source_sha256": "fd1399c5cc8fec7d2e030b2b88f42ad58f897d997f2741135d5f6b78163d6e04",
+      "value": "子分段设置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Rule/title",
+      "source_sha256": "37b145ea2f8c75d011310872a13d8691600428522327e9fa756408228cf0a916"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/extension/description",
+      "value": "文件扩展名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/extension/title",
+      "source_sha256": "a287357505b10bcc678605183b8a260719798057532020149b8673395478d36c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/id/description",
+      "value": "附件文件标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/mime_type/description",
+      "value": "文件的 MIME 类型。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/mime_type/title",
+      "source_sha256": "f6989c89c76bd36b2f820cc513de1076909f7d38e635bac20a42e768741f8e24"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/name/description",
+      "value": "原始文件名。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/size/description",
+      "value": "文件大小（字节）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/size/title",
+      "source_sha256": "60bb3338e0ad558c986d5dd4e957de1185ad02fdfa4edd6640c5c2bd0b97826e"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/source_url/description",
+      "value": "访问附件的 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/properties/source_url/title",
+      "source_sha256": "3d48f2577f877973dd0a3ab85975e367b5a9ab1964eb533d2cb3dd317134d453"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentAttachmentResponse/title",
+      "source_sha256": "265200114ec0ead4db2faf6278176361627bebcfabd2e0e399427f0c83132bc2"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/answer/description",
+      "source_sha256": "1c8774c8bb747a52e3cda74e99ac6d8915c11bbe47a7852a894e8a01f38aafe2",
+      "value": "问答模式的答案内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/attachment_ids/description",
+      "source_sha256": "146aa83a6e739feddb11f5165b492a60423ceb0d5b3254f84eec28fb6b4ddefa",
+      "value": "附件文件 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/attachment_ids/title",
+      "source_sha256": "477c1e5aa9f364630218d09c7e51bb851e632ef1f297ec491ef9e34c725bbcbd"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/content/description",
+      "source_sha256": "71ea7409b90e3003086ef8b0e331d337221966b33bcbe9f925927943ed8b4d5e",
+      "value": "分段文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/keywords/description",
+      "source_sha256": "e228361b7e8dacce7abb9f2a574065bc3e05f422294da5df3f4e5477da2b93d5",
+      "value": "分段的关键词。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateItemPayload/title",
+      "source_sha256": "794a619a5d9edb158a3ad415c72c23e2a276867117a567944f304eda604f25de"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/data/description",
+      "value": "已创建的分段列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/doc_form/description",
+      "value": "该文档使用的分块模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateListResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreateListResponse/title",
+      "source_sha256": "dddf326520ef179531d516395a20cdbc4f559439373f3d4caeaaf49e0daa8cc5"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentCreatePayload/properties/segments/description",
+      "source_sha256": "2d20feba674600400168bc8afcf74569c1b96c94ab0c1076c5c4e4690c8eb08e",
+      "value": "要创建的分段对象数组。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreatePayload/properties/segments/title",
+      "source_sha256": "505d8419cf4cc5e1048ae6b568b094d437dfbcb7e2beaa3ef069b7453ae04453"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentCreatePayload/title",
+      "source_sha256": "fb73672ae57c80d6fa43473e94455557ad048ea74aff2ede203d05216feb6bf0"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentDetailResponse/properties/data/description",
+      "value": "已创建的分段列表。"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentDetailResponse/properties/doc_form/description",
+      "value": "该文档使用的分块模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentDetailResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentDetailResponse/title",
+      "source_sha256": "0de38d68419929d7e241177982f8f3ed9101460431e000c55ae2a36b3cbfc25f"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/SegmentListQuery/properties/keyword/description",
       "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
       "value": "搜索关键词。"
@@ -5815,6 +11031,477 @@
       "op": "remove",
       "path": "/components/schemas/SegmentListQuery/title",
       "source_sha256": "0cd59385c6acbfa47454f1681728f3753d5b551e24e8ca993624fd336f64d154"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/data/description",
+      "value": "分段列表。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/data/title",
+      "source_sha256": "9dbfe00da249a44cb151cceca2860f71644dbc35730492cec5ebf104400f33ea"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/doc_form/description",
+      "value": "该文档使用的分块模式。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/doc_form/title",
+      "source_sha256": "2b736036f1afa110851ec8b903366ea7f9936b7760a2dab97ed34fa6f572446c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/has_more/description",
+      "value": "下一页是否还有更多项目。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/has_more/title",
+      "source_sha256": "ee30512bba4563825ee3b23454eb26ee9c90ce13cf90120ecb37a874f08a9cb9"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/limit/description",
+      "value": "每页条目数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/limit/title",
+      "source_sha256": "b663de8ac40f928cf87f61293bfbb44e140f2c2e5ebfa44a673b3896481ab415"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/page/description",
+      "value": "当前页码。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/page/title",
+      "source_sha256": "8bbbede63344badfcc6757ee207c821c60144c37dacb11b776e7886e60d377e8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentListResponse/properties/total/description",
+      "value": "匹配的分段总数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/properties/total/title",
+      "source_sha256": "bba745e2169cdf3c7fdd32f89c40fec79d230a8b3b07720a22a9be5aa9086579"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentListResponse/title",
+      "source_sha256": "baab7d72cdb208fbaca82b5d478ffc03ce2e8e05fdaca092bf5723f62cb924ef"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/answer/description",
+      "value": "回答内容，用于问答模式文档。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/attachments/description",
+      "value": "附加到该分段的文件。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/attachments/title",
+      "source_sha256": "7598bc1dde680e28fe88f4627a34b7dc34e02c54caa57e6df303af05e73856a6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/child_chunks/description",
+      "value": "属于该分段的子分段。仅在分层模式文档中存在。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/child_chunks/title",
+      "source_sha256": "bd2ab3b4c807f0086a23c8bcf021f57f9516f43bc3b3577bf84f78237dd361e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/completed_at/description",
+      "value": "完成时间，Unix 秒级时间戳；未完成时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/completed_at/title",
+      "source_sha256": "d962fe267dc5e24ab36e25f0e5e927fd56bfe226e903620532b174af72cb594b"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/content/description",
+      "value": "分段的文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/created_at/description",
+      "value": "创建时间戳（Unix 纪元，单位为秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/created_at/title",
+      "source_sha256": "38ec7a36c25064b3be215f6f8d216340f387c5ed586174713ca6e100aee125c4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/created_by/description",
+      "value": "创建该分段的用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/created_by/title",
+      "source_sha256": "358e44292ff4980bb0ac6c728ede024d89105fc5e12f6504ba2cde3ca19e86b6"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_at/description",
+      "value": "停用时间，Unix 秒级时间戳；启用时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_at/title",
+      "source_sha256": "277df9b160daf7f42774957e52c01d6f711c53e44dbf02ab55ac288cc21863e4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_by/description",
+      "value": "禁用该分段的用户 ID。启用时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/disabled_by/title",
+      "source_sha256": "40889b0d922bf0f08c7529d489c9c4ef3912b856b561e8428bbb77dd06d83d13"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/document_id/description",
+      "value": "该分段所属文档的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/document_id/title",
+      "source_sha256": "4fbe8a79f7cb45a68876bda5f9489bbd943cf4dde54c5ef3884a148110f17c01"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/enabled/description",
+      "value": "该分段是否启用检索。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/error/description",
+      "value": "索引失败时的错误消息。无错误时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/error/title",
+      "source_sha256": "fc4ac19649f0ee8f37c71d2e2030a3743038bb96c0c27359ba115dd8657565cc"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/hit_count/description",
+      "value": "该分段在检索查询中被匹配的次数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/hit_count/title",
+      "source_sha256": "8d38aafd2ed6edc2c37413545b3822a27102ea77ca41d70505857ae582765af8"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/id/description",
+      "value": "分段的唯一标识符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/id/title",
+      "source_sha256": "2aa085cd6a10506c7a54d3a445d856b22812cd6b22affbebb32669cde7be885c"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_hash/description",
+      "value": "索引内容的哈希值，用于检测变更。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_hash/title",
+      "source_sha256": "73b29a982ccdee085442eeb5711aa5d80fcbcf54ab5ba3b3f4d8011be8da2599"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_id/description",
+      "value": "向量存储中索引节点的 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/index_node_id/title",
+      "source_sha256": "0d45b0d6da2c05390b91146a6cd5de5845c26e58431ba1174c3e3c0793192b42"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/indexing_at/description",
+      "value": "索引开始时间，Unix 秒级时间戳；未开始时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/indexing_at/title",
+      "source_sha256": "3d4b6de81308d36e9b8544959f48c914d42c529120fa60ad2e08922d6b60fa8a"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/keywords/description",
+      "value": "与该分段关联的关键词，用于基于关键词的检索。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/position/description",
+      "value": "分段在文档中的位置。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/position/title",
+      "source_sha256": "9da0cbfad144d737214fb221351c773c3bc2b2f6d16d682c85aa2817533ef5ed"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/sign_content/description",
+      "value": "用于完整性验证的签名内容哈希。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/sign_content/title",
+      "source_sha256": "0b01a836c72cea937f5dc68e84213e59c3dc45e8a385ac28588608ab9c00bea4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/status/description",
+      "value": "分段的当前索引状态，例如 `completed`、`indexing`、`error`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/status/title",
+      "source_sha256": "7eeef5d986492416cd588a4fe5069857e7dccf9adc3780e491a38674bfd7ea19"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/stopped_at/description",
+      "value": "索引停止时间，Unix 秒级时间戳；未停止时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/stopped_at/title",
+      "source_sha256": "e6760f92f5dde2261be331d6fdc428cb187032976d9229b4171e068dc69a82d1"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/summary/description",
+      "value": "AI 生成的分段内容摘要。未启用摘要索引时为 `null`。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/tokens/description",
+      "value": "分段内容的令牌数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/tokens/title",
+      "source_sha256": "990a1a9b6f25facef6b315d11b206d0bcaaa2946859f92430e709a6ac184be98"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/updated_at/description",
+      "value": "最后更新时间戳（Unix 纪元，单位为秒）。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/updated_at/title",
+      "source_sha256": "a4d4644ca7c34c2bd984d93509178138bf0e1bf4cf45759a339d074f38e11204"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/updated_by/description",
+      "value": "最后更新该分段的用户 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/updated_by/title",
+      "source_sha256": "6b595a302a4b98836b4b277762776908278d6090a198a6ae17e592b71b68abb4"
+    },
+    {
+      "op": "add",
+      "path": "/components/schemas/SegmentResponse/properties/word_count/description",
+      "value": "分段内容的字数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/properties/word_count/title",
+      "source_sha256": "53e1053affde87e6dd73e12eabf686300a29f89364632df1a841a6b4598e6ef8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentResponse/title",
+      "source_sha256": "6404bd1128525d136b6a45e73b2694505f049c8e1e75ea00de143fd3e1b7fd0d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/answer/description",
+      "source_sha256": "ac824f4dcddbab22f3ce9dc7e3d6c13381d6320494435a7d45541c01cdce650c",
+      "value": "问答模式更新后的答案内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/answer/title",
+      "source_sha256": "204450777f959cf54d4573ae7879f98f72352aabb63adaf9ae0f891ce11c3bde"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/attachment_ids/description",
+      "source_sha256": "146aa83a6e739feddb11f5165b492a60423ceb0d5b3254f84eec28fb6b4ddefa",
+      "value": "附件文件 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/attachment_ids/title",
+      "source_sha256": "477c1e5aa9f364630218d09c7e51bb851e632ef1f297ec491ef9e34c725bbcbd"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/content/description",
+      "source_sha256": "a6fed04d64a04b5e81e04b54f9f44784d8d951fcaae249943e2e50b90fda2d7b",
+      "value": "更新后的分段文本内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/content/title",
+      "source_sha256": "57170bb74dc9d2ec590ce3213b0281f3483d8ea7d0e091ed13685e1c82db5815"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/enabled/description",
+      "source_sha256": "653a843fd539b8f89e946e500768ea941b52485c19de704ccbaf43686ddc3b40",
+      "value": "分段是否已启用。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/enabled/title",
+      "source_sha256": "847ced6ca02b78495373bb6d354a2f2451b40c8abdc5f20b04cfb568d57cc764"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/keywords/description",
+      "source_sha256": "765dbfdf86518f438f476e0e8fb37f019d873f0db584bd0c80b53117b2a2a6e9",
+      "value": "更新后的分段关键词。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/keywords/title",
+      "source_sha256": "b1e4722e5f8de34a8efe2240d57aec7e58b6f0a57e7d60189528f904f99077e3"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/regenerate_child_chunks/description",
+      "source_sha256": "17bb6ad58368cf7dea1246c975d2bb9fe29d556712ba97758999cb650fcb8d1f",
+      "value": "更新父分段后是否重新生成子分段。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/regenerate_child_chunks/title",
+      "source_sha256": "ec2820d3e42e3b34773484ca6c60e83ca7f205079caee9687775965d359aeb16"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/summary/description",
+      "source_sha256": "9b15e7c8c612b713dc47e670fb607972b6795f86d1c6c84e3aeaadb7ce777a99",
+      "value": "摘要索引的摘要内容。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/properties/summary/title",
+      "source_sha256": "485e809dae73c0d0ec72f8ac89dcbb34df25338ca55df990523010ee7891394f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdateArgs/title",
+      "source_sha256": "55d5ccff6c4f6d836ca1e8f0f130b687b3230266fdd5f69979908c39497cef9f"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SegmentUpdatePayload/properties/segment/description",
+      "source_sha256": "2f13c057f9e5d3e9a30dba43c8c80f9e5daae7378098cf14b4da7b89f38f0868",
+      "value": "分段更新载荷。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/SegmentUpdatePayload/title",
+      "source_sha256": "83e2265607c3090491856b9685849cb09461ed67bd933e662bf5e63e09685e42"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Segmentation/properties/chunk_overlap/description",
+      "source_sha256": "3971f5487af563a9fd717f1e6071497e03f2ab7ee852542be9a5dc513b458ff2",
+      "value": "分段之间的令牌重叠数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/properties/chunk_overlap/title",
+      "source_sha256": "1258b5681185c4c7c54b1eb931d232bc406095510421aff6ce0402837bbc0b12"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Segmentation/properties/max_tokens/description",
+      "source_sha256": "224e44872fb822ec84993241fcfd7777819f15c0eb3f0c0f6daf9f215d17e318",
+      "value": "每个分段的最大令牌数。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/properties/max_tokens/title",
+      "source_sha256": "c61948210aa9aa4ef842ff5b6e9beeb2f03177494459a33b35ef16a9bf64d175"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/Segmentation/properties/separator/description",
+      "source_sha256": "716e4b8d3f2cf08942737d72c44913ea805d4601e5349c0a0029a88b78a57146",
+      "value": "用于拆分文本的自定义分隔符。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/properties/separator/title",
+      "source_sha256": "acb8cb92b3674b508ab3d2eeebb1d7be4c00ce16dcbf8a973c743d57ad98bb17"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/Segmentation/title",
+      "source_sha256": "bd314aba55c9dbea14be93c16834e7dca8525f07640c58453b0f3f1766ac66a1"
     },
     {
       "op": "add",
@@ -6334,6 +12021,165 @@
     },
     {
       "op": "replace",
+      "path": "/components/schemas/TagBindingPayload/properties/tag_ids/description",
+      "source_sha256": "7cd1d6356651bdbafde8e8a450e4b972aa782fdeadeb6ea365e87f156a9f290f",
+      "value": "要绑定的标签 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagBindingPayload/properties/tag_ids/title",
+      "source_sha256": "185b1bbb86d24865700f4807ef17e5b4cfb00f26b994b81ed2961a16a08296b8"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagBindingPayload/properties/target_id/description",
+      "source_sha256": "4195040703f5cc998c6bf1fa04d556a88d3039b1f3e27ddfcccfd26d7ed0f250",
+      "value": "要绑定标签的知识库 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagBindingPayload/properties/target_id/title",
+      "source_sha256": "18bb786a77f9223c415b1aa4070c075e937065392d6775984cb969cc55b2245f"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagBindingPayload/title",
+      "source_sha256": "6912ed857c175a6876a684bbae51d94fd6ffbcec215e8f4acc34d6caf5348b8d"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagCreatePayload/properties/name/description",
+      "source_sha256": "56553c9544fcd74c2fa01c28faaf5387d82fc12d0d01ef5f07a7b2068b7e5128",
+      "value": "标签名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagCreatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagCreatePayload/title",
+      "source_sha256": "1ec17ce70ed4907e7fce6cb288629467e2459c357751367caff686a329ec0745"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagDeletePayload/properties/tag_id/description",
+      "source_sha256": "bc6d6da389505431b0818ecf8630fcd5bbbab380894977bad77e21fd290acbb7",
+      "value": "要删除的标签 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagDeletePayload/properties/tag_id/title",
+      "source_sha256": "298f8188e097a31d884ebc26e9900e5733bf6392046442e14d2993fe56b386f8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagDeletePayload/title",
+      "source_sha256": "c01697f6d6ef0b466cd8423bf40254e1fa3ca4da7266c35895b3fba0dd469022"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/0/properties/tag_id/description",
+      "source_sha256": "d2e8a9ade687a80f23be1d30e149ce88015f2c3b99e0b05ad0cc717de73f28bd",
+      "value": "Service API 兼容的旧版单个标签 ID。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/0",
+      "context_sha256": "8a2c4bf85948b5affc685aab7be95e8daf35d62ec20349da5e4c4789dd7f4372"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/0/properties/tag_ids/description",
+      "source_sha256": "f411ff70b5e6411aa8d211f0927cd25e3ef73e56a3faa3027237512e7303e6b5",
+      "value": "要解除绑定的标签 ID。新集成请使用此字段。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/0",
+      "context_sha256": "8a2c4bf85948b5affc685aab7be95e8daf35d62ec20349da5e4c4789dd7f4372"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/0/properties/target_id/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/0",
+      "context_sha256": "8a2c4bf85948b5affc685aab7be95e8daf35d62ec20349da5e4c4789dd7f4372"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/0/properties/target_id/title",
+      "source_sha256": "18bb786a77f9223c415b1aa4070c075e937065392d6775984cb969cc55b2245f",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/0",
+      "context_sha256": "8a2c4bf85948b5affc685aab7be95e8daf35d62ec20349da5e4c4789dd7f4372"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/1/properties/tag_id/description",
+      "source_sha256": "d2e8a9ade687a80f23be1d30e149ce88015f2c3b99e0b05ad0cc717de73f28bd",
+      "value": "Service API 兼容的旧版单个标签 ID。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/1",
+      "context_sha256": "daed8c26e0d1721cb98aa92cb51810ea4f811864ce0f7da2dd1583fca56fd134"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/1/properties/tag_ids/description",
+      "source_sha256": "f411ff70b5e6411aa8d211f0927cd25e3ef73e56a3faa3027237512e7303e6b5",
+      "value": "要解除绑定的标签 ID。新集成请使用此字段。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/1",
+      "context_sha256": "daed8c26e0d1721cb98aa92cb51810ea4f811864ce0f7da2dd1583fca56fd134"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/1/properties/target_id/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/1",
+      "context_sha256": "daed8c26e0d1721cb98aa92cb51810ea4f811864ce0f7da2dd1583fca56fd134"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUnbindingPayload/anyOf/1/properties/target_id/title",
+      "source_sha256": "18bb786a77f9223c415b1aa4070c075e937065392d6775984cb969cc55b2245f",
+      "context_path": "/components/schemas/TagUnbindingPayload/anyOf/1",
+      "context_sha256": "daed8c26e0d1721cb98aa92cb51810ea4f811864ce0f7da2dd1583fca56fd134"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUnbindingPayload/description",
+      "source_sha256": "017aca34d2c926dddc2bdece7a08b6c8584e8dd0c4055c321b240e53d3499dcd",
+      "value": "接受旧版 `tag_id` 载荷或标准化的 `tag_ids` 载荷。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUnbindingPayload/title",
+      "source_sha256": "4ed4b86ecca9595c8a2175f84db1d7d728c92ca7caf1df789acd8a33f5bf7efe"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUpdatePayload/properties/name/description",
+      "source_sha256": "56553c9544fcd74c2fa01c28faaf5387d82fc12d0d01ef5f07a7b2068b7e5128",
+      "value": "标签名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUpdatePayload/properties/name/title",
+      "source_sha256": "6cc5df35f0338e230e9e633ead9991f08f62cab45a3264978daedc6747867305"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/TagUpdatePayload/properties/tag_id/description",
+      "source_sha256": "c6bd4fb363813f0336a41316afd5bb58c08e8b6fd14e8bf5be044550e97fedb4",
+      "value": "要更新的标签 ID。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUpdatePayload/properties/tag_id/title",
+      "source_sha256": "298f8188e097a31d884ebc26e9900e5733bf6392046442e14d2993fe56b386f8"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/TagUpdatePayload/title",
+      "source_sha256": "1f28aef19bd0c3355b03284bf1367133e716e2f8897e283387a3faac4b1f7ccb"
+    },
+    {
+      "op": "replace",
       "path": "/components/schemas/TextToAudioPayload/properties/message_id/description",
       "source_sha256": "47f5efd48161cf7478427652060c2fbe41c0ffd3adea29c80a7e92824fb6f704",
       "value": "消息 ID。同时提供时，其优先级高于 `text`。"
@@ -6462,6 +12308,21 @@
       "source_sha256": "25ff44cb5514b1148a3243ce18e6135333123c6a437c924be3bd88f8be03028f"
     },
     {
+      "op": "add",
+      "path": "/components/schemas/UrlResponse/properties/url/description",
+      "value": "用于下载原始上传文件的签名 URL。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UrlResponse/properties/url/title",
+      "source_sha256": "0146bf069164386d9cbddfbb77eed14df29c3fbf0326244f5676fc1c06a30963"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/UrlResponse/title",
+      "source_sha256": "2dc437c1ca3d8756e3cf32966ba1e41fa5528de46dfec816612b0dba45e2bfc3"
+    },
+    {
       "op": "replace",
       "path": "/components/schemas/UserActionConfig/description",
       "source_sha256": "8335dbe54deb6d63d84583f2441b28057935bc5a7df092b6bb344bfd813b5f78",
@@ -6507,6 +12368,88 @@
       "op": "remove",
       "path": "/components/schemas/ValueSourceType/title",
       "source_sha256": "b27082732c38a38ed5997a127490a1121fdd96ed9079027df4ac09ff3e557856"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightKeywordSetting/properties/keyword_weight/description",
+      "source_sha256": "21c5fa00a0b4389101d5b387dec82085ec9797951766458bc2a5e0cea339dce2",
+      "value": "关键词检索权重，取值范围为 0 到 1。使用 `customized` 权重时，应与 `vector_weight` 相加等于 1。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightKeywordSetting/properties/keyword_weight/title",
+      "source_sha256": "577b14638d81d6d6c18433bcef87546069492150025ba80645a9ef107e8f9eb0"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightKeywordSetting/title",
+      "source_sha256": "4caae01e8644e200975766b29aa75b4669b97927984b55c555d483fe6956c374"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightModel/properties/keyword_setting/description",
+      "source_sha256": "a7d7742c1f5e3084d4e14da7cfecbd060e8d3331688081d096612f8bb11e370d",
+      "value": "关键词搜索权重设置。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightModel/properties/vector_setting/description",
+      "source_sha256": "67ac9f655ef66fccfd7cd13935099a6370a25994044620628e1a296af07d9159",
+      "value": "语义搜索权重设置。"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightModel/properties/weight_type/description",
+      "source_sha256": "274fb7d9ca59b2d9b3b90159e951c3edbcb6c0b2847b6ff71f4b687f87c80034",
+      "value": "平衡语义搜索和关键词搜索权重的策略。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightModel/properties/weight_type/title",
+      "source_sha256": "2e0fc6f3749fdbeac0065d9c56f1ce8fcdd30d133b1a8c00b5f42eda78ce8b2a"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightModel/title",
+      "source_sha256": "a0018f00973cb6f88d2cf5e2d013ea57b3bcb0f83d02e574b9010d1bfbebfce2"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightVectorSetting/properties/embedding_model_name/description",
+      "source_sha256": "b5a2b85a16a67eb58acc836bd6ca6e8d2f11c1fdec476de0c1c9b77293c26002",
+      "value": "用于向量搜索的嵌入模型名称。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/properties/embedding_model_name/title",
+      "source_sha256": "4d79d966137d5bf514424da3770d0535ef6289a20ce67d7d5be6038198ccd6bf"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightVectorSetting/properties/embedding_provider_name/description",
+      "source_sha256": "d0ed4932ead6cc30dffb91ac47acf5c952514e2a461259841468e0f5f45eb2ba",
+      "value": "用于向量搜索的嵌入模型供应商。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/properties/embedding_provider_name/title",
+      "source_sha256": "4e0310d84c92f0465d3c1184754fbd60864f0d6925435fa6eff884947966e073"
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/WeightVectorSetting/properties/vector_weight/description",
+      "source_sha256": "6c8623f8fde54ee57da16439061574fd8817dcf88817051669eec0e577ce87b9",
+      "value": "语义向量检索权重，取值范围为 0 到 1。使用 `customized` 权重时，应与 `keyword_weight` 相加等于 1。"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/properties/vector_weight/title",
+      "source_sha256": "6a405f1ff0999e072f0178b60240aecf12ebe66f212fc2c78450e2876050f29d"
+    },
+    {
+      "op": "remove",
+      "path": "/components/schemas/WeightVectorSetting/title",
+      "source_sha256": "5eb9d2cbdaac4147eb845112796b9d81aa66dd837756402b7df0f0f6bb21a282"
     },
     {
       "op": "add",

--- a/zh/api-reference/openapi_service.json
+++ b/zh/api-reference/openapi_service.json
@@ -15029,6 +15029,30 @@
         ],
         "type": "object"
       },
+      "ChildChunkCreatePayload": {
+        "properties": {
+          "content": {
+            "description": "子分段文本内容。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "ChildChunkDetailResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ChildChunkResponse",
+            "description": "子分段详情。"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "ChildChunkListQuery": {
         "properties": {
           "keyword": {
@@ -15056,6 +15080,100 @@
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "ChildChunkListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ChildChunkResponse"
+            },
+            "type": "array",
+            "description": "子分段列表。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "每页条目数。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "当前页码。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "子分段总数。"
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "总页数。"
+          }
+        },
+        "required": [
+          "data",
+          "limit",
+          "page",
+          "total",
+          "total_pages"
+        ],
+        "type": "object"
+      },
+      "ChildChunkResponse": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "子分段的文本内容。"
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "创建时间戳（Unix 纪元，单位为秒）。"
+          },
+          "id": {
+            "type": "string",
+            "description": "子分段的唯一标识符。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "子分段在父分段中的位置。"
+          },
+          "segment_id": {
+            "type": "string",
+            "description": "该子分段所属的父分段 ID。"
+          },
+          "type": {
+            "type": "string",
+            "description": "子分段的创建方式。通过 API 创建或更新的子分段始终为 `customized`。系统生成的子分段为 `automatic`。"
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "最后更新时间戳（Unix 纪元，单位为秒）。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "子分段内容的字数。"
+          }
+        },
+        "required": [
+          "content",
+          "created_at",
+          "id",
+          "position",
+          "segment_id",
+          "type",
+          "updated_at",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "ChildChunkUpdatePayload": {
+        "properties": {
+          "content": {
+            "description": "子分段文本内容。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
         "type": "object"
       },
       "CompletionBlockingResponse": {
@@ -15553,6 +15671,65 @@
         ],
         "type": "object"
       },
+      "Condition": {
+        "description": "条件详情。",
+        "properties": {
+          "comparison_operator": {
+            "description": "要应用的比较方式。字符串运算符（`contains`、`not contains`、`start with`、`end with`、`is`、`is not`、`empty`、`not empty`、`in`、`not in`）用于字符串或数组元数据；数值运算符（`=`、`≠`、`>`、`<`、`≥`、`≤`）用于数值元数据；时间运算符（`before`、`after`）用于时间元数据。",
+            "enum": [
+              "<",
+              "=",
+              ">",
+              "after",
+              "before",
+              "contains",
+              "empty",
+              "end with",
+              "in",
+              "is",
+              "is not",
+              "not contains",
+              "not empty",
+              "not in",
+              "start with",
+              "≠",
+              "≤",
+              "≥"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "description": "用于比较的元数据字段名称。",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于比较的值。类型取决于 `comparison_operator`：大多数字符串运算符使用字符串，`in` 和 `not in` 使用字符串数组，数值运算符使用数字，`empty` 和 `not empty` 应省略此值或使用 `null`。"
+          }
+        },
+        "required": [
+          "comparison_operator",
+          "name"
+        ],
+        "type": "object"
+      },
       "ConversationInfiniteScrollPagination": {
         "properties": {
           "data": {
@@ -15931,6 +16108,984 @@
         },
         "type": "object"
       },
+      "CustomConfigurationStatus": {
+        "description": "自定义配置状态的枚举。",
+        "enum": [
+          "active",
+          "no-configure"
+        ],
+        "type": "string"
+      },
+      "DatasetBoundTagListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetBoundTagResponse"
+            },
+            "type": "array",
+            "description": "绑定到此知识库的标签列表。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "绑定到该知识库的标签总数。"
+          }
+        },
+        "required": [
+          "data",
+          "total"
+        ],
+        "type": "object"
+      },
+      "DatasetBoundTagResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "标签标识符。"
+          },
+          "name": {
+            "type": "string",
+            "description": "标签显示名称。"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "DatasetCreatePayload": {
+        "properties": {
+          "description": {
+            "default": "",
+            "description": "知识库描述。",
+            "maxLength": 400,
+            "type": "string"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "嵌入模型名称。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `model` 字段，并将 `model_type` 设置为 `text-embedding`。"
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "嵌入模型提供商。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `provider` 字段，并将 `model_type` 设置为 `text-embedding`。"
+          },
+          "external_knowledge_api_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部知识 API 的 ID。"
+          },
+          "external_knowledge_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部知识库的 ID。"
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "enum": [
+                  "economy",
+                  "high_quality"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
+          },
+          "name": {
+            "description": "知识库名称。",
+            "maxLength": 40,
+            "minLength": 1,
+            "type": "string"
+          },
+          "permission": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PermissionEnum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "only_me",
+            "description": "控制谁可以访问此知识库。`only_me` 仅允许创建者访问，`all_team_members` 允许整个工作区访问，`partial_members` 仅允许指定成员访问。"
+          },
+          "provider": {
+            "default": "vendor",
+            "description": "知识库提供方：内部知识库使用 `vendor`，外部知识库使用 `external`。",
+            "enum": [
+              "external",
+              "vendor"
+            ],
+            "type": "string"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "检索模型配置，用于控制分段的搜索和排序方式。"
+          },
+          "summary_index_setting": {
+            "anyOf": [
+              {
+                "properties": {
+                  "enable": {
+                    "description": "是否启用摘要索引。",
+                    "type": "boolean"
+                  },
+                  "model_name": {
+                    "description": "用于生成摘要的模型名称。",
+                    "type": "string"
+                  },
+                  "model_provider_name": {
+                    "description": "摘要生成模型的供应商。",
+                    "type": "string"
+                  },
+                  "summary_prompt": {
+                    "description": "用于摘要生成的自定义提示词模板。",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "摘要索引配置。"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "DatasetDetailResponse": {
+        "properties": {
+          "app_count": {
+            "type": "integer",
+            "description": "当前使用该知识库的应用数量。"
+          },
+          "author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "创建者的显示名称。"
+          },
+          "built_in_field_enabled": {
+            "type": "boolean",
+            "description": "是否启用内置元数据字段（例如 `document_name`、`uploader`）。"
+          },
+          "chunk_structure": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "分段结构配置。"
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "创建时间戳（Unix 纪元，单位为秒）。"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "创建该知识库的用户 ID。"
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "文档的数据源类型，尚未配置时为 `null`。"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "描述知识库用途或内容的可选文本。"
+          },
+          "doc_form": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "文档分块模式。`text_model` 表示标准文本分块，`hierarchical_model` 表示父子结构，`qa_model` 表示问答对提取。"
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetDocMetadataResponse"
+            },
+            "type": "array",
+            "description": "知识库的元数据字段定义。"
+          },
+          "document_count": {
+            "type": "integer",
+            "description": "知识库中的文档总数。"
+          },
+          "embedding_available": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "配置的嵌入模型当前是否可用。"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "用于索引的嵌入模型名称。"
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "嵌入模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。旧版知识库可能返回简写形式（例如 `openai`）。"
+          },
+          "enable_api": {
+            "type": "boolean",
+            "description": "该知识库是否启用 API 访问。"
+          },
+          "external_knowledge_info": {
+            "$ref": "#/components/schemas/DatasetExternalKnowledgeInfoResponse",
+            "description": "外部知识库的连接详情。当 `provider` 为 `external` 时存在。"
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetExternalRetrievalModelResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "外部知识库的检索设置。内部知识库时为 `null`。"
+          },
+          "icon_info": {
+            "$ref": "#/components/schemas/DatasetIconInfoResponse",
+            "description": "知识库的图标显示配置。"
+          },
+          "id": {
+            "type": "string",
+            "description": "知识库的唯一标识符。"
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
+          },
+          "is_multimodal": {
+            "type": "boolean",
+            "description": "是否启用多模态内容处理。"
+          },
+          "is_published": {
+            "type": "boolean",
+            "description": "知识库是否已发布。"
+          },
+          "maintainer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "知识库维护者的显示名称。未设置时为 `null`。"
+          },
+          "name": {
+            "type": "string",
+            "description": "知识库的显示名称。在工作区内唯一。"
+          },
+          "permission": {
+            "type": "string",
+            "description": "控制谁可以访问此知识库。可选值：`only_me`、`all_team_members`、`partial_members`。"
+          },
+          "permission_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "授予当前调用方的权限标识符。"
+          },
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "自定义处理流水线的 ID（如果已配置）。"
+          },
+          "provider": {
+            "type": "string",
+            "description": "供应商类型。内部管理为 `vendor`，外部知识库连接为 `external`。"
+          },
+          "retrieval_model_dict": {
+            "$ref": "#/components/schemas/DatasetRetrievalModelResponse",
+            "description": "知识库的检索配置。"
+          },
+          "runtime_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "运行时处理模式。"
+          },
+          "summary_index_setting": {
+            "$ref": "#/components/schemas/DatasetSummaryIndexSettingResponse",
+            "description": "摘要索引配置。"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetTagResponse"
+            },
+            "type": "array",
+            "description": "与该知识库关联的标签。"
+          },
+          "total_available_documents": {
+            "type": "integer",
+            "description": "已启用且可用的文档数量。"
+          },
+          "total_documents": {
+            "type": "integer",
+            "description": "文档总数。"
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "最后更新时间戳（Unix 纪元，单位为秒）。"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "最后更新该知识库的用户 ID。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "所有文档的总字数。"
+          }
+        },
+        "required": [
+          "app_count",
+          "author_name",
+          "built_in_field_enabled",
+          "chunk_structure",
+          "created_at",
+          "created_by",
+          "data_source_type",
+          "description",
+          "doc_form",
+          "doc_metadata",
+          "document_count",
+          "embedding_model",
+          "embedding_model_provider",
+          "enable_api",
+          "external_retrieval_model",
+          "id",
+          "indexing_technique",
+          "is_multimodal",
+          "is_published",
+          "name",
+          "permission",
+          "pipeline_id",
+          "provider",
+          "retrieval_model_dict",
+          "runtime_mode",
+          "tags",
+          "total_available_documents",
+          "total_documents",
+          "updated_at",
+          "updated_by",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "DatasetDetailWithPartialMembersResponse": {
+        "properties": {
+          "app_count": {
+            "type": "integer",
+            "description": "当前使用该知识库的应用数量。"
+          },
+          "author_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "创建者的显示名称。"
+          },
+          "built_in_field_enabled": {
+            "type": "boolean",
+            "description": "是否启用内置元数据字段（例如 `document_name`、`uploader`）。"
+          },
+          "chunk_structure": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "分段结构配置。"
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "创建时间戳（Unix 纪元，单位为秒）。"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "创建该知识库的用户 ID。"
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "文档的数据源类型，尚未配置时为 `null`。"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "描述知识库用途或内容的可选文本。"
+          },
+          "doc_form": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "文档分块模式。`text_model` 表示标准文本分块，`hierarchical_model` 表示父子结构，`qa_model` 表示问答对提取。"
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetDocMetadataResponse"
+            },
+            "type": "array",
+            "description": "知识库的元数据字段定义。"
+          },
+          "document_count": {
+            "type": "integer",
+            "description": "知识库中的文档总数。"
+          },
+          "embedding_available": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "配置的嵌入模型当前是否可用。"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "用于索引的嵌入模型名称。"
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "嵌入模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。旧版知识库可能返回简写形式（例如 `openai`）。"
+          },
+          "enable_api": {
+            "type": "boolean",
+            "description": "该知识库是否启用 API 访问。"
+          },
+          "external_knowledge_info": {
+            "$ref": "#/components/schemas/DatasetExternalKnowledgeInfoResponse",
+            "description": "外部知识库的连接详情。当 `provider` 为 `external` 时存在。"
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetExternalRetrievalModelResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "外部知识库的检索设置。内部知识库时为 `null`。"
+          },
+          "icon_info": {
+            "$ref": "#/components/schemas/DatasetIconInfoResponse",
+            "description": "知识库的图标显示配置。"
+          },
+          "id": {
+            "type": "string",
+            "description": "知识库的唯一标识符。"
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
+          },
+          "is_multimodal": {
+            "type": "boolean",
+            "description": "是否启用多模态内容处理。"
+          },
+          "is_published": {
+            "type": "boolean",
+            "description": "知识库是否已发布。"
+          },
+          "maintainer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "知识库维护者的显示名称。未设置时为 `null`。"
+          },
+          "name": {
+            "type": "string",
+            "description": "知识库的显示名称。在工作区内唯一。"
+          },
+          "partial_member_list": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "当 `permission` 为 `partial_members` 时被授予访问权限的成员账户 ID。更新响应中始终返回；详情响应中仅当 `permission` 为 `partial_members` 时返回。"
+          },
+          "permission": {
+            "type": "string",
+            "description": "控制谁可以访问此知识库。可选值：`only_me`、`all_team_members`、`partial_members`。"
+          },
+          "permission_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "授予当前调用方的权限标识符。"
+          },
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "自定义处理流水线的 ID（如果已配置）。"
+          },
+          "provider": {
+            "type": "string",
+            "description": "供应商类型。内部管理为 `vendor`，外部知识库连接为 `external`。"
+          },
+          "retrieval_model_dict": {
+            "$ref": "#/components/schemas/DatasetRetrievalModelResponse",
+            "description": "知识库的检索配置。"
+          },
+          "runtime_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "运行时处理模式。"
+          },
+          "summary_index_setting": {
+            "$ref": "#/components/schemas/DatasetSummaryIndexSettingResponse",
+            "description": "摘要索引配置。"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetTagResponse"
+            },
+            "type": "array",
+            "description": "与该知识库关联的标签。"
+          },
+          "total_available_documents": {
+            "type": "integer",
+            "description": "已启用且可用的文档数量。"
+          },
+          "total_documents": {
+            "type": "integer",
+            "description": "文档总数。"
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "最后更新时间戳（Unix 纪元，单位为秒）。"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "最后更新该知识库的用户 ID。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "所有文档的总字数。"
+          }
+        },
+        "required": [
+          "app_count",
+          "author_name",
+          "built_in_field_enabled",
+          "chunk_structure",
+          "created_at",
+          "created_by",
+          "data_source_type",
+          "description",
+          "doc_form",
+          "doc_metadata",
+          "document_count",
+          "embedding_model",
+          "embedding_model_provider",
+          "enable_api",
+          "external_retrieval_model",
+          "id",
+          "indexing_technique",
+          "is_multimodal",
+          "is_published",
+          "name",
+          "permission",
+          "pipeline_id",
+          "provider",
+          "retrieval_model_dict",
+          "runtime_mode",
+          "tags",
+          "total_available_documents",
+          "total_documents",
+          "updated_at",
+          "updated_by",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "DatasetDocMetadataResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "元数据字段 ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "元数据字段名称。"
+          },
+          "type": {
+            "type": "string",
+            "description": "元数据值类型。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetExternalKnowledgeInfoResponse": {
+        "properties": {
+          "external_knowledge_api_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部知识库 API 的端点 URL。"
+          },
+          "external_knowledge_api_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部知识库 API 连接的 ID。"
+          },
+          "external_knowledge_api_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部知识库 API 的显示名称。"
+          },
+          "external_knowledge_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部知识库的 ID。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetExternalRetrievalModelResponse": {
+        "properties": {
+          "score_threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "检索结果需要达到的最低分数。"
+          },
+          "score_threshold_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "是否启用分数阈值筛选。"
+          },
+          "top_k": {
+            "type": "integer",
+            "description": "检索结果的最大数量。"
+          }
+        },
+        "required": [
+          "top_k"
+        ],
+        "type": "object"
+      },
+      "DatasetIconInfoResponse": {
+        "properties": {
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "图标标识符或表情符号。"
+          },
+          "icon_background": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "图标的背景颜色。"
+          },
+          "icon_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "图标类型。"
+          },
+          "icon_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "自定义图标图片的 URL。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetKeywordSettingResponse": {
+        "properties": {
+          "keyword_weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "分配给关键词搜索结果的权重。"
+          }
+        },
+        "type": "object"
+      },
       "DatasetListQuery": {
         "properties": {
           "include_all": {
@@ -15970,6 +17125,738 @@
         },
         "type": "object"
       },
+      "DatasetListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetDetailResponse"
+            },
+            "type": "array",
+            "description": "当前页的知识库列表。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "是否还有更多知识库。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "每页条目数。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "当前页码。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "匹配的知识库总数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataActionResponse": {
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "元数据操作结果。"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataBuiltInFieldResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "内置元数据字段名称。"
+          },
+          "type": {
+            "type": "string",
+            "description": "内置元数据值类型。"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataBuiltInFieldsResponse": {
+        "properties": {
+          "fields": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetMetadataBuiltInFieldResponse"
+            },
+            "type": "array",
+            "description": "系统提供的元数据字段列表。"
+          }
+        },
+        "required": [
+          "fields"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataListItemResponse": {
+        "properties": {
+          "count": {
+            "default": 0,
+            "type": "integer",
+            "description": "使用该元数据字段的文档数量。"
+          },
+          "id": {
+            "type": "string",
+            "description": "元数据字段标识符。"
+          },
+          "name": {
+            "type": "string",
+            "description": "元数据字段名称。"
+          },
+          "type": {
+            "type": "string",
+            "description": "元数据字段类型。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataListResponse": {
+        "properties": {
+          "built_in_field_enabled": {
+            "type": "boolean",
+            "description": "该知识库是否启用了内置元数据字段。"
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetMetadataListItemResponse"
+            },
+            "type": "array",
+            "description": "元数据字段定义列表。"
+          }
+        },
+        "required": [
+          "built_in_field_enabled",
+          "doc_metadata"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "元数据字段 ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "元数据字段名称。"
+          },
+          "type": {
+            "type": "string",
+            "description": "元数据值类型。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetRerankingModelResponse": {
+        "properties": {
+          "reranking_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "重排序模型名称。"
+          },
+          "reranking_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "重排序模型的提供商。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetRetrievalModelResponse": {
+        "properties": {
+          "reranking_enable": {
+            "type": "boolean",
+            "description": "是否启用重排序。"
+          },
+          "reranking_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "重排序模式。`reranking_model` 表示基于模型的重排序，`weighted_score` 表示基于分数的加权。重排序禁用时为 `null`。"
+          },
+          "reranking_model": {
+            "$ref": "#/components/schemas/DatasetRerankingModelResponse",
+            "description": "重排序模型配置。"
+          },
+          "score_threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "结果的最低相关性分数。仅在 `score_threshold_enabled` 为 `true` 时生效。"
+          },
+          "score_threshold_enabled": {
+            "type": "boolean",
+            "description": "是否启用分数阈值过滤。"
+          },
+          "search_method": {
+            "type": "string",
+            "description": "用于检索的搜索方式。`keyword_search` 表示关键词匹配，`semantic_search` 表示基于嵌入的语义相似度，`full_text_search` 表示全文索引，`hybrid_search` 表示语义和关键词混合搜索。"
+          },
+          "top_k": {
+            "type": "integer",
+            "description": "返回的最大结果数。"
+          },
+          "weights": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DatasetWeightedScoreResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "混合搜索的权重配置。"
+          }
+        },
+        "required": [
+          "reranking_enable",
+          "score_threshold_enabled",
+          "search_method",
+          "top_k"
+        ],
+        "type": "object"
+      },
+      "DatasetSummaryIndexSettingResponse": {
+        "properties": {
+          "enable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "是否启用摘要索引。"
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于生成摘要的模型名称。"
+          },
+          "model_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "摘要生成模型的供应商。"
+          },
+          "summary_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于生成文档摘要的提示词。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetTagResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "标签 ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "标签名称。"
+          },
+          "type": {
+            "type": "string",
+            "description": "标签类型。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatasetUpdatePayload": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 400,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "知识库描述。"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "嵌入模型名称。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `model` 字段，并将 `model_type` 设置为 `text-embedding`。"
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "嵌入模型提供商。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `provider` 字段，并将 `model_type` 设置为 `text-embedding`。"
+          },
+          "external_knowledge_api_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部知识 API 的 ID。"
+          },
+          "external_knowledge_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部知识库的 ID。"
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "properties": {
+                  "score_threshold": {
+                    "description": "用于筛选结果的最低相似度阈值。",
+                    "type": "number"
+                  },
+                  "score_threshold_enabled": {
+                    "description": "是否启用分数阈值过滤。",
+                    "type": "boolean"
+                  },
+                  "top_k": {
+                    "description": "最多返回的结果数量。",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部知识库的检索设置。"
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "enum": [
+                  "economy",
+                  "high_quality"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 40,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "知识库名称。"
+          },
+          "partial_member_list": {
+            "anyOf": [
+              {
+                "items": {
+                  "properties": {
+                    "user_id": {
+                      "description": "要授予访问权限的团队成员 ID。",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "当 `permission` 为 `partial_members` 时有访问权限的团队成员列表。"
+          },
+          "permission": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PermissionEnum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "控制谁可以访问此知识库。`only_me` 仅允许创建者访问，`all_team_members` 允许整个工作区访问，`partial_members` 仅允许指定成员访问。"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "检索模型配置，用于控制分段的搜索和排序方式。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetVectorSettingResponse": {
+        "properties": {
+          "embedding_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于向量搜索的嵌入模型名称。"
+          },
+          "embedding_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "用于向量搜索的嵌入模型供应商。"
+          },
+          "vector_weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "分配给语义（向量）搜索结果的权重。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetWeightedScoreResponse": {
+        "properties": {
+          "keyword_setting": {
+            "$ref": "#/components/schemas/DatasetKeywordSettingResponse",
+            "description": "关键词搜索权重设置。"
+          },
+          "vector_setting": {
+            "$ref": "#/components/schemas/DatasetVectorSettingResponse",
+            "description": "语义搜索权重设置。"
+          },
+          "weight_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "平衡语义搜索和关键词搜索权重的策略。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasourceCredentialInfoResponse": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "凭证 ID。调用 [执行数据源节点](/zh/api-reference/knowledge-pipeline/run-datasource-node) 时作为 `credential_id` 传入，或作为 [运行流水线](/zh/api-reference/knowledge-pipeline/run-pipeline) 各数据源项中的 `credential_id` 字段。"
+          },
+          "is_default": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该凭证是否为提供商的默认凭证。"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "凭证的显示名称。"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "数据源插件定义的凭证类型。"
+          }
+        },
+        "type": "object"
+      },
+      "DatasourceNodeRunPayload": {
+        "properties": {
+          "credential_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "数据源凭据 ID。省略时使用默认凭据。"
+          },
+          "datasource_type": {
+            "description": "数据源类型。",
+            "enum": [
+              "local_file",
+              "online_document",
+              "online_drive",
+              "website_crawl"
+            ],
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "数据源节点的输入变量。",
+            "type": "object"
+          },
+          "is_published": {
+            "description": "是否运行节点的已发布版本或草稿版本。`true` 运行已发布版本，`false` 运行草稿版本。",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "datasource_type",
+          "inputs",
+          "is_published"
+        ],
+        "type": "object"
+      },
+      "DatasourcePluginListResponse": {
+        "items": {
+          "$ref": "#/components/schemas/DatasourcePluginResponse"
+        },
+        "type": "array"
+      },
+      "DatasourcePluginResponse": {
+        "properties": {
+          "credentials": {
+            "items": {
+              "$ref": "#/components/schemas/DatasourceCredentialInfoResponse"
+            },
+            "type": "array",
+            "description": "可用于对该数据源进行认证的凭证列表。"
+          },
+          "datasource_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "数据源类型。取值为 `local_file`、`online_document`、`online_drive`、`website_crawl` 之一。"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "流水线工作流中数据源节点的 ID。调用 [执行数据源节点](/zh/api-reference/knowledge-pipeline/run-datasource-node) 时作为 `node_id` 传入，或调用 [运行流水线](/zh/api-reference/knowledge-pipeline/run-pipeline) 时作为 `start_node_id` 传入。"
+          },
+          "plugin_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "提供该节点的数据源插件的 ID。"
+          },
+          "provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "数据源插件注册的提供商名称。"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "插件显示标题。"
+          },
+          "user_input_variables": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "description": "调用方需要为该数据源提供的流水线输入变量，来自节点数据源参数中 `{{#...#}}` 引用的变量。每一项遵循工作流使用的流水线变量结构。"
+          }
+        },
+        "type": "object"
+      },
       "DatasourcePluginsQuery": {
         "properties": {
           "is_published": {
@@ -15978,6 +17865,312 @@
             "type": "boolean"
           }
         },
+        "type": "object"
+      },
+      "DocumentAndBatchResponse": {
+        "properties": {
+          "batch": {
+            "type": "string",
+            "description": "用于跟踪索引进度的批次 ID。"
+          },
+          "document": {
+            "$ref": "#/components/schemas/DocumentResponse",
+            "description": "匹配分段的父文档信息。"
+          }
+        },
+        "required": [
+          "batch",
+          "document"
+        ],
+        "type": "object"
+      },
+      "DocumentBatchDownloadZipPayload": {
+        "description": "将文档批量下载为 ZIP 压缩包的请求载荷。",
+        "properties": {
+          "document_ids": {
+            "description": "要包含在 ZIP 下载中的文档 ID 列表。",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "document_ids"
+        ],
+        "type": "object"
+      },
+      "DocumentDetailResponse": {
+        "properties": {
+          "archived": {
+            "default": null,
+            "type": "boolean",
+            "description": "文档是否已归档。"
+          },
+          "average_segment_length": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "default": null,
+            "description": "分段的平均字符长度。"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "完成时间，Unix 秒级时间戳；未完成时为 `null`。"
+          },
+          "created_at": {
+            "default": null,
+            "type": "integer",
+            "description": "创建时间，Unix 秒级时间戳。"
+          },
+          "created_by": {
+            "default": null,
+            "type": "string",
+            "description": "创建该文档的用户 ID。"
+          },
+          "created_from": {
+            "default": null,
+            "type": "string",
+            "description": "文档来源。通过 API 创建时为 `api`，通过 UI 创建时为 `web`。"
+          },
+          "data_source_info": {
+            "additionalProperties": true,
+            "default": null,
+            "type": "object",
+            "description": "数据源详情。文件上传时，此详情接口在 `upload_file` 下返回完整的文件对象，而列表接口仅返回 `upload_file_id`。"
+          },
+          "data_source_type": {
+            "default": null,
+            "type": "string",
+            "description": "文档的上传方式。文件上传为 `upload_file`，Notion 导入为 `notion_import`。"
+          },
+          "dataset_process_rule": {
+            "additionalProperties": true,
+            "default": null,
+            "type": "object",
+            "description": "知识库级别的处理规则配置。"
+          },
+          "dataset_process_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "应用于该文档的处理规则 ID。"
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "停用时间，Unix 秒级时间戳；启用时为 `null`。"
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "禁用该文档的用户 ID，启用时为 `null`。"
+          },
+          "display_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "适合 UI 显示的索引状态。"
+          },
+          "doc_form": {
+            "default": null,
+            "type": "string",
+            "description": "文档分块模式。`text_model` 表示标准文本，`hierarchical_model` 表示父子结构，`qa_model` 表示问答对。"
+          },
+          "doc_language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档内容的语言。"
+          },
+          "doc_metadata": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DocumentMetadataResponse"
+                },
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "此文档的自定义元数据键值对。"
+          },
+          "doc_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档类型分类，未设置时为 `null`。"
+          },
+          "document_process_rule": {
+            "additionalProperties": true,
+            "default": null,
+            "type": "object",
+            "description": "文档级别的处理规则配置。"
+          },
+          "enabled": {
+            "default": null,
+            "type": "boolean",
+            "description": "该文档是否启用检索。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "索引失败时的错误消息，否则为 `null`。"
+          },
+          "hit_count": {
+            "default": null,
+            "type": "integer",
+            "description": "该文档被检索的次数。"
+          },
+          "id": {
+            "type": "string",
+            "description": "文档标识符。"
+          },
+          "indexing_latency": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "索引耗时（秒），未完成时为 `null`。"
+          },
+          "indexing_status": {
+            "default": null,
+            "type": "string",
+            "description": "当前索引状态，例如 `waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、`error`、`paused`。"
+          },
+          "name": {
+            "default": null,
+            "type": "string",
+            "description": "文档名称。"
+          },
+          "need_summary": {
+            "default": null,
+            "type": "boolean",
+            "description": "该文档是否需要生成摘要。"
+          },
+          "position": {
+            "default": null,
+            "type": "integer",
+            "description": "在知识库中的位置索引。"
+          },
+          "segment_count": {
+            "default": null,
+            "type": "integer",
+            "description": "文档中的分段数。"
+          },
+          "summary_index_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "摘要索引的状态，未启用摘要索引时为 `null`。"
+          },
+          "tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档中的令牌数。"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "最后更新时间，Unix 秒级时间戳。"
+          }
+        },
+        "required": [
+          "id"
+        ],
         "type": "object"
       },
       "DocumentGetQuery": {
@@ -16039,6 +18232,877 @@
             ],
             "default": null,
             "description": "按显示状态筛选。"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentResponse"
+            },
+            "type": "array",
+            "description": "当前页的文档列表。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "是否还有更多文档。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "每页条目数。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "当前页码。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "匹配的文档总数。"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "DocumentMetadataOperation": {
+        "properties": {
+          "document_id": {
+            "description": "要更新元数据的文档 ID。",
+            "format": "uuid",
+            "type": "string"
+          },
+          "metadata_list": {
+            "description": "要更新的元数据字段。",
+            "items": {
+              "$ref": "#/components/schemas/MetadataDetail"
+            },
+            "type": "array"
+          },
+          "partial_update": {
+            "default": false,
+            "description": "是否部分更新元数据，保留未指定字段的现有值。",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "document_id",
+          "metadata_list"
+        ],
+        "type": "object"
+      },
+      "DocumentMetadataResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "元数据字段标识符。"
+          },
+          "name": {
+            "type": "string",
+            "description": "元数据字段名称。"
+          },
+          "type": {
+            "type": "string",
+            "description": "元数据字段值类型。"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "此文档的元数据值。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DocumentResponse": {
+        "properties": {
+          "archived": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档是否已归档。"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建时间戳（Unix 纪元，单位为秒）。"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "创建该文档的用户 ID。"
+          },
+          "created_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档来源。通过 API 创建时为 `api`，通过 UI 创建时为 `web`。"
+          },
+          "data_source_detail_dict": {
+            "additionalProperties": true,
+            "type": "object",
+            "description": "详细的数据源信息，包括文件详情。"
+          },
+          "data_source_info": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "原始数据源信息，随 `data_source_type` 而异。"
+          },
+          "data_source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档的创建方式。文件上传为 `upload_file`，Notion 导入为 `notion_import`。"
+          },
+          "dataset_process_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "应用于该文档的处理规则 ID。"
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "停用时间，Unix 秒级时间戳；启用时为 `null`。"
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "禁用该文档的用户 ID。启用时为 `null`。"
+          },
+          "display_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "基于 `indexing_status` 和 `enabled` 状态派生的面向用户的显示状态。"
+          },
+          "doc_form": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档分块模式。`text_model` 表示标准文本分块，`hierarchical_model` 表示父子结构，`qa_model` 表示问答对提取。"
+          },
+          "doc_metadata": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentMetadataResponse"
+            },
+            "type": "array",
+            "description": "分配给该文档的元数据值。"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该文档是否启用检索。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "索引失败时的错误消息。无错误时为 `null`。"
+          },
+          "hit_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该文档在检索查询中被匹配的次数。"
+          },
+          "id": {
+            "type": "string",
+            "description": "文档的唯一标识符。"
+          },
+          "indexing_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "当前索引状态。`waiting` 表示排队中，`parsing` 表示正在提取内容，`cleaning` 表示正在去噪，`splitting` 表示正在分块，`indexing` 表示正在构建向量，`completed` 表示就绪，`error` 表示失败，`paused` 表示手动暂停。"
+          },
+          "name": {
+            "type": "string",
+            "description": "文档名称。"
+          },
+          "need_summary": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "是否需要为该文档生成摘要。"
+          },
+          "position": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档在列表中的显示位置。"
+          },
+          "summary_index_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "该文档的摘要索引状态。未配置摘要索引时为 `null`。"
+          },
+          "tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档中的令牌总数。"
+          },
+          "word_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档的总字数。"
+          }
+        },
+        "required": [
+          "data_source_detail_dict",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "DocumentStatusListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentStatusResponse"
+            },
+            "type": "array",
+            "description": "文档处理状态记录。"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "DocumentStatusPayload": {
+        "properties": {
+          "document_ids": {
+            "description": "要更新的文档 ID 列表。为保持兼容，该字段为可选；省略或传入空数组时，请求成功但不会更新任何文档。",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentStatusResponse": {
+        "properties": {
+          "cleaning_completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "清洗完成时间，Unix 秒级时间戳。"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引完成时间，Unix 秒级时间戳。"
+          },
+          "completed_segments": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "已索引的分段数。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引失败时的错误信息。无错误时为 `null`。"
+          },
+          "error_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "处理错误代码；未发生错误时为 `null`。"
+          },
+          "estimated_vector_space_mb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "预计向量存储用量，单位为 MB。"
+          },
+          "id": {
+            "type": "string",
+            "description": "文档标识符。"
+          },
+          "indexing_status": {
+            "type": "string",
+            "description": "当前索引状态：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、`error` 或 `paused`。`completed` 和 `error` 为终态。Service API 无法恢复 `paused` 文档；请在 Dify 知识库控制台恢复后再继续轮询。"
+          },
+          "parsing_completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "解析完成时间，Unix 秒级时间戳。"
+          },
+          "paused_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引暂停时间，Unix 秒级时间戳；未暂停时为 `null`。"
+          },
+          "processing_started_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "处理开始时间，Unix 秒级时间戳。"
+          },
+          "splitting_completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "分段完成时间，Unix 秒级时间戳。"
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引停止时间，Unix 秒级时间戳；未停止时为 `null`。"
+          },
+          "total_segments": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "待索引的分段总数。"
+          },
+          "vector_space_limit_mb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "向量存储上限，单位为 MB。"
+          }
+        },
+        "required": [
+          "cleaning_completed_at",
+          "completed_at",
+          "error",
+          "id",
+          "indexing_status",
+          "parsing_completed_at",
+          "paused_at",
+          "processing_started_at",
+          "splitting_completed_at",
+          "stopped_at"
+        ],
+        "type": "object"
+      },
+      "DocumentTextCreatePayload": {
+        "properties": {
+          "doc_form": {
+            "default": "text_model",
+            "description": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。",
+            "enum": [
+              "hierarchical_model",
+              "qa_model",
+              "text_model"
+            ],
+            "type": "string"
+          },
+          "doc_language": {
+            "default": "English",
+            "description": "用于处理优化的文档语言。",
+            "type": "string"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "嵌入模型名称。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `model` 字段，并将 `model_type` 设置为 `text-embedding`。"
+          },
+          "embedding_model_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "嵌入模型提供商。使用[获取可用模型](/zh/api-reference/models/get-available-models)返回的 `provider` 字段，并将 `model_type` 设置为 `text-embedding`。"
+          },
+          "indexing_technique": {
+            "anyOf": [
+              {
+                "enum": [
+                  "economy",
+                  "high_quality"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。向知识库添加首个文档时必填；后续文档省略时会继承知识库的索引方式。"
+          },
+          "name": {
+            "description": "文档名称。",
+            "type": "string"
+          },
+          "original_document_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "要替换的原始文档 ID。"
+          },
+          "process_rule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProcessRule"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "分块处理规则。"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "检索模型配置，用于控制分段的搜索和排序方式。"
+          },
+          "text": {
+            "description": "文档文本内容。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "text"
+        ],
+        "type": "object"
+      },
+      "DocumentTextUpdate": {
+        "anyOf": [
+          {
+            "properties": {
+              "doc_form": {
+                "default": "text_model",
+                "description": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。",
+                "enum": [
+                  "hierarchical_model",
+                  "qa_model",
+                  "text_model"
+                ],
+                "type": "string"
+              },
+              "doc_language": {
+                "default": "English",
+                "description": "用于处理优化的文档语言。",
+                "type": "string"
+              },
+              "name": {
+                "default": null,
+                "description": "文档名称。当提供 `text` 时必填。",
+                "type": "string"
+              },
+              "process_rule": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ProcessRule"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "分块处理规则。"
+              },
+              "retrieval_model": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RetrievalModel"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "检索模型配置，用于控制分段的搜索和排序方式。"
+              },
+              "text": {
+                "default": null,
+                "description": "文档文本内容。",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "text"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "doc_form": {
+                "default": "text_model",
+                "description": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。",
+                "enum": [
+                  "hierarchical_model",
+                  "qa_model",
+                  "text_model"
+                ],
+                "type": "string"
+              },
+              "doc_language": {
+                "default": "English",
+                "description": "用于处理优化的文档语言。",
+                "type": "string"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "文档名称。当提供 `text` 时必填。"
+              },
+              "process_rule": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ProcessRule"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "分块处理规则。"
+              },
+              "retrieval_model": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RetrievalModel"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "检索模型配置，用于控制分段的搜索和排序方式。"
+              },
+              "text": {
+                "description": "文档文本内容。",
+                "type": "null"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "doc_form": {
+            "default": "text_model",
+            "description": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。",
+            "enum": [
+              "hierarchical_model",
+              "qa_model",
+              "text_model"
+            ],
+            "type": "string"
+          },
+          "doc_language": {
+            "default": "English",
+            "description": "用于处理优化的文档语言。",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档名称。当提供 `text` 时必填。"
+          },
+          "process_rule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProcessRule"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "分块处理规则。"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "检索模型配置，用于控制分段的搜索和排序方式。"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文档文本内容。"
           }
         },
         "type": "object"
@@ -16152,6 +19216,14 @@
           }
         },
         "type": "object"
+      },
+      "FetchFrom": {
+        "description": "用户标识符来源的枚举。",
+        "enum": [
+          "customizable-model",
+          "predefined-model"
+        ],
+        "type": "string"
       },
       "FileInputConfig": {
         "properties": {
@@ -16463,6 +19535,469 @@
           }
         ]
       },
+      "HitTestingChildChunk": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "子分段的文本内容。"
+          },
+          "id": {
+            "type": "string",
+            "description": "子分段的唯一标识符。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "子分段在父分段中的位置。"
+          },
+          "score": {
+            "type": "number",
+            "description": "子分段的相关性得分。"
+          }
+        },
+        "required": [
+          "content",
+          "id",
+          "position",
+          "score"
+        ],
+        "type": "object"
+      },
+      "HitTestingDocument": {
+        "properties": {
+          "data_source_type": {
+            "type": "string",
+            "description": "文档的创建方式。"
+          },
+          "doc_metadata": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "description": "文档的元数据值。未配置元数据时为 `null`。"
+          },
+          "doc_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "文档类型分类。未设置时为 `null`。"
+          },
+          "id": {
+            "type": "string",
+            "description": "文档的唯一标识符。"
+          },
+          "name": {
+            "type": "string",
+            "description": "文档名称。"
+          }
+        },
+        "required": [
+          "data_source_type",
+          "doc_metadata",
+          "doc_type",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "HitTestingFile": {
+        "properties": {
+          "extension": {
+            "type": "string",
+            "description": "文件扩展名。"
+          },
+          "id": {
+            "type": "string",
+            "description": "附件文件标识符。"
+          },
+          "mime_type": {
+            "type": "string",
+            "description": "文件的 MIME 类型。"
+          },
+          "name": {
+            "type": "string",
+            "description": "原始文件名。"
+          },
+          "size": {
+            "type": "integer",
+            "description": "文件大小（字节）。"
+          },
+          "source_url": {
+            "type": "string",
+            "description": "访问附件的 URL。"
+          }
+        },
+        "required": [
+          "extension",
+          "id",
+          "mime_type",
+          "name",
+          "size",
+          "source_url"
+        ],
+        "type": "object"
+      },
+      "HitTestingPayload": {
+        "properties": {
+          "attachment_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "已附加到知识库分段的图片文件 ID，可从 Dify 控制台上传或创建这些分段附件后返回的数据中获取。它们为多模态召回测试添加图片上下文。"
+          },
+          "external_retrieval_model": {
+            "anyOf": [
+              {
+                "properties": {
+                  "score_threshold": {
+                    "description": "用于筛选结果的最低相似度阈值。",
+                    "type": "number"
+                  },
+                  "score_threshold_enabled": {
+                    "description": "是否启用分数阈值过滤。",
+                    "type": "boolean"
+                  },
+                  "top_k": {
+                    "description": "最多返回的结果数量。",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "外部知识库的检索设置。"
+          },
+          "query": {
+            "description": "搜索查询文本。",
+            "maxLength": 250,
+            "type": "string"
+          },
+          "retrieval_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "检索模型配置，用于控制分段的搜索和排序方式。"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "HitTestingQuery": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "用于检索测试的查询文本。"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "HitTestingRecord": {
+        "properties": {
+          "child_chunks": {
+            "items": {
+              "$ref": "#/components/schemas/HitTestingChildChunk"
+            },
+            "type": "array",
+            "description": "使用分层索引时，分段内匹配的子分段。"
+          },
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/HitTestingFile"
+            },
+            "type": "array",
+            "description": "附加到该分段的文件。"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "相关性得分。"
+          },
+          "segment": {
+            "$ref": "#/components/schemas/HitTestingSegment",
+            "description": "从知识库中匹配的分段。"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "通过摘要索引检索到的摘要内容。"
+          },
+          "tsne_position": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "description": "t-SNE 可视化位置。"
+          }
+        },
+        "required": [
+          "child_chunks",
+          "files",
+          "score",
+          "segment",
+          "summary",
+          "tsne_position"
+        ],
+        "type": "object"
+      },
+      "HitTestingResponse": {
+        "properties": {
+          "query": {
+            "$ref": "#/components/schemas/HitTestingQuery",
+            "description": "原始查询对象。"
+          },
+          "records": {
+            "items": {
+              "$ref": "#/components/schemas/HitTestingRecord"
+            },
+            "type": "array",
+            "description": "匹配的检索记录列表。"
+          }
+        },
+        "required": [
+          "query",
+          "records"
+        ],
+        "type": "object"
+      },
+      "HitTestingSegment": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "回答内容，用于问答模式文档。"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "完成时间，Unix 秒级时间戳；未完成时为 `null`。"
+          },
+          "content": {
+            "type": "string",
+            "description": "分段的文本内容。"
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "创建时间戳（Unix 纪元，单位为秒）。"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "创建该分段的用户 ID。"
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "停用时间，Unix 秒级时间戳；启用时为 `null`。"
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "禁用该分段的用户 ID。启用时为 `null`。"
+          },
+          "document": {
+            "$ref": "#/components/schemas/HitTestingDocument",
+            "description": "匹配分段的父文档信息。"
+          },
+          "document_id": {
+            "type": "string",
+            "description": "该分段所属文档的 ID。"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "该分段是否启用检索。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引失败时的错误消息。无错误时为 `null`。"
+          },
+          "hit_count": {
+            "type": "integer",
+            "description": "该分段在检索查询中被匹配的次数。"
+          },
+          "id": {
+            "type": "string",
+            "description": "分段的唯一标识符。"
+          },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引内容的哈希值，用于检测变更。"
+          },
+          "index_node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "向量存储中索引节点的 ID。"
+          },
+          "indexing_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引开始时间，Unix 秒级时间戳；未开始时为 `null`。"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "与该分段关联的关键词，用于基于关键词的检索。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "分段在文档中的位置。"
+          },
+          "sign_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "用于完整性验证的签名内容哈希。"
+          },
+          "status": {
+            "type": "string",
+            "description": "分段的索引状态。"
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引停止时间，Unix 秒级时间戳；未停止时为 `null`。"
+          },
+          "tokens": {
+            "type": "integer",
+            "description": "分段内容的令牌数。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "分段内容的字数。"
+          }
+        },
+        "required": [
+          "answer",
+          "completed_at",
+          "content",
+          "created_at",
+          "created_by",
+          "disabled_at",
+          "disabled_by",
+          "document",
+          "document_id",
+          "enabled",
+          "error",
+          "hit_count",
+          "id",
+          "index_node_hash",
+          "index_node_id",
+          "indexing_at",
+          "keywords",
+          "position",
+          "sign_content",
+          "status",
+          "stopped_at",
+          "tokens",
+          "word_count"
+        ],
+        "type": "object"
+      },
       "HumanInputContent": {
         "properties": {
           "form_definition": {
@@ -16770,6 +20305,31 @@
         "properties": {},
         "type": "object"
       },
+      "I18nObject": {
+        "description": "国际化对象模型。",
+        "properties": {
+          "en_US": {
+            "type": "string",
+            "description": "英语（美国）文本。"
+          },
+          "zh_Hans": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "简体中文文本。"
+          }
+        },
+        "required": [
+          "en_US"
+        ],
+        "type": "object"
+      },
       "IndexInfoResponse": {
         "properties": {
           "api_version": {
@@ -16799,6 +20359,46 @@
       "JSONValue": {},
       "JSONValueType": {},
       "JsonValue": {},
+      "KnowledgeTagListResponse": {
+        "items": {
+          "$ref": "#/components/schemas/KnowledgeTagResponse"
+        },
+        "type": "array"
+      },
+      "KnowledgeTagResponse": {
+        "properties": {
+          "binding_count": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "绑定到该标签的知识库数量。"
+          },
+          "id": {
+            "type": "string",
+            "description": "标签标识符。"
+          },
+          "name": {
+            "type": "string",
+            "description": "标签显示名称。"
+          },
+          "type": {
+            "type": "string",
+            "description": "标签类型。知识库标签始终为 `knowledge`。"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
       "MessageFeedbackPayload": {
         "properties": {
           "content": {
@@ -17188,6 +20788,187 @@
           "conversation_id"
         ],
         "type": "object"
+      },
+      "MetadataArgs": {
+        "properties": {
+          "name": {
+            "description": "元数据字段名称。",
+            "type": "string"
+          },
+          "type": {
+            "description": "`string` 为文本值，`number` 为数值，`time` 为日期/时间值。",
+            "enum": [
+              "number",
+              "string",
+              "time"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "MetadataDetail": {
+        "properties": {
+          "id": {
+            "description": "元数据字段 ID。",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "元数据字段名称。",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "元数据值。可以是字符串、数字或 `null`。"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "MetadataFilteringCondition": {
+        "description": "元数据筛选条件。",
+        "properties": {
+          "conditions": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Condition"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "deprecated": true,
+            "description": "要评估的元数据条件列表。"
+          },
+          "logical_operator": {
+            "anyOf": [
+              {
+                "enum": [
+                  "and",
+                  "or"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "and",
+            "description": "多个条件之间的组合方式。"
+          }
+        },
+        "type": "object"
+      },
+      "MetadataOperationData": {
+        "description": "元数据操作数据。",
+        "properties": {
+          "operation_data": {
+            "description": "文档元数据更新操作数组。每个条目将一个文档 ID 映射到其元数据值。",
+            "items": {
+              "$ref": "#/components/schemas/DocumentMetadataOperation"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "operation_data"
+        ],
+        "type": "object"
+      },
+      "MetadataUpdatePayload": {
+        "properties": {
+          "name": {
+            "description": "新的元数据字段名称。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "ModelFeature": {
+        "description": "大语言模型功能的枚举。",
+        "enum": [
+          "agent-thought",
+          "audio",
+          "document",
+          "multi-tool-call",
+          "polling",
+          "stream-tool-call",
+          "structured-output",
+          "tool-call",
+          "video",
+          "vision"
+        ],
+        "type": "string"
+      },
+      "ModelPropertyKey": {
+        "description": "模型属性键的枚举。",
+        "enum": [
+          "audio_type",
+          "context_size",
+          "default_voice",
+          "file_upload_limit",
+          "max_characters_per_chunk",
+          "max_chunks",
+          "max_workers",
+          "mode",
+          "supported_file_extensions",
+          "voices",
+          "word_limit"
+        ],
+        "type": "string"
+      },
+      "ModelStatus": {
+        "description": "模型状态的枚举。",
+        "enum": [
+          "active",
+          "credential-removed",
+          "disabled",
+          "no-configure",
+          "no-permission",
+          "quota-exceeded"
+        ],
+        "type": "string"
+      },
+      "ModelType": {
+        "description": "模型类型的枚举。",
+        "enum": [
+          "llm",
+          "moderation",
+          "rerank",
+          "speech2text",
+          "text-embedding",
+          "tts"
+        ],
+        "type": "string"
       },
       "OptionalServiceApiUserPayload": {
         "properties": {
@@ -18638,6 +22419,557 @@
         ],
         "type": "object"
       },
+      "PermissionEnum": {
+        "description": "资源（知识库、凭据等）的共享权限级别。",
+        "enum": [
+          "all_team_members",
+          "only_me",
+          "partial_members"
+        ],
+        "type": "string"
+      },
+      "PipelineDataset": {
+        "properties": {
+          "chunk_structure": {
+            "type": "string",
+            "description": "知识库配置的分段结构。"
+          },
+          "description": {
+            "default": "",
+            "description": "知识库描述。",
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "资源 ID。"
+          },
+          "name": {
+            "type": "string",
+            "description": "资源名称。"
+          }
+        },
+        "required": [
+          "chunk_structure",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "PipelineDocument": {
+        "properties": {
+          "data_source_info": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "数据源特定的元数据（如有）。"
+          },
+          "data_source_type": {
+            "type": "string",
+            "description": "数据源类型。"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "文档是否已启用检索。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "索引错误；未发生错误时为 `null`。"
+          },
+          "id": {
+            "type": "string",
+            "description": "资源 ID。"
+          },
+          "indexing_status": {
+            "type": "string",
+            "description": "排队文档的当前索引状态。使用响应中的 `batch` 调用[获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 查看各阶段进度；`completed` 和 `error` 为终态，`paused` 则需恢复后再继续轮询。"
+          },
+          "name": {
+            "type": "string",
+            "description": "资源名称。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "文档在批次中的位置。"
+          }
+        },
+        "required": [
+          "data_source_type",
+          "enabled",
+          "id",
+          "indexing_status",
+          "name",
+          "position"
+        ],
+        "type": "object"
+      },
+      "PipelineRunApiEntity": {
+        "properties": {
+          "datasource_info_list": {
+            "description": "要处理的数据源对象列表。`datasource_type` 决定条目结构：`local_file` 使用 `reference`；`online_document` 使用 `workspace_id` 和 `page`；`online_drive` 使用 `id` 和 `type`（可选 `bucket`）；`website_crawl` 使用 `url`。生成的 `oneOf` 分支顺序为本地文件、在线文档、网页抓取、在线云盘。",
+            "items": {
+              "oneOf": [
+                {
+                  "properties": {
+                    "name": {
+                      "description": "文档标题。默认为 `untitled`。",
+                      "type": "string"
+                    },
+                    "reference": {
+                      "description": "使用[上传知识流水线文件](/zh/api-reference/knowledge-pipeline/upload-pipeline-file)接口返回的 `id`。也接受 `related_id` 作为别名。",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "reference"
+                  ],
+                  "title": "本地文件",
+                  "type": "object",
+                  "description": "本地文件引用。"
+                },
+                {
+                  "properties": {
+                    "credential_id": {
+                      "description": "用于向外部平台进行身份验证的凭据。省略时使用提供商的默认凭据。",
+                      "type": "string"
+                    },
+                    "page": {
+                      "description": "页面详情。",
+                      "properties": {
+                        "page_id": {
+                          "description": "在 Dify 中浏览已配置在线文档供应商的工作空间或数据库时，由供应商返回的页面 ID。",
+                          "type": "string"
+                        },
+                        "page_name": {
+                          "description": "显示名称。默认为 `untitled`。",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "数据源插件定义的页面类型。",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "page_id",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    "workspace_id": {
+                      "description": "已配置在线文档供应商中的工作空间或数据库 ID。在 Dify 中选择或浏览该供应商时获取；这是供应商自己的资源 ID，不是 Dify 工作区 ID。",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "page",
+                    "workspace_id"
+                  ],
+                  "title": "在线文档",
+                  "type": "object",
+                  "description": "在线文档供应商中的页面。"
+                },
+                {
+                  "properties": {
+                    "title": {
+                      "description": "用作文档名称。默认为 `untitled`。",
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "要抓取的 URL。",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ],
+                  "title": "网页抓取",
+                  "type": "object",
+                  "description": "要抓取的网站 URL。"
+                },
+                {
+                  "properties": {
+                    "bucket": {
+                      "description": "存储桶名称。某些驱动器提供商（如兼容 S3 的存储）需要此字段；若提供商不使用存储桶则省略。",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "在 Dify 中浏览已配置在线云盘供应商时，由供应商返回的文件或文件夹 ID。",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "文件名。默认为 `untitled`。",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "该条目是单个文件还是待展开的文件夹。",
+                      "enum": [
+                        "file",
+                        "folder"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "type"
+                  ],
+                  "title": "在线云盘",
+                  "type": "object",
+                  "description": "在线云盘供应商中的文件或文件夹。"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "datasource_type": {
+            "description": "数据源类型。决定 `datasource_info_list` 中条目所需的字段。",
+            "enum": [
+              "local_file",
+              "online_document",
+              "online_drive",
+              "website_crawl"
+            ],
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "流水线输入变量的键值对，对应工作流中定义的流水线变量。如果流水线没有输入变量，传 `{}`。",
+            "type": "object"
+          },
+          "is_published": {
+            "description": "是否运行知识流水线的已发布版本或草稿版本。`true` 运行最新已发布版本；`false` 运行当前草稿，适合测试未发布的更改。",
+            "type": "boolean"
+          },
+          "response_mode": {
+            "description": "草稿运行的响应模式。SSE 使用 `streaming`，JSON 使用 `blocking`。已发布版本的运行会进入队列，并始终以 JSON 返回批次元数据。",
+            "enum": [
+              "blocking",
+              "streaming"
+            ],
+            "type": "string"
+          },
+          "start_node_id": {
+            "description": "流水线起始数据源节点的 ID。数据源节点是知识流水线读取文件、供应商页面、云盘或 URL 的入口步骤。使用[获取数据源插件列表](/zh/api-reference/knowledge-pipeline/list-datasource-plugins)返回的 `node_id`。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "datasource_info_list",
+          "datasource_type",
+          "inputs",
+          "is_published",
+          "response_mode",
+          "start_node_id"
+        ],
+        "type": "object"
+      },
+      "PipelineRunJsonResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PublishedPipelineRunResponse"
+          },
+          {
+            "$ref": "#/components/schemas/WorkflowBlockingResponse"
+          }
+        ]
+      },
+      "PipelineUploadFileResponse": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "上传时间戳（ISO 8601 格式）。在记录创建过程中可能为 `null`。"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "上传文件的用户 ID。"
+          },
+          "extension": {
+            "type": "string",
+            "description": "文件扩展名。"
+          },
+          "id": {
+            "type": "string",
+            "description": "已上传文件的唯一标识符。"
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "文件的 MIME 类型。若上传未包含 MIME 类型则可能为 `null`。"
+          },
+          "name": {
+            "type": "string",
+            "description": "原始文件名。"
+          },
+          "size": {
+            "type": "integer",
+            "description": "文件大小（字节）。"
+          }
+        },
+        "required": [
+          "created_by",
+          "extension",
+          "id",
+          "name",
+          "size"
+        ],
+        "type": "object"
+      },
+      "PreProcessingRule": {
+        "properties": {
+          "enabled": {
+            "description": "该预处理规则是否启用。",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "规则标识符。",
+            "enum": [
+              "remove_extra_spaces",
+              "remove_stopwords",
+              "remove_urls_emails"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "enabled",
+          "id"
+        ],
+        "type": "object"
+      },
+      "ProcessRule": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/ProcessRuleMode",
+            "description": "处理模式。`automatic` 使用内置规则，`custom` 允许手动配置，`hierarchical` 为 `doc_form: hierarchical_model` 启用父子分段结构。"
+          },
+          "rules": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Rule"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "自定义处理规则。"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "ProcessRuleMode": {
+        "description": "知识库处理规则模式。",
+        "enum": [
+          "automatic",
+          "custom",
+          "hierarchical"
+        ],
+        "type": "string"
+      },
+      "ProviderModelWithStatusEntity": {
+        "description": "模型响应的数据模型。",
+        "properties": {
+          "deprecated": {
+            "default": false,
+            "type": "boolean",
+            "description": "模型是否已弃用。"
+          },
+          "features": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ModelFeature"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "模型支持的功能，无功能时为 `null`。"
+          },
+          "fetch_from": {
+            "$ref": "#/components/schemas/FetchFrom",
+            "description": "模型定义的来源。`predefined-model` 表示内置模型，`customizable-model` 表示用户自配置的模型。"
+          },
+          "has_invalid_load_balancing_configs": {
+            "default": false,
+            "type": "boolean",
+            "description": "模型是否存在无效的负载均衡配置。"
+          },
+          "label": {
+            "$ref": "#/components/schemas/I18nObject",
+            "description": "模型的本地化显示名称。"
+          },
+          "load_balancing_enabled": {
+            "default": false,
+            "type": "boolean",
+            "description": "模型是否启用负载均衡。"
+          },
+          "model": {
+            "type": "string",
+            "description": "模型标识符。创建或更新知识库时，将此值作为 `embedding_model` 参数使用。"
+          },
+          "model_properties": {
+            "additionalProperties": true,
+            "propertyNames": {
+              "$ref": "#/components/schemas/ModelPropertyKey"
+            },
+            "type": "object",
+            "description": "模型特定的属性，例如 `context_size`。"
+          },
+          "model_type": {
+            "$ref": "#/components/schemas/ModelType",
+            "description": "模型类型，与 `model_type` 路径参数匹配。"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ModelStatus",
+            "description": "模型可用状态。就绪时为 `active`。"
+          }
+        },
+        "required": [
+          "fetch_from",
+          "label",
+          "model",
+          "model_properties",
+          "model_type",
+          "status"
+        ],
+        "type": "object"
+      },
+      "ProviderWithModelsListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ProviderWithModelsResponse"
+            },
+            "type": "array",
+            "description": "模型提供商及其可用模型。"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ProviderWithModelsResponse": {
+        "description": "包含模型列表的提供商响应数据模型。",
+        "properties": {
+          "icon_small": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/I18nObject"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "供应商小图标的 URL。"
+          },
+          "icon_small_dark": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/I18nObject"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "深色模式图标 URL；供应商没有时为 `null`。"
+          },
+          "label": {
+            "$ref": "#/components/schemas/I18nObject",
+            "description": "供应商的本地化显示名称。"
+          },
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/ProviderModelWithStatusEntity"
+            },
+            "type": "array",
+            "description": "该供应商的可用模型列表。"
+          },
+          "provider": {
+            "type": "string",
+            "description": "模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。旧版供应商可能返回简写形式（例如 `openai`）。"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CustomConfigurationStatus",
+            "description": "供应商状态。凭证已配置且有效时为 `active`。"
+          },
+          "tenant_id": {
+            "type": "string",
+            "description": "该供应商配置所属的工作空间 ID。"
+          }
+        },
+        "required": [
+          "label",
+          "models",
+          "provider",
+          "status",
+          "tenant_id"
+        ],
+        "type": "object"
+      },
+      "PublishedPipelineRunResponse": {
+        "properties": {
+          "batch": {
+            "type": "string",
+            "description": "已排队发布运行的批次 ID。将其作为 `batch` 传给[获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status)，轮询直到所有文档完成、失败或暂停。"
+          },
+          "dataset": {
+            "$ref": "#/components/schemas/PipelineDataset",
+            "description": "接收生成文档的知识库。"
+          },
+          "documents": {
+            "items": {
+              "$ref": "#/components/schemas/PipelineDocument"
+            },
+            "type": "array",
+            "description": "已创建并排队等待索引的文档。"
+          }
+        },
+        "required": [
+          "batch",
+          "dataset",
+          "documents"
+        ],
+        "type": "object"
+      },
       "RequiredServiceApiUserPayload": {
         "properties": {
           "user": {
@@ -18648,6 +22980,35 @@
         "required": [
           "user"
         ],
+        "type": "object"
+      },
+      "RerankingModel": {
+        "properties": {
+          "reranking_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "重排序模型名称。"
+          },
+          "reranking_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "重排序模型的提供商名称。"
+          }
+        },
         "type": "object"
       },
       "ResultResponse": {
@@ -18662,187 +23023,105 @@
         ],
         "type": "object"
       },
-      "RetrievalModel": {
-        "type": "object",
-        "required": [
-          "search_method",
-          "reranking_enable",
-          "top_k",
-          "score_threshold_enabled"
+      "RetrievalMethod": {
+        "enum": [
+          "full_text_search",
+          "hybrid_search",
+          "keyword_search",
+          "semantic_search"
         ],
+        "type": "string"
+      },
+      "RetrievalModel": {
         "properties": {
-          "search_method": {
-            "type": "string",
-            "description": "用于检索的搜索方法。",
-            "enum": [
-              "keyword_search",
-              "semantic_search",
-              "full_text_search",
-              "hybrid_search"
-            ]
+          "metadata_filtering_conditions": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MetadataFilteringCondition"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "仅检索文档元数据匹配指定条件的分段。条件由服务端基于文档元数据字段评估。"
           },
           "reranking_enable": {
-            "type": "boolean",
-            "description": "是否启用重排序。"
-          },
-          "reranking_model": {
-            "type": "object",
-            "description": "重排序模型配置。",
-            "properties": {
-              "reranking_provider_name": {
-                "type": "string",
-                "description": "重排序模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/cohere/cohere`）。`cohere` 这类简写会展开为 `langgenius/<name>/<name>`，仅对 langgenius 发布的插件有效。\n\n有效取值从 [获取可用模型](/zh/api-reference/models/get-available-models) 中 `model_type=rerank` 返回的 `provider` 字段获取。"
-              },
-              "reranking_model_name": {
-                "type": "string",
-                "description": "重排序模型名称。"
-              }
-            }
+            "description": "是否启用重排序。",
+            "type": "boolean"
           },
           "reranking_mode": {
-            "type": "string",
-            "enum": [
-              "reranking_model",
-              "weighted_score"
+            "anyOf": [
+              {
+                "enum": [
+                  "reranking_model",
+                  "weighted_score"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "nullable": true,
+            "default": null,
             "description": "重排序模式。当 `reranking_enable` 为 `true` 时必填。"
           },
-          "top_k": {
-            "type": "integer",
-            "description": "返回的最大结果数。"
-          },
-          "score_threshold_enabled": {
-            "type": "boolean",
-            "description": "是否启用分数阈值过滤。"
+          "reranking_model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RerankingModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "重排序模型配置。"
           },
           "score_threshold": {
-            "type": "number",
-            "nullable": true,
-            "description": "结果的最低相关性分数。仅在 `score_threshold_enabled` 为 `true` 时生效。"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "最低相似度分数，取值范围为 0 到 1。仅在 `score_threshold_enabled` 为 `true` 时生效。"
+          },
+          "score_threshold_enabled": {
+            "description": "是否启用分数阈值过滤。",
+            "type": "boolean"
+          },
+          "search_method": {
+            "$ref": "#/components/schemas/RetrievalMethod",
+            "description": "用于检索的搜索方法。"
+          },
+          "top_k": {
+            "description": "返回的最大结果数。",
+            "type": "integer"
           },
           "weights": {
-            "type": "object",
-            "nullable": true,
-            "description": "混合搜索的权重配置。",
-            "properties": {
-              "weight_type": {
-                "type": "string",
-                "description": "平衡语义搜索和关键词搜索权重的策略。",
-                "enum": [
-                  "semantic_first",
-                  "keyword_first",
-                  "customized"
-                ]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WeightModel"
               },
-              "vector_setting": {
-                "type": "object",
-                "description": "语义搜索权重设置。",
-                "properties": {
-                  "vector_weight": {
-                    "type": "number",
-                    "description": "分配给语义（向量）搜索结果的权重。"
-                  },
-                  "embedding_provider_name": {
-                    "type": "string",
-                    "description": "用于向量搜索的嵌入模型供应商。"
-                  },
-                  "embedding_model_name": {
-                    "type": "string",
-                    "description": "用于向量搜索的嵌入模型名称。"
-                  }
-                }
-              },
-              "keyword_setting": {
-                "type": "object",
-                "description": "关键词搜索权重设置。",
-                "properties": {
-                  "keyword_weight": {
-                    "type": "number",
-                    "description": "分配给关键词搜索结果的权重。"
-                  }
-                }
+              {
+                "type": "null"
               }
-            }
-          },
-          "metadata_filtering_conditions": {
-            "type": "object",
-            "nullable": true,
-            "description": "仅检索文档元数据匹配指定条件的分段。条件由服务端基于文档元数据字段评估。",
-            "properties": {
-              "logical_operator": {
-                "type": "string",
-                "enum": [
-                  "and",
-                  "or"
-                ],
-                "default": "and",
-                "nullable": true,
-                "description": "多个条件之间的组合方式。"
-              },
-              "conditions": {
-                "type": "array",
-                "nullable": true,
-                "description": "要评估的元数据条件列表。",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "name",
-                    "comparison_operator"
-                  ],
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "用于比较的元数据字段名称。"
-                    },
-                    "comparison_operator": {
-                      "type": "string",
-                      "description": "按元数据类型选择要应用的比较方式：\n\n- 字符串或数组类型元数据：`contains`、`not contains`、`start with`、`end with`、`is`、`is not`、`empty`、`not empty`、`in`、`not in`\n- 数值类型元数据：`=`、`≠`、`>`、`<`、`≥`、`≤`\n- 时间类型元数据：`before`、`after`",
-                      "enum": [
-                        "contains",
-                        "not contains",
-                        "start with",
-                        "end with",
-                        "is",
-                        "is not",
-                        "empty",
-                        "not empty",
-                        "in",
-                        "not in",
-                        "=",
-                        "≠",
-                        ">",
-                        "<",
-                        "≥",
-                        "≤",
-                        "before",
-                        "after"
-                      ]
-                    },
-                    "value": {
-                      "nullable": true,
-                      "description": "用于比较的值。类型取决于 `comparison_operator`：大多数字符串运算符使用字符串；`in` 和 `not in` 使用字符串数组；数值运算符使用数字；`empty` 和 `not empty` 时省略。",
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        {
-                          "type": "number"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
+            ],
+            "default": null,
+            "description": "混合搜索的权重配置。"
           }
-        }
+        },
+        "required": [
+          "reranking_enable",
+          "score_threshold_enabled",
+          "search_method",
+          "top_k"
+        ],
+        "type": "object"
       },
       "RetrieverResource": {
         "properties": {
@@ -19040,6 +23319,218 @@
         "type": "object",
         "description": "检索资源的引用和归属信息。"
       },
+      "Rule": {
+        "properties": {
+          "parent_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "full-doc",
+                  "paragraph"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "父子分段模式。"
+          },
+          "pre_processing_rules": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PreProcessingRule"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "分段前应用的预处理规则。"
+          },
+          "segmentation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Segmentation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "父分段设置。"
+          },
+          "subchunk_segmentation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Segmentation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "子分段设置。"
+          }
+        },
+        "type": "object"
+      },
+      "SegmentAttachmentResponse": {
+        "properties": {
+          "extension": {
+            "type": "string",
+            "description": "文件扩展名。"
+          },
+          "id": {
+            "type": "string",
+            "description": "附件文件标识符。"
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "文件的 MIME 类型。"
+          },
+          "name": {
+            "type": "string",
+            "description": "原始文件名。"
+          },
+          "size": {
+            "type": "integer",
+            "description": "文件大小（字节）。"
+          },
+          "source_url": {
+            "type": "string",
+            "description": "访问附件的 URL。"
+          }
+        },
+        "required": [
+          "extension",
+          "id",
+          "mime_type",
+          "name",
+          "size",
+          "source_url"
+        ],
+        "type": "object"
+      },
+      "SegmentCreateItemPayload": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "问答模式的答案内容。"
+          },
+          "attachment_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "附件文件 ID。"
+          },
+          "content": {
+            "description": "分段文本内容。",
+            "minLength": 1,
+            "type": "string"
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "分段的关键词。"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "SegmentCreateListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SegmentResponse"
+            },
+            "type": "array",
+            "description": "已创建的分段列表。"
+          },
+          "doc_form": {
+            "type": "string",
+            "description": "该文档使用的分块模式。"
+          }
+        },
+        "required": [
+          "data",
+          "doc_form"
+        ],
+        "type": "object"
+      },
+      "SegmentCreatePayload": {
+        "properties": {
+          "segments": {
+            "description": "要创建的分段对象数组。",
+            "items": {
+              "$ref": "#/components/schemas/SegmentCreateItemPayload"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "segments"
+        ],
+        "type": "object"
+      },
+      "SegmentDetailResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SegmentResponse",
+            "description": "已创建的分段列表。"
+          },
+          "doc_form": {
+            "type": "string",
+            "description": "该文档使用的分块模式。"
+          }
+        },
+        "required": [
+          "data",
+          "doc_form"
+        ],
+        "type": "object"
+      },
       "SegmentListQuery": {
         "properties": {
           "keyword": {
@@ -19074,6 +23565,403 @@
             "type": "array"
           }
         },
+        "type": "object"
+      },
+      "SegmentListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SegmentResponse"
+            },
+            "type": "array",
+            "description": "分段列表。"
+          },
+          "doc_form": {
+            "type": "string",
+            "description": "该文档使用的分块模式。"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "下一页是否还有更多项目。"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "每页条目数。"
+          },
+          "page": {
+            "type": "integer",
+            "description": "当前页码。"
+          },
+          "total": {
+            "type": "integer",
+            "description": "匹配的分段总数。"
+          }
+        },
+        "required": [
+          "data",
+          "doc_form",
+          "has_more",
+          "limit",
+          "page",
+          "total"
+        ],
+        "type": "object"
+      },
+      "SegmentResponse": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "回答内容，用于问答模式文档。"
+          },
+          "attachments": {
+            "items": {
+              "$ref": "#/components/schemas/SegmentAttachmentResponse"
+            },
+            "type": "array",
+            "description": "附加到该分段的文件。"
+          },
+          "child_chunks": {
+            "items": {
+              "$ref": "#/components/schemas/ChildChunkResponse"
+            },
+            "type": "array",
+            "description": "属于该分段的子分段。仅在分层模式文档中存在。"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "完成时间，Unix 秒级时间戳；未完成时为 `null`。"
+          },
+          "content": {
+            "type": "string",
+            "description": "分段的文本内容。"
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "创建时间戳（Unix 纪元，单位为秒）。"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "创建该分段的用户 ID。"
+          },
+          "disabled_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "停用时间，Unix 秒级时间戳；启用时为 `null`。"
+          },
+          "disabled_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "禁用该分段的用户 ID。启用时为 `null`。"
+          },
+          "document_id": {
+            "type": "string",
+            "description": "该分段所属文档的 ID。"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "该分段是否启用检索。"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引失败时的错误消息。无错误时为 `null`。"
+          },
+          "hit_count": {
+            "type": "integer",
+            "description": "该分段在检索查询中被匹配的次数。"
+          },
+          "id": {
+            "type": "string",
+            "description": "分段的唯一标识符。"
+          },
+          "index_node_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引内容的哈希值，用于检测变更。"
+          },
+          "index_node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "向量存储中索引节点的 ID。"
+          },
+          "indexing_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引开始时间，Unix 秒级时间戳；未开始时为 `null`。"
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "与该分段关联的关键词，用于基于关键词的检索。"
+          },
+          "position": {
+            "type": "integer",
+            "description": "分段在文档中的位置。"
+          },
+          "sign_content": {
+            "type": "string",
+            "description": "用于完整性验证的签名内容哈希。"
+          },
+          "status": {
+            "type": "string",
+            "description": "分段的当前索引状态，例如 `completed`、`indexing`、`error`。"
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "索引停止时间，Unix 秒级时间戳；未停止时为 `null`。"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "AI 生成的分段内容摘要。未启用摘要索引时为 `null`。"
+          },
+          "tokens": {
+            "type": "integer",
+            "description": "分段内容的令牌数。"
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "最后更新时间戳（Unix 纪元，单位为秒）。"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "最后更新该分段的用户 ID。"
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "分段内容的字数。"
+          }
+        },
+        "required": [
+          "answer",
+          "attachments",
+          "child_chunks",
+          "completed_at",
+          "content",
+          "created_at",
+          "created_by",
+          "disabled_at",
+          "disabled_by",
+          "document_id",
+          "enabled",
+          "error",
+          "hit_count",
+          "id",
+          "index_node_hash",
+          "index_node_id",
+          "indexing_at",
+          "keywords",
+          "position",
+          "sign_content",
+          "status",
+          "stopped_at",
+          "summary",
+          "tokens",
+          "updated_at",
+          "updated_by",
+          "word_count"
+        ],
+        "type": "object"
+      },
+      "SegmentUpdateArgs": {
+        "properties": {
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "问答模式更新后的答案内容。"
+          },
+          "attachment_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "附件文件 ID。"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "更新后的分段文本内容。"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "分段是否已启用。"
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "更新后的分段关键词。"
+          },
+          "regenerate_child_chunks": {
+            "default": false,
+            "description": "更新父分段后是否重新生成子分段。",
+            "type": "boolean"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "摘要索引的摘要内容。"
+          }
+        },
+        "type": "object"
+      },
+      "SegmentUpdatePayload": {
+        "properties": {
+          "segment": {
+            "$ref": "#/components/schemas/SegmentUpdateArgs",
+            "description": "分段更新载荷。"
+          }
+        },
+        "required": [
+          "segment"
+        ],
+        "type": "object"
+      },
+      "Segmentation": {
+        "properties": {
+          "chunk_overlap": {
+            "default": 0,
+            "description": "分段之间的令牌重叠数。",
+            "type": "integer"
+          },
+          "max_tokens": {
+            "description": "每个分段的最大令牌数。",
+            "type": "integer"
+          },
+          "separator": {
+            "default": "\n",
+            "description": "用于拆分文本的自定义分隔符。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "max_tokens"
+        ],
         "type": "object"
       },
       "SelectInputConfig": {
@@ -19510,6 +24398,136 @@
         ],
         "type": "object"
       },
+      "TagBindingPayload": {
+        "properties": {
+          "tag_ids": {
+            "description": "要绑定的标签 ID。",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "target_id": {
+            "description": "要绑定标签的知识库 ID。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag_ids",
+          "target_id"
+        ],
+        "type": "object"
+      },
+      "TagCreatePayload": {
+        "properties": {
+          "name": {
+            "description": "标签名称。",
+            "maxLength": 50,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "TagDeletePayload": {
+        "properties": {
+          "tag_id": {
+            "description": "要删除的标签 ID。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag_id"
+        ],
+        "type": "object"
+      },
+      "TagUnbindingPayload": {
+        "anyOf": [
+          {
+            "properties": {
+              "tag_id": {
+                "deprecated": true,
+                "description": "Service API 兼容的旧版单个标签 ID。",
+                "type": "string"
+              },
+              "tag_ids": {
+                "description": "要解除绑定的标签 ID。新集成请使用此字段。",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "target_id": {
+                "description": "知识库 ID。",
+                "type": "string"
+              }
+            },
+            "required": [
+              "tag_id",
+              "target_id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "tag_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "deprecated": true,
+                "description": "Service API 兼容的旧版单个标签 ID。"
+              },
+              "tag_ids": {
+                "description": "要解除绑定的标签 ID。新集成请使用此字段。",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "target_id": {
+                "description": "知识库 ID。",
+                "type": "string"
+              }
+            },
+            "required": [
+              "tag_ids",
+              "target_id"
+            ],
+            "type": "object"
+          }
+        ],
+        "description": "接受旧版 `tag_id` 载荷或标准化的 `tag_ids` 载荷。"
+      },
+      "TagUpdatePayload": {
+        "properties": {
+          "name": {
+            "description": "标签名称。",
+            "maxLength": 50,
+            "minLength": 1,
+            "type": "string"
+          },
+          "tag_id": {
+            "description": "要更新的标签 ID。",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "tag_id"
+        ],
+        "type": "object"
+      },
       "TextToAudioPayload": {
         "properties": {
           "message_id": {
@@ -19639,6 +24657,18 @@
         ],
         "type": "object"
       },
+      "UrlResponse": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "用于下载原始上传文件的签名 URL。"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
       "UserActionConfig": {
         "description": "用户操作配置。",
         "properties": {
@@ -19672,6 +24702,86 @@
           "variable"
         ],
         "type": "string"
+      },
+      "WeightKeywordSetting": {
+        "properties": {
+          "keyword_weight": {
+            "description": "关键词检索权重，取值范围为 0 到 1。使用 `customized` 权重时，应与 `vector_weight` 相加等于 1。",
+            "type": "number"
+          }
+        },
+        "required": [
+          "keyword_weight"
+        ],
+        "type": "object"
+      },
+      "WeightModel": {
+        "properties": {
+          "keyword_setting": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WeightKeywordSetting"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "关键词搜索权重设置。"
+          },
+          "vector_setting": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WeightVectorSetting"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "语义搜索权重设置。"
+          },
+          "weight_type": {
+            "anyOf": [
+              {
+                "enum": [
+                  "customized",
+                  "keyword_first",
+                  "semantic_first"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "平衡语义搜索和关键词搜索权重的策略。"
+          }
+        },
+        "type": "object"
+      },
+      "WeightVectorSetting": {
+        "properties": {
+          "embedding_model_name": {
+            "description": "用于向量搜索的嵌入模型名称。",
+            "type": "string"
+          },
+          "embedding_provider_name": {
+            "description": "用于向量搜索的嵌入模型供应商。",
+            "type": "string"
+          },
+          "vector_weight": {
+            "description": "语义向量检索权重，取值范围为 0 到 1。使用 `customized` 权重时，应与 `keyword_weight` 相加等于 1。",
+            "type": "number"
+          }
+        },
+        "required": [
+          "embedding_model_name",
+          "embedding_provider_name",
+          "vector_weight"
+        ],
+        "type": "object"
       },
       "WorkflowAppLogPaginationResponse": {
         "properties": {


### PR DESCRIPTION
## Summary

- align 104 schemas used only by knowledge Service API operations
- add the corresponding reviewed English, Chinese, and Japanese overlay actions
- leave operation paths unchanged for the dedicated knowledge-reference layers

## Validation

- three-locale structural parity — 0 issues