### PR TITLE
docs: generate application api references

### DIFF
--- a/en/api-reference/openapi_service.json
+++ b/en/api-reference/openapi_service.json
@@ -91,21 +91,1039 @@
     }
   ],
   "paths": {
-    "/chat-messages": {
-      "post": {
-        "summary": "Send Chat Message",
-        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nSends a message to a chat app and returns the assistant's reply. The events in the streaming response vary by app type.",
-        "operationId": "sendChatMessage",
+    "/": {
+      "get": {
+        "operationId": "get_index_api",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexInfoResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Success",
+                    "value": {
+                      "welcome": "Dify OpenAPI",
+                      "api_version": "v1",
+                      "server_version": "1.17.0"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Service API and server version information."
+          }
+        },
+        "security": [],
+        "summary": "Get API Information",
         "tags": [
-          "Chat Messages"
+          "Applications"
+        ],
+        "description": "Returns the Service API and server versions.",
+        "x-mint": {
+          "href": "/en/api-reference/applications/get-api-information",
+          "metadata": {
+            "title": "Get API Information",
+            "sidebarTitle": "Get API Information"
+          }
+        }
+      }
+    },
+    "/app/feedbacks": {
+      "get": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent, Text Generator apps.\n\nReturns a paginated list of all feedback on the app's messages, including both end-user and admin submissions.\n\nLists feedback records one page at a time. The response has no total or `has_more` field; stop when `data` is empty or contains fewer records than the requested `limit`.",
+        "operationId": "getChatAppFeedbacks",
+        "parameters": [
+          {
+            "description": "Feedback items per page.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of records per page.",
+              "maximum": 101,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "Page number for pagination.",
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppFeedbackListResponse"
+                },
+                "examples": {
+                  "feedbacksList": {
+                    "summary": "Response Example",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
+                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                          "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
+                          "rating": "like",
+                          "content": "The response accurately answered my question about product specifications.",
+                          "from_source": "user",
+                          "from_end_user_id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                          "from_account_id": null,
+                          "created_at": "2025-01-16T14:30:29Z",
+                          "updated_at": "2025-01-16T14:30:29Z"
+                        },
+                        {
+                          "id": "c8f3a9b2-4d5e-6f70-8901-bcdef2345678",
+                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "conversation_id": "56812a93-9229-5cd6-9f0c-75673b666603",
+                          "message_id": "ae24b5c0-f814-584d-a493-5439e5d6b7b1",
+                          "rating": "dislike",
+                          "content": "The answer was too vague and did not address the specific pricing question.",
+                          "from_source": "user",
+                          "from_end_user_id": "d2c1b0a9-8765-4321-fedc-ba9876543210",
+                          "from_account_id": null,
+                          "created_at": "2025-01-15T09:12:45Z",
+                          "updated_at": "2025-01-15T09:12:45Z"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "A list of application feedbacks."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          }
+        },
+        "summary": "List App Feedbacks",
+        "tags": [
+          "Feedback"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/feedback/list-app-feedbacks",
+          "metadata": {
+            "title": "List App Feedbacks",
+            "sidebarTitle": "List App Feedbacks"
+          }
+        }
+      }
+    },
+    "/apps/annotation-reply/{action}": {
+      "post": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nEnables or disables annotation reply for the app. Runs asynchronously; track progress with [Get Annotation Reply Job Status](/en/api-reference/annotations/get-annotation-reply-job-status).\n\nThe body is validated before the action runs, so `score_threshold`, `embedding_provider_name`, and `embedding_model_name` are required even for `disable`. Call [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding` and copy its `provider` and `model` values; the request example uses `openai` and `text-embedding-3-small`.",
+        "operationId": "initialAnnotationReplySettings",
+        "parameters": [
+          {
+            "description": "Action to perform: `enable` or `disable`.",
+            "in": "path",
+            "name": "action",
+            "required": true,
+            "schema": {
+              "description": "Action to perform: `enable` or `disable`.",
+              "enum": [
+                "disable",
+                "enable"
+              ],
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
-          "description": "Request body to send a chat message.",
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ChatRequest"
+                "$ref": "#/components/schemas/AnnotationReplyActionPayload"
+              },
+              "examples": {
+                "enableAnnotationReply": {
+                  "summary": "Request Example",
+                  "value": {
+                    "score_threshold": 0.9,
+                    "embedding_provider_name": "openai",
+                    "embedding_model_name": "text-embedding-3-small"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationJobStatusResponse"
+                },
+                "examples": {
+                  "annotationReplyResponse": {
+                    "summary": "Response Example",
+                    "value": {
+                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "job_status": "waiting"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Annotation reply settings task initiated."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          }
+        },
+        "summary": "Configure Annotation Reply",
+        "tags": [
+          "Annotations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/annotations/configure-annotation-reply",
+          "metadata": {
+            "title": "Configure Annotation Reply",
+            "sidebarTitle": "Configure Annotation Reply"
+          }
+        }
+      }
+    },
+    "/apps/annotation-reply/{action}/status/{job_id}": {
+      "get": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nReturns the status of an annotation reply configuration job started by [Configure Annotation Reply](/en/api-reference/annotations/configure-annotation-reply).",
+        "operationId": "getInitialAnnotationReplySettingsStatus",
+        "parameters": [
+          {
+            "description": "Action to perform: `enable` or `disable`.",
+            "in": "path",
+            "name": "action",
+            "required": true,
+            "schema": {
+              "description": "Action to perform: `enable` or `disable`.",
+              "enum": [
+                "disable",
+                "enable"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Job ID returned by [Configure Annotation Reply](/en/api-reference/annotations/configure-annotation-reply).",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "Job ID returned by [Configure Annotation Reply](/en/api-reference/annotations/configure-annotation-reply).",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationJobStatusDetailResponse"
+                },
+                "examples": {
+                  "jobStatus": {
+                    "summary": "Response Example",
+                    "value": {
+                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "job_status": "completed",
+                      "error_msg": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successfully retrieved task status."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "The job does not exist."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param` : The job does not exist. This is the status returned by the current runtime for an unknown or expired job ID."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "Reserved compatibility response. The current runtime reports an unknown or expired job as `400 invalid_param`, not `404`."
+          }
+        },
+        "summary": "Get Annotation Reply Job Status",
+        "tags": [
+          "Annotations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/annotations/get-annotation-reply-job-status",
+          "metadata": {
+            "title": "Get Annotation Reply Job Status",
+            "sidebarTitle": "Get Annotation Reply Job Status"
+          }
+        }
+      }
+    },
+    "/apps/annotations": {
+      "get": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nLists the app's annotations, optionally filtered by keyword.",
+        "operationId": "getAnnotationList",
+        "parameters": [
+          {
+            "description": "Keyword to filter annotations by question or answer content.",
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "Keyword to filter annotations by question or answer content.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of items per page. Requests above 100 are capped at 100.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of items per page.",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "Page number for pagination.",
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationList"
+                },
+                "examples": {
+                  "annotationList": {
+                    "summary": "Response Example",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "question": "What is Dify?",
+                          "answer": "Dify is an open-source LLM application development platform.",
+                          "hit_count": 5,
+                          "created_at": 1705407629
+                        }
+                      ],
+                      "has_more": false,
+                      "limit": 20,
+                      "total": 1,
+                      "page": 1
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successfully retrieved annotation list."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          }
+        },
+        "summary": "List Annotations",
+        "tags": [
+          "Annotations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/annotations/list-annotations",
+          "metadata": {
+            "title": "List Annotations",
+            "sidebarTitle": "List Annotations"
+          }
+        }
+      },
+      "post": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nCreates an annotation. Annotations are predefined question-answer pairs the app returns directly on a match, instead of generating a fresh response.",
+        "operationId": "createAnnotation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationCreatePayload"
+              },
+              "examples": {
+                "createAnnotation": {
+                  "summary": "Request Example",
+                  "value": {
+                    "question": "What is Dify?",
+                    "answer": "Dify is an open-source LLM application development platform."
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                },
+                "examples": {
+                  "createdAnnotation": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "question": "What is Dify?",
+                      "answer": "Dify is an open-source LLM application development platform.",
+                      "hit_count": 0,
+                      "created_at": 1705407629
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Annotation created successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          }
+        },
+        "summary": "Create Annotation",
+        "tags": [
+          "Annotations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/annotations/create-annotation",
+          "metadata": {
+            "title": "Create Annotation",
+            "sidebarTitle": "Create Annotation"
+          }
+        }
+      }
+    },
+    "/apps/annotations/{annotation_id}": {
+      "delete": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nDeletes an annotation and its associated hit history.",
+        "operationId": "deleteAnnotation",
+        "parameters": [
+          {
+            "description": "ID of the annotation to delete. Get annotation IDs from [List Annotations](/en/api-reference/annotations/list-annotations).",
+            "in": "path",
+            "name": "annotation_id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the annotation to delete.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Annotation deleted successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Annotation not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Annotation does not exist."
+          }
+        },
+        "summary": "Delete Annotation",
+        "tags": [
+          "Annotations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/annotations/delete-annotation",
+          "metadata": {
+            "title": "Delete Annotation",
+            "sidebarTitle": "Delete Annotation"
+          }
+        }
+      },
+      "put": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nUpdates an annotation's question and answer.",
+        "operationId": "updateAnnotation",
+        "parameters": [
+          {
+            "description": "ID of the annotation to update. Get annotation IDs from [List Annotations](/en/api-reference/annotations/list-annotations).",
+            "in": "path",
+            "name": "annotation_id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the annotation to update.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationCreatePayload"
+              },
+              "examples": {
+                "updateAnnotation": {
+                  "summary": "Request Example",
+                  "value": {
+                    "question": "What is Dify?",
+                    "answer": "Dify is an open-source LLM application development platform for building AI-powered apps."
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                },
+                "examples": {
+                  "updatedAnnotation": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "question": "What is Dify?",
+                      "answer": "Dify is an open-source LLM application development platform for building AI-powered apps.",
+                      "hit_count": 5,
+                      "created_at": 1705407629
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Annotation updated successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Annotation not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Annotation does not exist."
+          }
+        },
+        "summary": "Update Annotation",
+        "tags": [
+          "Annotations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/annotations/update-annotation",
+          "metadata": {
+            "title": "Update Annotation",
+            "sidebarTitle": "Update Annotation"
+          }
+        }
+      }
+    },
+    "/audio-to-text": {
+      "post": {
+        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nTranscribes an uploaded audio file to text using the workspace's default speech-to-text model.",
+        "operationId": "audioToText",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "description": "Audio file to transcribe. Supported MIME types: `audio/mp3`, `audio/mpga`, `audio/m4a`, `audio/x-m4a`, `audio/wav`, and `audio/amr`. File size limit is `30 MB`.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "user": {
+                    "description": "User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AudioTranscriptResponse"
+                },
+                "examples": {
+                  "audioToTextSuccess": {
+                    "summary": "Response Example",
+                    "value": {
+                      "text": "Hello, I would like to know more about the iPhone 13 Pro Max."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successfully converted audio to text."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_audio_uploaded": {
+                    "summary": "no_audio_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_audio_uploaded",
+                      "message": "Please upload your audio."
+                    }
+                  },
+                  "speech_to_text_disabled": {
+                    "summary": "speech_to_text_disabled",
+                    "value": {
+                      "status": 400,
+                      "code": "speech_to_text_disabled",
+                      "message": "Speech to text is disabled."
+                    }
+                  },
+                  "provider_not_support_speech_to_text": {
+                    "summary": "provider_not_support_speech_to_text",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_support_speech_to_text",
+                      "message": "Provider not support speech to text."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `no_audio_uploaded` : No audio file was provided in the `file` field.\n- `speech_to_text_disabled` : Speech-to-text is disabled for this app.\n- `provider_not_support_speech_to_text` : The model provider does not support speech-to-text.\n- `provider_not_initialize` : No valid model provider credentials are configured.\n- `completion_request_error` : The speech recognition request failed."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "audio_too_large": {
+                    "summary": "audio_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "audio_too_large",
+                      "message": "Audio size larger than 30 mb"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`audio_too_large` : The audio file exceeds the `30 MB` size limit."
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_audio_type": {
+                    "summary": "unsupported_audio_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_audio_type",
+                      "message": "Audio type not allowed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`unsupported_audio_type` : The file's MIME type is not one of the accepted audio types (see the `file` field)."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error` : Internal server error."
+          }
+        },
+        "summary": "Convert Audio to Text",
+        "tags": [
+          "Audio"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/audio-to-text' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@meeting-question.mp3' \\\n  --form 'user={user}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/audio/convert-audio-to-text",
+          "metadata": {
+            "title": "Convert Audio to Text",
+            "sidebarTitle": "Convert Audio to Text"
+          }
+        }
+      }
+    },
+    "/chat-messages": {
+      "post": {
+        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nSends a message to a chat app and returns the assistant's reply. The events in the streaming response vary by app type.",
+        "operationId": "sendChatMessage",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequestPayloadWithUser"
               },
               "examples": {
                 "streaming_example": {
@@ -139,15 +1157,16 @@
                 }
               }
             }
-          }
+          },
+          "required": true,
+          "description": "Request body to send a chat message."
         },
         "responses": {
           "200": {
-            "description": "Successful response. The content type and structure depend on the `response_mode` parameter in the request.\n\n- If `response_mode` is `blocking`, returns `application/json` with a `ChatCompletionResponse` object.\n- If `response_mode` is `streaming`, returns `text/event-stream` with a stream of Server-Sent Events.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChatCompletionResponse"
+                  "$ref": "#/components/schemas/ChatBlockingResponse"
                 },
                 "examples": {
                   "blockingResponse": {
@@ -217,10 +1236,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Successful response. In `blocking` mode, returns `application/json` with a `ChatBlockingResponse` object. In `streaming` mode, returns `text/event-stream` with Server-Sent Events."
           },
           "400": {
-            "description": "- `app_unavailable` : App unavailable or misconfigured.\n- `not_chat_app` : App mode does not match the API route.\n- `provider_not_initialize` : No valid model provider credentials found.\n- `provider_quota_exceeded` : Model provider quota exhausted.\n- `model_currently_not_support` : Current model unavailable.\n- `completion_request_error` : Text generation failed.\n- `bad_request` : Cannot use draft workflow version.\n- `bad_request` : Invalid `workflow_id` format.\n- `bad_request` : `blocking` response mode with a New Agent app.\n- `invalid_param` : The New Agent app has no bound Agent.\n- `agent_not_published` : The bound Agent has no published version. (New Agent apps)\n- `conversation_completed` : The conversation has ended; start a new one by omitting `conversation_id`.",
             "content": {
               "application/json": {
                 "examples": {
@@ -322,10 +1341,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `app_unavailable` : App unavailable or misconfigured.\n- `not_chat_app` : App mode does not match the API route.\n- `provider_not_initialize` : No valid model provider credentials found.\n- `provider_quota_exceeded` : Model provider quota exhausted.\n- `model_currently_not_support` : Current model unavailable.\n- `completion_request_error` : Text generation failed.\n- `bad_request` : Cannot use draft workflow version.\n- `bad_request` : Invalid `workflow_id` format.\n- `bad_request` : `blocking` response mode with a New Agent app.\n- `invalid_param` : The New Agent app has no bound Agent.\n- `agent_not_published` : The bound Agent has no published version. (New Agent apps)\n- `conversation_completed` : The conversation has ended; start a new one by omitting `conversation_id`."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`workflow_version_execution_not_allowed` : A Chatflow request pinned a workflow version via `workflow_id` on the Dify Cloud Sandbox plan.",
             "content": {
               "application/json": {
                 "examples": {
@@ -339,10 +1375,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`workflow_version_execution_not_allowed` : A Chatflow request pinned a workflow version via `workflow_id` on the Dify Cloud Sandbox plan."
           },
           "404": {
-            "description": "- `not_found` : Conversation does not exist.\n- `not_found` : Workflow not found with the specified `workflow_id`.",
             "content": {
               "application/json": {
                 "examples": {
@@ -364,10 +1400,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Conversation does not exist.\n- `not_found` : Workflow not found with the specified `workflow_id`."
           },
           "429": {
-            "description": "- `too_many_requests` : Too many concurrent requests for this app.\n- `rate_limit_error` : The workspace's Dify Cloud quota for workflow executions has been exhausted.",
             "content": {
               "application/json": {
                 "examples": {
@@ -389,10 +1425,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `too_many_requests` : Too many concurrent requests for this app.\n- `rate_limit_error` : The workspace's Dify Cloud quota for workflow executions has been exhausted."
           },
           "500": {
-            "description": "`internal_server_error` : Internal server error.",
             "content": {
               "application/json": {
                 "examples": {
@@ -406,59 +1442,51 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`internal_server_error` : Internal server error."
           }
         },
-        "x-mint": {
-          "href": "/en/api-reference/chat-messages/send-chat-message",
-          "metadata": {
-            "title": "Send Chat Message",
-            "sidebarTitle": "Send Chat Message"
-          }
-        },
+        "summary": "Send Chat Message",
+        "tags": [
+          "Chat Messages"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request POST \\\n  --url 'https://{api_base_url}/chat-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"query\": \"What are the specs of the iPhone 13 Pro Max?\", \"inputs\": {}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/chat-messages/send-chat-message",
+          "metadata": {
+            "title": "Send Chat Message",
+            "sidebarTitle": "Send Chat Message"
+          }
+        }
       }
     },
     "/chat-messages/{task_id}/stop": {
       "post": {
-        "summary": "Stop Chat Message Generation",
         "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nStops a chat message generation task. Only supported in `streaming` mode.",
         "operationId": "stopChatMessageGeneration",
-        "tags": [
-          "Chat Messages"
-        ],
         "parameters": [
           {
-            "name": "task_id",
-            "in": "path",
-            "required": true,
             "description": "Task ID, from the streaming events of [Send Chat Message](/en/api-reference/chat-messages/send-chat-message).",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
             "schema": {
+              "description": "Task ID, obtained from a streaming chunk returned by the Send Chat Message API.",
               "type": "string"
             }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "user"
-                ],
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "End-user identifier, defined by your app and unique within it. Must match the `user` sent with the original message; if it differs, the stop silently does nothing and still returns success. See [End User Identity](/en/api-reference/guides/end-user-identity)."
-                  }
-                }
+                "$ref": "#/components/schemas/RequiredServiceApiUserPayload"
               },
               "examples": {
                 "example": {
@@ -469,14 +1497,24 @@
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "$ref": "#/components/responses/SuccessResult"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "Task stopped successfully"
           },
           "400": {
-            "description": "- `not_chat_app` : App mode does not match the API route.\n- `invalid_param` : The required `user` field is missing.",
             "content": {
               "application/json": {
                 "examples": {
@@ -498,9 +1536,60 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_chat_app` : App mode does not match the API route.\n- `invalid_param` : The required `user` field is missing."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "Reserved compatibility response. The current runtime does not verify task existence before setting the stop flag and returns the normal `200` result even when the task is no longer running."
           }
         },
+        "summary": "Stop Chat Message Generation",
+        "tags": [
+          "Chat Messages"
+        ],
         "x-mint": {
           "href": "/en/api-reference/chat-messages/stop-chat-message-generation",
           "metadata": {
@@ -510,3863 +1599,15 @@
         }
       }
     },
-    "/messages/{message_id}/suggested": {
-      "get": {
-        "summary": "Get Next Suggested Questions",
-        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nReturns the follow-up questions suggested for a message.",
-        "operationId": "getSuggestedQuestions",
-        "tags": [
-          "Chat Messages"
-        ],
-        "parameters": [
-          {
-            "name": "message_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the message to get suggestions for. Get it from a chat response or [List Conversation Messages](/en/api-reference/conversations/list-conversation-messages).",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": true,
-            "description": "End-user identifier, defined by your app and unique within it. See [End User Identity](/en/api-reference/guides/end-user-identity).",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved suggested questions.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SuggestedQuestionsResponse"
-                },
-                "examples": {
-                  "suggestedQuestions": {
-                    "summary": "Response Example",
-                    "value": {
-                      "result": "success",
-                      "data": [
-                        "What colors does the iPhone 13 Pro Max come in?",
-                        "How does the battery compare to iPhone 12?",
-                        "What is the price range?"
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : App mode does not match the API route.\n- `bad_request` : Suggested questions feature is disabled.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "bad_request": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "Suggested Questions Is Disabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Message does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "message_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Message Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : Internal server error.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages/{message_id}/suggested?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
-        "x-mint": {
-          "href": "/en/api-reference/chat-messages/get-next-suggested-questions",
-          "metadata": {
-            "title": "Get Next Suggested Questions",
-            "sidebarTitle": "Get Next Suggested Questions"
-          }
-        }
-      }
-    },
-    "/files/upload": {
-      "post": {
-        "summary": "Upload File",
-        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nUploads a file and returns its `id` for later requests to reference. The file belongs to the uploading end user: only requests carrying the same `user` can reference it.\n\nWhich file types an app actually consumes depends on its file-upload settings; read them from [Get App Parameters](/en/api-reference/applications/get-app-parameters).",
-        "operationId": "uploadChatFile",
-        "tags": [
-          "Files"
-        ],
-        "requestBody": {
-          "description": "File upload request. Requires multipart/form-data.",
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "file"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "The file to upload, as one `multipart/form-data` part. The filename must not contain `/` or `\\`.\n\nAny extension is accepted unless it is on the deployment's security blacklist (`UPLOAD_FILE_EXTENSION_BLACKLIST`, empty by default).\n\nSize limits per category: images 10 MB, audio 50 MB, video 100 MB, other files 15 MB by default (Dify Cloud uses the defaults). Self-hosted deployments adjust them with the `UPLOAD_*_FILE_SIZE_LIMIT` [environment variables](/en/self-host/deploy/configuration/environments)."
-                  },
-                  "user": {
-                    "type": "string",
-                    "description": "End-user identifier this upload belongs to, defined by your app and unique within it. Omit it to attribute the upload to the shared `DEFAULT-USER`. Only later requests with the same `user` can reference the file. See [End User Identity](/en/api-reference/guides/end-user-identity)."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "File uploaded successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileUploadResponse"
-                },
-                "examples": {
-                  "uploadSuccess": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "reference": null,
-                      "name": "product-photo.png",
-                      "size": 204800,
-                      "extension": "png",
-                      "mime_type": "image/png",
-                      "created_by": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                      "created_at": 1705407629,
-                      "preview_url": null,
-                      "source_url": "https://upload.dify.ai/files/a1b2c3d4-5678-90ab-cdef-1234567890ab/file-preview?timestamp=1705407629&nonce=8b3e26a5&sign=rN5DXW3xkVGwGE5MSvptu_BhQVXpMbXWmVJ0ib0LMzI=",
-                      "original_url": null,
-                      "user_id": null,
-                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
-                      "conversation_id": null,
-                      "file_key": null
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `invalid_param` : The filename contains `/` or `\\`, or the file's extension is on the deployment's blacklist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_file_uploaded": {
-                    "summary": "no_file_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_file_uploaded",
-                      "message": "Please upload your file."
-                    }
-                  },
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "File extension '.exe' is not allowed for security reasons"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : The file exceeds its category's size limit (see the `file` field). The runtime `message` is currently returned as an empty string (a known backend quirk); rely on the `code` and status.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_file_type` : The uploaded `file` part declares no MIME type.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_file_type": {
-                    "summary": "unsupported_file_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_file_type",
-                      "message": "File type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/files/upload-file",
-          "metadata": {
-            "title": "Upload File",
-            "sidebarTitle": "Upload File"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/files/upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@product-photo.png' \\\n  --form 'user={user}'"
-          }
-        ]
-      }
-    },
-    "/files/{file_id}/preview": {
-      "get": {
-        "summary": "Download File",
-        "description": "**Available for**: Chatflow, Chatbot, Agent, Text Generator apps.\n\nReturns the raw bytes of a file previously returned by [Upload File](/en/api-reference/files/upload-file). A file is reachable only through the app whose messages reference it.",
-        "operationId": "previewChatFile",
-        "tags": [
-          "Files"
-        ],
-        "parameters": [
-          {
-            "name": "file_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the file to download, from the Upload File response.",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "as_attachment",
-            "in": "query",
-            "required": false,
-            "description": "When `true`, the file downloads as an attachment instead of rendering inline in the browser.",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "End-user identifier, defined by your app and unique within it. It has no effect on file access here, which is scoped by app and message rather than by `user`. See [End User Identity](/en/api-reference/guides/end-user-identity).",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns the raw file content. The `Content-Type` header is set to the file's MIME type. If `as_attachment` is `true`, the file is returned as a download with `Content-Disposition: attachment`.",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`file_access_denied` : The file exists but belongs to a different app or workspace.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_access_denied": {
-                    "summary": "file_access_denied",
-                    "value": {
-                      "status": 403,
-                      "code": "file_access_denied",
-                      "message": "Access to the requested file is denied."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`file_not_found` : No file with this ID is reachable through this app's messages.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_not_found": {
-                    "summary": "file_not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "file_not_found",
-                      "message": "The requested file was not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/files/download-file",
-          "metadata": {
-            "title": "Download File",
-            "sidebarTitle": "Download File"
-          }
-        }
-      }
-    },
-    "/end-users/{end_user_id}": {
-      "get": {
-        "summary": "Get End User Info",
-        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns an end user's details by ID. Useful for resolving an end-user ID returned by another endpoint, such as `created_by` in the [Upload File](/en/api-reference/files/upload-file) response.",
-        "operationId": "getEndUserChat",
-        "tags": [
-          "End Users"
-        ],
-        "parameters": [
-          {
-            "name": "end_user_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the end user to look up.",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "End user retrieved successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EndUserDetail"
-                },
-                "examples": {
-                  "endUserDetail": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
-                      "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "type": "service-api",
-                      "external_user_id": "abc-123",
-                      "name": null,
-                      "is_anonymous": false,
-                      "session_id": "abc-123",
-                      "created_at": "2024-01-16T12:00:29Z",
-                      "updated_at": "2024-01-16T12:00:29Z"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`end_user_not_found` : End user not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "end_user_not_found": {
-                    "summary": "end_user_not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "end_user_not_found",
-                      "message": "End user not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/end-users/get-end-user-info",
-          "metadata": {
-            "title": "Get End User Info",
-            "sidebarTitle": "Get End User Info"
-          }
-        }
-      }
-    },
-    "/messages/{message_id}/feedbacks": {
-      "post": {
-        "summary": "Submit Message Feedback",
-        "description": "**Available for**: Chatflow, Chatbot, Agent, Text Generator apps.\n\nRecords a `like` or `dislike` rating, plus an optional comment, on a message. Submitting `null` for `rating` revokes the message's existing feedback.",
-        "operationId": "postChatMessageFeedback",
-        "tags": [
-          "Feedback"
-        ],
-        "parameters": [
-          {
-            "name": "message_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the message to give feedback on. Get message IDs from [List Conversation Messages](/en/api-reference/conversations/list-conversation-messages).",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MessageFeedbackRequest"
-              },
-              "examples": {
-                "likeFeedback": {
-                  "summary": "Request Example",
-                  "value": {
-                    "rating": "like",
-                    "user": "abc-123",
-                    "content": "This answer was very helpful!"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/SuccessResult"
-          },
-          "400": {
-            "description": "`invalid_param` : The required `user` field is omitted, or `rating` is `null` but there is no existing feedback to revoke.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Message does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "message_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Message Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/feedback/submit-message-feedback",
-          "metadata": {
-            "title": "Submit Message Feedback",
-            "sidebarTitle": "Submit Message Feedback"
-          }
-        }
-      }
-    },
-    "/app/feedbacks": {
-      "get": {
-        "summary": "List App Feedbacks",
-        "description": "**Available for**: Chatflow, Chatbot, Agent, Text Generator apps.\n\nReturns a paginated list of all feedback on the app's messages, including both end-user and admin submissions.",
-        "operationId": "getChatAppFeedbacks",
-        "tags": [
-          "Feedback"
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Feedback items per page.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 101
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of application feedbacks.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppFeedbacksResponse"
-                },
-                "examples": {
-                  "feedbacksList": {
-                    "summary": "Response Example",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
-                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                          "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
-                          "rating": "like",
-                          "content": "The response accurately answered my question about product specifications.",
-                          "from_source": "user",
-                          "from_end_user_id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                          "from_account_id": null,
-                          "created_at": "2025-01-16T14:30:29Z",
-                          "updated_at": "2025-01-16T14:30:29Z"
-                        },
-                        {
-                          "id": "c8f3a9b2-4d5e-6f70-8901-bcdef2345678",
-                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "conversation_id": "56812a93-9229-5cd6-9f0c-75673b666603",
-                          "message_id": "ae24b5c0-f814-584d-a493-5439e5d6b7b1",
-                          "rating": "dislike",
-                          "content": "The answer was too vague and did not address the specific pricing question.",
-                          "from_source": "user",
-                          "from_end_user_id": "d2c1b0a9-8765-4321-fedc-ba9876543210",
-                          "from_account_id": null,
-                          "created_at": "2025-01-15T09:12:45Z",
-                          "updated_at": "2025-01-15T09:12:45Z"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/feedback/list-app-feedbacks",
-          "metadata": {
-            "title": "List App Feedbacks",
-            "sidebarTitle": "List App Feedbacks"
-          }
-        }
-      }
-    },
-    "/conversations": {
-      "get": {
-        "summary": "List Conversations",
-        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nLists an end user's conversations, most recently active first.",
-        "operationId": "getConversationsList",
-        "tags": [
-          "Conversations"
-        ],
-        "parameters": [
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "End-user identifier, defined by your app and unique within it. See [End User Identity](/en/api-reference/guides/end-user-identity).",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "last_id",
-            "in": "query",
-            "required": false,
-            "description": "Pagination cursor: the `id` of the last conversation on the current page. Omit to fetch the first page.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "Number of records to return.",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          },
-          {
-            "name": "sort_by",
-            "in": "query",
-            "required": false,
-            "description": "Field to sort by. Prefix with `-` for descending order.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "created_at",
-                "-created_at",
-                "updated_at",
-                "-updated_at"
-              ],
-              "default": "-updated_at"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved conversations list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationsListResponse"
-                },
-                "examples": {
-                  "conversationsList": {
-                    "summary": "Response Example",
-                    "value": {
-                      "limit": 20,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                          "name": "iPhone Specs Chat",
-                          "inputs": {
-                            "city": "San Francisco"
-                          },
-                          "status": "normal",
-                          "introduction": "Welcome! How can I help you today?",
-                          "created_at": 1705407629,
-                          "updated_at": 1705411229
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_chat_app` : App mode does not match the API route.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Last conversation does not exist (invalid `last_id`).",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "last_conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Last Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/conversations/list-conversations",
-          "metadata": {
-            "title": "List Conversations",
-            "sidebarTitle": "List Conversations"
-          }
-        }
-      }
-    },
-    "/messages": {
-      "get": {
-        "summary": "List Conversation Messages",
-        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nReturns a conversation's message history, newest first. Pass `first_id` to page backward into older messages.",
-        "operationId": "getConversationHistory",
-        "tags": [
-          "Conversations"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "query",
-            "required": true,
-            "description": "ID of the conversation to read. Get conversation IDs from [List Conversations](/en/api-reference/conversations/list-conversations).",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "End-user identifier, defined by your app and unique within it. See [End User Identity](/en/api-reference/guides/end-user-identity).",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "first_id",
-            "in": "query",
-            "required": false,
-            "description": "Pagination cursor: the `id` of the first message on the current page. Pass it to fetch the previous (older) page; omit to fetch the latest messages.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "Number of chat history messages to return per request.",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved conversation history.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationHistoryResponse"
-                },
-                "examples": {
-                  "conversationHistory": {
-                    "summary": "Response Example",
-                    "value": {
-                      "limit": 20,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "9da23599-e713-473b-982c-4328d4f5c78a",
-                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                          "parent_message_id": null,
-                          "inputs": {
-                            "city": "San Francisco"
-                          },
-                          "query": "What are the specs of the iPhone 13 Pro Max?",
-                          "answer": "iPhone 13 Pro Max specs are listed here:...",
-                          "status": "normal",
-                          "error": null,
-                          "message_files": [],
-                          "feedback": {
-                            "rating": "like"
-                          },
-                          "retriever_resources": [],
-                          "agent_thoughts": [],
-                          "created_at": 1705407629,
-                          "extra_contents": [],
-                          "message_tokens": 100,
-                          "answer_tokens": 58,
-                          "total_tokens": 158,
-                          "provider_response_latency": 1.234,
-                          "total_price": "0.0012825",
-                          "currency": "USD"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_chat_app` : App mode does not match the API route.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Conversation does not exist.\n- `not_found` : First message does not exist (invalid `first_id`).",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  },
-                  "first_message_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "First Message Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages?conversation_id={conversation_id}&user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
-        "x-mint": {
-          "href": "/en/api-reference/conversations/list-conversation-messages",
-          "metadata": {
-            "title": "List Conversation Messages",
-            "sidebarTitle": "List Conversation Messages"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}/variables": {
-      "get": {
-        "summary": "List Conversation Variables",
-        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nLists the variables stored in a conversation.",
-        "operationId": "getConversationVariables",
-        "tags": [
-          "Conversations"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the conversation whose variables to list. Get conversation IDs from [List Conversations](/en/api-reference/conversations/list-conversations).",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "End-user identifier, defined by your app and unique within it. See [End User Identity](/en/api-reference/guides/end-user-identity).",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "last_id",
-            "in": "query",
-            "required": false,
-            "description": "Pagination cursor: the `id` of the last variable on the current page. Omit to fetch the first page.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "Number of records to return.",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          },
-          {
-            "name": "variable_name",
-            "in": "query",
-            "required": false,
-            "description": "Filter variables by a specific name.",
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 255
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved conversation variables.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationVariablesResponse"
-                },
-                "examples": {
-                  "conversationVariables": {
-                    "summary": "Response Example",
-                    "value": {
-                      "limit": 20,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "name": "user_preference",
-                          "value_type": "string",
-                          "value": "dark_mode",
-                          "description": "User preference setting",
-                          "created_at": 1705407629,
-                          "updated_at": 1705411229
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : App mode does not match the API route.\n- `invalid_param` : The `last_id` does not match any variable in this conversation.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "invalid_last_id": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Conversation does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/conversations/list-conversation-variables",
-          "metadata": {
-            "title": "List Conversation Variables",
-            "sidebarTitle": "List Conversation Variables"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}/name": {
-      "post": {
-        "summary": "Rename Conversation",
-        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nRenames a conversation, or auto-generates a name from its messages when `auto_generate` is `true`. The name is what clients display in a multi-conversation list.",
-        "operationId": "renameConversation",
-        "tags": [
-          "Conversations"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the conversation to rename. Get conversation IDs from [List Conversations](/en/api-reference/conversations/list-conversations).",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ConversationRenameRequest"
-              },
-              "examples": {
-                "renameExample": {
-                  "summary": "Request Example",
-                  "value": {
-                    "name": "iPhone Specs Chat",
-                    "user": "abc-123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Conversation renamed successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationListItem"
-                },
-                "examples": {
-                  "renamedConversation": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                      "name": "iPhone Specs Chat",
-                      "inputs": {
-                        "city": "San Francisco"
-                      },
-                      "status": "normal",
-                      "introduction": "Welcome! How can I help you today?",
-                      "created_at": 1705407629,
-                      "updated_at": 1705411229
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : App mode does not match the API route.\n- `invalid_param` : `auto_generate` is `true` but the conversation has no messages to generate a name from.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "no_messages": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Conversation does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/conversations/rename-conversation",
-          "metadata": {
-            "title": "Rename Conversation",
-            "sidebarTitle": "Rename Conversation"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}/variables/{variable_id}": {
-      "put": {
-        "summary": "Update Conversation Variable",
-        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nUpdates a conversation variable's value. The new value must match the variable's existing type.",
-        "operationId": "updateChatConversationVariable",
-        "tags": [
-          "Conversations"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the conversation that owns the variable. Get conversation IDs from [List Conversations](/en/api-reference/conversations/list-conversations).",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "variable_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the variable to update. Get variable IDs from [List Conversation Variables](/en/api-reference/conversations/list-conversation-variables).",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ConversationVariableUpdateRequest"
-              },
-              "examples": {
-                "updateStringVariable": {
-                  "summary": "Request Example",
-                  "value": {
-                    "value": "new value",
-                    "user": "abc-123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Variable updated successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationVariableItem"
-                },
-                "examples": {
-                  "updatedVariable": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "name": "user_preference",
-                      "value_type": "string",
-                      "value": "new value",
-                      "description": "User preference setting",
-                      "created_at": 1705407629,
-                      "updated_at": 1705411229
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : App mode does not match the API route.\n- `bad_request` : Variable value type mismatch.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "type_mismatch": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "Type mismatch: variable 'user_preference' expects string, but got number type"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Conversation does not exist.\n- `not_found` : Conversation variable does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  },
-                  "variable_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Variable Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/conversations/update-conversation-variable",
-          "metadata": {
-            "title": "Update Conversation Variable",
-            "sidebarTitle": "Update Conversation Variable"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}": {
-      "delete": {
-        "summary": "Delete Conversation",
-        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nDeletes a conversation.",
-        "operationId": "deleteConversation",
-        "tags": [
-          "Conversations"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the conversation to delete. Get conversation IDs from [List Conversations](/en/api-reference/conversations/list-conversations).",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "A JSON body is always required, even when `user` is omitted; send `{}` in that case.",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "End-user identifier, defined by your app and unique within it. See [End User Identity](/en/api-reference/guides/end-user-identity)."
-                  }
-                }
-              },
-              "examples": {
-                "deleteExample": {
-                  "value": {
-                    "user": "abc-123"
-                  },
-                  "summary": "Request Example"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Conversation deleted successfully. No content returned."
-          },
-          "400": {
-            "description": "`not_chat_app` : App mode does not match the API route.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Conversation does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/conversations/delete-conversation",
-          "metadata": {
-            "title": "Delete Conversation",
-            "sidebarTitle": "Delete Conversation"
-          }
-        }
-      }
-    },
-    "/audio-to-text": {
-      "post": {
-        "summary": "Convert Audio to Text",
-        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nTranscribes an uploaded audio file to text using the workspace's default speech-to-text model.",
-        "operationId": "audioToText",
-        "tags": [
-          "Audio"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/AudioToTextRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successfully converted audio to text.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AudioToTextResponse"
-                },
-                "examples": {
-                  "audioToTextSuccess": {
-                    "summary": "Response Example",
-                    "value": {
-                      "text": "Hello, I would like to know more about the iPhone 13 Pro Max."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_audio_uploaded` : No audio file was provided in the `file` field.\n- `speech_to_text_disabled` : Speech-to-text is disabled for this app.\n- `provider_not_support_speech_to_text` : The model provider does not support speech-to-text.\n- `provider_not_initialize` : No valid model provider credentials are configured.\n- `completion_request_error` : The speech recognition request failed.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_audio_uploaded": {
-                    "summary": "no_audio_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_audio_uploaded",
-                      "message": "Please upload your audio."
-                    }
-                  },
-                  "speech_to_text_disabled": {
-                    "summary": "speech_to_text_disabled",
-                    "value": {
-                      "status": 400,
-                      "code": "speech_to_text_disabled",
-                      "message": "Speech to text is disabled."
-                    }
-                  },
-                  "provider_not_support_speech_to_text": {
-                    "summary": "provider_not_support_speech_to_text",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_support_speech_to_text",
-                      "message": "Provider not support speech to text."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`audio_too_large` : The audio file exceeds the `30 MB` size limit.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "audio_too_large": {
-                    "summary": "audio_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "audio_too_large",
-                      "message": "Audio size larger than 30 mb"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_audio_type` : The file's MIME type is not one of the accepted audio types (see the `file` field).",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_audio_type": {
-                    "summary": "unsupported_audio_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_audio_type",
-                      "message": "Audio type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : Internal server error.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/audio/convert-audio-to-text",
-          "metadata": {
-            "title": "Convert Audio to Text",
-            "sidebarTitle": "Convert Audio to Text"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/audio-to-text' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@meeting-question.mp3' \\\n  --form 'user={user}'"
-          }
-        ]
-      }
-    },
-    "/text-to-audio": {
-      "post": {
-        "summary": "Convert Text to Audio",
-        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nConverts text to speech audio. Pass `text` to synthesize arbitrary text, or `message_id` to voice an existing message's answer.",
-        "operationId": "textToAudioChat",
-        "tags": [
-          "Audio"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TextToAudioRequest"
-              },
-              "examples": {
-                "textToAudioExample": {
-                  "summary": "Request Example",
-                  "value": {
-                    "text": "Hello, welcome to our service.",
-                    "user": "abc-123",
-                    "voice": "alloy",
-                    "streaming": false
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Returns the generated audio. The `Content-Type` header reflects the provider's audio container, verified from the response bytes when recognizable.\n\nThe body can be AAC, FLAC, MP4, MP3, Ogg, WAV, or WebM. Output that cannot be recognized is labeled with the provider's declared type, or `audio/mpeg` when none is declared.\n\nStreamed provider output is delivered with chunked transfer encoding; the request `streaming` field does not control this.",
-            "content": {
-              "audio/aac": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/flac": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/mp4": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/mpeg": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/ogg": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/wav": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/webm": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `app_unavailable` : The app is unavailable or misconfigured.\n- `invalid_param` : Text-to-speech is not enabled, `text` is missing, or no voice is available.\n- `provider_not_initialize` : No valid model provider credentials are configured.\n- `provider_quota_exceeded` : The model provider quota is exhausted.\n- `model_currently_not_support` : The current model does not support this operation.\n- `completion_request_error` : The text-to-speech request failed.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "app_unavailable": {
-                    "summary": "app_unavailable",
-                    "value": {
-                      "status": 400,
-                      "code": "app_unavailable",
-                      "message": "App unavailable, please check your app configurations."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "TTS is not enabled"
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : Internal server error.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/audio/convert-text-to-audio",
-          "metadata": {
-            "title": "Convert Text to Audio",
-            "sidebarTitle": "Convert Text to Audio"
-          }
-        }
-      }
-    },
-    "/info": {
-      "get": {
-        "summary": "Get App Info",
-        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns basic information about the app: name, description, tags, mode, and author.",
-        "operationId": "getChatAppInfo",
-        "tags": [
-          "Applications"
-        ],
-        "responses": {
-          "200": {
-            "description": "Basic information of the application.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfoResponse"
-                },
-                "examples": {
-                  "appInfo": {
-                    "summary": "Response Example",
-                    "value": {
-                      "name": "My Chat App",
-                      "description": "A helpful customer service chatbot.",
-                      "tags": [
-                        "customer-service",
-                        "chatbot"
-                      ],
-                      "mode": "chat",
-                      "author_name": "Dify Team"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/applications/get-app-info",
-          "metadata": {
-            "title": "Get App Info",
-            "sidebarTitle": "Get App Info"
-          }
-        }
-      }
-    },
-    "/parameters": {
-      "get": {
-        "summary": "Get App Parameters",
-        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns the app's front-end configuration: the opening statement and suggested questions, feature toggles, the user input form, and file-upload limits. Use it to render the app's inputs and apply the correct upload limits.",
-        "operationId": "getChatAppParameters",
-        "tags": [
-          "Applications"
-        ],
-        "responses": {
-          "200": {
-            "description": "Application parameters information.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppParametersResponse"
-                },
-                "examples": {
-                  "appParameters": {
-                    "summary": "Response Example",
-                    "value": {
-                      "opening_statement": "Hello! How can I help you today?",
-                      "suggested_questions": [
-                        "What can you do?",
-                        "Tell me about your features."
-                      ],
-                      "suggested_questions_after_answer": {
-                        "enabled": true
-                      },
-                      "speech_to_text": {
-                        "enabled": false
-                      },
-                      "text_to_speech": {
-                        "enabled": false,
-                        "voice": "alloy",
-                        "language": "en-US",
-                        "autoPlay": "disabled"
-                      },
-                      "retriever_resource": {
-                        "enabled": true
-                      },
-                      "annotation_reply": {
-                        "enabled": false
-                      },
-                      "more_like_this": {
-                        "enabled": false
-                      },
-                      "sensitive_word_avoidance": {
-                        "enabled": false
-                      },
-                      "user_input_form": [
-                        {
-                          "text-input": {
-                            "label": "City",
-                            "variable": "city",
-                            "required": true,
-                            "default": ""
-                          }
-                        }
-                      ],
-                      "file_upload": {
-                        "image": {
-                          "enabled": true,
-                          "number_limits": 3,
-                          "detail": "high",
-                          "transfer_methods": [
-                            "remote_url",
-                            "local_file"
-                          ]
-                        }
-                      },
-                      "system_parameters": {
-                        "file_size_limit": 15,
-                        "image_file_size_limit": 10,
-                        "audio_file_size_limit": 50,
-                        "video_file_size_limit": 100,
-                        "workflow_file_upload_limit": 10
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `app_unavailable` : The app is unavailable or misconfigured.\n- `agent_not_published` : The app's Agent has no published version yet. (New Agent apps)",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "app_unavailable": {
-                    "summary": "app_unavailable",
-                    "value": {
-                      "status": 400,
-                      "code": "app_unavailable",
-                      "message": "App unavailable, please check your app configurations."
-                    }
-                  },
-                  "agent_not_published": {
-                    "summary": "agent_not_published",
-                    "value": {
-                      "code": "agent_not_published",
-                      "message": "Agent has not been published. Please publish the Agent before using the API.",
-                      "status": 400
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/applications/get-app-parameters",
-          "metadata": {
-            "title": "Get App Parameters",
-            "sidebarTitle": "Get App Parameters"
-          }
-        }
-      }
-    },
-    "/meta": {
-      "get": {
-        "summary": "Get App Meta",
-        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns the display icons for the tools this app uses, keyed by tool name.",
-        "operationId": "getChatAppMeta",
-        "tags": [
-          "Applications"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved application meta information.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppMetaResponse"
-                },
-                "examples": {
-                  "appMeta": {
-                    "summary": "Response Example",
-                    "value": {
-                      "tool_icons": {
-                        "dalle3": "https://example.com/icons/dalle3.png",
-                        "calculator": {
-                          "background": "#4A90D9",
-                          "content": "🧮"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/applications/get-app-meta",
-          "metadata": {
-            "title": "Get App Meta",
-            "sidebarTitle": "Get App Meta"
-          }
-        }
-      }
-    },
-    "/site": {
-      "get": {
-        "summary": "Get App WebApp Settings",
-        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns the branding and display settings for the app's hosted web app, such as its title, icon, theme colors, and default language.",
-        "operationId": "getChatWebAppSettings",
-        "tags": [
-          "Applications"
-        ],
-        "responses": {
-          "200": {
-            "description": "Web app settings of the application.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WebAppSettingsResponse"
-                },
-                "examples": {
-                  "webAppSettings": {
-                    "summary": "Response Example",
-                    "value": {
-                      "title": "My Chat App",
-                      "chat_color_theme": "#4A90D9",
-                      "chat_color_theme_inverted": false,
-                      "icon_type": "emoji",
-                      "icon": "🤖",
-                      "icon_background": "#FFFFFF",
-                      "icon_url": null,
-                      "description": "A helpful customer service chatbot.",
-                      "copyright": "2025 Dify",
-                      "privacy_policy": "https://example.com/privacy",
-                      "input_placeholder": "Ask me anything about our products...",
-                      "custom_disclaimer": "",
-                      "default_language": "en-US",
-                      "show_workflow_steps": false,
-                      "use_icon_as_answer_icon": true
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : Site not found for this application or the workspace has been archived.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/applications/get-app-webapp-settings",
-          "metadata": {
-            "title": "Get App WebApp Settings",
-            "sidebarTitle": "Get App WebApp Settings"
-          }
-        }
-      }
-    },
-    "/apps/annotations": {
-      "post": {
-        "summary": "Create Annotation",
-        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nCreates an annotation. Annotations are predefined question-answer pairs the app returns directly on a match, instead of generating a fresh response.",
-        "operationId": "createAnnotation",
-        "tags": [
-          "Annotations"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateAnnotationRequest"
-              },
-              "examples": {
-                "createAnnotation": {
-                  "summary": "Request Example",
-                  "value": {
-                    "question": "What is Dify?",
-                    "answer": "Dify is an open-source LLM application development platform."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Annotation created successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnnotationItem"
-                },
-                "examples": {
-                  "createdAnnotation": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "question": "What is Dify?",
-                      "answer": "Dify is an open-source LLM application development platform.",
-                      "hit_count": 0,
-                      "created_at": 1705407629
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/annotations/create-annotation",
-          "metadata": {
-            "title": "Create Annotation",
-            "sidebarTitle": "Create Annotation"
-          }
-        }
-      },
-      "get": {
-        "summary": "List Annotations",
-        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nLists the app's annotations, optionally filtered by keyword.",
-        "operationId": "getAnnotationList",
-        "tags": [
-          "Annotations"
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of items per page. Requests above 100 are capped at 100.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1
-            }
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "description": "Keyword to filter annotations by question or answer content.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved annotation list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnnotationListResponse"
-                },
-                "examples": {
-                  "annotationList": {
-                    "summary": "Response Example",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "question": "What is Dify?",
-                          "answer": "Dify is an open-source LLM application development platform.",
-                          "hit_count": 5,
-                          "created_at": 1705407629
-                        }
-                      ],
-                      "has_more": false,
-                      "limit": 20,
-                      "total": 1,
-                      "page": 1
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/annotations/list-annotations",
-          "metadata": {
-            "title": "List Annotations",
-            "sidebarTitle": "List Annotations"
-          }
-        }
-      }
-    },
-    "/apps/annotations/{annotation_id}": {
-      "put": {
-        "summary": "Update Annotation",
-        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nUpdates an annotation's question and answer.",
-        "operationId": "updateAnnotation",
-        "tags": [
-          "Annotations"
-        ],
-        "parameters": [
-          {
-            "name": "annotation_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the annotation to update. Get annotation IDs from [List Annotations](/en/api-reference/annotations/list-annotations).",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateAnnotationRequest"
-              },
-              "examples": {
-                "updateAnnotation": {
-                  "summary": "Request Example",
-                  "value": {
-                    "question": "What is Dify?",
-                    "answer": "Dify is an open-source LLM application development platform for building AI-powered apps."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Annotation updated successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnnotationItem"
-                },
-                "examples": {
-                  "updatedAnnotation": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "question": "What is Dify?",
-                      "answer": "Dify is an open-source LLM application development platform for building AI-powered apps.",
-                      "hit_count": 5,
-                      "created_at": 1705407629
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Annotation does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Annotation not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/annotations/update-annotation",
-          "metadata": {
-            "title": "Update Annotation",
-            "sidebarTitle": "Update Annotation"
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Annotation",
-        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nDeletes an annotation and its associated hit history.",
-        "operationId": "deleteAnnotation",
-        "tags": [
-          "Annotations"
-        ],
-        "parameters": [
-          {
-            "name": "annotation_id",
-            "in": "path",
-            "required": true,
-            "description": "ID of the annotation to delete. Get annotation IDs from [List Annotations](/en/api-reference/annotations/list-annotations).",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Annotation deleted successfully."
-          },
-          "404": {
-            "description": "`not_found` : Annotation does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Annotation not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/annotations/delete-annotation",
-          "metadata": {
-            "title": "Delete Annotation",
-            "sidebarTitle": "Delete Annotation"
-          }
-        }
-      }
-    },
-    "/apps/annotation-reply/{action}": {
-      "post": {
-        "summary": "Configure Annotation Reply",
-        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nEnables or disables annotation reply for the app. Runs asynchronously; track progress with [Get Annotation Reply Job Status](/en/api-reference/annotations/get-annotation-reply-job-status).\n\nThe body is validated before the action runs, so `score_threshold`, `embedding_provider_name`, and `embedding_model_name` are required even for `disable`.",
-        "operationId": "initialAnnotationReplySettings",
-        "tags": [
-          "Annotations"
-        ],
-        "parameters": [
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "description": "Whether to enable or disable annotation reply.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InitialAnnotationReplySettingsRequest"
-              },
-              "examples": {
-                "enableAnnotationReply": {
-                  "summary": "Request Example",
-                  "value": {
-                    "score_threshold": 0.9,
-                    "embedding_provider_name": "openai",
-                    "embedding_model_name": "text-embedding-3-small"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Annotation reply settings task initiated.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InitialAnnotationReplySettingsResponse"
-                },
-                "examples": {
-                  "annotationReplyResponse": {
-                    "summary": "Response Example",
-                    "value": {
-                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "job_status": "waiting"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/annotations/configure-annotation-reply",
-          "metadata": {
-            "title": "Configure Annotation Reply",
-            "sidebarTitle": "Configure Annotation Reply"
-          }
-        }
-      }
-    },
-    "/apps/annotation-reply/{action}/status/{job_id}": {
-      "get": {
-        "summary": "Get Annotation Reply Job Status",
-        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nReturns the status of an annotation reply configuration job started by [Configure Annotation Reply](/en/api-reference/annotations/configure-annotation-reply).",
-        "operationId": "getInitialAnnotationReplySettingsStatus",
-        "tags": [
-          "Annotations"
-        ],
-        "parameters": [
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "description": "Action type, must match the [Configure Annotation Reply](/en/api-reference/annotations/configure-annotation-reply) call.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            }
-          },
-          {
-            "name": "job_id",
-            "in": "path",
-            "required": true,
-            "description": "Job ID returned by [Configure Annotation Reply](/en/api-reference/annotations/configure-annotation-reply).",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved task status.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InitialAnnotationReplySettingsStatusResponse"
-                },
-                "examples": {
-                  "jobStatus": {
-                    "summary": "Response Example",
-                    "value": {
-                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "job_status": "completed",
-                      "error_msg": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : The specified job does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "The job does not exist."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/annotations/get-annotation-reply-job-status",
-          "metadata": {
-            "title": "Get Annotation Reply Job Status",
-            "sidebarTitle": "Get Annotation Reply Job Status"
-          }
-        }
-      }
-    },
-    "/workflows/run/{workflow_run_id}": {
-      "get": {
-        "summary": "Get Workflow Run Detail",
-        "description": "**Available for**: Chatflow, Workflow apps.\n\nGet a single workflow run's status, inputs, outputs, and execution metrics.",
-        "operationId": "getWorkflowRunDetail",
-        "tags": [
-          "Workflow Runs"
-        ],
-        "parameters": [
-          {
-            "name": "workflow_run_id",
-            "in": "path",
-            "required": true,
-            "description": "Workflow run ID, from the response or streaming events of [Run Workflow](/en/api-reference/workflow-runs/run-workflow), or from message metadata in Chatflow apps.",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved workflow run details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowRunDetailResponse"
-                },
-                "examples": {
-                  "workflowRunDetail": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                      "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
-                      "status": "succeeded",
-                      "inputs": "{\"query\": \"Translate this to French\"}",
-                      "outputs": {
-                        "result": "Traduisez ceci en francais"
-                      },
-                      "error": null,
-                      "total_steps": 3,
-                      "total_tokens": 150,
-                      "created_at": 1705407629,
-                      "finished_at": 1705407630,
-                      "elapsed_time": 1.23
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_workflow_app` : App mode does not match the API route.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Workflow run not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "workflow_run_not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Workflow run not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/workflow-runs/get-workflow-run-detail",
-          "metadata": {
-            "title": "Get Workflow Run Detail",
-            "sidebarTitle": "Get Workflow Run Detail"
-          }
-        }
-      }
-    },
-    "/workflows/logs": {
-      "get": {
-        "summary": "List Workflow Logs",
-        "description": "**Available for**: Chatflow, Workflow apps.\n\nList past workflow runs with optional filters. Each entry is a run-level summary (status, token usage, step count, and timing), not a node-by-node execution log.\n\nTo follow a run's node-level events, stream it instead:\n\n- **A run you start**: use [Run Workflow](/en/api-reference/workflow-runs/run-workflow) in streaming mode, which emits `node_started` and `node_finished` as the run executes.\n- **A run already in progress**: call [Stream Workflow Events](/en/api-reference/workflow-runs/stream-workflow-events) with `include_state_snapshot=true` to replay each executed node's status, then stream the rest.\n\nA finished run's node-level logs aren't available through the Service API.",
-        "operationId": "getWorkflowLogs",
-        "tags": [
-          "Workflow Runs"
-        ],
-        "parameters": [
-          {
-            "name": "keyword",
-            "in": "query",
-            "description": "Keyword to search in logs.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "Filter by execution status.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "succeeded",
-                "failed",
-                "stopped"
-              ]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number.",
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1,
-              "maximum": 99999
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of items per page.",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          },
-          {
-            "name": "created_at__before",
-            "in": "query",
-            "description": "Filter logs created before this ISO 8601 timestamp.",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "created_at__after",
-            "in": "query",
-            "description": "Filter logs created after this ISO 8601 timestamp.",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "created_by_end_user_session_id",
-            "in": "query",
-            "description": "Filter by end user session ID.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "created_by_account",
-            "in": "query",
-            "description": "Filter by the creator's account email (e.g., `name@example.com`).",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved workflow logs.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowLogsResponse"
-                },
-                "examples": {
-                  "workflowLogs": {
-                    "summary": "Response Example",
-                    "value": {
-                      "page": 1,
-                      "limit": 20,
-                      "total": 1,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
-                          "workflow_run": {
-                            "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                            "version": "2025-01-16 12:00:00.000000",
-                            "status": "succeeded",
-                            "error": null,
-                            "elapsed_time": 1.23,
-                            "total_tokens": 150,
-                            "total_steps": 3,
-                            "created_at": 1705407629,
-                            "finished_at": 1705407630,
-                            "exceptions_count": 0,
-                            "triggered_from": "app-run"
-                          },
-                          "created_from": "service-api",
-                          "created_by_role": "end_user",
-                          "created_by_account": null,
-                          "created_by_end_user": {
-                            "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                            "type": "service-api",
-                            "is_anonymous": false,
-                            "session_id": "user_workflow_123"
-                          },
-                          "created_at": 1705407629
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : A query parameter is invalid, such as a `created_by_account` value matching no account, a malformed `created_at__before` or `created_at__after` timestamp, or an out-of-range `page`, `limit`, or `status` value.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Account not found: name@example.com"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/workflow-runs/list-workflow-logs",
-          "metadata": {
-            "title": "List Workflow Logs",
-            "sidebarTitle": "List Workflow Logs"
-          }
-        }
-      }
-    },
-    "/form/human_input/{form_token}": {
-      "get": {
-        "tags": [
-          "Human Input"
-        ],
-        "summary": "Get Human Input Form",
-        "description": "**Available for**: Chatflow, Workflow apps.\n\nReturns the contents of a paused Human Input form. Requires web app delivery.\n\nFor the full sequence of Human Input calls, see [Human Input Flow](/en/api-reference/guides/human-input-flow).",
-        "operationId": "getChatflowHumanInputForm",
-        "parameters": [
-          {
-            "name": "form_token",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Access token for the paused form, returned in the `human_input_required` event from the Run Workflow or Send Chat Message endpoint in streaming mode."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Form contents retrieved successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "form_content": {
-                      "type": "string",
-                      "description": "Pre-rendered form body with workflow variables substituted."
-                    },
-                    "inputs": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "description": "Form input control type. Available values: `paragraph` (multi-line text input), `select` (single-choice from a list), `file` (single file upload), and `file-list` (multiple file uploads)."
-                          },
-                          "output_variable_name": {
-                            "type": "string",
-                            "description": "Variable name used to reference this input's submitted value inside the workflow. Corresponds to the key in the submission `inputs` object."
-                          },
-                          "default": {
-                            "type": "object",
-                            "nullable": true,
-                            "description": "Raw default-value configuration for `paragraph` inputs. The client should not resolve this directly; use `resolved_default_values` to display defaults. absent for other input types or when no default is configured.",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "description": "Source of the default. `constant` means `value` is used as a literal string; `variable` means `selector` points to a workflow variable."
-                              },
-                              "selector": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "Variable reference path (for example, `[\"node_id\", \"var_name\"]`) when `type` is `variable`. Must contain at least two elements."
-                              },
-                              "value": {
-                                "type": "string",
-                                "description": "Literal default value when `type` is `constant`. Always a string."
-                              }
-                            }
-                          },
-                          "option_source": {
-                            "type": "object",
-                            "description": "Source of options for `select` inputs. Present only when `type` is `select`.",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "enum": [
-                                  "variable",
-                                  "constant"
-                                ],
-                                "description": "Origin of the options. `constant` means `value` lists the options literally; `variable` means `selector` points to an `array[string]` workflow variable that provides them."
-                              },
-                              "selector": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "Variable reference path when `type` is `variable`."
-                              },
-                              "value": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "Literal option list when `type` is `constant`."
-                              }
-                            }
-                          },
-                          "allowed_file_types": {
-                            "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": [
-                                "image",
-                                "document",
-                                "audio",
-                                "video",
-                                "custom"
-                              ]
-                            },
-                            "description": "File categories the recipient may upload. Present for `file` and `file-list` inputs. Values: `image`, `document`, `audio`, `video`, `custom`."
-                          },
-                          "allowed_file_extensions": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            },
-                            "description": "Allowed file extensions when `allowed_file_types` includes `custom`. Include the leading `.` in each extension, for example `.md`. Present for `file` and `file-list` inputs."
-                          },
-                          "allowed_file_upload_methods": {
-                            "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": [
-                                "local_file",
-                                "remote_url"
-                              ]
-                            },
-                            "description": "Upload methods the recipient may use. Values: `local_file`, `remote_url`. Present for `file` and `file-list` inputs."
-                          },
-                          "number_limits": {
-                            "type": "integer",
-                            "description": "Maximum number of files the recipient may upload. Present only for `file-list` inputs."
-                          }
-                        }
-                      },
-                      "description": "Form input field definitions."
-                    },
-                    "resolved_default_values": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      },
-                      "description": "Pre-rendered values to display in the form. Keyed by input `output_variable_name`. Populated for `paragraph` inputs whose default resolves from a workflow variable; empty for inputs with no resolvable default. Display these values; do not re-resolve `default` on the client. All values are stringified."
-                    },
-                    "user_actions": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "maxLength": 20,
-                            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
-                            "description": "Identifier of the action button. Pass as `action` on [Submit Human Input Form](/en/api-reference/human-input/submit-human-input-form) when the recipient selects this button."
-                          },
-                          "title": {
-                            "type": "string",
-                            "maxLength": 100,
-                            "description": "Button label shown to the recipient."
-                          },
-                          "button_style": {
-                            "type": "string",
-                            "description": "Visual style of the button. Available values: `primary`, `default`, `accent`, `ghost`."
-                          }
-                        }
-                      },
-                      "description": "Available submission actions."
-                    },
-                    "expiration_time": {
-                      "type": "integer",
-                      "format": "int64",
-                      "description": "Unix timestamp (seconds) after which this form can no longer be submitted.",
-                      "nullable": true
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "form_content": "Please review the draft, set a priority, and confirm or request changes.",
-                      "inputs": [
-                        {
-                          "type": "paragraph",
-                          "output_variable_name": "feedback",
-                          "default": {
-                            "type": "constant",
-                            "selector": [],
-                            "value": ""
-                          }
-                        },
-                        {
-                          "type": "select",
-                          "output_variable_name": "priority",
-                          "option_source": {
-                            "type": "constant",
-                            "selector": [],
-                            "value": [
-                              "low",
-                              "medium",
-                              "high"
-                            ]
-                          }
-                        },
-                        {
-                          "type": "file",
-                          "output_variable_name": "attachment",
-                          "allowed_file_types": [
-                            "image",
-                            "document"
-                          ],
-                          "allowed_file_extensions": [],
-                          "allowed_file_upload_methods": [
-                            "local_file",
-                            "remote_url"
-                          ]
-                        },
-                        {
-                          "type": "file-list",
-                          "output_variable_name": "attachments",
-                          "allowed_file_types": [
-                            "image",
-                            "document"
-                          ],
-                          "allowed_file_extensions": [],
-                          "allowed_file_upload_methods": [
-                            "local_file",
-                            "remote_url"
-                          ],
-                          "number_limits": 5
-                        }
-                      ],
-                      "resolved_default_values": {
-                        "feedback": ""
-                      },
-                      "user_actions": [
-                        {
-                          "id": "approve",
-                          "title": "Approve",
-                          "button_style": "primary"
-                        },
-                        {
-                          "id": "reject",
-                          "title": "Request changes",
-                          "button_style": "default"
-                        }
-                      ],
-                      "expiration_time": 1745510400
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Form not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Form not found"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "412": {
-            "description": "- `human_input_form_submitted` : Form already submitted. Forms are one-shot; the first response wins regardless of which user submits it.\n- `human_input_form_expired` : The form's expiration time passed before submission arrived.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "human_input_form_submitted": {
-                    "summary": "human_input_form_submitted",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_submitted",
-                      "message": "This form has already been submitted by another user, form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  },
-                  "human_input_form_expired": {
-                    "summary": "human_input_form_expired",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_expired",
-                      "message": "This form has expired, form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/human-input/get-human-input-form",
-          "metadata": {
-            "title": "Get Human Input Form",
-            "sidebarTitle": "Get Human Input Form"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Human Input"
-        ],
-        "summary": "Submit Human Input Form",
-        "description": "**Available for**: Chatflow, Workflow apps.\n\nSubmits the recipient's response to a paused Human Input form. On acceptance the workflow resumes; follow the resumed run via [Stream Workflow Events](/en/api-reference/workflow-runs/stream-workflow-events). Requires web app delivery.",
-        "operationId": "submitChatflowHumanInputForm",
-        "parameters": [
-          {
-            "name": "form_token",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Access token for the paused form, returned in the `human_input_required` event from the Run Workflow or Send Chat Message endpoint in streaming mode."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "inputs",
-                  "action",
-                  "user"
-                ],
-                "properties": {
-                  "inputs": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "Submitted values keyed by each input's `output_variable_name`. Paragraph and select inputs take a string; a `file` input takes one file mapping; a `file-list` input takes an array of file mappings.\n\nA file mapping is `{transfer_method: local_file, upload_file_id, type}` or `{transfer_method: remote_url, url, type}`, where `type` is one of the field's `allowed_file_types`. For `local_file`, `upload_file_id` is the `id` from [Upload File](/en/api-reference/files/upload-file).\n\nUse a consistent `user` across the run, upload, and submit."
-                  },
-                  "action": {
-                    "type": "string",
-                    "description": "ID of the action button the recipient selected. Must match one of the `id` values from the form's `user_actions` list (returned by [Get Human Input Form](/en/api-reference/human-input/get-human-input-form))."
-                  },
-                  "user": {
-                    "type": "string",
-                    "description": "End-user identifier, defined by your app and unique within it. Service API and web app user IDs are separate, even when identical. See [End User Identity](/en/api-reference/guides/end-user-identity)."
-                  }
-                }
-              },
-              "examples": {
-                "approve": {
-                  "summary": "Request Example",
-                  "value": {
-                    "inputs": {
-                      "feedback": "Looks good to ship",
-                      "priority": "high",
-                      "attachment": {
-                        "transfer_method": "local_file",
-                        "upload_file_id": "3c8fa1b2-7d4e-4f9a-b0c1-d2e3f4a5b6c7",
-                        "type": "image"
-                      },
-                      "attachments": [
-                        {
-                          "transfer_method": "local_file",
-                          "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee",
-                          "type": "document"
-                        },
-                        {
-                          "transfer_method": "remote_url",
-                          "url": "https://example.com/report.pdf",
-                          "type": "document"
-                        }
-                      ]
-                    },
-                    "action": "approve",
-                    "user": "abc-123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Form submitted successfully. The response body is an empty object.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {}
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `bad_request` : Form recipient type is invalid.\n- `invalid_form_data` : Submission failed validation against the form definition.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "bad_request": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "Form recipient type is invalid"
-                    }
-                  },
-                  "invalid_form_data": {
-                    "summary": "invalid_form_data",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_form_data",
-                      "message": "Missing required inputs: feedback"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Form not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Form not found"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "412": {
-            "description": "- `human_input_form_submitted` : Form already submitted. Forms are one-shot; the first response wins regardless of which user submits it.\n- `human_input_form_expired` : The form's expiration time passed before submission arrived.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "human_input_form_submitted": {
-                    "summary": "human_input_form_submitted",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_submitted",
-                      "message": "This form has already been submitted by another user, form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  },
-                  "human_input_form_expired": {
-                    "summary": "human_input_form_expired",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_expired",
-                      "message": "This form has expired, form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/human-input/submit-human-input-form",
-          "metadata": {
-            "title": "Submit Human Input Form",
-            "sidebarTitle": "Submit Human Input Form"
-          }
-        }
-      }
-    },
-    "/workflow/{workflow_run_id}/events": {
-      "get": {
-        "tags": [
-          "Workflow Runs"
-        ],
-        "summary": "Stream Workflow Events",
-        "description": "**Available for**: Chatflow, Workflow apps.\n\nResume the Server-Sent Events stream for a workflow run after a pause or a dropped SSE connection. For runs that have already finished, the stream emits a single `workflow_finished` event and closes.\n\nTo check an in-progress run's node-level status and progress, call it with `include_state_snapshot=true`: the stream replays each already-executed node's status before streaming new events.",
-        "operationId": "streamWorkflowEvents",
-        "parameters": [
-          {
-            "name": "workflow_run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Workflow run ID whose event stream to resume, from the response or streaming events of [Run Workflow](/en/api-reference/workflow-runs/run-workflow)."
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "End-user identifier, defined by your app and unique within it. Must match the `user` that started the run. See [End User Identity](/en/api-reference/guides/end-user-identity)."
-          },
-          {
-            "name": "include_state_snapshot",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "When `true`, replay from the persisted state snapshot to include a status summary of already-executed nodes before streaming new events."
-          },
-          {
-            "name": "continue_on_pause",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "Set to `true` to keep the stream open across multiple `workflow_paused` events (useful when the workflow has more than one Human Input node in sequence). Default closes the stream after the first pause."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Server-Sent Events stream. It opens with a bare `event: ping` frame (keep-alive; more arrive roughly every 10 seconds); every other event is delivered as `data: {JSON}\\n\\n`. Event payloads follow the same schemas as the original streaming response.",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "SSE stream of events from a resumed workflow run, in the same format as [Run Workflow](/en/api-reference/workflow-runs/run-workflow) (Workflow apps) or [Send Chat Message](/en/api-reference/chat-messages/send-chat-message) (Chatflow apps). When the resumed portion runs an LLM node with `reasoning_format: separated`, this stream also carries `reasoning_chunk` events."
-                },
-                "examples": {
-                  "resumedRun": {
-                    "summary": "Response Example - Resumed run (Workflow)",
-                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"rendered_content\": \"Please review the draft.\", \"action_id\": \"approve\", \"action_text\": \"Approve\", \"submitted_data\": {\"comment\": \"Looks good.\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_2\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Approved, now translating.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour\"}, \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
-                  },
-                  "resumedRunChatflow": {
-                    "summary": "Response Example - Resumed run (Chatflow)",
-                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"rendered_content\": \"Please review the draft.\", \"action_id\": \"approve\", \"action_text\": \"Approve\", \"submitted_data\": {\"comment\": \"Looks good.\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"The reviewer approved the draft.\", \"node_id\": \"node_llm_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"\", \"node_id\": \"node_llm_1\", \"is_final\": true}}\n\ndata: {\"event\": \"message\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"answer\": \"Approved\", \"created_at\": 1705407706}\n\ndata: {\"event\": \"node_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"status\": \"succeeded\", \"elapsed_time\": 1.2, \"created_at\": 1705407705, \"finished_at\": 1705407706}}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"metadata\": {\"usage\": {\"total_tokens\": 42, \"latency\": 1.3}}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_workflow_app` : Please check if your app mode matches the right API route.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Workflow run not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Workflow run not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "Resume stream",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          },
-          {
-            "lang": "bash",
-            "label": "With state snapshot",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}&include_state_snapshot=true' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
-        "x-mint": {
-          "href": "/en/api-reference/workflow-runs/stream-workflow-events",
-          "metadata": {
-            "title": "Stream Workflow Events",
-            "sidebarTitle": "Stream Workflow Events"
-          }
-        }
-      }
-    },
-    "/workflows/run": {
-      "post": {
-        "summary": "Run Workflow",
-        "description": "**Available for**: Workflow apps.\n\nRun the app's published workflow and return its outputs, either in a single `blocking` response or as a `streaming` Server-Sent Events feed. Requires a published workflow.",
-        "operationId": "executeWorkflow",
-        "tags": [
-          "Workflow Runs"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkflowExecutionRequest"
-              },
-              "examples": {
-                "streaming_example": {
-                  "summary": "Request Example - Streaming mode",
-                  "value": {
-                    "inputs": {
-                      "query": "Summarize this text: The quick brown fox jumps over the lazy dog."
-                    },
-                    "response_mode": "streaming",
-                    "user": "user_workflow_123"
-                  }
-                },
-                "blocking_example": {
-                  "summary": "Request Example - Blocking mode",
-                  "value": {
-                    "inputs": {
-                      "query": "Translate this to French: Hello world"
-                    },
-                    "response_mode": "blocking",
-                    "user": "user_workflow_456"
-                  }
-                },
-                "with_file_array_variable": {
-                  "summary": "Request Example - File array input",
-                  "value": {
-                    "inputs": {
-                      "my_documents": [
-                        {
-                          "type": "document",
-                          "transfer_method": "local_file",
-                          "upload_file_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab"
-                        },
-                        {
-                          "type": "image",
-                          "transfer_method": "remote_url",
-                          "url": "https://example.com/image.jpg"
-                        }
-                      ]
-                    },
-                    "response_mode": "blocking",
-                    "user": "user_workflow_789"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response. The content type and structure depend on the `response_mode` parameter in the request.\n\n- If `response_mode` is `blocking`, returns `application/json` with a `WorkflowBlockingResponse` object.\n- If `response_mode` is `streaming`, returns `text/event-stream` with a stream of `ChunkWorkflowEvent` objects.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
-                },
-                "examples": {
-                  "blockingResponse": {
-                    "summary": "Response Example - Blocking mode",
-                    "value": {
-                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
-                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                      "data": {
-                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
-                        "status": "succeeded",
-                        "outputs": {
-                          "result": "Bonjour le monde"
-                        },
-                        "error": null,
-                        "elapsed_time": 1.23,
-                        "total_tokens": 150,
-                        "total_steps": 3,
-                        "created_at": 1705407629,
-                        "finished_at": 1705407630
-                      }
-                    }
-                  }
-                }
-              },
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "A stream of Server-Sent Events. Parse it per the [SSE Streaming guide](/en/api-reference/guides/streaming): read `data:` lines, dispatch on the `event` field, skip `ping` (keep-alive; the stream opens with one, then more arrive roughly every 10 seconds).\n\n**Stream lifecycle**: The stream closes when a `workflow_finished`, `workflow_paused`, or `error` event is received. Errors are delivered in-stream with HTTP status `200`; inspect the event payload for details rather than relying on the status code.\n\n**Reasoning events**:\n- `reasoning_chunk`: A chain-of-thought delta from an LLM node whose `reasoning_format` is `separated`. Concatenate consecutive `reasoning_chunk` events to rebuild the full reasoning; an event with `is_final: true` marks the node finished thinking (and may carry an empty `reasoning`). The payload sits under `data` and, unlike chat apps, carries `message_id: null` and no `conversation_id`. The parallel `text_chunk` stream stays free of `<think>` tags.\n\n**Human Input events**:\n- `human_input_required`: Fires together with `workflow_paused` when the workflow reaches a Human Input node. Use the `form_token` from the payload to drive the form-handling flow via the [Human Input API](/en/api-reference/human-input/get-human-input-form).\n- `human_input_form_filled`: A recipient submitted the form; workflow execution resumes.\n- `human_input_form_timeout`: The form expired without a response. Workflow follows the timeout fallback edge if defined."
-                },
-                "examples": {
-                  "streamingResponse": {
-                    "summary": "Response Example - Streaming mode",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"Translate this\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Let me translate that.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
-                  },
-                  "humanInputPause": {
-                    "summary": "Response Example - Human Input pause",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"Hello\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"form_content\": \"Please review the draft.\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"Approve\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_workflow_app` : App mode does not match the API route.\n- `provider_not_initialize` : No valid model provider credentials found.\n- `provider_quota_exceeded` : Model provider quota exhausted.\n- `model_currently_not_support` : Current model unavailable.\n- `completion_request_error` : Workflow execution request failed.\n- `invalid_param` : A request parameter is missing or invalid, such as a missing `user` or an unpublished workflow.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "- `too_many_requests` : Too many concurrent requests for this app.\n- `rate_limit_error` : The Dify Cloud workflow execution quota for this workspace has been reached.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "too_many_requests": {
-                    "summary": "too_many_requests",
-                    "value": {
-                      "status": 429,
-                      "code": "too_many_requests",
-                      "message": "Too many requests. Please try again later."
-                    }
-                  },
-                  "rate_limit_error": {
-                    "summary": "rate_limit_error",
-                    "value": {
-                      "status": 429,
-                      "code": "rate_limit_error",
-                      "message": "Rate Limit Error"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : Internal server error.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "Internal Server Error."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/workflow-runs/run-workflow",
-          "metadata": {
-            "title": "Run Workflow",
-            "sidebarTitle": "Run Workflow"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl -N --request POST \\\n  --url 'https://{api_base_url}/workflows/run' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"inputs\": {\"query\": \"Summarize this text: The quick brown fox jumps over the lazy dog.\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
-      }
-    },
-    "/workflows/{workflow_id}/run": {
-      "post": {
-        "summary": "Run Workflow by ID",
-        "description": "**Available for**: Workflow apps.\n\nRun a specific published workflow version, identified by the `workflow_id` in the path. Request body, response, and streaming behavior match [Run Workflow](/en/api-reference/workflow-runs/run-workflow); only the executed version differs.",
-        "operationId": "runWorkflowById",
-        "tags": [
-          "Workflow Runs"
-        ],
-        "parameters": [
-          {
-            "name": "workflow_id",
-            "in": "path",
-            "required": true,
-            "description": "Published workflow version to run. Returned in the `workflow_id` field of [Run Workflow](/en/api-reference/workflow-runs/run-workflow) responses and [Get Workflow Run Detail](/en/api-reference/workflow-runs/get-workflow-run-detail). Must reference a published version; a draft version ID is rejected with `bad_request`.",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkflowExecutionRequest"
-              },
-              "examples": {
-                "example": {
-                  "summary": "Request Example",
-                  "value": {
-                    "inputs": {
-                      "query": "Summarize this article"
-                    },
-                    "response_mode": "blocking",
-                    "user": "user_workflow_123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response. The content type and structure depend on the `response_mode` parameter in the request.\n\n- If `response_mode` is `blocking`, returns `application/json` with a `WorkflowBlockingResponse` object.\n- If `response_mode` is `streaming`, returns `text/event-stream` with a stream of `ChunkWorkflowEvent` objects.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
-                },
-                "examples": {
-                  "blockingResponse": {
-                    "summary": "Response Example - Blocking mode",
-                    "value": {
-                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
-                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                      "data": {
-                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
-                        "status": "succeeded",
-                        "outputs": {
-                          "result": "Article summary here"
-                        },
-                        "error": null,
-                        "elapsed_time": 2.45,
-                        "total_tokens": 280,
-                        "total_steps": 4,
-                        "created_at": 1705407629,
-                        "finished_at": 1705407631
-                      }
-                    }
-                  }
-                }
-              },
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "A stream of Server-Sent Events. Parse it per the [SSE Streaming guide](/en/api-reference/guides/streaming): read `data:` lines, dispatch on the `event` field, skip `ping` (keep-alive; the stream opens with one, then more arrive roughly every 10 seconds).\n\n**Stream lifecycle**: The stream closes when a `workflow_finished`, `workflow_paused`, or `error` event is received. Errors are delivered in-stream with HTTP status `200`; inspect the event payload for details rather than relying on the status code.\n\n**Reasoning events**:\n- `reasoning_chunk`: A chain-of-thought delta from an LLM node whose `reasoning_format` is `separated`. Concatenate consecutive `reasoning_chunk` events to rebuild the full reasoning; an event with `is_final: true` marks the node finished thinking (and may carry an empty `reasoning`). The payload sits under `data` and, unlike chat apps, carries `message_id: null` and no `conversation_id`. The parallel `text_chunk` stream stays free of `<think>` tags.\n\n**Human Input events**:\n- `human_input_required`: Fires together with `workflow_paused` when the workflow reaches a Human Input node. Use the `form_token` from the payload to drive the form-handling flow via the [Human Input API](/en/api-reference/human-input/get-human-input-form).\n- `human_input_form_filled`: A recipient submitted the form; workflow execution resumes.\n- `human_input_form_timeout`: The form expired without a response. Workflow follows the timeout fallback edge if defined."
-                },
-                "examples": {
-                  "streamingResponse": {
-                    "summary": "Response Example - Streaming mode",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"Translate this\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Let me translate that.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
-                  },
-                  "humanInputPause": {
-                    "summary": "Response Example - Human Input pause",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"Hello\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"form_content\": \"Please review the draft.\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"Approve\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_workflow_app` : App mode does not match the API route.\n- `bad_request` : Workflow is a draft or has an invalid ID format.\n- `provider_not_initialize` : No valid model provider credentials found.\n- `provider_quota_exceeded` : Model provider quota exhausted.\n- `model_currently_not_support` : Current model unavailable.\n- `completion_request_error` : Workflow execution request failed.\n- `invalid_param` : A request parameter is missing or invalid, such as a missing `user`.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "bad_request": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "Cannot use draft workflow version. Workflow ID: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345. Please use a published workflow version or leave workflow_id empty."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`workflow_version_execution_not_allowed` : Executing a specific workflow version is not available on the Dify Cloud Sandbox plan.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "workflow_version_execution_not_allowed": {
-                    "summary": "workflow_version_execution_not_allowed",
-                    "value": {
-                      "status": 403,
-                      "code": "workflow_version_execution_not_allowed",
-                      "message": "Workflow version execution is not available on your current plan. Please upgrade to a paid plan."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Workflow not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Workflow not found with id: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "- `too_many_requests` : Too many concurrent requests for this app.\n- `rate_limit_error` : The Dify Cloud workflow execution quota for this workspace has been reached.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "too_many_requests": {
-                    "summary": "too_many_requests",
-                    "value": {
-                      "status": 429,
-                      "code": "too_many_requests",
-                      "message": "Too many requests. Please try again later."
-                    }
-                  },
-                  "rate_limit_error": {
-                    "summary": "rate_limit_error",
-                    "value": {
-                      "status": 429,
-                      "code": "rate_limit_error",
-                      "message": "Rate Limit Error"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : Internal server error.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "Internal Server Error."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/workflow-runs/run-workflow-by-id",
-          "metadata": {
-            "title": "Run Workflow by ID",
-            "sidebarTitle": "Run Workflow by ID"
-          }
-        }
-      }
-    },
-    "/workflows/tasks/{task_id}/stop": {
-      "post": {
-        "summary": "Stop Workflow Task",
-        "description": "**Available for**: Workflow apps.\n\nStop a running workflow task. Only supported in `streaming` mode.",
-        "operationId": "stopWorkflowTaskGeneration",
-        "tags": [
-          "Workflow Runs"
-        ],
-        "parameters": [
-          {
-            "name": "task_id",
-            "in": "path",
-            "required": true,
-            "description": "Task ID, from the streaming events of [Run Workflow](/en/api-reference/workflow-runs/run-workflow).",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "user"
-                ],
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "End-user identifier, defined by your app and unique within it. Need not match the `user` that started the run; the stop applies to the task regardless of `user`. See [End User Identity](/en/api-reference/guides/end-user-identity)."
-                  }
-                }
-              },
-              "examples": {
-                "example": {
-                  "summary": "Request Example",
-                  "value": {
-                    "user": "user_workflow_123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/SuccessResult"
-          },
-          "400": {
-            "description": "- `not_workflow_app` : App mode does not match the API route.\n- `invalid_param` : A request parameter is missing or invalid, such as a missing `user`.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/workflow-runs/stop-workflow-task",
-          "metadata": {
-            "title": "Stop Workflow Task",
-            "sidebarTitle": "Stop Workflow Task"
-          }
-        }
-      }
-    },
     "/completion-messages": {
       "post": {
-        "summary": "Send Completion Message",
         "description": "**Available for**: Text Generator apps.\n\nSends a request to a text-generation app and returns the generated text.",
         "operationId": "createCompletionMessage",
-        "tags": [
-          "Completion Messages"
-        ],
         "requestBody": {
-          "description": "Request body to create a completion message.",
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CompletionRequest"
+                "$ref": "#/components/schemas/CompletionRequestPayloadWithUser"
               },
               "examples": {
                 "streaming_example": {
@@ -4400,15 +1641,16 @@
                 }
               }
             }
-          }
+          },
+          "required": true,
+          "description": "Request body to create a completion message."
         },
         "responses": {
           "200": {
-            "description": "Successful response. The content type and structure depend on the `response_mode` parameter in the request.\n\n- If `response_mode` is `blocking`, returns `application/json` with a `CompletionResponse` object.\n- If `response_mode` is `streaming`, returns `text/event-stream` with a stream of `ChunkCompletionEvent` objects.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CompletionResponse"
+                  "$ref": "#/components/schemas/CompletionBlockingResponse"
                 },
                 "examples": {
                   "blockingResponse": {
@@ -4444,7 +1686,7 @@
               "text/event-stream": {
                 "schema": {
                   "type": "string",
-                  "description": "A stream of Server-Sent Events. Parse it per the [SSE Streaming guide](/en/api-reference/guides/streaming): read `data:` lines, dispatch on the `event` field, skip `ping` (keep-alive every 10 seconds). See `ChunkCompletionEvent` for the event structures.\n\n**Stream lifecycle**: the reply streams as `message` chunks and ends with `message_end`. An `error` event ends the stream early; HTTP status stays `200`, so inspect the event payload for details."
+                  "description": "Server-Sent Events emitted while text generation is in progress."
                 },
                 "examples": {
                   "streamingResponse": {
@@ -4453,10 +1695,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Successful response. In `blocking` mode, returns `application/json` with a `CompletionBlockingResponse` object. In `streaming` mode, returns `text/event-stream` with streaming completion events."
           },
           "400": {
-            "description": "- `app_unavailable` : App unavailable or misconfigured.\n- `provider_not_initialize` : No valid model provider credentials found.\n- `provider_quota_exceeded` : Model provider quota exhausted.\n- `model_currently_not_support` : Current model unavailable.\n- `completion_request_error` : Text generation failed.\n- `invalid_param` : The required `user` field is missing.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4510,10 +1752,56 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `app_unavailable` : App unavailable or misconfigured.\n- `provider_not_initialize` : No valid model provider credentials found.\n- `provider_quota_exceeded` : Model provider quota exhausted.\n- `model_currently_not_support` : Current model unavailable.\n- `completion_request_error` : Text generation failed.\n- `invalid_param` : The required `user` field is missing."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "Reserved compatibility response inherited from the endpoint declaration. This completion request does not accept a `conversation_id`, and the current runtime does not use this response for conversation lookup."
           },
           "429": {
-            "description": "`too_many_requests` : Too many concurrent requests for this app.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4527,10 +1815,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`too_many_requests` : Too many concurrent requests for this app."
           },
           "500": {
-            "description": "`internal_server_error` : Internal server error.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4544,59 +1832,51 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`internal_server_error` : Internal server error."
           }
         },
-        "x-mint": {
-          "href": "/en/api-reference/completion-messages/send-completion-message",
-          "metadata": {
-            "title": "Send Completion Message",
-            "sidebarTitle": "Send Completion Message"
-          }
-        },
+        "summary": "Send Completion Message",
+        "tags": [
+          "Completion Messages"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request POST \\\n  --url 'https://{api_base_url}/completion-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"inputs\": {\"city\": \"San Francisco\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/completion-messages/send-completion-message",
+          "metadata": {
+            "title": "Send Completion Message",
+            "sidebarTitle": "Send Completion Message"
+          }
+        }
       }
     },
     "/completion-messages/{task_id}/stop": {
       "post": {
-        "summary": "Stop Completion Message Generation",
         "description": "**Available for**: Text Generator apps.\n\nStops a completion message generation task. Only supported in `streaming` mode.",
         "operationId": "stopGenerate",
-        "tags": [
-          "Completion Messages"
-        ],
         "parameters": [
           {
-            "name": "task_id",
-            "in": "path",
-            "required": true,
             "description": "Task ID, from the streaming events of [Send Completion Message](/en/api-reference/completion-messages/send-completion-message).",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
             "schema": {
+              "description": "Task ID, obtained from a streaming chunk returned by the Send Completion Message API.",
               "type": "string"
             }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "user"
-                ],
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "End-user identifier, defined by your app and unique within it. Must match the `user` sent with the original message; if it differs, the stop silently does nothing and still returns success. See [End User Identity](/en/api-reference/guides/end-user-identity)."
-                  }
-                }
+                "$ref": "#/components/schemas/RequiredServiceApiUserPayload"
               },
               "examples": {
                 "example": {
@@ -4607,14 +1887,24 @@
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "$ref": "#/components/responses/SuccessResult"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "Task stopped successfully"
           },
           "400": {
-            "description": "- `app_unavailable` : App unavailable or misconfigured.\n- `invalid_param` : The required `user` field is missing.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4636,14 +1926,864 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `app_unavailable` : App unavailable or misconfigured.\n- `invalid_param` : The required `user` field is missing."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "Reserved compatibility response. The current runtime does not verify task existence before setting the stop flag and returns the normal `200` result even when the task is no longer running."
           }
         },
+        "summary": "Stop Completion Message Generation",
+        "tags": [
+          "Completion Messages"
+        ],
         "x-mint": {
           "href": "/en/api-reference/completion-messages/stop-completion-message-generation",
           "metadata": {
             "title": "Stop Completion Message Generation",
             "sidebarTitle": "Stop Completion Message Generation"
+          }
+        }
+      }
+    },
+    "/conversations": {
+      "get": {
+        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nLists an end user's conversations, most recently active first.",
+        "operationId": "getConversationsList",
+        "parameters": [
+          {
+            "description": "Pagination cursor: the `id` of the last conversation on the current page. Omit to fetch the first page.",
+            "in": "query",
+            "name": "last_id",
+            "required": false,
+            "schema": {
+              "description": "The ID of the last record on the current page. Used to fetch the next page.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of records to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of records to return.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sorting field. Use the `-` prefix for descending order.",
+            "in": "query",
+            "name": "sort_by",
+            "required": false,
+            "schema": {
+              "default": "-updated_at",
+              "description": "Sorting field. Use the `-` prefix for descending order.",
+              "enum": [
+                "-created_at",
+                "-updated_at",
+                "created_at",
+                "updated_at"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "End-user identifier, defined by your app and unique within it. See [End User Identity](/en/api-reference/guides/end-user-identity).",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "User identifier, used for end-user context.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationInfiniteScrollPagination"
+                },
+                "examples": {
+                  "conversationsList": {
+                    "summary": "Response Example",
+                    "value": {
+                      "limit": 20,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                          "name": "iPhone Specs Chat",
+                          "inputs": {
+                            "city": "San Francisco"
+                          },
+                          "status": "normal",
+                          "introduction": "Welcome! How can I help you today?",
+                          "created_at": 1705407629,
+                          "updated_at": 1705411229
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successfully retrieved conversations list."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_chat_app` : App mode does not match the API route."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "last_conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Last Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found` : Last conversation does not exist (invalid `last_id`)."
+          }
+        },
+        "summary": "List Conversations",
+        "tags": [
+          "Conversations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/conversations/list-conversations",
+          "metadata": {
+            "title": "List Conversations",
+            "sidebarTitle": "List Conversations"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}": {
+      "delete": {
+        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nDeletes a conversation.",
+        "operationId": "deleteConversation",
+        "parameters": [
+          {
+            "description": "ID of the conversation to delete. Get conversation IDs from [List Conversations](/en/api-reference/conversations/list-conversations).",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "Conversation ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OptionalServiceApiUserPayload"
+              },
+              "examples": {
+                "deleteExample": {
+                  "value": {
+                    "user": "abc-123"
+                  },
+                  "summary": "Request Example"
+                }
+              }
+            }
+          },
+          "required": true,
+          "description": "A JSON body is always required, even when `user` is omitted; send `{}` in that case."
+        },
+        "responses": {
+          "204": {
+            "description": "Conversation deleted successfully. No content returned."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_chat_app` : App mode does not match the API route."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found` : Conversation does not exist."
+          }
+        },
+        "summary": "Delete Conversation",
+        "tags": [
+          "Conversations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/conversations/delete-conversation",
+          "metadata": {
+            "title": "Delete Conversation",
+            "sidebarTitle": "Delete Conversation"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}/name": {
+      "post": {
+        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nRenames a conversation, or auto-generates a name from its messages when `auto_generate` is `true`. The name is what clients display in a multi-conversation list.",
+        "operationId": "renameConversation",
+        "parameters": [
+          {
+            "description": "ID of the conversation to rename. Get conversation IDs from [List Conversations](/en/api-reference/conversations/list-conversations).",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "Conversation ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConversationRenamePayloadWithUser"
+              },
+              "examples": {
+                "renameExample": {
+                  "summary": "Request Example",
+                  "value": {
+                    "name": "iPhone Specs Chat",
+                    "user": "abc-123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleConversation"
+                },
+                "examples": {
+                  "renamedConversation": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                      "name": "iPhone Specs Chat",
+                      "inputs": {
+                        "city": "San Francisco"
+                      },
+                      "status": "normal",
+                      "introduction": "Welcome! How can I help you today?",
+                      "created_at": 1705407629,
+                      "updated_at": 1705411229
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Conversation renamed successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "no_messages": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app` : App mode does not match the API route.\n- `invalid_param` : `auto_generate` is `true` but the conversation has no messages to generate a name from."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found` : Conversation does not exist."
+          }
+        },
+        "summary": "Rename Conversation",
+        "tags": [
+          "Conversations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/conversations/rename-conversation",
+          "metadata": {
+            "title": "Rename Conversation",
+            "sidebarTitle": "Rename Conversation"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}/variables": {
+      "get": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nLists the variables stored in a conversation.",
+        "operationId": "getConversationVariables",
+        "parameters": [
+          {
+            "description": "ID of the conversation whose variables to list. Get conversation IDs from [List Conversations](/en/api-reference/conversations/list-conversations).",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "Conversation ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pagination cursor: the `id` of the last variable on the current page. Omit to fetch the first page.",
+            "in": "query",
+            "name": "last_id",
+            "required": false,
+            "schema": {
+              "description": "The ID of the last record on the current page. Used to fetch the next page.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of records to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of records to return.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End-user identifier, defined by your app and unique within it. See [End User Identity](/en/api-reference/guides/end-user-identity).",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "User identifier, used for end-user context.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter variables by a specific name.",
+            "in": "query",
+            "name": "variable_name",
+            "required": false,
+            "schema": {
+              "description": "Filter variables by a specific name.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationVariableInfiniteScrollPaginationResponse"
+                },
+                "examples": {
+                  "conversationVariables": {
+                    "summary": "Response Example",
+                    "value": {
+                      "limit": 20,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "name": "user_preference",
+                          "value_type": "string",
+                          "value": "dark_mode",
+                          "description": "User preference setting",
+                          "created_at": 1705407629,
+                          "updated_at": 1705411229
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successfully retrieved conversation variables."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "invalid_last_id": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app` : App mode does not match the API route.\n- `invalid_param` : The `last_id` does not match any variable in this conversation."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found` : Conversation does not exist."
+          }
+        },
+        "summary": "List Conversation Variables",
+        "tags": [
+          "Conversations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/conversations/list-conversation-variables",
+          "metadata": {
+            "title": "List Conversation Variables",
+            "sidebarTitle": "List Conversation Variables"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}/variables/{variable_id}": {
+      "put": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent apps.\n\nUpdates a conversation variable's value. The new value must match the variable's existing type.",
+        "operationId": "updateChatConversationVariable",
+        "parameters": [
+          {
+            "description": "ID of the conversation that owns the variable. Get conversation IDs from [List Conversations](/en/api-reference/conversations/list-conversations).",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "Conversation ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ID of the variable to update. Get variable IDs from [List Conversation Variables](/en/api-reference/conversations/list-conversation-variables).",
+            "in": "path",
+            "name": "variable_id",
+            "required": true,
+            "schema": {
+              "description": "Variable ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConversationVariableUpdatePayloadWithUser"
+              },
+              "examples": {
+                "updateStringVariable": {
+                  "summary": "Request Example",
+                  "value": {
+                    "value": "new value",
+                    "user": "abc-123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationVariableResponse"
+                },
+                "examples": {
+                  "updatedVariable": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "name": "user_preference",
+                      "value_type": "string",
+                      "value": "new value",
+                      "description": "User preference setting",
+                      "created_at": 1705407629,
+                      "updated_at": 1705411229
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Variable updated successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "type_mismatch": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "Type mismatch: variable 'user_preference' expects string, but got number type"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app` : App mode does not match the API route.\n- `bad_request` : Variable value type mismatch."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  },
+                  "variable_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Variable Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Conversation does not exist.\n- `not_found` : Conversation variable does not exist."
+          }
+        },
+        "summary": "Update Conversation Variable",
+        "tags": [
+          "Conversations"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/conversations/update-conversation-variable",
+          "metadata": {
+            "title": "Update Conversation Variable",
+            "sidebarTitle": "Update Conversation Variable"
           }
         }
       }
@@ -5042,6 +3182,645 @@
           "metadata": {
             "title": "List Knowledge Bases",
             "sidebarTitle": "List Knowledge Bases"
+          }
+        }
+      }
+    },
+    "/datasets/pipeline/file-upload": {
+      "post": {
+        "tags": [
+          "Knowledge Pipeline"
+        ],
+        "summary": "Upload Pipeline File",
+        "description": "Uploads a file for use in a knowledge pipeline. Use the returned `id` as the `reference` of a `local_file` item in [Run Pipeline](/en/api-reference/knowledge-pipeline/run-pipeline).",
+        "operationId": "uploadPipelineFile",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "The file to upload, as one `multipart/form-data` part. Document files are capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments).\n\nOn Dify Cloud, Professional and Team plans raise the document cap to 50 MB. Images, audio, and video follow their own limits: 10 MB, 50 MB, and 100 MB by default."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "File uploaded successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier of the uploaded file."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Original file name."
+                    },
+                    "size": {
+                      "type": "integer",
+                      "description": "File size in bytes."
+                    },
+                    "extension": {
+                      "type": "string",
+                      "description": "File extension."
+                    },
+                    "mime_type": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "MIME type of the file. May be `null` if the upload did not include one."
+                    },
+                    "created_by": {
+                      "type": "string",
+                      "description": "ID of the user who uploaded the file."
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Upload timestamp in ISO 8601 format. May be `null` while the record is being created."
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "name": "report.pdf",
+                      "size": 524288,
+                      "extension": "pdf",
+                      "mime_type": "application/pdf",
+                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "created_at": "2025-03-06T12:00:00"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `too_many_files` : Only one file is allowed per request.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "`file_too_large` : The file exceeds the upload size limit.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "`unsupported_file_type` : The file type is not supported.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/knowledge-pipeline/upload-pipeline-file",
+          "metadata": {
+            "title": "Upload Pipeline File",
+            "sidebarTitle": "Upload Pipeline File"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
+          }
+        ]
+      }
+    },
+    "/datasets/tags": {
+      "post": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Create Knowledge Tag",
+        "description": "Create a tag for organizing knowledge bases.",
+        "operationId": "createKnowledgeTag",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50,
+                    "description": "Tag name. Must be unique within the workspace."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tag created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Tag identifier."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Tag display name."
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Tag type. Always `knowledge` for knowledge base tags."
+                    },
+                    "binding_count": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Number of knowledge bases bound to this tag."
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                      "name": "Product Docs",
+                      "type": "knowledge",
+                      "binding_count": "0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_param` : A knowledge tag with the same name already exists.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Tag name already exists"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/tags/create-knowledge-tag",
+          "metadata": {
+            "title": "Create Knowledge Tag",
+            "sidebarTitle": "Create Knowledge Tag"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "List Knowledge Tags",
+        "description": "Returns all knowledge base tags in the workspace.",
+        "operationId": "getKnowledgeTags",
+        "responses": {
+          "200": {
+            "description": "List of tags.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Tag identifier."
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Tag display name."
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "Tag type. Always `knowledge` for knowledge base tags."
+                      },
+                      "binding_count": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Number of knowledge bases bound to this tag."
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": [
+                      {
+                        "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                        "name": "Product Docs",
+                        "type": "knowledge",
+                        "binding_count": "0"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/tags/list-knowledge-tags",
+          "metadata": {
+            "title": "List Knowledge Tags",
+            "sidebarTitle": "List Knowledge Tags"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Update Knowledge Tag",
+        "description": "Rename a knowledge base tag.",
+        "operationId": "updateKnowledgeTag",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tag_id",
+                  "name"
+                ],
+                "properties": {
+                  "tag_id": {
+                    "type": "string",
+                    "description": "ID of the tag to rename. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags)."
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50,
+                    "description": "New name for the tag. Must be unique within the workspace."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tag updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Tag identifier."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Tag display name."
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Tag type. Always `knowledge` for knowledge base tags."
+                    },
+                    "binding_count": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Number of knowledge bases bound to this tag."
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                      "name": "Product Docs",
+                      "type": "knowledge",
+                      "binding_count": "0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_param` : A knowledge tag with the same name already exists.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Tag name already exists"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : The specified tag does not exist.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Tag not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/tags/update-knowledge-tag",
+          "metadata": {
+            "title": "Update Knowledge Tag",
+            "sidebarTitle": "Update Knowledge Tag"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Delete Knowledge Tag",
+        "description": "Permanently delete a knowledge base tag. Does not delete the knowledge bases that were tagged.",
+        "operationId": "deleteKnowledgeTag",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tag_id"
+                ],
+                "properties": {
+                  "tag_id": {
+                    "type": "string",
+                    "description": "ID of the tag to delete. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "404": {
+            "description": "`not_found` : The specified tag does not exist.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Tag not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/tags/delete-knowledge-tag",
+          "metadata": {
+            "title": "Delete Knowledge Tag",
+            "sidebarTitle": "Delete Knowledge Tag"
+          }
+        }
+      }
+    },
+    "/datasets/tags/binding": {
+      "post": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Create Tag Binding",
+        "description": "Bind one or more tags to a knowledge base. A knowledge base can have multiple tags.",
+        "operationId": "bindTagsToDataset",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tag_ids",
+                  "target_id"
+                ],
+                "properties": {
+                  "tag_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "description": "IDs of the tags to bind. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags). Unknown tag IDs are silently ignored."
+                  },
+                  "target_id": {
+                    "type": "string",
+                    "description": "Knowledge base to bind the tags to. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "404": {
+            "description": "`not_found` : The target knowledge base does not exist.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/tags/create-tag-binding",
+          "metadata": {
+            "title": "Create Tag Binding",
+            "sidebarTitle": "Create Tag Binding"
+          }
+        }
+      }
+    },
+    "/datasets/tags/unbinding": {
+      "post": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Delete Tag Binding",
+        "description": "Remove one or more tags from a knowledge base.",
+        "operationId": "unbindTagFromDataset",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "target_id"
+                ],
+                "properties": {
+                  "tag_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "description": "Tag IDs to unbind. Required unless the legacy `tag_id` is provided. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags)."
+                  },
+                  "tag_id": {
+                    "type": "string",
+                    "deprecated": true,
+                    "description": "Legacy single-tag form. Normalized into `tag_ids` server-side. Use `tag_ids` for new integrations."
+                  },
+                  "target_id": {
+                    "type": "string",
+                    "description": "Knowledge base to unbind the tags from. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "404": {
+            "description": "`not_found` : The target knowledge base does not exist.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/tags/delete-tag-binding",
+          "metadata": {
+            "title": "Delete Tag Binding",
+            "sidebarTitle": "Delete Tag Binding"
           }
         }
       }
@@ -5496,6 +4275,275 @@
         }
       }
     },
+    "/datasets/{dataset_id}/document/create-by-file": {
+      "post": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Create Document by File",
+        "description": "Creates a document in a knowledge base from an uploaded file. Common formats such as PDF, TXT, and DOCX are supported. Indexing runs asynchronously; track it with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status).",
+        "operationId": "createDocumentFromFile",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
+                  },
+                  "data": {
+                    "type": "string",
+                    "description": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`indexing_technique`, `doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`.",
+                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Document created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "document": {
+                      "$ref": "#/components/schemas/Document"
+                    },
+                    "batch": {
+                      "type": "string",
+                      "description": "Batch ID for tracking indexing progress."
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 0,
+                        "indexing_status": "indexing",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "indexing",
+                        "word_count": 0,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The knowledge base is external, `indexing_technique` is required, or `process_rule` is missing.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_external": {
+                    "summary": "invalid_param (external)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "External datasets are not supported."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (documents limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The number of documents has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : Knowledge base not found.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "`file_too_large` : The uploaded file exceeds the maximum size.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "service_unavailable": {
+                    "summary": "service_unavailable",
+                    "value": {
+                      "status": 503,
+                      "code": "service_unavailable",
+                      "message": "Unable to verify vector space usage right now. Please try again later."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/documents/create-document-by-file",
+          "metadata": {
+            "title": "Create Document by File",
+            "sidebarTitle": "Create Document by File"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
+          }
+        ]
+      }
+    },
     "/datasets/{dataset_id}/document/create-by-text": {
       "post": {
         "tags": [
@@ -5818,275 +4866,6 @@
         }
       }
     },
-    "/datasets/{dataset_id}/document/create-by-file": {
-      "post": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Create Document by File",
-        "description": "Creates a document in a knowledge base from an uploaded file. Common formats such as PDF, TXT, and DOCX are supported. Indexing runs asynchronously; track it with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status).",
-        "operationId": "createDocumentFromFile",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "file"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
-                  },
-                  "data": {
-                    "type": "string",
-                    "description": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`indexing_technique`, `doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`.",
-                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Document created successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "Batch ID for tracking indexing progress."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "document": {
-                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "position": 1,
-                        "data_source_type": "upload_file",
-                        "data_source_info": {
-                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                        },
-                        "data_source_detail_dict": {
-                          "upload_file": {
-                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                            "name": "guide.txt",
-                            "size": 2048,
-                            "extension": "txt",
-                            "mime_type": "text/plain",
-                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200
-                          }
-                        },
-                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
-                        "name": "guide.txt",
-                        "created_from": "api",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "tokens": 0,
-                        "indexing_status": "indexing",
-                        "error": null,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "archived": false,
-                        "display_status": "indexing",
-                        "word_count": 0,
-                        "hit_count": 0,
-                        "doc_form": "text_model",
-                        "doc_metadata": [],
-                        "summary_index_status": null,
-                        "need_summary": false
-                      },
-                      "batch": "20250306150245647595"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The knowledge base is external, `indexing_technique` is required, or `process_rule` is missing.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_file_uploaded": {
-                    "summary": "no_file_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_file_uploaded",
-                      "message": "Please upload your file."
-                    }
-                  },
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "invalid_param_external": {
-                    "summary": "invalid_param (external)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "External datasets are not supported."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (documents limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The number of documents has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Knowledge base not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : The uploaded file exceeds the maximum size.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": "File size exceeded."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/documents/create-document-by-file",
-          "metadata": {
-            "title": "Create Document by File",
-            "sidebarTitle": "Create Document by File"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
-          }
-        ]
-      }
-    },
     "/datasets/{dataset_id}/documents": {
       "get": {
         "tags": [
@@ -6277,6 +5056,664 @@
           "metadata": {
             "title": "List Documents",
             "sidebarTitle": "List Documents"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/download-zip": {
+      "post": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Download Documents as ZIP",
+        "description": "Downloads one or more documents as a single ZIP archive. Only documents that were uploaded as files can be included.",
+        "operationId": "downloadDocumentsZip",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "document_ids"
+                ],
+                "properties": {
+                  "document_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "description": "Document IDs to include in the archive. Get them from [List Documents](/en/api-reference/documents/list-documents)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ZIP archive containing the requested documents.",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary",
+                  "description": "ZIP archive binary stream."
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : You do not have permission to access this knowledge base.\n- `forbidden` : You do not have permission for one of the requested documents.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (dataset permission)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You do not have permission to access this dataset."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden (document permission)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "No permission."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "- `not_found` : Document not found.\n- `not_found` : Knowledge base not found. Also returned as \"Only uploaded-file documents can be downloaded as ZIP.\" when a requested document has no uploaded file.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found_3",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Only uploaded-file documents can be downloaded as ZIP."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/documents/download-documents-as-zip",
+          "metadata": {
+            "title": "Download Documents as ZIP",
+            "sidebarTitle": "Download Documents as ZIP"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/metadata": {
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "summary": "Update Document Metadata in Batch",
+        "description": "Update metadata values for multiple documents in a single request.",
+        "operationId": "batchUpdateDocumentMetadata",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "operation_data"
+                ],
+                "properties": {
+                  "operation_data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "document_id",
+                        "metadata_list"
+                      ],
+                      "properties": {
+                        "document_id": {
+                          "type": "string",
+                          "description": "ID of the document to update. See [List Documents](/en/api-reference/documents/list-documents)."
+                        },
+                        "metadata_list": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "id",
+                              "name"
+                            ],
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "Metadata field ID. See [List Metadata Fields](/en/api-reference/metadata/list-metadata-fields)."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Metadata field name."
+                              },
+                              "value": {
+                                "description": "Metadata value. Can be a string, number, or `null`."
+                              }
+                            }
+                          },
+                          "description": "Metadata fields to set on the document."
+                        },
+                        "partial_update": {
+                          "type": "boolean",
+                          "default": false,
+                          "description": "Whether to partially update metadata, keeping existing values for unspecified fields."
+                        }
+                      }
+                    },
+                    "description": "Document metadata update operations, one entry per document."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Document metadata updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "description": "Operation result."
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "result": "success"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_param` : Another metadata operation is already running for a document in this request.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Another document metadata operation is running, please wait a moment."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : A document referenced in `operation_data` does not exist in this knowledge base.\n- `not_found` : A metadata field referenced in `metadata_list` does not exist in this knowledge base.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found (knowledge base)",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found (document)",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found (metadata)",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Metadata not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/metadata/update-document-metadata-in-batch",
+          "metadata": {
+            "title": "Update Document Metadata in Batch",
+            "sidebarTitle": "Update Document Metadata in Batch"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/status/{action}": {
+      "patch": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Update Document Status in Batch",
+        "description": "Enables, disables, archives, or unarchives multiple documents in one request.",
+        "operationId": "batchUpdateDocumentStatus",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          },
+          {
+            "name": "action",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enable",
+                "disable",
+                "archive",
+                "un_archive"
+              ]
+            },
+            "description": "`enable` activates documents for retrieval, `disable` deactivates them, `archive` moves them to the archive, `un_archive` restores them from the archive."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "document_ids"
+                ],
+                "properties": {
+                  "document_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Document IDs to update. Get them from [List Documents](/en/api-reference/documents/list-documents)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Documents updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "description": "Operation result."
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "result": "success"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_action` : Invalid action, or a document is in a state that does not allow the action (e.g. still indexing, or not completed).",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_action": {
+                    "summary": "invalid_action",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_action",
+                      "message": "Invalid action."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : Knowledge base API access is not enabled.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : Knowledge base not found.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/documents/update-document-status-in-batch",
+          "metadata": {
+            "title": "Update Document Status in Batch",
+            "sidebarTitle": "Update Document Status in Batch"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{batch}/indexing-status": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Get Document Indexing Status",
+        "description": "Returns indexing progress for every document in a batch: the current stage and chunk completion counts. Poll until each `indexing_status` reaches `completed` or `error`. Status advances through `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed`.",
+        "operationId": "getDocumentIndexingStatus",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          },
+          {
+            "name": "batch",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Batch ID returned when you create or update a document."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indexing status for documents in the batch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "description": "List of indexing status entries.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Document identifier."
+                          },
+                          "indexing_status": {
+                            "type": "string",
+                            "description": "Current indexing status: `waiting`, `parsing`, `cleaning`, `splitting`, `indexing`, `completed`, or `error`."
+                          },
+                          "processing_started_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "Unix timestamp when processing started."
+                          },
+                          "parsing_completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "Unix timestamp when parsing completed."
+                          },
+                          "cleaning_completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "Unix timestamp when cleaning completed."
+                          },
+                          "splitting_completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "Unix timestamp when splitting completed."
+                          },
+                          "completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "Unix timestamp when indexing completed."
+                          },
+                          "paused_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "Timestamp when indexing was paused. `null` if not paused."
+                          },
+                          "error": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Error message if indexing failed. `null` if no error."
+                          },
+                          "stopped_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "Timestamp when indexing was stopped. `null` if not stopped."
+                          },
+                          "completed_segments": {
+                            "type": "integer",
+                            "description": "Number of chunks that have been indexed."
+                          },
+                          "total_segments": {
+                            "type": "integer",
+                            "description": "Total number of chunks to be indexed."
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                          "indexing_status": "completed",
+                          "processing_started_at": 1741267200,
+                          "parsing_completed_at": 1741267200,
+                          "cleaning_completed_at": 1741267200,
+                          "splitting_completed_at": 1741267200,
+                          "completed_at": 1741267200,
+                          "paused_at": null,
+                          "error": null,
+                          "stopped_at": null,
+                          "completed_segments": 5,
+                          "total_segments": 5
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : Knowledge base API access is not enabled.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Documents not found.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "documents_not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Documents not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/documents/get-document-indexing-status",
+          "metadata": {
+            "title": "Get Document Indexing Status",
+            "sidebarTitle": "Get Document Indexing Status"
           }
         }
       }
@@ -7167,1068 +6604,6 @@
           "metadata": {
             "title": "Download Document",
             "sidebarTitle": "Download Document"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{batch}/indexing-status": {
-      "get": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Get Document Indexing Status",
-        "description": "Returns indexing progress for every document in a batch: the current stage and chunk completion counts. Poll until each `indexing_status` reaches `completed` or `error`. Status advances through `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed`.",
-        "operationId": "getDocumentIndexingStatus",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "batch",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Batch ID returned when you create or update a document."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Indexing status for documents in the batch.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of indexing status entries.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "Document identifier."
-                          },
-                          "indexing_status": {
-                            "type": "string",
-                            "description": "Current indexing status: `waiting`, `parsing`, `cleaning`, `splitting`, `indexing`, `completed`, or `error`."
-                          },
-                          "processing_started_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Unix timestamp when processing started."
-                          },
-                          "parsing_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Unix timestamp when parsing completed."
-                          },
-                          "cleaning_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Unix timestamp when cleaning completed."
-                          },
-                          "splitting_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Unix timestamp when splitting completed."
-                          },
-                          "completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Unix timestamp when indexing completed."
-                          },
-                          "paused_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Timestamp when indexing was paused. `null` if not paused."
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Error message if indexing failed. `null` if no error."
-                          },
-                          "stopped_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Timestamp when indexing was stopped. `null` if not stopped."
-                          },
-                          "completed_segments": {
-                            "type": "integer",
-                            "description": "Number of chunks that have been indexed."
-                          },
-                          "total_segments": {
-                            "type": "integer",
-                            "description": "Total number of chunks to be indexed."
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                          "indexing_status": "completed",
-                          "processing_started_at": 1741267200,
-                          "parsing_completed_at": 1741267200,
-                          "cleaning_completed_at": 1741267200,
-                          "splitting_completed_at": 1741267200,
-                          "completed_at": 1741267200,
-                          "paused_at": null,
-                          "error": null,
-                          "stopped_at": null,
-                          "completed_segments": 5,
-                          "total_segments": 5
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : Knowledge base API access is not enabled.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Documents not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "dataset_not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "documents_not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Documents not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/documents/get-document-indexing-status",
-          "metadata": {
-            "title": "Get Document Indexing Status",
-            "sidebarTitle": "Get Document Indexing Status"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/update-by-text": {
-      "post": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Update Document by Text",
-        "description": "Updates a document's text content, name, or processing configuration. Re-indexes the document when its text changes.",
-        "operationId": "updateDocumentByText",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents)."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Document name. Required when `text` is provided."
-                  },
-                  "text": {
-                    "type": "string",
-                    "description": "Document text content."
-                  },
-                  "process_rule": {
-                    "type": "object",
-                    "description": "Processing rules for chunking.",
-                    "required": [
-                      "mode"
-                    ],
-                    "properties": {
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "automatic",
-                          "custom",
-                          "hierarchical"
-                        ],
-                        "description": "`automatic` uses built-in rules, `custom` allows manual configuration, `hierarchical` enables parent-child chunk structure (use with `doc_form: hierarchical_model`)."
-                      },
-                      "rules": {
-                        "type": "object",
-                        "properties": {
-                          "pre_processing_rules": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "enum": [
-                                    "remove_stopwords",
-                                    "remove_extra_spaces",
-                                    "remove_urls_emails"
-                                  ],
-                                  "description": "Rule identifier."
-                                },
-                                "enabled": {
-                                  "type": "boolean",
-                                  "description": "Whether this preprocessing rule is enabled."
-                                }
-                              }
-                            }
-                          },
-                          "segmentation": {
-                            "type": "object",
-                            "properties": {
-                              "separator": {
-                                "type": "string",
-                                "default": "\n",
-                                "description": "Custom separator for splitting text."
-                              },
-                              "max_tokens": {
-                                "type": "integer",
-                                "description": "Maximum token count per chunk."
-                              },
-                              "chunk_overlap": {
-                                "type": "integer",
-                                "default": 0,
-                                "description": "Token overlap between chunks."
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "doc_form": {
-                    "type": "string",
-                    "enum": [
-                      "text_model",
-                      "hierarchical_model",
-                      "qa_model"
-                    ],
-                    "default": "text_model",
-                    "description": "`text_model` for standard text chunking, `hierarchical_model` for parent-child chunk structure, `qa_model` for question-answer pair extraction."
-                  },
-                  "doc_language": {
-                    "type": "string",
-                    "default": "English",
-                    "description": "Language of the document for processing optimization."
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "Controls how chunks are searched and ranked when querying this knowledge base."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Document updated successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "Batch ID for tracking indexing progress."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "document": {
-                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "position": 1,
-                        "data_source_type": "upload_file",
-                        "data_source_info": {
-                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                        },
-                        "data_source_detail_dict": {
-                          "upload_file": {
-                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                            "name": "guide.txt",
-                            "size": 2048,
-                            "extension": "txt",
-                            "mime_type": "text/plain",
-                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200
-                          }
-                        },
-                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
-                        "name": "guide.txt",
-                        "created_from": "api",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "tokens": 512,
-                        "indexing_status": "completed",
-                        "error": null,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "archived": false,
-                        "display_status": "available",
-                        "word_count": 350,
-                        "hit_count": 0,
-                        "doc_form": "text_model",
-                        "doc_metadata": [],
-                        "summary_index_status": null,
-                        "need_summary": false
-                      },
-                      "batch": "20250306150245647595"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : `name` is required when `text` is provided, or `doc_form` is invalid.\n- `invalid_param` : The document is not available for update (only available documents can be updated).",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "invalid_param_name": {
-                    "summary": "invalid_param (name required)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "name is required when text is provided."
-                    }
-                  },
-                  "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Document is not available"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/documents/update-document-by-text",
-          "metadata": {
-            "title": "Update Document by Text",
-            "sidebarTitle": "Update Document by Text"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/update-by-file": {
-      "post": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Update Document by File",
-        "description": "Deprecated. Use [Update Document](/en/api-reference/documents/update-document) instead. Updates a document by uploading a new file, then re-indexes it.",
-        "operationId": "updateDocumentByFile",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents)."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
-                  },
-                  "data": {
-                    "type": "string",
-                    "description": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`.",
-                    "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Document updated successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "Batch ID for tracking indexing progress."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "document": {
-                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "position": 1,
-                        "data_source_type": "upload_file",
-                        "data_source_info": {
-                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                        },
-                        "data_source_detail_dict": {
-                          "upload_file": {
-                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                            "name": "guide.txt",
-                            "size": 2048,
-                            "extension": "txt",
-                            "mime_type": "text/plain",
-                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200
-                          }
-                        },
-                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
-                        "name": "guide.txt",
-                        "created_from": "api",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "tokens": 512,
-                        "indexing_status": "completed",
-                        "error": null,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "archived": false,
-                        "display_status": "available",
-                        "word_count": 350,
-                        "hit_count": 0,
-                        "doc_form": "text_model",
-                        "doc_metadata": [],
-                        "summary_index_status": null,
-                        "need_summary": false
-                      },
-                      "batch": "20250306150245647595"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The document is not available for update (only available documents can be updated).",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Document is not available"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : The uploaded file exceeds the maximum size.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": "File size exceeded."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_file_type` : The uploaded file's type is not supported.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_file_type": {
-                    "summary": "unsupported_file_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_file_type",
-                      "message": "File type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "deprecated": true,
-        "x-mint": {
-          "href": "/en/api-reference/documents/update-document-by-file",
-          "metadata": {
-            "title": "Update Document by File",
-            "sidebarTitle": "Update Document by File"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/download-zip": {
-      "post": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Download Documents as ZIP",
-        "description": "Downloads one or more documents as a single ZIP archive. Only documents that were uploaded as files can be included.",
-        "operationId": "downloadDocumentsZip",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 100,
-                    "items": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "description": "Document IDs to include in the archive. Get them from [List Documents](/en/api-reference/documents/list-documents)."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "ZIP archive containing the requested documents.",
-            "content": {
-              "application/zip": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary",
-                  "description": "ZIP archive binary stream."
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : You do not have permission to access this knowledge base.\n- `forbidden` : You do not have permission for one of the requested documents.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (dataset permission)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "You do not have permission to access this dataset."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (document permission)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "No permission."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Document not found.\n- `not_found` : Knowledge base not found. Also returned as \"Only uploaded-file documents can be downloaded as ZIP.\" when a requested document has no uploaded file.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found_3",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Only uploaded-file documents can be downloaded as ZIP."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/documents/download-documents-as-zip",
-          "metadata": {
-            "title": "Download Documents as ZIP",
-            "sidebarTitle": "Download Documents as ZIP"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/status/{action}": {
-      "patch": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Update Document Status in Batch",
-        "description": "Enables, disables, archives, or unarchives multiple documents in one request.",
-        "operationId": "batchUpdateDocumentStatus",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable",
-                "archive",
-                "un_archive"
-              ]
-            },
-            "description": "`enable` activates documents for retrieval, `disable` deactivates them, `archive` moves them to the archive, `un_archive` restores them from the archive."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Document IDs to update. Get them from [List Documents](/en/api-reference/documents/list-documents)."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Documents updated successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "Operation result."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "result": "success"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_action` : Invalid action, or a document is in a state that does not allow the action (e.g. still indexing, or not completed).",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_action": {
-                    "summary": "invalid_action",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_action",
-                      "message": "Invalid action."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : Knowledge base API access is not enabled.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Knowledge base not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/documents/update-document-status-in-batch",
-          "metadata": {
-            "title": "Update Document Status in Batch",
-            "sidebarTitle": "Update Document Status in Batch"
           }
         }
       }
@@ -10117,14 +8492,14 @@
         }
       }
     },
-    "/datasets/{dataset_id}/retrieve": {
+    "/datasets/{dataset_id}/documents/{document_id}/update-by-file": {
       "post": {
         "tags": [
-          "Knowledge Bases"
+          "Documents"
         ],
-        "summary": "Retrieve Chunks from a Knowledge Base / Test Retrieval",
-        "description": "Searches a knowledge base and returns the chunks most relevant to the query, for both production retrieval and test retrieval.",
-        "operationId": "retrieveSegments",
+        "summary": "Update Document by File",
+        "description": "Deprecated. Use [Update Document](/en/api-reference/documents/update-document) instead. Updates a document by uploading a new file, then re-indexes it.",
+        "operationId": "updateDocumentByFile",
         "parameters": [
           {
             "name": "dataset_id",
@@ -10134,53 +8509,35 @@
               "type": "string",
               "format": "uuid"
             },
-            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          },
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents)."
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "query"
-                ],
                 "properties": {
-                  "query": {
+                  "file": {
                     "type": "string",
-                    "maxLength": 250,
-                    "description": "Search query text."
+                    "format": "binary",
+                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
                   },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "Retrieval model configuration. Controls how chunks are searched and ranked when querying this knowledge base."
-                  },
-                  "attachment_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true,
-                    "description": "List of attachment IDs to include in the retrieval context."
-                  },
-                  "external_retrieval_model": {
-                    "type": "object",
-                    "description": "Retrieval settings for external knowledge bases.",
-                    "properties": {
-                      "top_k": {
-                        "type": "integer",
-                        "description": "Maximum number of results to return."
-                      },
-                      "score_threshold": {
-                        "type": "number",
-                        "description": "Minimum similarity score threshold for filtering results."
-                      },
-                      "score_threshold_enabled": {
-                        "type": "boolean",
-                        "description": "Whether score threshold filtering is enabled."
-                      }
-                    }
+                  "data": {
+                    "type": "string",
+                    "description": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`.",
+                    "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
                   }
                 }
               }
@@ -10189,233 +8546,18 @@
         },
         "responses": {
           "200": {
-            "description": "Retrieval results.",
+            "description": "Document updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "query": {
-                      "type": "object",
-                      "description": "The original query object.",
-                      "properties": {
-                        "content": {
-                          "type": "string",
-                          "description": "The query text."
-                        }
-                      }
+                    "document": {
+                      "$ref": "#/components/schemas/Document"
                     },
-                    "records": {
-                      "type": "array",
-                      "description": "List of matched retrieval records.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "segment": {
-                            "type": "object",
-                            "description": "Matched chunk from the knowledge base.",
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "Unique identifier of the chunk."
-                              },
-                              "position": {
-                                "type": "integer",
-                                "description": "Position of the chunk within the document."
-                              },
-                              "document_id": {
-                                "type": "string",
-                                "description": "ID of the document this chunk belongs to."
-                              },
-                              "content": {
-                                "type": "string",
-                                "description": "Text content of the chunk."
-                              },
-                              "sign_content": {
-                                "type": "string",
-                                "description": "Signed content hash for integrity verification."
-                              },
-                              "answer": {
-                                "type": "string",
-                                "description": "Answer content, used in Q&A mode documents."
-                              },
-                              "word_count": {
-                                "type": "integer",
-                                "description": "Word count of the chunk content."
-                              },
-                              "tokens": {
-                                "type": "integer",
-                                "description": "Token count of the chunk content."
-                              },
-                              "keywords": {
-                                "type": "array",
-                                "description": "Keywords associated with this chunk for keyword-based retrieval.",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "index_node_id": {
-                                "type": "string",
-                                "description": "ID of the index node in the vector store."
-                              },
-                              "index_node_hash": {
-                                "type": "string",
-                                "description": "Hash of the indexed content, used to detect changes."
-                              },
-                              "hit_count": {
-                                "type": "integer",
-                                "description": "Number of times this chunk has been matched in retrieval queries."
-                              },
-                              "enabled": {
-                                "type": "boolean",
-                                "description": "Whether the chunk is enabled for retrieval."
-                              },
-                              "disabled_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "Timestamp when the chunk was disabled. `null` if enabled."
-                              },
-                              "disabled_by": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "ID of the user who disabled the chunk. `null` if enabled."
-                              },
-                              "status": {
-                                "type": "string",
-                                "description": "Indexing status of the chunk."
-                              },
-                              "created_by": {
-                                "type": "string",
-                                "description": "ID of the user who created the chunk."
-                              },
-                              "created_at": {
-                                "type": "number",
-                                "description": "Creation timestamp (Unix epoch in seconds)."
-                              },
-                              "indexing_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "Timestamp when indexing started. `null` if not yet started."
-                              },
-                              "completed_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "Timestamp when indexing completed. `null` if not yet completed."
-                              },
-                              "error": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "Error message if indexing failed. `null` when no error."
-                              },
-                              "stopped_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "Timestamp when indexing was stopped. `null` if not stopped."
-                              },
-                              "document": {
-                                "type": "object",
-                                "description": "Parent document information for the matched chunk.",
-                                "properties": {
-                                  "id": {
-                                    "type": "string",
-                                    "description": "Unique identifier of the document."
-                                  },
-                                  "data_source_type": {
-                                    "type": "string",
-                                    "description": "How the document was created."
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "Document name."
-                                  },
-                                  "doc_type": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Document type classification. `null` if not set."
-                                  },
-                                  "doc_metadata": {
-                                    "type": "object",
-                                    "nullable": true,
-                                    "description": "Metadata values for the document. `null` if no metadata is configured."
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "child_chunks": {
-                            "type": "array",
-                            "description": "Matched child chunks within the chunk, if using hierarchical indexing.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "Unique identifier of the child chunk."
-                                },
-                                "content": {
-                                  "type": "string",
-                                  "description": "Text content of the child chunk."
-                                },
-                                "position": {
-                                  "type": "integer",
-                                  "description": "Position of the child chunk within the parent chunk."
-                                },
-                                "score": {
-                                  "type": "number",
-                                  "description": "Similarity score of the child chunk."
-                                }
-                              }
-                            }
-                          },
-                          "score": {
-                            "type": "number",
-                            "description": "Similarity score."
-                          },
-                          "tsne_position": {
-                            "type": "object",
-                            "nullable": true,
-                            "description": "t-SNE visualization position."
-                          },
-                          "files": {
-                            "type": "array",
-                            "description": "Files attached to this chunk.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "Attachment file identifier."
-                                },
-                                "name": {
-                                  "type": "string",
-                                  "description": "Original file name."
-                                },
-                                "size": {
-                                  "type": "integer",
-                                  "description": "File size in bytes."
-                                },
-                                "extension": {
-                                  "type": "string",
-                                  "description": "File extension."
-                                },
-                                "mime_type": {
-                                  "type": "string",
-                                  "description": "MIME type of the file."
-                                },
-                                "source_url": {
-                                  "type": "string",
-                                  "description": "URL to access the attachment."
-                                }
-                              }
-                            }
-                          },
-                          "summary": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Summary content if retrieved via summary index."
-                          }
-                        }
-                      }
+                    "batch": {
+                      "type": "string",
+                      "description": "Batch ID for tracking indexing progress."
                     }
                   }
                 },
@@ -10423,53 +8565,45 @@
                   "success": {
                     "summary": "Response Example",
                     "value": {
-                      "query": {
-                        "content": "What is Dify?"
-                      },
-                      "records": [
-                        {
-                          "segment": {
-                            "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                            "position": 1,
-                            "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                            "content": "Dify is an open-source LLM app development platform.",
-                            "sign_content": "",
-                            "answer": "",
-                            "word_count": 9,
-                            "tokens": 12,
-                            "keywords": [
-                              "dify",
-                              "platform",
-                              "llm"
-                            ],
-                            "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
-                            "index_node_hash": "abc123def456",
-                            "hit_count": 1,
-                            "enabled": true,
-                            "disabled_at": null,
-                            "disabled_by": null,
-                            "status": "completed",
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
                             "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200,
-                            "indexing_at": 1741267200,
-                            "completed_at": 1741267200,
-                            "error": null,
-                            "stopped_at": null,
-                            "document": {
-                              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                              "data_source_type": "upload_file",
-                              "name": "guide.txt",
-                              "doc_type": null,
-                              "doc_metadata": null
-                            }
-                          },
-                          "child_chunks": [],
-                          "score": 0.92,
-                          "tsne_position": null,
-                          "files": [],
-                          "summary": null
-                        }
-                      ]
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
                     }
                   }
                 }
@@ -10477,16 +8611,24 @@
             }
           },
           "400": {
-            "description": "- `dataset_not_initialized` : The knowledge base is still initializing or indexing.\n- `provider_not_initialize` : The model provider has no valid credentials configured.\n- `provider_quota_exceeded` : The Dify-hosted model provider quota is exhausted.\n- `model_currently_not_support` : The selected model is not currently supported.\n- `completion_request_error` : The model request failed.\n- `invalid_param` : A request parameter is invalid.",
+            "description": "- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The document is not available for update (only available documents can be updated).",
             "content": {
               "application/json": {
                 "examples": {
-                  "dataset_not_initialized": {
-                    "summary": "dataset_not_initialized",
+                  "too_many_files": {
+                    "summary": "too_many_files",
                     "value": {
                       "status": 400,
-                      "code": "dataset_not_initialized",
-                      "message": "The dataset is still being initialized or indexing. Please wait a moment."
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
                     }
                   },
                   "provider_not_initialize": {
@@ -10497,36 +8639,12 @@
                       "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
                     }
                   },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
+                  "invalid_param_not_available": {
+                    "summary": "invalid_param (not available)",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
-                      "message": "Invalid parameter value."
+                      "message": "Document is not available"
                     }
                   }
                 }
@@ -10534,7 +8652,7 @@
             }
           },
           "403": {
-            "description": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached.",
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10547,6 +8665,14 @@
                     }
                   },
                   "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
                     "summary": "forbidden (rate limit)",
                     "value": {
                       "status": 403,
@@ -10559,33 +8685,75 @@
             }
           },
           "404": {
-            "description": "`not_found` : No knowledge base matches `dataset_id`.",
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found.",
             "content": {
               "application/json": {
                 "examples": {
-                  "not_found": {
+                  "not_found_1": {
                     "summary": "not_found",
                     "value": {
                       "status": 404,
                       "code": "not_found",
                       "message": "Dataset not found."
                     }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
                   }
                 }
               }
             }
           },
-          "500": {
-            "description": "`internal_server_error` : An internal error occurred during retrieval.",
+          "413": {
+            "description": "`file_too_large` : The uploaded file exceeds the maximum size.",
             "content": {
               "application/json": {
                 "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
+                  "file_too_large": {
+                    "summary": "file_too_large",
                     "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "An internal error occurred."
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "`unsupported_file_type` : The uploaded file's type is not supported.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "service_unavailable": {
+                    "summary": "service_unavailable",
+                    "value": {
+                      "status": 503,
+                      "code": "service_unavailable",
+                      "message": "Unable to verify vector space usage right now. Please try again later."
                     }
                   }
                 }
@@ -10593,493 +8761,24 @@
             }
           }
         },
+        "deprecated": true,
         "x-mint": {
-          "href": "/en/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
+          "href": "/en/api-reference/documents/update-document-by-file",
           "metadata": {
-            "title": "Retrieve Chunks from a Knowledge Base / Test Retrieval",
-            "sidebarTitle": "Retrieve Chunks from a Knowledge Base / Test Retrieval"
+            "title": "Update Document by File",
+            "sidebarTitle": "Update Document by File"
           }
         }
       }
     },
-    "/datasets/tags": {
+    "/datasets/{dataset_id}/documents/{document_id}/update-by-text": {
       "post": {
         "tags": [
-          "Tags"
+          "Documents"
         ],
-        "summary": "Create Knowledge Tag",
-        "description": "Create a tag for organizing knowledge bases.",
-        "operationId": "createKnowledgeTag",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "Tag name. Must be unique within the workspace."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Tag created successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Tag identifier."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Tag display name."
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "Tag type. Always `knowledge` for knowledge base tags."
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Number of knowledge bases bound to this tag."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
-                      "type": "knowledge",
-                      "binding_count": "0"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : A knowledge tag with the same name already exists.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Tag name already exists"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/tags/create-knowledge-tag",
-          "metadata": {
-            "title": "Create Knowledge Tag",
-            "sidebarTitle": "Create Knowledge Tag"
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "List Knowledge Tags",
-        "description": "Returns all knowledge base tags in the workspace.",
-        "operationId": "getKnowledgeTags",
-        "responses": {
-          "200": {
-            "description": "List of tags.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "description": "Tag identifier."
-                      },
-                      "name": {
-                        "type": "string",
-                        "description": "Tag display name."
-                      },
-                      "type": {
-                        "type": "string",
-                        "description": "Tag type. Always `knowledge` for knowledge base tags."
-                      },
-                      "binding_count": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Number of knowledge bases bound to this tag."
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": [
-                      {
-                        "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                        "name": "Product Docs",
-                        "type": "knowledge",
-                        "binding_count": "0"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/tags/list-knowledge-tags",
-          "metadata": {
-            "title": "List Knowledge Tags",
-            "sidebarTitle": "List Knowledge Tags"
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Update Knowledge Tag",
-        "description": "Rename a knowledge base tag.",
-        "operationId": "updateKnowledgeTag",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id",
-                  "name"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "ID of the tag to rename. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags)."
-                  },
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "New name for the tag. Must be unique within the workspace."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Tag updated successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Tag identifier."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Tag display name."
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "Tag type. Always `knowledge` for knowledge base tags."
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Number of knowledge bases bound to this tag."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
-                      "type": "knowledge",
-                      "binding_count": "0"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : A knowledge tag with the same name already exists.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Tag name already exists"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : The specified tag does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Tag not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/tags/update-knowledge-tag",
-          "metadata": {
-            "title": "Update Knowledge Tag",
-            "sidebarTitle": "Update Knowledge Tag"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Delete Knowledge Tag",
-        "description": "Permanently delete a knowledge base tag. Does not delete the knowledge bases that were tagged.",
-        "operationId": "deleteKnowledgeTag",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "ID of the tag to delete. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags)."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : The specified tag does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Tag not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/tags/delete-knowledge-tag",
-          "metadata": {
-            "title": "Delete Knowledge Tag",
-            "sidebarTitle": "Delete Knowledge Tag"
-          }
-        }
-      }
-    },
-    "/datasets/tags/binding": {
-      "post": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Create Tag Binding",
-        "description": "Bind one or more tags to a knowledge base. A knowledge base can have multiple tags.",
-        "operationId": "bindTagsToDataset",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "tag_ids",
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "IDs of the tags to bind. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags). Unknown tag IDs are silently ignored."
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "Knowledge base to bind the tags to. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : The target knowledge base does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/tags/create-tag-binding",
-          "metadata": {
-            "title": "Create Tag Binding",
-            "sidebarTitle": "Create Tag Binding"
-          }
-        }
-      }
-    },
-    "/datasets/tags/unbinding": {
-      "post": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Delete Tag Binding",
-        "description": "Remove one or more tags from a knowledge base.",
-        "operationId": "unbindTagFromDataset",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "Tag IDs to unbind. Required unless the legacy `tag_id` is provided. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags)."
-                  },
-                  "tag_id": {
-                    "type": "string",
-                    "deprecated": true,
-                    "description": "Legacy single-tag form. Normalized into `tag_ids` server-side. Use `tag_ids` for new integrations."
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "Knowledge base to unbind the tags from. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : The target knowledge base does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/tags/delete-tag-binding",
-          "metadata": {
-            "title": "Delete Tag Binding",
-            "sidebarTitle": "Delete Tag Binding"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/tags": {
-      "get": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Get Knowledge Base Tags",
-        "description": "Returns the tags bound to a knowledge base.",
-        "operationId": "queryDatasetTags",
+        "summary": "Update Document by Text",
+        "description": "Updates a document's text content, name, or processing configuration. Re-indexes the document when its text changes.",
+        "operationId": "updateDocumentByText",
         "parameters": [
           {
             "name": "dataset_id",
@@ -11089,37 +8788,135 @@
               "type": "string",
               "format": "uuid"
             },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          },
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents)."
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Document name. Required when `text` is provided."
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "Document text content."
+                  },
+                  "process_rule": {
+                    "type": "object",
+                    "description": "Processing rules for chunking.",
+                    "required": [
+                      "mode"
+                    ],
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "automatic",
+                          "custom",
+                          "hierarchical"
+                        ],
+                        "description": "`automatic` uses built-in rules, `custom` allows manual configuration, `hierarchical` enables parent-child chunk structure (use with `doc_form: hierarchical_model`)."
+                      },
+                      "rules": {
+                        "type": "object",
+                        "properties": {
+                          "pre_processing_rules": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "enum": [
+                                    "remove_stopwords",
+                                    "remove_extra_spaces",
+                                    "remove_urls_emails"
+                                  ],
+                                  "description": "Rule identifier."
+                                },
+                                "enabled": {
+                                  "type": "boolean",
+                                  "description": "Whether this preprocessing rule is enabled."
+                                }
+                              }
+                            }
+                          },
+                          "segmentation": {
+                            "type": "object",
+                            "properties": {
+                              "separator": {
+                                "type": "string",
+                                "default": "\n",
+                                "description": "Custom separator for splitting text."
+                              },
+                              "max_tokens": {
+                                "type": "integer",
+                                "description": "Maximum token count per chunk."
+                              },
+                              "chunk_overlap": {
+                                "type": "integer",
+                                "default": 0,
+                                "description": "Token overlap between chunks."
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "doc_form": {
+                    "type": "string",
+                    "enum": [
+                      "text_model",
+                      "hierarchical_model",
+                      "qa_model"
+                    ],
+                    "default": "text_model",
+                    "description": "`text_model` for standard text chunking, `hierarchical_model` for parent-child chunk structure, `qa_model` for question-answer pair extraction."
+                  },
+                  "doc_language": {
+                    "type": "string",
+                    "default": "English",
+                    "description": "Language of the document for processing optimization."
+                  },
+                  "retrieval_model": {
+                    "$ref": "#/components/schemas/RetrievalModel",
+                    "description": "Controls how chunks are searched and ranked when querying this knowledge base."
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Tags bound to the knowledge base.",
+            "description": "Document updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of tags bound to this knowledge base.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "Tag identifier."
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "Tag display name."
-                          }
-                        }
-                      }
+                    "document": {
+                      "$ref": "#/components/schemas/Document"
                     },
-                    "total": {
-                      "type": "integer",
-                      "description": "Total number of tags bound to this knowledge base."
+                    "batch": {
+                      "type": "string",
+                      "description": "Batch ID for tracking indexing progress."
                     }
                   }
                 },
@@ -11127,13 +8924,78 @@
                   "success": {
                     "summary": "Response Example",
                     "value": {
-                      "data": [
-                        {
-                          "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                          "name": "Product Docs"
-                        }
-                      ],
-                      "total": 1
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : `name` is required when `text` is provided, or `doc_form` is invalid.\n- `invalid_param` : The document is not available for update (only available documents can be updated).",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_name": {
+                    "summary": "invalid_param (name required)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "name is required when text is provided."
+                    }
+                  },
+                  "invalid_param_not_available": {
+                    "summary": "invalid_param (not available)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Document is not available"
                     }
                   }
                 }
@@ -11141,16 +9003,32 @@
             }
           },
           "403": {
-            "description": "`forbidden` : Dataset api access is not enabled.",
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
-                  "forbidden": {
+                  "forbidden_1": {
                     "summary": "forbidden (api access)",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
                       "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
                     }
                   }
                 }
@@ -11158,16 +9036,41 @@
             }
           },
           "404": {
-            "description": "`not_found` : Dataset not found.",
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found.",
             "content": {
               "application/json": {
                 "examples": {
-                  "not_found": {
+                  "not_found_1": {
                     "summary": "not_found",
                     "value": {
                       "status": 404,
                       "code": "not_found",
                       "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "service_unavailable": {
+                    "summary": "service_unavailable",
+                    "value": {
+                      "status": 503,
+                      "code": "service_unavailable",
+                      "message": "Unable to verify vector space usage right now. Please try again later."
                     }
                   }
                 }
@@ -11176,10 +9079,10 @@
           }
         },
         "x-mint": {
-          "href": "/en/api-reference/tags/get-knowledge-base-tags",
+          "href": "/en/api-reference/documents/update-document-by-text",
           "metadata": {
-            "title": "Get Knowledge Base Tags",
-            "sidebarTitle": "Get Knowledge Base Tags"
+            "title": "Update Document by Text",
+            "sidebarTitle": "Update Document by Text"
           }
         }
       }
@@ -11457,6 +9360,239 @@
         }
       }
     },
+    "/datasets/{dataset_id}/metadata/built-in": {
+      "get": {
+        "tags": [
+          "Metadata"
+        ],
+        "summary": "Get Built-in Metadata Fields",
+        "description": "Returns the built-in metadata fields provided by the system.",
+        "operationId": "getBuiltInMetadataFields",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Built-in metadata fields.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fields": {
+                      "type": "array",
+                      "description": "List of system-provided metadata fields.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "Built-in field identifier. `document_name` for the document title, `uploader` for the creator, `upload_date` for creation time, `last_update_date` for last modification time, `source` for the document origin."
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "Field data type. `string` for text values, `time` for date/time values."
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "fields": [
+                        {
+                          "name": "document_name",
+                          "type": "string"
+                        },
+                        {
+                          "name": "uploader",
+                          "type": "string"
+                        },
+                        {
+                          "name": "upload_date",
+                          "type": "time"
+                        },
+                        {
+                          "name": "last_update_date",
+                          "type": "time"
+                        },
+                        {
+                          "name": "source",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : Dataset api access is not enabled.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : Dataset not found.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/metadata/get-built-in-metadata-fields",
+          "metadata": {
+            "title": "Get Built-in Metadata Fields",
+            "sidebarTitle": "Get Built-in Metadata Fields"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/metadata/built-in/{action}": {
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "summary": "Update Built-in Metadata Field",
+        "description": "Enable or disable built-in metadata fields for the knowledge base.",
+        "operationId": "toggleBuiltInMetadataField",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          },
+          {
+            "name": "action",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enable",
+                "disable"
+              ]
+            },
+            "description": "`enable` to activate built-in metadata fields, `disable` to deactivate them."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Built-in metadata field toggled successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "description": "Operation result."
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "result": "success"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : Dataset not found.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/metadata/update-built-in-metadata-field",
+          "metadata": {
+            "title": "Update Built-in Metadata Field",
+            "sidebarTitle": "Update Built-in Metadata Field"
+          }
+        }
+      }
+    },
     "/datasets/{dataset_id}/metadata/{metadata_id}": {
       "patch": {
         "tags": [
@@ -11692,815 +9828,6 @@
             "sidebarTitle": "Delete Metadata Field"
           }
         }
-      }
-    },
-    "/datasets/{dataset_id}/metadata/built-in": {
-      "get": {
-        "tags": [
-          "Metadata"
-        ],
-        "summary": "Get Built-in Metadata Fields",
-        "description": "Returns the built-in metadata fields provided by the system.",
-        "operationId": "getBuiltInMetadataFields",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Built-in metadata fields.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "fields": {
-                      "type": "array",
-                      "description": "List of system-provided metadata fields.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "Built-in field identifier. `document_name` for the document title, `uploader` for the creator, `upload_date` for creation time, `last_update_date` for last modification time, `source` for the document origin."
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "Field data type. `string` for text values, `time` for date/time values."
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "fields": [
-                        {
-                          "name": "document_name",
-                          "type": "string"
-                        },
-                        {
-                          "name": "uploader",
-                          "type": "string"
-                        },
-                        {
-                          "name": "upload_date",
-                          "type": "time"
-                        },
-                        {
-                          "name": "last_update_date",
-                          "type": "time"
-                        },
-                        {
-                          "name": "source",
-                          "type": "string"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : Dataset api access is not enabled.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Dataset not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/metadata/get-built-in-metadata-fields",
-          "metadata": {
-            "title": "Get Built-in Metadata Fields",
-            "sidebarTitle": "Get Built-in Metadata Fields"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/metadata/built-in/{action}": {
-      "post": {
-        "tags": [
-          "Metadata"
-        ],
-        "summary": "Update Built-in Metadata Field",
-        "description": "Enable or disable built-in metadata fields for the knowledge base.",
-        "operationId": "toggleBuiltInMetadataField",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            },
-            "description": "`enable` to activate built-in metadata fields, `disable` to deactivate them."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Built-in metadata field toggled successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "Operation result."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "result": "success"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Dataset not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/metadata/update-built-in-metadata-field",
-          "metadata": {
-            "title": "Update Built-in Metadata Field",
-            "sidebarTitle": "Update Built-in Metadata Field"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/metadata": {
-      "post": {
-        "tags": [
-          "Metadata"
-        ],
-        "summary": "Update Document Metadata in Batch",
-        "description": "Update metadata values for multiple documents in a single request.",
-        "operationId": "batchUpdateDocumentMetadata",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "operation_data"
-                ],
-                "properties": {
-                  "operation_data": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "document_id",
-                        "metadata_list"
-                      ],
-                      "properties": {
-                        "document_id": {
-                          "type": "string",
-                          "description": "ID of the document to update. See [List Documents](/en/api-reference/documents/list-documents)."
-                        },
-                        "metadata_list": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "id",
-                              "name"
-                            ],
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "Metadata field ID. See [List Metadata Fields](/en/api-reference/metadata/list-metadata-fields)."
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "Metadata field name."
-                              },
-                              "value": {
-                                "description": "Metadata value. Can be a string, number, or `null`."
-                              }
-                            }
-                          },
-                          "description": "Metadata fields to set on the document."
-                        },
-                        "partial_update": {
-                          "type": "boolean",
-                          "default": false,
-                          "description": "Whether to partially update metadata, keeping existing values for unspecified fields."
-                        }
-                      }
-                    },
-                    "description": "Document metadata update operations, one entry per document."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Document metadata updated successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "Operation result."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "result": "success"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : Another metadata operation is already running for a document in this request.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Another document metadata operation is running, please wait a moment."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : A document referenced in `operation_data` does not exist in this knowledge base.\n- `not_found` : A metadata field referenced in `metadata_list` does not exist in this knowledge base.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found (knowledge base)",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found (document)",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found (metadata)",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Metadata not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/metadata/update-document-metadata-in-batch",
-          "metadata": {
-            "title": "Update Document Metadata in Batch",
-            "sidebarTitle": "Update Document Metadata in Batch"
-          }
-        }
-      }
-    },
-    "/workspaces/current/models/model-types/{model_type}": {
-      "get": {
-        "tags": [
-          "Models"
-        ],
-        "summary": "Get Available Models",
-        "description": "Returns the available models of a given type. Use it to find the `text-embedding` and `rerank` models to configure on a knowledge base.",
-        "operationId": "getAvailableModels",
-        "parameters": [
-          {
-            "name": "model_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "text-embedding",
-                "rerank",
-                "llm",
-                "tts",
-                "speech2text",
-                "moderation"
-              ]
-            },
-            "description": "Type of model to retrieve. For knowledge base configuration, use `text-embedding` for embedding models or `rerank` for reranking models."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Available models for the specified type.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of model providers with their available models.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "provider": {
-                            "type": "string",
-                            "description": "Model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). Legacy providers may return the bare short form (e.g. `openai`)."
-                          },
-                          "label": {
-                            "type": "object",
-                            "description": "Localized display name of the provider.",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "English display name."
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "Chinese display name."
-                              }
-                            }
-                          },
-                          "icon_small": {
-                            "type": "object",
-                            "description": "URL of the provider's small icon.",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "Small icon URL."
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "Chinese icon URL."
-                              }
-                            }
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "Provider status. `active` when credentials are configured and valid."
-                          },
-                          "models": {
-                            "type": "array",
-                            "description": "List of available models from this provider.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "model": {
-                                  "type": "string",
-                                  "description": "Model identifier. Use this as the `embedding_model` value when creating or updating a knowledge base."
-                                },
-                                "label": {
-                                  "type": "object",
-                                  "description": "Localized display name of the model.",
-                                  "properties": {
-                                    "en_US": {
-                                      "type": "string",
-                                      "description": "English model name."
-                                    },
-                                    "zh_Hans": {
-                                      "type": "string",
-                                      "description": "Chinese model name."
-                                    }
-                                  }
-                                },
-                                "model_type": {
-                                  "type": "string",
-                                  "description": "Type of the model, matching the `model_type` path parameter."
-                                },
-                                "features": {
-                                  "type": "array",
-                                  "nullable": true,
-                                  "description": "Supported features of the model, `null` if none.",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "fetch_from": {
-                                  "type": "string",
-                                  "description": "Where the model definition comes from. `predefined-model` for built-in models, `customizable-model` for user-configured models."
-                                },
-                                "model_properties": {
-                                  "type": "object",
-                                  "description": "Model-specific properties such as `context_size`."
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "description": "Model availability status. `active` when ready to use."
-                                },
-                                "deprecated": {
-                                  "type": "boolean",
-                                  "description": "Whether the model is deprecated."
-                                },
-                                "load_balancing_enabled": {
-                                  "type": "boolean",
-                                  "description": "Whether load balancing is enabled for the model."
-                                },
-                                "has_invalid_load_balancing_configs": {
-                                  "type": "boolean",
-                                  "description": "Whether the model has invalid load-balancing configurations."
-                                }
-                              }
-                            }
-                          },
-                          "tenant_id": {
-                            "type": "string",
-                            "description": "Workspace ID the provider configuration belongs to."
-                          },
-                          "icon_small_dark": {
-                            "type": "object",
-                            "description": "Dark-mode icon URLs; `null` when the provider has none.",
-                            "properties": {
-                              "en_US": {
-                                "type": "string"
-                              },
-                              "zh_Hans": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "data": [
-                        {
-                          "provider": "langgenius/openai/openai",
-                          "label": {
-                            "en_US": "OpenAI",
-                            "zh_Hans": "OpenAI"
-                          },
-                          "icon_small": {
-                            "en_US": "https://example.com/openai-small.svg",
-                            "zh_Hans": "https://example.com/openai-small.svg"
-                          },
-                          "status": "active",
-                          "models": [
-                            {
-                              "model": "text-embedding-3-small",
-                              "label": {
-                                "en_US": "text-embedding-3-small",
-                                "zh_Hans": "text-embedding-3-small"
-                              },
-                              "model_type": "text-embedding",
-                              "features": null,
-                              "fetch_from": "predefined-model",
-                              "model_properties": {
-                                "context_size": 8191
-                              },
-                              "status": "active",
-                              "deprecated": false,
-                              "load_balancing_enabled": false,
-                              "has_invalid_load_balancing_configs": false
-                            }
-                          ],
-                          "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
-                          "icon_small_dark": null
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/models/get-available-models",
-          "metadata": {
-            "title": "Get Available Models",
-            "sidebarTitle": "Get Available Models"
-          }
-        }
-      }
-    },
-    "/datasets/pipeline/file-upload": {
-      "post": {
-        "tags": [
-          "Knowledge Pipeline"
-        ],
-        "summary": "Upload Pipeline File",
-        "description": "Uploads a file for use in a knowledge pipeline. Use the returned `id` as the `reference` of a `local_file` item in [Run Pipeline](/en/api-reference/knowledge-pipeline/run-pipeline).",
-        "operationId": "uploadPipelineFile",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "file"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "The file to upload, as one `multipart/form-data` part. Document files are capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments).\n\nOn Dify Cloud, Professional and Team plans raise the document cap to 50 MB. Images, audio, and video follow their own limits: 10 MB, 50 MB, and 100 MB by default."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "File uploaded successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Unique identifier of the uploaded file."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Original file name."
-                    },
-                    "size": {
-                      "type": "integer",
-                      "description": "File size in bytes."
-                    },
-                    "extension": {
-                      "type": "string",
-                      "description": "File extension."
-                    },
-                    "mime_type": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "MIME type of the file. May be `null` if the upload did not include one."
-                    },
-                    "created_by": {
-                      "type": "string",
-                      "description": "ID of the user who uploaded the file."
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Upload timestamp in ISO 8601 format. May be `null` while the record is being created."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                      "name": "report.pdf",
-                      "size": 524288,
-                      "extension": "pdf",
-                      "mime_type": "application/pdf",
-                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "created_at": "2025-03-06T12:00:00"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `too_many_files` : Only one file is allowed per request.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_file_uploaded": {
-                    "summary": "no_file_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_file_uploaded",
-                      "message": "Please upload your file."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : The file exceeds the upload size limit.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": "File size exceeded."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_file_type` : The file type is not supported.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_file_type": {
-                    "summary": "unsupported_file_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_file_type",
-                      "message": "File type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/knowledge-pipeline/upload-pipeline-file",
-          "metadata": {
-            "title": "Upload Pipeline File",
-            "sidebarTitle": "Upload Pipeline File"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
-          }
-        ]
       }
     },
     "/datasets/{dataset_id}/pipeline/datasource-plugins": {
@@ -13193,6 +10520,3909 @@
           "metadata": {
             "title": "Run Pipeline",
             "sidebarTitle": "Run Pipeline"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/retrieve": {
+      "post": {
+        "tags": [
+          "Knowledge Bases"
+        ],
+        "summary": "Retrieve Chunks from a Knowledge Base / Test Retrieval",
+        "description": "Searches a knowledge base and returns the chunks most relevant to the query, for both production retrieval and test retrieval.",
+        "operationId": "retrieveSegments",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "maxLength": 250,
+                    "description": "Search query text."
+                  },
+                  "retrieval_model": {
+                    "$ref": "#/components/schemas/RetrievalModel",
+                    "description": "Retrieval model configuration. Controls how chunks are searched and ranked when querying this knowledge base."
+                  },
+                  "attachment_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "description": "List of attachment IDs to include in the retrieval context."
+                  },
+                  "external_retrieval_model": {
+                    "type": "object",
+                    "description": "Retrieval settings for external knowledge bases.",
+                    "properties": {
+                      "top_k": {
+                        "type": "integer",
+                        "description": "Maximum number of results to return."
+                      },
+                      "score_threshold": {
+                        "type": "number",
+                        "description": "Minimum similarity score threshold for filtering results."
+                      },
+                      "score_threshold_enabled": {
+                        "type": "boolean",
+                        "description": "Whether score threshold filtering is enabled."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Retrieval results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "query": {
+                      "type": "object",
+                      "description": "The original query object.",
+                      "properties": {
+                        "content": {
+                          "type": "string",
+                          "description": "The query text."
+                        }
+                      }
+                    },
+                    "records": {
+                      "type": "array",
+                      "description": "List of matched retrieval records.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "segment": {
+                            "type": "object",
+                            "description": "Matched chunk from the knowledge base.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "Unique identifier of the chunk."
+                              },
+                              "position": {
+                                "type": "integer",
+                                "description": "Position of the chunk within the document."
+                              },
+                              "document_id": {
+                                "type": "string",
+                                "description": "ID of the document this chunk belongs to."
+                              },
+                              "content": {
+                                "type": "string",
+                                "description": "Text content of the chunk."
+                              },
+                              "sign_content": {
+                                "type": "string",
+                                "description": "Signed content hash for integrity verification."
+                              },
+                              "answer": {
+                                "type": "string",
+                                "description": "Answer content, used in Q&A mode documents."
+                              },
+                              "word_count": {
+                                "type": "integer",
+                                "description": "Word count of the chunk content."
+                              },
+                              "tokens": {
+                                "type": "integer",
+                                "description": "Token count of the chunk content."
+                              },
+                              "keywords": {
+                                "type": "array",
+                                "description": "Keywords associated with this chunk for keyword-based retrieval.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "index_node_id": {
+                                "type": "string",
+                                "description": "ID of the index node in the vector store."
+                              },
+                              "index_node_hash": {
+                                "type": "string",
+                                "description": "Hash of the indexed content, used to detect changes."
+                              },
+                              "hit_count": {
+                                "type": "integer",
+                                "description": "Number of times this chunk has been matched in retrieval queries."
+                              },
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "Whether the chunk is enabled for retrieval."
+                              },
+                              "disabled_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "Timestamp when the chunk was disabled. `null` if enabled."
+                              },
+                              "disabled_by": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "ID of the user who disabled the chunk. `null` if enabled."
+                              },
+                              "status": {
+                                "type": "string",
+                                "description": "Indexing status of the chunk."
+                              },
+                              "created_by": {
+                                "type": "string",
+                                "description": "ID of the user who created the chunk."
+                              },
+                              "created_at": {
+                                "type": "number",
+                                "description": "Creation timestamp (Unix epoch in seconds)."
+                              },
+                              "indexing_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "Timestamp when indexing started. `null` if not yet started."
+                              },
+                              "completed_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "Timestamp when indexing completed. `null` if not yet completed."
+                              },
+                              "error": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Error message if indexing failed. `null` when no error."
+                              },
+                              "stopped_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "Timestamp when indexing was stopped. `null` if not stopped."
+                              },
+                              "document": {
+                                "type": "object",
+                                "description": "Parent document information for the matched chunk.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "Unique identifier of the document."
+                                  },
+                                  "data_source_type": {
+                                    "type": "string",
+                                    "description": "How the document was created."
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Document name."
+                                  },
+                                  "doc_type": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Document type classification. `null` if not set."
+                                  },
+                                  "doc_metadata": {
+                                    "type": "object",
+                                    "nullable": true,
+                                    "description": "Metadata values for the document. `null` if no metadata is configured."
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "child_chunks": {
+                            "type": "array",
+                            "description": "Matched child chunks within the chunk, if using hierarchical indexing.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "Unique identifier of the child chunk."
+                                },
+                                "content": {
+                                  "type": "string",
+                                  "description": "Text content of the child chunk."
+                                },
+                                "position": {
+                                  "type": "integer",
+                                  "description": "Position of the child chunk within the parent chunk."
+                                },
+                                "score": {
+                                  "type": "number",
+                                  "description": "Similarity score of the child chunk."
+                                }
+                              }
+                            }
+                          },
+                          "score": {
+                            "type": "number",
+                            "description": "Similarity score."
+                          },
+                          "tsne_position": {
+                            "type": "object",
+                            "nullable": true,
+                            "description": "t-SNE visualization position."
+                          },
+                          "files": {
+                            "type": "array",
+                            "description": "Files attached to this chunk.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "Attachment file identifier."
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "Original file name."
+                                },
+                                "size": {
+                                  "type": "integer",
+                                  "description": "File size in bytes."
+                                },
+                                "extension": {
+                                  "type": "string",
+                                  "description": "File extension."
+                                },
+                                "mime_type": {
+                                  "type": "string",
+                                  "description": "MIME type of the file."
+                                },
+                                "source_url": {
+                                  "type": "string",
+                                  "description": "URL to access the attachment."
+                                }
+                              }
+                            }
+                          },
+                          "summary": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Summary content if retrieved via summary index."
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "query": {
+                        "content": "What is Dify?"
+                      },
+                      "records": [
+                        {
+                          "segment": {
+                            "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                            "position": 1,
+                            "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                            "content": "Dify is an open-source LLM app development platform.",
+                            "sign_content": "",
+                            "answer": "",
+                            "word_count": 9,
+                            "tokens": 12,
+                            "keywords": [
+                              "dify",
+                              "platform",
+                              "llm"
+                            ],
+                            "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                            "index_node_hash": "abc123def456",
+                            "hit_count": 1,
+                            "enabled": true,
+                            "disabled_at": null,
+                            "disabled_by": null,
+                            "status": "completed",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200,
+                            "indexing_at": 1741267200,
+                            "completed_at": 1741267200,
+                            "error": null,
+                            "stopped_at": null,
+                            "document": {
+                              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                              "data_source_type": "upload_file",
+                              "name": "guide.txt",
+                              "doc_type": null,
+                              "doc_metadata": null
+                            }
+                          },
+                          "child_chunks": [],
+                          "score": 0.92,
+                          "tsne_position": null,
+                          "files": [],
+                          "summary": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `dataset_not_initialized` : The knowledge base is still initializing or indexing.\n- `provider_not_initialize` : The model provider has no valid credentials configured.\n- `provider_quota_exceeded` : The Dify-hosted model provider quota is exhausted.\n- `model_currently_not_support` : The selected model is not currently supported.\n- `completion_request_error` : The model request failed.\n- `invalid_param` : A request parameter is invalid.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_not_initialized": {
+                    "summary": "dataset_not_initialized",
+                    "value": {
+                      "status": 400,
+                      "code": "dataset_not_initialized",
+                      "message": "The dataset is still being initialized or indexing. Please wait a moment."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Invalid parameter value."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : No knowledge base matches `dataset_id`.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "`internal_server_error` : An internal error occurred during retrieval.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "An internal error occurred."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
+          "metadata": {
+            "title": "Retrieve Chunks from a Knowledge Base / Test Retrieval",
+            "sidebarTitle": "Retrieve Chunks from a Knowledge Base / Test Retrieval"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/tags": {
+      "get": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Get Knowledge Base Tags",
+        "description": "Returns the tags bound to a knowledge base.",
+        "operationId": "queryDatasetTags",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tags bound to the knowledge base.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "description": "List of tags bound to this knowledge base.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Tag identifier."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Tag display name."
+                          }
+                        }
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "Total number of tags bound to this knowledge base."
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                          "name": "Product Docs"
+                        }
+                      ],
+                      "total": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : Dataset api access is not enabled.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : Dataset not found.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/tags/get-knowledge-base-tags",
+          "metadata": {
+            "title": "Get Knowledge Base Tags",
+            "sidebarTitle": "Get Knowledge Base Tags"
+          }
+        }
+      }
+    },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns an end user's details by ID. Useful for resolving an end-user ID returned by another endpoint, such as `created_by` in the [Upload File](/en/api-reference/files/upload-file) response.",
+        "operationId": "getEndUserChat",
+        "parameters": [
+          {
+            "description": "ID of the end user to look up.",
+            "in": "path",
+            "name": "end_user_id",
+            "required": true,
+            "schema": {
+              "description": "End user ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndUserDetail"
+                },
+                "examples": {
+                  "endUserDetail": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                      "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "type": "service-api",
+                      "external_user_id": "abc-123",
+                      "name": null,
+                      "is_anonymous": false,
+                      "session_id": "abc-123",
+                      "created_at": "2024-01-16T12:00:29Z",
+                      "updated_at": "2024-01-16T12:00:29Z"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "End user retrieved successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "end_user_not_found": {
+                    "summary": "end_user_not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "end_user_not_found",
+                      "message": "End user not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`end_user_not_found` : End user not found."
+          }
+        },
+        "summary": "Get End User Info",
+        "tags": [
+          "End Users"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/end-users/get-end-user-info",
+          "metadata": {
+            "title": "Get End User Info",
+            "sidebarTitle": "Get End User Info"
+          }
+        }
+      }
+    },
+    "/files/upload": {
+      "post": {
+        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nUploads a file and returns its `id` for later requests to reference. The file belongs to the uploading end user: only requests carrying the same `user` can reference it.\n\nWhich file types an app actually consumes depends on its file-upload settings; read them from [Get App Parameters](/en/api-reference/applications/get-app-parameters).",
+        "operationId": "uploadChatFile",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "description": "The file to upload, as one `multipart/form-data` part. The filename must not contain `/` or `\\`.\n\nAny extension is accepted unless it is on the deployment's security blacklist (`UPLOAD_FILE_EXTENSION_BLACKLIST`, empty by default).\n\nSize limits per category: images 10 MB, audio 50 MB, video 100 MB, other files 15 MB by default (Dify Cloud uses the defaults). Self-hosted deployments adjust them with the `UPLOAD_*_FILE_SIZE_LIMIT` [environment variables](/en/self-host/deploy/configuration/environments).",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "user": {
+                    "description": "End-user identifier this upload belongs to, defined by your app and unique within it. Omit it to attribute the upload to the shared `DEFAULT-USER`. Only later requests with the same `user` can reference the file. See [End User Identity](/en/api-reference/guides/end-user-identity).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true,
+          "description": "File upload request. Requires multipart/form-data."
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileResponse"
+                },
+                "examples": {
+                  "uploadSuccess": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "reference": null,
+                      "name": "product-photo.png",
+                      "size": 204800,
+                      "extension": "png",
+                      "mime_type": "image/png",
+                      "created_by": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                      "created_at": 1705407629,
+                      "preview_url": null,
+                      "source_url": "https://upload.dify.ai/files/a1b2c3d4-5678-90ab-cdef-1234567890ab/file-preview?timestamp=1705407629&nonce=8b3e26a5&sign=rN5DXW3xkVGwGE5MSvptu_BhQVXpMbXWmVJ0ib0LMzI=",
+                      "original_url": null,
+                      "user_id": null,
+                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                      "conversation_id": null,
+                      "file_key": null
+                    }
+                  }
+                }
+              }
+            },
+            "description": "File uploaded successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "File extension '.exe' is not allowed for security reasons"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `invalid_param` : The filename contains `/` or `\\`, or the file's extension is on the deployment's blacklist."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_too_large` : The file exceeds its category's size limit (see the `file` field). The runtime `message` is currently returned as an empty string (a known backend quirk); rely on the `code` and status."
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`unsupported_file_type` : The uploaded `file` part declares no MIME type."
+          }
+        },
+        "summary": "Upload File",
+        "tags": [
+          "Files"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/files/upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@product-photo.png' \\\n  --form 'user={user}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/files/upload-file",
+          "metadata": {
+            "title": "Upload File",
+            "sidebarTitle": "Upload File"
+          }
+        }
+      }
+    },
+    "/files/{file_id}/preview": {
+      "get": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent, Text Generator apps.\n\nReturns the raw bytes of a file previously returned by [Upload File](/en/api-reference/files/upload-file). A file is reachable only through the app whose messages reference it.",
+        "operationId": "previewChatFile",
+        "parameters": [
+          {
+            "description": "ID of the file to download, from the Upload File response.",
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the file to preview, obtained from the [Upload File](/en/api-reference/files/upload-file) API response.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "When `true`, the file downloads as an attachment instead of rendering inline in the browser.",
+            "in": "query",
+            "name": "as_attachment",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "If `true`, forces the file to download as an attachment instead of previewing in browser.",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "End-user identifier, defined by your app and unique within it. It has no effect on file access here, which is scoped by app and message rather than by `user`. See [End User Identity](/en/api-reference/guides/end-user-identity).",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "User identifier, used for end-user context.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Returns the raw file content. The `Content-Type` header is set to the file's MIME type. If `as_attachment` is `true`, the file is returned as a download with `Content-Disposition: attachment`."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_access_denied": {
+                    "summary": "file_access_denied",
+                    "value": {
+                      "status": 403,
+                      "code": "file_access_denied",
+                      "message": "Access to the requested file is denied."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_access_denied` : The file exists but belongs to a different app or workspace."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_not_found": {
+                    "summary": "file_not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "file_not_found",
+                      "message": "The requested file was not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_not_found` : No file with this ID is reachable through this app's messages."
+          }
+        },
+        "summary": "Download File",
+        "tags": [
+          "Files"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/files/download-file",
+          "metadata": {
+            "title": "Download File",
+            "sidebarTitle": "Download File"
+          }
+        }
+      }
+    },
+    "/form/human_input/{form_token}": {
+      "get": {
+        "description": "**Available for**: Chatflow, Workflow apps.\n\nReturns the contents of a paused Human Input form. In the Human Input node, enable the **Web App** delivery method; this creates the standalone-web-app recipient and makes its `form_token` usable through these Service API endpoints. Email-only or console-only delivery does not.\n\nFor the full sequence of Human Input calls, see [Human Input Flow](/en/api-reference/guides/human-input-flow).",
+        "operationId": "getChatflowHumanInputForm",
+        "parameters": [
+          {
+            "description": "Access token for the paused form, returned in the `human_input_required` event from the Run Workflow or Send Chat Message endpoint in streaming mode.",
+            "in": "path",
+            "name": "form_token",
+            "required": true,
+            "schema": {
+              "description": "Human input form token",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumanInputFormDefinitionResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "form_content": "Please review the draft, set a priority, and confirm or request changes.",
+                      "inputs": [
+                        {
+                          "type": "paragraph",
+                          "output_variable_name": "feedback",
+                          "default": {
+                            "type": "constant",
+                            "selector": [],
+                            "value": ""
+                          }
+                        },
+                        {
+                          "type": "select",
+                          "output_variable_name": "priority",
+                          "option_source": {
+                            "type": "constant",
+                            "selector": [],
+                            "value": [
+                              "low",
+                              "medium",
+                              "high"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "file",
+                          "output_variable_name": "attachment",
+                          "allowed_file_types": [
+                            "image",
+                            "document"
+                          ],
+                          "allowed_file_extensions": [],
+                          "allowed_file_upload_methods": [
+                            "local_file",
+                            "remote_url"
+                          ]
+                        },
+                        {
+                          "type": "file-list",
+                          "output_variable_name": "attachments",
+                          "allowed_file_types": [
+                            "image",
+                            "document"
+                          ],
+                          "allowed_file_extensions": [],
+                          "allowed_file_upload_methods": [
+                            "local_file",
+                            "remote_url"
+                          ],
+                          "number_limits": 5
+                        }
+                      ],
+                      "resolved_default_values": {
+                        "feedback": ""
+                      },
+                      "user_actions": [
+                        {
+                          "id": "approve",
+                          "title": "Approve",
+                          "button_style": "primary"
+                        },
+                        {
+                          "id": "reject",
+                          "title": "Request changes",
+                          "button_style": "default"
+                        }
+                      ],
+                      "expiration_time": 1745510400
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Form contents retrieved successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Form not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Form not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "human_input_form_submitted": {
+                    "summary": "human_input_form_submitted",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_submitted",
+                      "message": "This form has already been submitted by another user, form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  },
+                  "human_input_form_expired": {
+                    "summary": "human_input_form_expired",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_expired",
+                      "message": "This form has expired, form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `human_input_form_submitted` : Form already submitted. Forms are one-shot; the first response wins regardless of which user submits it.\n- `human_input_form_expired` : The form's expiration time passed before submission arrived."
+          }
+        },
+        "summary": "Get Human Input Form",
+        "tags": [
+          "Human Input"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/human-input/get-human-input-form",
+          "metadata": {
+            "title": "Get Human Input Form",
+            "sidebarTitle": "Get Human Input Form"
+          }
+        }
+      },
+      "post": {
+        "description": "**Available for**: Chatflow, Workflow apps.\n\nSubmits the recipient's response to a paused Human Input form. On acceptance the workflow resumes; follow the resumed run via [Stream Workflow Events](/en/api-reference/workflow-runs/stream-workflow-events). In the Human Input node, enable the **Web App** delivery method; email-only or console-only delivery does not expose the form through these Service API endpoints.",
+        "operationId": "submitChatflowHumanInputForm",
+        "parameters": [
+          {
+            "description": "Access token for the paused form, returned in the `human_input_required` event from the Run Workflow or Send Chat Message endpoint in streaming mode.",
+            "in": "path",
+            "name": "form_token",
+            "required": true,
+            "schema": {
+              "description": "Human input form token",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HumanInputFormSubmitPayloadWithUser"
+              },
+              "examples": {
+                "approve": {
+                  "summary": "Request Example",
+                  "value": {
+                    "inputs": {
+                      "feedback": "Looks good to ship",
+                      "priority": "high",
+                      "attachment": {
+                        "transfer_method": "local_file",
+                        "upload_file_id": "3c8fa1b2-7d4e-4f9a-b0c1-d2e3f4a5b6c7",
+                        "type": "image"
+                      },
+                      "attachments": [
+                        {
+                          "transfer_method": "local_file",
+                          "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee",
+                          "type": "document"
+                        },
+                        {
+                          "transfer_method": "remote_url",
+                          "url": "https://example.com/report.pdf",
+                          "type": "document"
+                        }
+                      ]
+                    },
+                    "action": "approve",
+                    "user": "abc-123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumanInputFormSubmitResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {}
+                  }
+                }
+              }
+            },
+            "description": "Form submitted successfully. The response body is an empty object."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "bad_request": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "Form recipient type is invalid"
+                    }
+                  },
+                  "invalid_form_data": {
+                    "summary": "invalid_form_data",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_form_data",
+                      "message": "Missing required inputs: feedback"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `bad_request` : Form recipient type is invalid.\n- `invalid_form_data` : Submission failed validation against the form definition."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Form not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Form not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "human_input_form_submitted": {
+                    "summary": "human_input_form_submitted",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_submitted",
+                      "message": "This form has already been submitted by another user, form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  },
+                  "human_input_form_expired": {
+                    "summary": "human_input_form_expired",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_expired",
+                      "message": "This form has expired, form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `human_input_form_submitted` : Form already submitted. Forms are one-shot; the first response wins regardless of which user submits it.\n- `human_input_form_expired` : The form's expiration time passed before submission arrived."
+          }
+        },
+        "summary": "Submit Human Input Form",
+        "tags": [
+          "Human Input"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/human-input/submit-human-input-form",
+          "metadata": {
+            "title": "Submit Human Input Form",
+            "sidebarTitle": "Submit Human Input Form"
+          }
+        }
+      }
+    },
+    "/info": {
+      "get": {
+        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns basic information about the app: name, description, tags, mode, and author.",
+        "operationId": "getChatAppInfo",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfoResponse"
+                },
+                "examples": {
+                  "appInfo": {
+                    "summary": "Response Example",
+                    "value": {
+                      "name": "My Chat App",
+                      "description": "A helpful customer service chatbot.",
+                      "tags": [
+                        "customer-service",
+                        "chatbot"
+                      ],
+                      "mode": "chat",
+                      "author_name": "Dify Team"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Basic information of the application."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "Application not found"
+          }
+        },
+        "summary": "Get App Info",
+        "tags": [
+          "Applications"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl -X GET 'https://{api_base_url}/info' \\\n  -H 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/applications/get-app-info",
+          "metadata": {
+            "title": "Get App Info",
+            "sidebarTitle": "Get App Info"
+          }
+        }
+      }
+    },
+    "/messages": {
+      "get": {
+        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nReturns a conversation's message history, newest first. Pass `first_id` to page backward into older messages.",
+        "operationId": "getConversationHistory",
+        "parameters": [
+          {
+            "description": "ID of the conversation to read. Get conversation IDs from [List Conversations](/en/api-reference/conversations/list-conversations).",
+            "in": "query",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "Conversation ID.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pagination cursor: the `id` of the first message on the current page. Pass it to fetch the previous (older) page; omit to fetch the latest messages.",
+            "in": "query",
+            "name": "first_id",
+            "required": false,
+            "schema": {
+              "description": "The ID of the first chat record on the current page. Omit this value to fetch the latest messages; for subsequent pages, use the first message ID from the current list to fetch older messages.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of chat history messages to return per request.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of chat history messages to return per request.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End-user identifier, defined by your app and unique within it. See [End User Identity](/en/api-reference/guides/end-user-identity).",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "User identifier, used for end-user context.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageInfiniteScrollPagination"
+                },
+                "examples": {
+                  "conversationHistory": {
+                    "summary": "Response Example",
+                    "value": {
+                      "limit": 20,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "9da23599-e713-473b-982c-4328d4f5c78a",
+                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                          "parent_message_id": null,
+                          "inputs": {
+                            "city": "San Francisco"
+                          },
+                          "query": "What are the specs of the iPhone 13 Pro Max?",
+                          "answer": "iPhone 13 Pro Max specs are listed here:...",
+                          "status": "normal",
+                          "error": null,
+                          "message_files": [],
+                          "feedback": {
+                            "rating": "like"
+                          },
+                          "retriever_resources": [],
+                          "agent_thoughts": [],
+                          "created_at": 1705407629,
+                          "extra_contents": [],
+                          "message_tokens": 100,
+                          "answer_tokens": 58,
+                          "total_tokens": 158,
+                          "provider_response_latency": 1.234,
+                          "total_price": "0.0012825",
+                          "currency": "USD"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successfully retrieved conversation history."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_chat_app` : App mode does not match the API route."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  },
+                  "first_message_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "First Message Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Conversation does not exist.\n- `not_found` : First message does not exist (invalid `first_id`)."
+          }
+        },
+        "summary": "List Conversation Messages",
+        "tags": [
+          "Conversations"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages?conversation_id={conversation_id}&user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/conversations/list-conversation-messages",
+          "metadata": {
+            "title": "List Conversation Messages",
+            "sidebarTitle": "List Conversation Messages"
+          }
+        }
+      }
+    },
+    "/messages/{message_id}/feedbacks": {
+      "post": {
+        "description": "**Available for**: Chatflow, Chatbot, Agent, Text Generator apps.\n\nRecords a `like` or `dislike` rating, plus an optional comment, on a message. Submitting `null` for `rating` revokes the message's existing feedback.",
+        "operationId": "postChatMessageFeedback",
+        "parameters": [
+          {
+            "description": "ID of the message to give feedback on. Get message IDs from [List Conversation Messages](/en/api-reference/conversations/list-conversation-messages).",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "Message ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MessageFeedbackPayloadWithUser"
+              },
+              "examples": {
+                "likeFeedback": {
+                  "summary": "Request Example",
+                  "value": {
+                    "rating": "like",
+                    "user": "abc-123",
+                    "content": "This answer was very helpful!"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "Feedback submitted successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param` : The required `user` field is omitted, or `rating` is `null` but there is no existing feedback to revoke."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "message_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Message Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found` : Message does not exist."
+          }
+        },
+        "summary": "Submit Message Feedback",
+        "tags": [
+          "Feedback"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/feedback/submit-message-feedback",
+          "metadata": {
+            "title": "Submit Message Feedback",
+            "sidebarTitle": "Submit Message Feedback"
+          }
+        }
+      }
+    },
+    "/messages/{message_id}/suggested": {
+      "get": {
+        "description": "**Available for**: Chatflow, New Agent, Chatbot, Agent apps.\n\nReturns the follow-up questions suggested for a message.",
+        "operationId": "getSuggestedQuestions",
+        "parameters": [
+          {
+            "description": "ID of the message to get suggestions for. Get it from a chat response or [List Conversation Messages](/en/api-reference/conversations/list-conversation-messages).",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "Message ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "End-user identifier, defined by your app and unique within it. See [End User Identity](/en/api-reference/guides/end-user-identity).",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "description": "User identifier, used for end-user context.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultStringListResponse"
+                },
+                "examples": {
+                  "suggestedQuestions": {
+                    "summary": "Response Example",
+                    "value": {
+                      "result": "success",
+                      "data": [
+                        "What colors does the iPhone 13 Pro Max come in?",
+                        "How does the battery compare to iPhone 12?",
+                        "What is the price range?"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successfully retrieved suggested questions."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "bad_request": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "Suggested Questions Is Disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app` : App mode does not match the API route.\n- `bad_request` : Suggested questions feature is disabled."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "message_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Message Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found` : Message does not exist."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error` : Internal server error."
+          }
+        },
+        "summary": "Get Next Suggested Questions",
+        "tags": [
+          "Chat Messages"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages/{message_id}/suggested?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/chat-messages/get-next-suggested-questions",
+          "metadata": {
+            "title": "Get Next Suggested Questions",
+            "sidebarTitle": "Get Next Suggested Questions"
+          }
+        }
+      }
+    },
+    "/meta": {
+      "get": {
+        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns the display icons for the tools this app uses, keyed by tool name.",
+        "operationId": "getChatAppMeta",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppMetaResponse"
+                },
+                "examples": {
+                  "appMeta": {
+                    "summary": "Response Example",
+                    "value": {
+                      "tool_icons": {
+                        "dalle3": "https://example.com/icons/dalle3.png",
+                        "calculator": {
+                          "background": "#4A90D9",
+                          "content": "🧮"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successfully retrieved application meta information."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "Application not found"
+          }
+        },
+        "summary": "Get App Meta",
+        "tags": [
+          "Applications"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/applications/get-app-meta",
+          "metadata": {
+            "title": "Get App Meta",
+            "sidebarTitle": "Get App Meta"
+          }
+        }
+      }
+    },
+    "/parameters": {
+      "get": {
+        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns the app's front-end configuration: the opening statement and suggested questions, feature toggles, the user input form, and file-upload limits. Use it to render the app's inputs and apply the correct upload limits.",
+        "operationId": "getChatAppParameters",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Parameters"
+                },
+                "examples": {
+                  "appParameters": {
+                    "summary": "Response Example",
+                    "value": {
+                      "opening_statement": "Hello! How can I help you today?",
+                      "suggested_questions": [
+                        "What can you do?",
+                        "Tell me about your features."
+                      ],
+                      "suggested_questions_after_answer": {
+                        "enabled": true
+                      },
+                      "speech_to_text": {
+                        "enabled": false
+                      },
+                      "text_to_speech": {
+                        "enabled": false,
+                        "voice": "alloy",
+                        "language": "en-US",
+                        "autoPlay": "disabled"
+                      },
+                      "retriever_resource": {
+                        "enabled": true
+                      },
+                      "annotation_reply": {
+                        "enabled": false
+                      },
+                      "more_like_this": {
+                        "enabled": false
+                      },
+                      "sensitive_word_avoidance": {
+                        "enabled": false
+                      },
+                      "user_input_form": [
+                        {
+                          "text-input": {
+                            "label": "City",
+                            "variable": "city",
+                            "required": true,
+                            "default": ""
+                          }
+                        }
+                      ],
+                      "file_upload": {
+                        "image": {
+                          "enabled": true,
+                          "number_limits": 3,
+                          "detail": "high",
+                          "transfer_methods": [
+                            "remote_url",
+                            "local_file"
+                          ]
+                        }
+                      },
+                      "system_parameters": {
+                        "file_size_limit": 15,
+                        "image_file_size_limit": 10,
+                        "audio_file_size_limit": 50,
+                        "video_file_size_limit": 100,
+                        "workflow_file_upload_limit": 10
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Application parameters information."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "app_unavailable": {
+                    "summary": "app_unavailable",
+                    "value": {
+                      "status": 400,
+                      "code": "app_unavailable",
+                      "message": "App unavailable, please check your app configurations."
+                    }
+                  },
+                  "agent_not_published": {
+                    "summary": "agent_not_published",
+                    "value": {
+                      "code": "agent_not_published",
+                      "message": "Agent has not been published. Please publish the Agent before using the API.",
+                      "status": 400
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `app_unavailable` : The app is unavailable or misconfigured.\n- `agent_not_published` : The app's Agent has no published version yet. (New Agent apps)"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "Application not found"
+          }
+        },
+        "summary": "Get App Parameters",
+        "tags": [
+          "Applications"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/applications/get-app-parameters",
+          "metadata": {
+            "title": "Get App Parameters",
+            "sidebarTitle": "Get App Parameters"
+          }
+        }
+      }
+    },
+    "/site": {
+      "get": {
+        "description": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns the branding and display settings for the app's hosted web app, such as its title, icon, theme colors, and default language.",
+        "operationId": "getChatWebAppSettings",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Site"
+                },
+                "examples": {
+                  "webAppSettings": {
+                    "summary": "Response Example",
+                    "value": {
+                      "title": "My Chat App",
+                      "chat_color_theme": "#4A90D9",
+                      "chat_color_theme_inverted": false,
+                      "icon_type": "emoji",
+                      "icon": "🤖",
+                      "icon_background": "#FFFFFF",
+                      "icon_url": null,
+                      "description": "A helpful customer service chatbot.",
+                      "copyright": "2025 Dify",
+                      "privacy_policy": "https://example.com/privacy",
+                      "input_placeholder": "Ask me anything about our products...",
+                      "custom_disclaimer": "",
+                      "default_language": "en-US",
+                      "show_workflow_steps": false,
+                      "use_icon_as_answer_icon": true
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Web app settings of the application."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Site not found for this application or the workspace has been archived."
+          }
+        },
+        "summary": "Get App WebApp Settings",
+        "tags": [
+          "Applications"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/applications/get-app-webapp-settings",
+          "metadata": {
+            "title": "Get App WebApp Settings",
+            "sidebarTitle": "Get App WebApp Settings"
+          }
+        }
+      }
+    },
+    "/text-to-audio": {
+      "post": {
+        "description": "**Available for**: Chatflow, Workflow, new Agent, Chatbot, Agent, and Text Generator apps.\n\nConverts text to speech. Provide at least one of `text` or `message_id`. Use `text` to synthesize arbitrary content, or `message_id` to synthesize an existing message's answer; `message_id` takes priority when both are present. The generated schema does not yet express this cross-field requirement, so clients must enforce it before sending the request.",
+        "operationId": "textToAudioChat",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TextToAudioPayloadWithUser"
+              },
+              "examples": {
+                "textToAudioExample": {
+                  "summary": "Request Example",
+                  "value": {
+                    "text": "Hello, welcome to our service.",
+                    "user": "abc-123",
+                    "voice": "alloy",
+                    "streaming": false
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "audio/aac": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/flac": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/mp4": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/mpeg": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/ogg": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/wav": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/webm": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Returns the generated audio. The `Content-Type` header reflects the provider's audio container, verified from the response bytes when recognizable.\n\nThe body can be AAC, FLAC, MP4, MP3, Ogg, WAV, or WebM. Output that cannot be recognized is labeled with the provider's declared type, or `audio/mpeg` when none is declared.\n\nStreamed provider output is delivered with chunked transfer encoding; the request `streaming` field does not control this."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "app_unavailable": {
+                    "summary": "app_unavailable",
+                    "value": {
+                      "status": 400,
+                      "code": "app_unavailable",
+                      "message": "App unavailable, please check your app configurations."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "TTS is not enabled"
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `app_unavailable` : The app is unavailable or misconfigured.\n- `invalid_param` : Text-to-speech is not enabled, `text` is missing, or no voice is available.\n- `provider_not_initialize` : No valid model provider credentials are configured.\n- `provider_quota_exceeded` : The model provider quota is exhausted.\n- `model_currently_not_support` : The current model does not support this operation.\n- `completion_request_error` : The text-to-speech request failed."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error` : Internal server error."
+          }
+        },
+        "summary": "Convert Text to Audio",
+        "tags": [
+          "Audio"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/audio/convert-text-to-audio",
+          "metadata": {
+            "title": "Convert Text to Audio",
+            "sidebarTitle": "Convert Text to Audio"
+          }
+        }
+      }
+    },
+    "/workflow/{workflow_run_id}/events": {
+      "get": {
+        "description": "**Available for**: Chatflow, Workflow apps.\n\nResume the Server-Sent Events stream for a workflow run after a pause or a dropped SSE connection. For runs that have already finished, the stream emits a single `workflow_finished` event and closes.\n\nTo check an in-progress run's node-level status and progress, call it with `include_state_snapshot=true`: the stream replays each already-executed node's status before streaming new events.",
+        "operationId": "streamWorkflowEvents",
+        "parameters": [
+          {
+            "description": "Workflow run ID whose event stream to resume, from the response or streaming events of [Run Workflow](/en/api-reference/workflow-runs/run-workflow).",
+            "in": "path",
+            "name": "workflow_run_id",
+            "required": true,
+            "schema": {
+              "description": "Workflow run ID returned by the original workflow run request.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Set to `true` to keep the stream open across multiple `workflow_paused` events (useful when the workflow has more than one Human Input node in sequence). Default closes the stream after the first pause.",
+            "in": "query",
+            "name": "continue_on_pause",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Set to `true` to keep the stream open across multiple `workflow_paused` events, which is useful when the workflow has more than one Human Input node in sequence. By default, the stream closes after the first pause.",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "When `true`, replay from the persisted state snapshot to include a status summary of already-executed nodes before streaming new events.",
+            "in": "query",
+            "name": "include_state_snapshot",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "When `true`, replay from the persisted state snapshot to include a status summary of already-executed nodes before streaming new events.",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "End-user identifier, defined by your app and unique within it. Must match the `user` that started the run. See [End User Identity](/en/api-reference/guides/end-user-identity).",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "description": "End-user identifier that originally triggered the run. Must match the creator of the run.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "SSE stream of events from a resumed workflow run, in the same format as [Run Workflow](/en/api-reference/workflow-runs/run-workflow) (Workflow apps) or [Send Chat Message](/en/api-reference/chat-messages/send-chat-message) (Chatflow apps). When the resumed portion runs an LLM node with `reasoning_format: separated`, this stream also carries `reasoning_chunk` events."
+                },
+                "examples": {
+                  "resumedRun": {
+                    "summary": "Response Example - Resumed run (Workflow)",
+                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"rendered_content\": \"Please review the draft.\", \"action_id\": \"approve\", \"action_text\": \"Approve\", \"submitted_data\": {\"comment\": \"Looks good.\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_2\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Approved, now translating.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour\"}, \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
+                  },
+                  "resumedRunChatflow": {
+                    "summary": "Response Example - Resumed run (Chatflow)",
+                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"rendered_content\": \"Please review the draft.\", \"action_id\": \"approve\", \"action_text\": \"Approve\", \"submitted_data\": {\"comment\": \"Looks good.\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"The reviewer approved the draft.\", \"node_id\": \"node_llm_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"\", \"node_id\": \"node_llm_1\", \"is_final\": true}}\n\ndata: {\"event\": \"message\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"answer\": \"Approved\", \"created_at\": 1705407706}\n\ndata: {\"event\": \"node_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"status\": \"succeeded\", \"elapsed_time\": 1.2, \"created_at\": 1705407705, \"finished_at\": 1705407706}}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"metadata\": {\"usage\": {\"total_tokens\": 42, \"latency\": 1.3}}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
+                  }
+                }
+              }
+            },
+            "description": "Server-Sent Events stream. It opens with a bare `event: ping` frame (keep-alive; more arrive roughly every 10 seconds); every other event is delivered as `data: {JSON}\\n\\n`. Event payloads follow the same schemas as the original streaming response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_workflow_app` : Please check if your app mode matches the right API route."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Workflow run not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Workflow run not found."
+          }
+        },
+        "summary": "Stream Workflow Events",
+        "tags": [
+          "Workflow Runs"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "Resume stream",
+            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
+          },
+          {
+            "lang": "bash",
+            "label": "With state snapshot",
+            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}&include_state_snapshot=true' \\\n  --header 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/workflow-runs/stream-workflow-events",
+          "metadata": {
+            "title": "Stream Workflow Events",
+            "sidebarTitle": "Stream Workflow Events"
+          }
+        }
+      }
+    },
+    "/workflows/logs": {
+      "get": {
+        "description": "**Available for**: Chatflow, Workflow apps.\n\nList past workflow runs with optional filters. Each entry is a run-level summary (status, token usage, step count, and timing), not a node-by-node execution log.\n\nTo follow a run's node-level events, stream it instead:\n\n- **A run you start**: use [Run Workflow](/en/api-reference/workflow-runs/run-workflow) in streaming mode, which emits `node_started` and `node_finished` as the run executes.\n- **A run already in progress**: call [Stream Workflow Events](/en/api-reference/workflow-runs/stream-workflow-events) with `include_state_snapshot=true` to replay each executed node's status, then stream the rest.\n\nA finished run's node-level logs aren't available through the Service API.",
+        "operationId": "getWorkflowLogs",
+        "parameters": [
+          {
+            "description": "Filter logs created after this ISO 8601 timestamp.",
+            "in": "query",
+            "name": "created_at__after",
+            "required": false,
+            "schema": {
+              "description": "Filter logs created after this ISO 8601 timestamp.",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter logs created before this ISO 8601 timestamp.",
+            "in": "query",
+            "name": "created_at__before",
+            "required": false,
+            "schema": {
+              "description": "Filter logs created before this ISO 8601 timestamp.",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by account ID.",
+            "in": "query",
+            "name": "created_by_account",
+            "required": false,
+            "schema": {
+              "description": "Filter by account ID.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by end user session ID.",
+            "in": "query",
+            "name": "created_by_end_user_session_id",
+            "required": false,
+            "schema": {
+              "description": "Filter by end user session ID.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Keyword to search in logs.",
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "description": "Keyword to search in logs.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number for pagination.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "Page number for pagination.",
+              "maximum": 99999,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by execution status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "Filter by execution status.",
+              "enum": [
+                "failed",
+                "stopped",
+                "succeeded"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowAppLogPaginationResponse"
+                },
+                "examples": {
+                  "workflowLogs": {
+                    "summary": "Response Example",
+                    "value": {
+                      "page": 1,
+                      "limit": 20,
+                      "total": 1,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
+                          "workflow_run": {
+                            "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                            "version": "2025-01-16 12:00:00.000000",
+                            "status": "succeeded",
+                            "error": null,
+                            "elapsed_time": 1.23,
+                            "total_tokens": 150,
+                            "total_steps": 3,
+                            "created_at": 1705407629,
+                            "finished_at": 1705407630,
+                            "exceptions_count": 0,
+                            "triggered_from": "app-run"
+                          },
+                          "created_from": "service-api",
+                          "created_by_role": "end_user",
+                          "created_by_account": null,
+                          "created_by_end_user": {
+                            "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                            "type": "service-api",
+                            "is_anonymous": false,
+                            "session_id": "user_workflow_123"
+                          },
+                          "created_at": 1705407629
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successfully retrieved workflow logs."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Account not found: name@example.com"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param` : A query parameter is invalid, such as a `created_by_account` value matching no account, a malformed `created_at__before` or `created_at__after` timestamp, or an out-of-range `page`, `limit`, or `status` value."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          }
+        },
+        "summary": "List Workflow Logs",
+        "tags": [
+          "Workflow Runs"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/workflow-runs/list-workflow-logs",
+          "metadata": {
+            "title": "List Workflow Logs",
+            "sidebarTitle": "List Workflow Logs"
+          }
+        }
+      }
+    },
+    "/workflows/run": {
+      "post": {
+        "description": "**Available for**: Workflow apps.\n\nRun the app's published workflow and return its outputs, either in a single `blocking` response or as a `streaming` Server-Sent Events feed. Requires a published workflow. Omitting a version ID runs the app's current published workflow. Drafts exist only in the editor and cannot be called through the Service API; publishing makes that draft the current published version. Use [Run Workflow by ID](/en/api-reference/workflow-runs/run-workflow-by-id) only for an earlier published `workflow_id`.",
+        "operationId": "executeWorkflow",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowRunPayloadWithUser"
+              },
+              "examples": {
+                "streaming_example": {
+                  "summary": "Request Example - Streaming mode",
+                  "value": {
+                    "inputs": {
+                      "query": "Summarize this text: The quick brown fox jumps over the lazy dog."
+                    },
+                    "response_mode": "streaming",
+                    "user": "user_workflow_123"
+                  }
+                },
+                "blocking_example": {
+                  "summary": "Request Example - Blocking mode",
+                  "value": {
+                    "inputs": {
+                      "query": "Translate this to French: Hello world"
+                    },
+                    "response_mode": "blocking",
+                    "user": "user_workflow_456"
+                  }
+                },
+                "with_file_array_variable": {
+                  "summary": "Request Example - File array input",
+                  "value": {
+                    "inputs": {
+                      "my_documents": [
+                        {
+                          "type": "document",
+                          "transfer_method": "local_file",
+                          "upload_file_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+                        },
+                        {
+                          "type": "image",
+                          "transfer_method": "remote_url",
+                          "url": "https://example.com/image.jpg"
+                        }
+                      ]
+                    },
+                    "response_mode": "blocking",
+                    "user": "user_workflow_789"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
+                },
+                "examples": {
+                  "blockingResponse": {
+                    "summary": "Response Example - Blocking mode",
+                    "value": {
+                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
+                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "data": {
+                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "status": "succeeded",
+                        "outputs": {
+                          "result": "Bonjour le monde"
+                        },
+                        "error": null,
+                        "elapsed_time": 1.23,
+                        "total_tokens": 150,
+                        "total_steps": 3,
+                        "created_at": 1705407629,
+                        "finished_at": 1705407630
+                      }
+                    }
+                  }
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "A stream of Server-Sent Events. Parse it per the [SSE Streaming guide](/en/api-reference/guides/streaming): read `data:` lines, dispatch on the `event` field, skip `ping` (keep-alive; the stream opens with one, then more arrive roughly every 10 seconds).\n\n**Stream lifecycle**: The stream closes when a `workflow_finished`, `workflow_paused`, or `error` event is received. Errors are delivered in-stream with HTTP status `200`; inspect the event payload for details rather than relying on the status code.\n\n**Reasoning events**:\n- `reasoning_chunk`: A chain-of-thought delta from an LLM node whose `reasoning_format` is `separated`. Concatenate consecutive `reasoning_chunk` events to rebuild the full reasoning; an event with `is_final: true` marks the node finished thinking (and may carry an empty `reasoning`). The payload sits under `data` and, unlike chat apps, carries `message_id: null` and no `conversation_id`. The parallel `text_chunk` stream stays free of `<think>` tags.\n\n**Human Input events**:\n- `human_input_required`: Fires together with `workflow_paused` when the workflow reaches a Human Input node. Use the `form_token` from the payload to drive the form-handling flow via the [Human Input API](/en/api-reference/human-input/get-human-input-form).\n- `human_input_form_filled`: A recipient submitted the form; workflow execution resumes.\n- `human_input_form_timeout`: The form expired without a response. Workflow follows the timeout fallback edge if defined."
+                },
+                "examples": {
+                  "streamingResponse": {
+                    "summary": "Response Example - Streaming mode",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"Translate this\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Let me translate that.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
+                  },
+                  "humanInputPause": {
+                    "summary": "Response Example - Human Input pause",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"Hello\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"form_content\": \"Please review the draft.\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"Approve\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
+                  }
+                }
+              }
+            },
+            "description": "Successful response. In `blocking` mode, returns `application/json` with a `WorkflowBlockingResponse` object. In `streaming` mode, returns `text/event-stream` with workflow events."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_workflow_app` : App mode does not match the API route.\n- `provider_not_initialize` : No valid model provider credentials found.\n- `provider_quota_exceeded` : Model provider quota exhausted.\n- `model_currently_not_support` : Current model unavailable.\n- `completion_request_error` : Workflow execution request failed.\n- `invalid_param` : A request parameter is missing or invalid, such as a missing `user` or an unpublished workflow."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "Workflow not found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "too_many_requests": {
+                    "summary": "too_many_requests",
+                    "value": {
+                      "status": 429,
+                      "code": "too_many_requests",
+                      "message": "Too many requests. Please try again later."
+                    }
+                  },
+                  "rate_limit_error": {
+                    "summary": "rate_limit_error",
+                    "value": {
+                      "status": 429,
+                      "code": "rate_limit_error",
+                      "message": "Rate Limit Error"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `too_many_requests` : Too many concurrent requests for this app.\n- `rate_limit_error` : The Dify Cloud workflow execution quota for this workspace has been reached."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "Internal Server Error."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error` : Internal server error."
+          }
+        },
+        "summary": "Run Workflow",
+        "tags": [
+          "Workflow Runs"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl -N --request POST \\\n  --url 'https://{api_base_url}/workflows/run' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"inputs\": {\"query\": \"Summarize this text: The quick brown fox jumps over the lazy dog.\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/workflow-runs/run-workflow",
+          "metadata": {
+            "title": "Run Workflow",
+            "sidebarTitle": "Run Workflow"
+          }
+        }
+      }
+    },
+    "/workflows/run/{workflow_run_id}": {
+      "get": {
+        "description": "**Available for**: Chatflow, Workflow apps.\n\nGet a single workflow run's status, inputs, outputs, and execution metrics.",
+        "operationId": "getWorkflowRunDetail",
+        "parameters": [
+          {
+            "description": "Workflow run ID, from the response or streaming events of [Run Workflow](/en/api-reference/workflow-runs/run-workflow), or from message metadata in Chatflow apps.",
+            "in": "path",
+            "name": "workflow_run_id",
+            "required": true,
+            "schema": {
+              "description": "Workflow run ID, obtained from the workflow execution response or streaming events.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowRunResponse"
+                },
+                "examples": {
+                  "workflowRunDetail": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                      "status": "succeeded",
+                      "inputs": "{\"query\": \"Translate this to French\"}",
+                      "outputs": {
+                        "result": "Traduisez ceci en francais"
+                      },
+                      "error": null,
+                      "total_steps": 3,
+                      "total_tokens": 150,
+                      "created_at": 1705407629,
+                      "finished_at": 1705407630,
+                      "elapsed_time": 1.23
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Successfully retrieved workflow run details."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_workflow_app` : App mode does not match the API route."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "workflow_run_not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Workflow run not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found` : Workflow run not found."
+          }
+        },
+        "summary": "Get Workflow Run Detail",
+        "tags": [
+          "Workflow Runs"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/workflow-runs/get-workflow-run-detail",
+          "metadata": {
+            "title": "Get Workflow Run Detail",
+            "sidebarTitle": "Get Workflow Run Detail"
+          }
+        }
+      }
+    },
+    "/workflows/tasks/{task_id}/stop": {
+      "post": {
+        "description": "**Available for**: Workflow apps.\n\nStop a running workflow task. Only supported in `streaming` mode.",
+        "operationId": "stopWorkflowTaskGeneration",
+        "parameters": [
+          {
+            "description": "Task ID, from the streaming events of [Run Workflow](/en/api-reference/workflow-runs/run-workflow).",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "description": "Task ID, obtained from the streaming chunk returned by the Run Workflow API.",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RequiredServiceApiUserPayload"
+              },
+              "examples": {
+                "example": {
+                  "summary": "Request Example",
+                  "value": {
+                    "user": "user_workflow_123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "Task stopped successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_workflow_app` : App mode does not match the API route.\n- `invalid_param` : A request parameter is missing or invalid, such as a missing `user`."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : The app API is disabled, the app state is abnormal, or the workspace is archived."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "Reserved compatibility response. The current runtime does not verify task existence before setting the stop flag and returns the normal `200` result even when the task is no longer running."
+          }
+        },
+        "summary": "Stop Workflow Task",
+        "tags": [
+          "Workflow Runs"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/workflow-runs/stop-workflow-task",
+          "metadata": {
+            "title": "Stop Workflow Task",
+            "sidebarTitle": "Stop Workflow Task"
+          }
+        }
+      }
+    },
+    "/workflows/{workflow_id}/run": {
+      "post": {
+        "description": "**Available for**: Workflow apps.\n\nRun a specific published workflow version, identified by the `workflow_id` in the path. Request body, response, and streaming behavior match [Run Workflow](/en/api-reference/workflow-runs/run-workflow); only the executed version differs.",
+        "operationId": "runWorkflowById",
+        "parameters": [
+          {
+            "description": "Published workflow version to run. Returned in the `workflow_id` field of [Run Workflow](/en/api-reference/workflow-runs/run-workflow) responses and [Get Workflow Run Detail](/en/api-reference/workflow-runs/get-workflow-run-detail). Must reference a published version; a draft version ID is rejected with `bad_request`.",
+            "in": "path",
+            "name": "workflow_id",
+            "required": true,
+            "schema": {
+              "description": "Workflow ID of the specific version to execute. This value is returned in the `workflow_id` field of workflow run responses.",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowRunPayloadWithUser"
+              },
+              "examples": {
+                "example": {
+                  "summary": "Request Example",
+                  "value": {
+                    "inputs": {
+                      "query": "Summarize this article"
+                    },
+                    "response_mode": "blocking",
+                    "user": "user_workflow_123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
+                },
+                "examples": {
+                  "blockingResponse": {
+                    "summary": "Response Example - Blocking mode",
+                    "value": {
+                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
+                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "data": {
+                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "status": "succeeded",
+                        "outputs": {
+                          "result": "Article summary here"
+                        },
+                        "error": null,
+                        "elapsed_time": 2.45,
+                        "total_tokens": 280,
+                        "total_steps": 4,
+                        "created_at": 1705407629,
+                        "finished_at": 1705407631
+                      }
+                    }
+                  }
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "A stream of Server-Sent Events. Parse it per the [SSE Streaming guide](/en/api-reference/guides/streaming): read `data:` lines, dispatch on the `event` field, skip `ping` (keep-alive; the stream opens with one, then more arrive roughly every 10 seconds).\n\n**Stream lifecycle**: The stream closes when a `workflow_finished`, `workflow_paused`, or `error` event is received. Errors are delivered in-stream with HTTP status `200`; inspect the event payload for details rather than relying on the status code.\n\n**Reasoning events**:\n- `reasoning_chunk`: A chain-of-thought delta from an LLM node whose `reasoning_format` is `separated`. Concatenate consecutive `reasoning_chunk` events to rebuild the full reasoning; an event with `is_final: true` marks the node finished thinking (and may carry an empty `reasoning`). The payload sits under `data` and, unlike chat apps, carries `message_id: null` and no `conversation_id`. The parallel `text_chunk` stream stays free of `<think>` tags.\n\n**Human Input events**:\n- `human_input_required`: Fires together with `workflow_paused` when the workflow reaches a Human Input node. Use the `form_token` from the payload to drive the form-handling flow via the [Human Input API](/en/api-reference/human-input/get-human-input-form).\n- `human_input_form_filled`: A recipient submitted the form; workflow execution resumes.\n- `human_input_form_timeout`: The form expired without a response. Workflow follows the timeout fallback edge if defined."
+                },
+                "examples": {
+                  "streamingResponse": {
+                    "summary": "Response Example - Streaming mode",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"Translate this\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Let me translate that.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
+                  },
+                  "humanInputPause": {
+                    "summary": "Response Example - Human Input pause",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"Hello\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"form_content\": \"Please review the draft.\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"Approve\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
+                  }
+                }
+              }
+            },
+            "description": "Successful response. In `blocking` mode, returns `application/json` with a `WorkflowBlockingResponse` object. In `streaming` mode, returns `text/event-stream` with workflow events."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "bad_request": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "Cannot use draft workflow version. Workflow ID: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345. Please use a published workflow version or leave workflow_id empty."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_workflow_app` : App mode does not match the API route.\n- `bad_request` : Workflow is a draft or has an invalid ID format.\n- `provider_not_initialize` : No valid model provider credentials found.\n- `provider_quota_exceeded` : Model provider quota exhausted.\n- `model_currently_not_support` : Current model unavailable.\n- `completion_request_error` : Workflow execution request failed.\n- `invalid_param` : A request parameter is missing or invalid, such as a missing `user`."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "workflow_version_execution_not_allowed": {
+                    "summary": "workflow_version_execution_not_allowed",
+                    "value": {
+                      "status": 403,
+                      "code": "workflow_version_execution_not_allowed",
+                      "message": "Workflow version execution is not available on your current plan. Please upgrade to a paid plan."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`workflow_version_execution_not_allowed` : Executing a specific workflow version is not available on the Dify Cloud Sandbox plan."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Workflow not found with id: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Workflow not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "too_many_requests": {
+                    "summary": "too_many_requests",
+                    "value": {
+                      "status": 429,
+                      "code": "too_many_requests",
+                      "message": "Too many requests. Please try again later."
+                    }
+                  },
+                  "rate_limit_error": {
+                    "summary": "rate_limit_error",
+                    "value": {
+                      "status": 429,
+                      "code": "rate_limit_error",
+                      "message": "Rate Limit Error"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `too_many_requests` : Too many concurrent requests for this app.\n- `rate_limit_error` : The Dify Cloud workflow execution quota for this workspace has been reached."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "Internal Server Error."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error` : Internal server error."
+          }
+        },
+        "summary": "Run Workflow by ID",
+        "tags": [
+          "Workflow Runs"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/workflow-runs/run-workflow-by-id",
+          "metadata": {
+            "title": "Run Workflow by ID",
+            "sidebarTitle": "Run Workflow by ID"
+          }
+        }
+      }
+    },
+    "/workspaces/current/models/model-types/{model_type}": {
+      "get": {
+        "tags": [
+          "Models"
+        ],
+        "summary": "Get Available Models",
+        "description": "Returns the available models of a given type. Use it to find the `text-embedding` and `rerank` models to configure on a knowledge base.",
+        "operationId": "getAvailableModels",
+        "parameters": [
+          {
+            "name": "model_type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "text-embedding",
+                "rerank",
+                "llm",
+                "tts",
+                "speech2text",
+                "moderation"
+              ]
+            },
+            "description": "Type of model to retrieve. For knowledge base configuration, use `text-embedding` for embedding models or `rerank` for reranking models."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Available models for the specified type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "description": "List of model providers with their available models.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "provider": {
+                            "type": "string",
+                            "description": "Model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). Legacy providers may return the bare short form (e.g. `openai`)."
+                          },
+                          "label": {
+                            "type": "object",
+                            "description": "Localized display name of the provider.",
+                            "properties": {
+                              "en_US": {
+                                "type": "string",
+                                "description": "English display name."
+                              },
+                              "zh_Hans": {
+                                "type": "string",
+                                "description": "Chinese display name."
+                              }
+                            }
+                          },
+                          "icon_small": {
+                            "type": "object",
+                            "description": "URL of the provider's small icon.",
+                            "properties": {
+                              "en_US": {
+                                "type": "string",
+                                "description": "Small icon URL."
+                              },
+                              "zh_Hans": {
+                                "type": "string",
+                                "description": "Chinese icon URL."
+                              }
+                            }
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Provider status. `active` when credentials are configured and valid."
+                          },
+                          "models": {
+                            "type": "array",
+                            "description": "List of available models from this provider.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string",
+                                  "description": "Model identifier. Use this as the `embedding_model` value when creating or updating a knowledge base."
+                                },
+                                "label": {
+                                  "type": "object",
+                                  "description": "Localized display name of the model.",
+                                  "properties": {
+                                    "en_US": {
+                                      "type": "string",
+                                      "description": "English model name."
+                                    },
+                                    "zh_Hans": {
+                                      "type": "string",
+                                      "description": "Chinese model name."
+                                    }
+                                  }
+                                },
+                                "model_type": {
+                                  "type": "string",
+                                  "description": "Type of the model, matching the `model_type` path parameter."
+                                },
+                                "features": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "description": "Supported features of the model, `null` if none.",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "fetch_from": {
+                                  "type": "string",
+                                  "description": "Where the model definition comes from. `predefined-model` for built-in models, `customizable-model` for user-configured models."
+                                },
+                                "model_properties": {
+                                  "type": "object",
+                                  "description": "Model-specific properties such as `context_size`."
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "description": "Model availability status. `active` when ready to use."
+                                },
+                                "deprecated": {
+                                  "type": "boolean",
+                                  "description": "Whether the model is deprecated."
+                                },
+                                "load_balancing_enabled": {
+                                  "type": "boolean",
+                                  "description": "Whether load balancing is enabled for the model."
+                                },
+                                "has_invalid_load_balancing_configs": {
+                                  "type": "boolean",
+                                  "description": "Whether the model has invalid load-balancing configurations."
+                                }
+                              }
+                            }
+                          },
+                          "tenant_id": {
+                            "type": "string",
+                            "description": "Workspace ID the provider configuration belongs to."
+                          },
+                          "icon_small_dark": {
+                            "type": "object",
+                            "description": "Dark-mode icon URLs; `null` when the provider has none.",
+                            "properties": {
+                              "en_US": {
+                                "type": "string"
+                              },
+                              "zh_Hans": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "data": [
+                        {
+                          "provider": "langgenius/openai/openai",
+                          "label": {
+                            "en_US": "OpenAI",
+                            "zh_Hans": "OpenAI"
+                          },
+                          "icon_small": {
+                            "en_US": "https://example.com/openai-small.svg",
+                            "zh_Hans": "https://example.com/openai-small.svg"
+                          },
+                          "status": "active",
+                          "models": [
+                            {
+                              "model": "text-embedding-3-small",
+                              "label": {
+                                "en_US": "text-embedding-3-small",
+                                "zh_Hans": "text-embedding-3-small"
+                              },
+                              "model_type": "text-embedding",
+                              "features": null,
+                              "fetch_from": "predefined-model",
+                              "model_properties": {
+                                "context_size": 8191
+                              },
+                              "status": "active",
+                              "deprecated": false,
+                              "load_balancing_enabled": false,
+                              "has_invalid_load_balancing_configs": false
+                            }
+                          ],
+                          "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                          "icon_small_dark": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/en/api-reference/models/get-available-models",
+          "metadata": {
+            "title": "Get Available Models",
+            "sidebarTitle": "Get Available Models"
           }
         }
       }

--- a/ja/api-reference/openapi_service.json
+++ b/ja/api-reference/openapi_service.json
@@ -91,30 +91,1048 @@
     }
   ],
   "paths": {
-    "/chat-messages": {
-      "post": {
-        "summary": "チャットメッセージを送信",
-        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\nチャットアプリにメッセージを送信し、アシスタントの応答を返します。ストリーミングレスポンスのイベントはアプリタイプによって異なります。",
-        "operationId": "sendBasicChatMessageJa",
+    "/": {
+      "get": {
+        "operationId": "get_index_api",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexInfoResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "成功",
+                    "value": {
+                      "welcome": "Dify OpenAPI",
+                      "api_version": "v1",
+                      "server_version": "1.17.0"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Service API とサーバーのバージョン情報。"
+          }
+        },
+        "security": [],
+        "summary": "API 情報を取得",
         "tags": [
-          "チャットメッセージ"
+          "アプリケーション設定"
+        ],
+        "description": "Service API とサーバーのバージョンを返します。",
+        "x-mint": {
+          "href": "/ja/api-reference/applications/get-api-information",
+          "metadata": {
+            "title": "API 情報を取得",
+            "sidebarTitle": "API 情報を取得"
+          }
+        }
+      }
+    },
+    "/app/feedbacks": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent、テキストジェネレーター。\n\nアプリのメッセージに対するすべてのフィードバックのページネーション付きリストを返します。エンドユーザーと管理者の両方の送信が含まれます。\n\nフィードバックをページ単位で一覧表示します。レスポンスには総数や `has_more` がありません。`data` が空、または件数が指定した `limit` 未満になったらページ取得を終了してください。",
+        "operationId": "getChatAppFeedbacks",
+        "parameters": [
+          {
+            "description": "1 ページあたりのフィードバック件数。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "1 ページあたりのレコード数。",
+              "maximum": 101,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "ページ番号。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "ページネーションのページ番号。",
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppFeedbackListResponse"
+                },
+                "examples": {
+                  "feedbacksList": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
+                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                          "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
+                          "rating": "like",
+                          "content": "製品仕様に関する質問に正確に答えてくれました。",
+                          "from_source": "user",
+                          "from_end_user_id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                          "from_account_id": null,
+                          "created_at": "2025-01-16T14:30:29Z",
+                          "updated_at": "2025-01-16T14:30:29Z"
+                        },
+                        {
+                          "id": "c8f3a9b2-4d5e-6f70-8901-bcdef2345678",
+                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "conversation_id": "56812a93-9229-5cd6-9f0c-75673b666603",
+                          "message_id": "ae24b5c0-f814-584d-a493-5439e5d6b7b1",
+                          "rating": "dislike",
+                          "content": "回答が曖昧で、具体的な価格の質問に答えていませんでした。",
+                          "from_source": "user",
+                          "from_end_user_id": "d2c1b0a9-8765-4321-fedc-ba9876543210",
+                          "from_account_id": null,
+                          "created_at": "2025-01-15T09:12:45Z",
+                          "updated_at": "2025-01-15T09:12:45Z"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "アプリケーションフィードバックのリスト。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          }
+        },
+        "summary": "アプリのフィードバック一覧を取得",
+        "tags": [
+          "メッセージフィードバック"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/feedback/list-app-feedbacks",
+          "metadata": {
+            "title": "アプリのフィードバック一覧を取得",
+            "sidebarTitle": "アプリのフィードバック一覧を取得"
+          }
+        }
+      }
+    },
+    "/apps/annotation-reply/{action}": {
+      "post": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\nアプリのアノテーション返信を有効または無効にします。非同期で実行されます。進捗は [アノテーション返信の初期設定タスクステータスを取得](/ja/api-reference/annotations/get-annotation-reply-job-status) で追跡してください。\n\nリクエストボディはアクションの実行前に検証されるため、`disable` の場合でも `score_threshold`、`embedding_provider_name`、`embedding_model_name` が必須です。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models) に `model_type=text-embedding` を指定し、レスポンスの `provider` と `model` の値をコピーしてください。リクエスト例では `openai` と `text-embedding-3-small` を使用しています。",
+        "operationId": "initialAnnotationReplySettings",
+        "parameters": [
+          {
+            "description": "実行する操作：`enable` または `disable`。",
+            "in": "path",
+            "name": "action",
+            "required": true,
+            "schema": {
+              "description": "実行する操作：`enable` または `disable`。",
+              "enum": [
+                "disable",
+                "enable"
+              ],
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
-          "description": "チャットメッセージを送信するためのリクエストボディ。",
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ChatRequest"
+                "$ref": "#/components/schemas/AnnotationReplyActionPayload"
+              },
+              "examples": {
+                "enableAnnotationReply": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "score_threshold": 0.9,
+                    "embedding_provider_name": "openai",
+                    "embedding_model_name": "text-embedding-3-small"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationJobStatusResponse"
+                },
+                "examples": {
+                  "annotationReplyResponse": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "job_status": "waiting"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "アノテーション返信設定タスクが開始されました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          }
+        },
+        "summary": "アノテーション返信を設定",
+        "tags": [
+          "アノテーション管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/annotations/configure-annotation-reply",
+          "metadata": {
+            "title": "アノテーション返信を設定",
+            "sidebarTitle": "アノテーション返信を設定"
+          }
+        }
+      }
+    },
+    "/apps/annotation-reply/{action}/status/{job_id}": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\n[アノテーション返信を設定](/ja/api-reference/annotations/configure-annotation-reply) で開始されたアノテーション返信設定ジョブのステータスを返します。",
+        "operationId": "getInitialAnnotationReplySettingsStatus",
+        "parameters": [
+          {
+            "description": "実行する操作：`enable` または `disable`。",
+            "in": "path",
+            "name": "action",
+            "required": true,
+            "schema": {
+              "description": "実行する操作：`enable` または `disable`。",
+              "enum": [
+                "disable",
+                "enable"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "[アノテーション返信を設定](/ja/api-reference/annotations/configure-annotation-reply) から返されたジョブ ID です。",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "[アノテーション返信を設定](/ja/api-reference/annotations/configure-annotation-reply)で返されるジョブ ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationJobStatusDetailResponse"
+                },
+                "examples": {
+                  "jobStatus": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "job_status": "completed",
+                      "error_msg": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "タスクステータスの取得に成功しました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "The job does not exist."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：ジョブが存在しません。現在のランタイムでは、不明または期限切れのジョブ ID にこのステータスを返します。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "互換性のために予約されたレスポンスです。現在のランタイムは、不明または期限切れのジョブを `404` ではなく `400 invalid_param` として返します。"
+          }
+        },
+        "summary": "アノテーション返信の初期設定タスクステータスを取得",
+        "tags": [
+          "アノテーション管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/annotations/get-annotation-reply-job-status",
+          "metadata": {
+            "title": "アノテーション返信の初期設定タスクステータスを取得",
+            "sidebarTitle": "アノテーション返信の初期設定タスクステータスを取得"
+          }
+        }
+      }
+    },
+    "/apps/annotations": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\nアプリのアノテーションを、任意でキーワードでフィルタリングして一覧表示します。",
+        "operationId": "getAnnotationList",
+        "parameters": [
+          {
+            "description": "質問または回答の内容でアノテーションをフィルタリングするためのキーワードです。",
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "質問または回答の内容でアノテーションをフィルタリングするためのキーワードです。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "1 ページあたりのアイテム数。100 を超えるリクエストは 100 に制限されます。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "1 ページあたりの件数です。",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "ページ番号。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "ページネーションのページ番号。",
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationList"
+                },
+                "examples": {
+                  "annotationList": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "question": "Dify とは何ですか？",
+                          "answer": "Dify はオープンソースの LLM アプリケーション開発プラットフォームです。",
+                          "hit_count": 5,
+                          "created_at": 1705407629
+                        }
+                      ],
+                      "has_more": false,
+                      "limit": 20,
+                      "total": 1,
+                      "page": 1
+                    }
+                  }
+                }
+              }
+            },
+            "description": "アノテーションリストの取得に成功しました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          }
+        },
+        "summary": "アノテーションリストを取得",
+        "tags": [
+          "アノテーション管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/annotations/list-annotations",
+          "metadata": {
+            "title": "アノテーションリストを取得",
+            "sidebarTitle": "アノテーションリストを取得"
+          }
+        }
+      },
+      "post": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\nアノテーションを作成します。アノテーションは、一致したときにアプリが新しい応答を生成する代わりに直接返す、事前定義された質問と回答のペアです。",
+        "operationId": "createAnnotation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationCreatePayload"
+              },
+              "examples": {
+                "createAnnotation": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "question": "Dify とは何ですか？",
+                    "answer": "Dify はオープンソースの LLM アプリケーション開発プラットフォームです。"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                },
+                "examples": {
+                  "createdAnnotation": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "question": "Dify とは何ですか？",
+                      "answer": "Dify はオープンソースの LLM アプリケーション開発プラットフォームです。",
+                      "hit_count": 0,
+                      "created_at": 1705407629
+                    }
+                  }
+                }
+              }
+            },
+            "description": "アノテーションが正常に作成されました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          }
+        },
+        "summary": "アノテーションを作成",
+        "tags": [
+          "アノテーション管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/annotations/create-annotation",
+          "metadata": {
+            "title": "アノテーションを作成",
+            "sidebarTitle": "アノテーションを作成"
+          }
+        }
+      }
+    },
+    "/apps/annotations/{annotation_id}": {
+      "delete": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\nアノテーションとその関連するヒット履歴を削除します。",
+        "operationId": "deleteAnnotation",
+        "parameters": [
+          {
+            "description": "削除するアノテーションの ID です。アノテーション ID は [アノテーションリストを取得](/ja/api-reference/annotations/list-annotations) から取得します。",
+            "in": "path",
+            "name": "annotation_id",
+            "required": true,
+            "schema": {
+              "description": "削除するアノテーションの一意な識別子。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "アノテーションが正常に削除されました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Annotation not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：アノテーションが存在しません。"
+          }
+        },
+        "summary": "アノテーションを削除",
+        "tags": [
+          "アノテーション管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/annotations/delete-annotation",
+          "metadata": {
+            "title": "アノテーションを削除",
+            "sidebarTitle": "アノテーションを削除"
+          }
+        }
+      },
+      "put": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\nアノテーションの質問と回答を更新します。",
+        "operationId": "updateAnnotation",
+        "parameters": [
+          {
+            "description": "更新するアノテーションの ID です。アノテーション ID は [アノテーションリストを取得](/ja/api-reference/annotations/list-annotations) から取得します。",
+            "in": "path",
+            "name": "annotation_id",
+            "required": true,
+            "schema": {
+              "description": "更新するアノテーションの一意な識別子。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationCreatePayload"
+              },
+              "examples": {
+                "updateAnnotation": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "question": "Dify とは何ですか？",
+                    "answer": "Dify は AI アプリを構築するためのオープンソース LLM アプリケーション開発プラットフォームです。"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                },
+                "examples": {
+                  "updatedAnnotation": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "question": "Dify とは何ですか？",
+                      "answer": "Dify は AI アプリを構築するためのオープンソース LLM アプリケーション開発プラットフォームです。",
+                      "hit_count": 5,
+                      "created_at": 1705407629
+                    }
+                  }
+                }
+              }
+            },
+            "description": "アノテーションが正常に更新されました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Annotation not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：アノテーションが存在しません。"
+          }
+        },
+        "summary": "アノテーションを更新",
+        "tags": [
+          "アノテーション管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/annotations/update-annotation",
+          "metadata": {
+            "title": "アノテーションを更新",
+            "sidebarTitle": "アノテーションを更新"
+          }
+        }
+      }
+    },
+    "/audio-to-text": {
+      "post": {
+        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nワークスペースのデフォルト音声認識モデルを使用して、アップロードされた音声ファイルをテキストに文字起こしします。",
+        "operationId": "audioToText",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "description": "文字起こしする音声ファイル。対応 MIME タイプは `audio/mp3`、`audio/mpga`、`audio/m4a`、`audio/x-m4a`、`audio/wav`、`audio/amr` です。ファイルサイズ上限は `30 MB` です。",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "user": {
+                    "description": "アプリケーション内で一意のユーザー識別子。この識別子によってデータアクセスの範囲が決まり、ある `user` 値で作成したリソースは、同じ `user` 値で照会した場合にのみ表示されます。",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AudioTranscriptResponse"
+                },
+                "examples": {
+                  "audioToTextSuccess": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "text": "こんにちは。iPhone 13 Pro Max について詳しく教えてください。"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "音声からテキストへの変換に成功しました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_audio_uploaded": {
+                    "summary": "no_audio_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_audio_uploaded",
+                      "message": "Please upload your audio."
+                    }
+                  },
+                  "speech_to_text_disabled": {
+                    "summary": "speech_to_text_disabled",
+                    "value": {
+                      "status": 400,
+                      "code": "speech_to_text_disabled",
+                      "message": "Speech to text is disabled."
+                    }
+                  },
+                  "provider_not_support_speech_to_text": {
+                    "summary": "provider_not_support_speech_to_text",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_support_speech_to_text",
+                      "message": "Provider not support speech to text."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `no_audio_uploaded`：音声ファイルがアップロードされていません（`file` フィールドがありません）。\n- `speech_to_text_disabled`：このアプリでは音声からテキストへの変換が無効になっています。\n- `provider_not_support_speech_to_text`：モデルプロバイダーが音声認識をサポートしていません。\n- `provider_not_initialize`：有効なモデルプロバイダーの認証情報が見つかりません。\n- `completion_request_error`：音声認識リクエストに失敗しました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "audio_too_large": {
+                    "summary": "audio_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "audio_too_large",
+                      "message": "Audio size larger than 30 mb"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`audio_too_large`：音声ファイルが `30 MB` のサイズ上限を超えています。"
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_audio_type": {
+                    "summary": "unsupported_audio_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_audio_type",
+                      "message": "Audio type not allowed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`unsupported_audio_type`：ファイルの MIME タイプが、受け付ける音声タイプのいずれでもありません（`file` フィールドを参照）。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：内部サーバーエラー。"
+          }
+        },
+        "summary": "音声をテキストに変換",
+        "tags": [
+          "音声・テキスト変換"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/audio-to-text' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@meeting-question.mp3' \\\n  --form 'user={user}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/audio/convert-audio-to-text",
+          "metadata": {
+            "title": "音声をテキストに変換",
+            "sidebarTitle": "音声をテキストに変換"
+          }
+        }
+      }
+    },
+    "/chat-messages": {
+      "post": {
+        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\nチャットアプリにメッセージを送信し、アシスタントの応答を返します。ストリーミングレスポンスのイベントはアプリタイプによって異なります。",
+        "operationId": "sendChatMessage",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequestPayloadWithUser"
               },
               "examples": {
                 "streaming_example": {
                   "summary": "リクエスト例 - ストリーミングモード",
                   "value": {
                     "inputs": {
-                      "city": "San Francisco"
+                      "city": "サンフランシスコ"
                     },
-                    "query": "What are the specs of the iPhone 13 Pro Max?",
+                    "query": "iPhone 13 Pro Max の仕様を教えてください。",
                     "response_mode": "streaming",
                     "conversation_id": "",
                     "user": "abc-123",
@@ -131,7 +1149,7 @@
                   "summary": "リクエスト例 - ブロッキングモード",
                   "value": {
                     "inputs": {},
-                    "query": "What are the specs of the iPhone 13 Pro Max?",
+                    "query": "iPhone 13 Pro Max の仕様を教えてください。",
                     "response_mode": "blocking",
                     "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
                     "user": "abc-123"
@@ -139,15 +1157,16 @@
                 }
               }
             }
-          }
+          },
+          "required": true,
+          "description": "チャットメッセージを送信するためのリクエストボディ。"
         },
         "responses": {
           "200": {
-            "description": "リクエスト成功。コンテンツタイプと構造はリクエストの `response_mode` パラメータに依存します。\n\n- `response_mode` が `blocking` の場合、 `application/json` で `ChatCompletionResponse` オブジェクトを返します。\n- `response_mode` が `streaming` の場合、`text/event-stream` でサーバー送信イベントのストリームを返します。",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChatCompletionResponse"
+                  "$ref": "#/components/schemas/ChatBlockingResponse"
                 },
                 "examples": {
                   "blockingResponse": {
@@ -159,7 +1178,7 @@
                       "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
                       "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
                       "mode": "chat",
-                      "answer": "iPhone 13 Pro Max specs are listed here:...",
+                      "answer": "iPhone 13 Pro Max の仕様は次のとおりです……",
                       "metadata": {
                         "usage": {
                           "prompt_tokens": 1033,
@@ -181,10 +1200,10 @@
                             "dataset_id": "101b4c97-fc2e-463c-90b1-5261a4cdcafb",
                             "dataset_name": "iPhone",
                             "document_id": "8dd1ad74-0b5f-4175-b735-7d98bbbb4e00",
-                            "document_name": "iPhone List",
+                            "document_name": "iPhone 一覧",
                             "segment_id": "ed599c7f-2766-4294-9d1d-e5235a61270a",
                             "score": 0.98457545,
-                            "content": "\"Model\",\"Release Date\",\"Display Size\",\"Resolution\",\"Processor\",\"RAM\",\"Storage\",\"Camera\",\"Battery\",\"Operating System\" \"iPhone 13 Pro Max\",\"September 24, 2021\",\"6.7 inch\",\"1284 x 2778\",\"Hexa-core (2x3.23 GHz Avalanche + 4x1.82 GHz Blizzard)\",\"6 GB\",\"128, 256, 512 GB, 1TB\",\"12 MP\",\"4352 mAh\",\"iOS 15\""
+                            "content": "\"モデル\",\"発売日\",\"画面サイズ\",\"解像度\",\"プロセッサ\",\"メモリ\",\"ストレージ\",\"カメラ\",\"バッテリー\",\"OS\" \"iPhone 13 Pro Max\",\"2021 年 9 月 24 日\",\"6.7 インチ\",\"1284 x 2778\",\"6 コアプロセッサ\",\"6 GB\",\"128、256、512 GB、1 TB\",\"1,200 万画素\",\"4352 mAh\",\"iOS 15\""
                           }
                         ]
                       },
@@ -200,27 +1219,27 @@
                 },
                 "examples": {
                   "streamingResponseBasic": {
-                    "summary": "Response Example - Streaming (Basic)",
-                    "value": "data: {\"event\": \"message\", \"task_id\": \"mock_task_id\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"conversation_id\": \"45701982-8118-4bc5-8e9b-64562b4555f2\", \"answer\": \" I\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"mock_task_id\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"conversation_id\": \"45701982-8118-4bc5-8e9b-64562b4555f2\", \"created_at\": 1679586595, \"metadata\": {\"usage\": {\"total_tokens\": 10, \"latency\": 1.0}}}"
+                    "summary": "レスポンス例 — 基本ストリーミング",
+                    "value": "data: {\"event\": \"message\", \"task_id\": \"mock_task_id\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"conversation_id\": \"45701982-8118-4bc5-8e9b-64562b4555f2\", \"answer\": \"私\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"mock_task_id\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"conversation_id\": \"45701982-8118-4bc5-8e9b-64562b4555f2\", \"created_at\": 1679586595, \"metadata\": {\"usage\": {\"total_tokens\": 10, \"latency\": 1.0}}}"
                   },
                   "streamingResponseAgent": {
-                    "summary": "Response Example - Streaming (Agent)",
-                    "value": "data: {\"event\": \"agent_thought\", \"id\": \"agent_thought_id_1\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"position\": 1, \"thought\": \"Thinking about calling a tool...\", \"tool\": \"dalle3\", \"tool_input\": \"{\\\"dalle3\\\": {\\\"prompt\\\": \\\"a cute cat\\\"}}\", \"created_at\": 1705395332}\n\ndata: {\"event\": \"message_file\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"id\": \"file_id_1\", \"type\": \"image\", \"belongs_to\": \"assistant\", \"url\": \"https://example.com/cat.png\", \"created_at\": 1705395332}\n\ndata: {\"event\": \"agent_message\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"answer\": \"Here is the image: \", \"created_at\": 1705395333}\n\ndata: {\"event\": \"message_end\", \"task_id\":\"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"metadata\": {\"usage\": {\"total_tokens\": 50, \"latency\": 2.5}}}"
+                    "summary": "レスポンス例 — Agent ストリーミング",
+                    "value": "data: {\"event\": \"agent_thought\", \"id\": \"agent_thought_id_1\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"position\": 1, \"thought\": \"ツールの呼び出しを検討しています……\", \"tool\": \"dalle3\", \"tool_input\": \"{\\\"dalle3\\\": {\\\"prompt\\\": \\\"かわいい猫\\\"}}\", \"created_at\": 1705395332}\n\ndata: {\"event\": \"message_file\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"id\": \"file_id_1\", \"type\": \"image\", \"belongs_to\": \"assistant\", \"url\": \"https://example.com/cat.png\", \"created_at\": 1705395332}\n\ndata: {\"event\": \"agent_message\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"answer\": \"画像はこちらです：\", \"created_at\": 1705395333}\n\ndata: {\"event\": \"message_end\", \"task_id\":\"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"metadata\": {\"usage\": {\"total_tokens\": 50, \"latency\": 2.5}}}"
                   },
                   "streamingResponseWorkflow": {
-                    "summary": "Response Example - Streaming (Workflow)",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395332, \"data\": {\"id\": \"wfr_abc123\", \"workflow_id\": \"wf_def456\", \"inputs\": {\"city\": \"San Francisco\"}, \"created_at\": 1705395332}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395332, \"data\": {\"id\": \"ne_001\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 1, \"created_at\": 1705395332}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395333, \"data\": {\"message_id\": \"msg123\", \"reasoning\": \"The user greeted me, so\", \"node_id\": \"node_llm_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395333, \"data\": {\"message_id\": \"msg123\", \"reasoning\": \"\", \"node_id\": \"node_llm_1\", \"is_final\": true}}\n\ndata: {\"event\": \"message\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"answer\": \" I\", \"created_at\": 1705395333}\n\ndata: {\"event\": \"node_finished\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395334, \"data\": {\"id\": \"ne_001\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 1, \"status\": \"succeeded\", \"elapsed_time\": 1.5, \"created_at\": 1705395332, \"finished_at\": 1705395334}}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395334, \"metadata\": {\"usage\": {\"total_tokens\": 50, \"latency\": 2.5}}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395335, \"data\": {\"id\": \"wfr_abc123\", \"workflow_id\": \"wf_def456\", \"status\": \"succeeded\", \"elapsed_time\": 2.5, \"total_tokens\": 50, \"total_steps\": 2, \"created_at\": 1705395332, \"finished_at\": 1705395335}}"
+                    "summary": "レスポンス例 - ストリーミング（Workflow）",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395332, \"data\": {\"id\": \"wfr_abc123\", \"workflow_id\": \"wf_def456\", \"inputs\": {\"city\": \"サンフランシスコ\"}, \"created_at\": 1705395332}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395332, \"data\": {\"id\": \"ne_001\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 1, \"created_at\": 1705395332}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395333, \"data\": {\"message_id\": \"msg123\", \"reasoning\": \"ユーザーが挨拶したので\", \"node_id\": \"node_llm_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395333, \"data\": {\"message_id\": \"msg123\", \"reasoning\": \"\", \"node_id\": \"node_llm_1\", \"is_final\": true}}\n\ndata: {\"event\": \"message\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"answer\": \"私\", \"created_at\": 1705395333}\n\ndata: {\"event\": \"node_finished\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395334, \"data\": {\"id\": \"ne_001\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 1, \"status\": \"succeeded\", \"elapsed_time\": 1.5, \"created_at\": 1705395332, \"finished_at\": 1705395334}}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395334, \"metadata\": {\"usage\": {\"total_tokens\": 50, \"latency\": 2.5}}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395335, \"data\": {\"id\": \"wfr_abc123\", \"workflow_id\": \"wf_def456\", \"status\": \"succeeded\", \"elapsed_time\": 2.5, \"total_tokens\": 50, \"total_steps\": 2, \"created_at\": 1705395332, \"finished_at\": 1705395335}}"
                   },
                   "humanInputPause": {
                     "summary": "レスポンス例 - 人間の入力での一時停止",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"Hello\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"form_content\": \"ドラフトを確認してください。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"承認\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"paused_nodes\": [\"approval_node\"], \"outputs\": {}, \"reasons\": [{\"TYPE\": \"human_input_required\", \"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_content\": \"ドラフトを確認してください。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"承認\", \"button_style\": \"primary\"}], \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"resolved_default_values\": {\"comment\": \"\"}, \"form_token\": \"tok_abc123\", \"expiration_time\": 1705494029}], \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5, \"total_tokens\": 0, \"total_steps\": 1}}"
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"こんにちは\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"承認\", \"form_content\": \"ドラフトを確認してください。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"承認\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"paused_nodes\": [\"approval_node\"], \"outputs\": {}, \"reasons\": [{\"TYPE\": \"human_input_required\", \"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_content\": \"ドラフトを確認してください。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"承認\", \"button_style\": \"primary\"}], \"node_id\": \"approval_node\", \"node_title\": \"承認\", \"resolved_default_values\": {\"comment\": \"\"}, \"form_token\": \"tok_abc123\", \"expiration_time\": 1705494029}], \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5, \"total_tokens\": 0, \"total_steps\": 1}}"
                   }
                 }
               }
-            }
+            },
+            "description": "成功レスポンス。`blocking` モードは `ChatBlockingResponse` オブジェクトを含む `application/json`、`streaming` モードは Server-Sent Events（SSE）を含む `text/event-stream` を返します。"
           },
           "400": {
-            "description": "- `app_unavailable` : アプリケーションが利用できないか、設定が正しくありません。\n- `not_chat_app` : App mode does not match the API route.\n- `provider_not_initialize` : 有効なモデルプロバイダーの認証情報が見つかりません。\n- `provider_quota_exceeded` : モデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support` : 現在のモデルは利用できません。\n- `completion_request_error` : テキスト生成に失敗しました。\n- `bad_request` : Cannot use draft workflow version.\n- `bad_request` : Invalid `workflow_id` format.\n- `bad_request` : 新しい Agent アプリで `blocking` レスポンスモードが指定されました。\n- `invalid_param` : 新しい Agent アプリに Agent がバインドされていません。\n- `agent_not_published` : バインドされた Agent が公開されていません。（新しい Agent アプリ）\n- `conversation_completed` : 会話は終了しています。`conversation_id` を省略して新しい会話を開始してください。",
             "content": {
               "application/json": {
                 "examples": {
@@ -277,7 +1296,7 @@
                     "value": {
                       "status": 400,
                       "code": "bad_request",
-                      "message": "Cannot use draft workflow version. Workflow ID: a1b2c3d4-5678-90ab-cdef-1234567890ab. "
+                      "message": "ドラフトのワークフローバージョンは使用できません。 Workflow ID: a1b2c3d4-5678-90ab-cdef-1234567890ab. "
                     }
                   },
                   "workflow_id_format_error": {
@@ -322,10 +1341,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `app_unavailable`：アプリケーションが利用できないか、設定が正しくありません。\n- `not_chat_app`：アプリモードが API ルートと一致しません。\n- `provider_not_initialize`：有効なモデルプロバイダーの認証情報が見つかりません。\n- `provider_quota_exceeded`：モデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support`：現在のモデルは利用できません。\n- `completion_request_error`：テキスト生成に失敗しました。\n- `bad_request`：ドラフトのワークフローバージョンは使用できません。\n- `bad_request`：`workflow_id` の形式が無効です。\n- `bad_request`：新しい Agent アプリで `blocking` レスポンスモードが指定されました。\n- `invalid_param`：新しい Agent アプリに Agent がバインドされていません。\n- `agent_not_published`：バインドされた Agent が公開されていません。（新しい Agent アプリ）\n- `conversation_completed`：会話は終了しています。`conversation_id` を省略して新しい会話を開始してください。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`workflow_version_execution_not_allowed` : Dify Cloud の Sandbox プランで、Chatflow リクエストが `workflow_id` によりワークフローバージョンを指定しました。",
             "content": {
               "application/json": {
                 "examples": {
@@ -339,10 +1375,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`workflow_version_execution_not_allowed`：Dify Cloud の Sandbox プランで、Chatflow リクエストが `workflow_id` によりワークフローバージョンを指定しました。"
           },
           "404": {
-            "description": "- `not_found` : 会話が存在しません。\n- `not_found` : 指定された `workflow_id` のワークフローが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -364,10 +1400,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：会話が存在しません。\n- `not_found`：指定された `workflow_id` のワークフローが見つかりません。"
           },
           "429": {
-            "description": "- `too_many_requests` : このアプリケーションへの同時リクエストが多すぎます。\n- `rate_limit_error` : ワークスペースの Dify Cloud のワークフロー実行クォータを使い切りました。",
             "content": {
               "application/json": {
                 "examples": {
@@ -389,10 +1425,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `too_many_requests`：このアプリケーションへの同時リクエストが多すぎます。\n- `rate_limit_error`：ワークスペースの Dify Cloud のワークフロー実行クォータを使い切りました。"
           },
           "500": {
-            "description": "`internal_server_error` : 内部サーバーエラー。",
             "content": {
               "application/json": {
                 "examples": {
@@ -406,59 +1442,51 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`internal_server_error`：内部サーバーエラー。"
           }
         },
+        "summary": "チャットメッセージを送信",
+        "tags": [
+          "チャットメッセージ"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/chat-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"query\": \"iPhone 13 Pro Max の仕様を教えてください。\", \"inputs\": {}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
+          }
+        ],
         "x-mint": {
           "href": "/ja/api-reference/chat-messages/send-chat-message",
           "metadata": {
             "title": "チャットメッセージを送信",
             "sidebarTitle": "チャットメッセージを送信"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/chat-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"query\": \"What are the specs of the iPhone 13 Pro Max?\", \"inputs\": {}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/chat-messages/{task_id}/stop": {
       "post": {
-        "summary": "生成を停止",
         "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\nチャットメッセージ生成タスクを停止します。`streaming` モードでのみサポートされます。",
-        "operationId": "stopBasicChatMessageGenerationJa",
-        "tags": [
-          "チャットメッセージ"
-        ],
+        "operationId": "stopChatMessageGeneration",
         "parameters": [
           {
-            "name": "task_id",
-            "in": "path",
-            "required": true,
             "description": "タスク ID です。[チャットメッセージを送信](/ja/api-reference/chat-messages/send-chat-message) のストリーミングイベントから取得します。",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
             "schema": {
+              "description": "チャットメッセージ送信 API が返すストリーミングチャンクから取得するタスク ID。",
               "type": "string"
             }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "user"
-                ],
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。元のメッセージ送信時に渡した `user` と一致する必要があります。一致しない場合、停止は行われず、成功が返されます。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。"
-                  }
-                }
+                "$ref": "#/components/schemas/RequiredServiceApiUserPayload"
               },
               "examples": {
                 "example": {
@@ -469,14 +1497,24 @@
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "$ref": "#/components/responses/SuccessResult"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "タスクを停止しました"
           },
           "400": {
-            "description": "- `not_chat_app` : アプリモードが API ルートと一致しません。\n- `invalid_param` : 必須の `user` フィールドがありません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -498,9 +1536,60 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_chat_app`：アプリモードが API ルートと一致しません。\n- `invalid_param`：必須の `user` フィールドがありません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "互換性のために予約されたレスポンスです。現在のランタイムは停止フラグを設定する前にタスクの存在を確認しないため、タスクがすでに実行中でなくても通常の `200` 結果を返します。"
           }
         },
+        "summary": "生成を停止",
+        "tags": [
+          "チャットメッセージ"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/chat-messages/stop-chat-message-generation",
           "metadata": {
@@ -510,3872 +1599,24 @@
         }
       }
     },
-    "/messages/{message_id}/suggested": {
-      "get": {
-        "summary": "次の推奨質問を取得",
-        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\nメッセージに対して提案されたフォローアップ質問を返します。",
-        "operationId": "getBasicChatSuggestedQuestionsJa",
-        "tags": [
-          "チャットメッセージ"
-        ],
-        "parameters": [
-          {
-            "name": "message_id",
-            "in": "path",
-            "required": true,
-            "description": "推奨質問を取得するメッセージの ID です。チャットのレスポンス、または [会話履歴メッセージ一覧を取得](/ja/api-reference/conversations/list-conversation-messages) から取得します。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": true,
-            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "提案された質問の取得に成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SuggestedQuestionsResponse"
-                },
-                "examples": {
-                  "suggestedQuestions": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "result": "success",
-                      "data": [
-                        "What colors does the iPhone 13 Pro Max come in?",
-                        "How does the battery compare to iPhone 12?",
-                        "What is the price range?"
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : アプリモードが API ルートと一致しません。\n- `bad_request` : 推奨質問機能が無効です。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "bad_request": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "Suggested Questions Is Disabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : メッセージが存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "message_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Message Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : 内部サーバーエラー。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages/{message_id}/suggested?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
-        "x-mint": {
-          "href": "/ja/api-reference/chat-messages/get-next-suggested-questions",
-          "metadata": {
-            "title": "次の推奨質問を取得",
-            "sidebarTitle": "次の推奨質問を取得"
-          }
-        }
-      }
-    },
-    "/files/upload": {
-      "post": {
-        "summary": "ファイルをアップロード",
-        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nファイルをアップロードし、後続のリクエストから参照するための `id` を返します。ファイルはアップロードしたエンドユーザーに属し、同じ `user` を持つリクエストだけがそのファイルを参照できます。\n\nアプリが実際に扱えるファイル種別は、アプリのファイルアップロード設定によって決まります。[アプリケーションのパラメータ情報を取得](/ja/api-reference/applications/get-app-parameters) で確認できます。",
-        "operationId": "uploadBasicChatFileJa",
-        "tags": [
-          "ファイル操作"
-        ],
-        "requestBody": {
-          "description": "ファイルアップロードリクエスト。multipart/form-data 形式が必要です。",
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "file"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "アップロードするファイル。`multipart/form-data` の 1 パートとして送信します。ファイル名に `/` や `\\` は使えません。\n\nデプロイの安全ブラックリスト（`UPLOAD_FILE_EXTENSION_BLACKLIST`、デフォルトは空）にある拡張子を除き、任意の拡張子を受け付けます。\n\nサイズ上限はカテゴリごとに適用されます：画像 10 MB、音声 50 MB、動画 100 MB、その他のファイル 15 MB（デフォルト値。Dify Cloud はデフォルト値を使用）。セルフホスト環境では `UPLOAD_*_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。"
-                  },
-                  "user": {
-                    "type": "string",
-                    "description": "このアップロードが属するエンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。省略すると、共有の `DEFAULT-USER` に帰属します。同じ `user` を持つ後続のリクエストだけがこのファイルを参照できます。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "ファイルが正常にアップロードされました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileUploadResponse"
-                },
-                "examples": {
-                  "uploadSuccess": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "reference": null,
-                      "name": "product-photo.png",
-                      "size": 204800,
-                      "extension": "png",
-                      "mime_type": "image/png",
-                      "created_by": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                      "created_at": 1705407629,
-                      "preview_url": null,
-                      "source_url": "https://upload.dify.ai/files/a1b2c3d4-5678-90ab-cdef-1234567890ab/file-preview?timestamp=1705407629&nonce=8b3e26a5&sign=rN5DXW3xkVGwGE5MSvptu_BhQVXpMbXWmVJ0ib0LMzI=",
-                      "original_url": null,
-                      "user_id": null,
-                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
-                      "conversation_id": null,
-                      "file_key": null
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_file_uploaded` : リクエストにファイルが提供されていません。\n- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `invalid_param` : ファイル名に `/` または `\\` が含まれているか、ファイルの拡張子がデプロイのブラックリストにあります。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_file_uploaded": {
-                    "summary": "no_file_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_file_uploaded",
-                      "message": "Please upload your file."
-                    }
-                  },
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "File extension '.exe' is not allowed for security reasons"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : ファイルがカテゴリごとのサイズ上限（`file` フィールドを参照）を超えています。現在、実行時の `message` は空文字列で返ります（既知のバックエンドの問題）。`code` とステータスコードで判定してください。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_file_type` : アップロードされた `file` パートに MIME タイプが宣言されていません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_file_type": {
-                    "summary": "unsupported_file_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_file_type",
-                      "message": "File type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/files/upload-file",
-          "metadata": {
-            "title": "ファイルをアップロード",
-            "sidebarTitle": "ファイルをアップロード"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/files/upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@product-photo.png' \\\n  --form 'user={user}'"
-          }
-        ]
-      }
-    },
-    "/files/{file_id}/preview": {
-      "get": {
-        "summary": "ファイルをダウンロード",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent、テキストジェネレーター。\n\n以前 [ファイルをアップロード](/ja/api-reference/files/upload-file) が返したファイルの生のバイト列を返します。ファイルには、そのメッセージが参照しているアプリからのみアクセスできます。",
-        "operationId": "previewBasicChatFileJa",
-        "tags": [
-          "ファイル操作"
-        ],
-        "parameters": [
-          {
-            "name": "file_id",
-            "in": "path",
-            "required": true,
-            "description": "ダウンロードするファイルの ID です。ファイルアップロードのレスポンスから取得します。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "as_attachment",
-            "in": "query",
-            "required": false,
-            "description": "`true` の場合、ファイルはブラウザでインライン表示される代わりに、添付ファイルとしてダウンロードされます。",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。ここではファイルアクセスに影響しません。アクセスは `user` ではなくアプリとメッセージによってスコープされます。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "生のファイルコンテンツを返します。`Content-Type` ヘッダーはファイルの MIME タイプに設定されます。`as_attachment` が `true` の場合、ファイルは `Content-Disposition: attachment` としてダウンロード形式で返されます。",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`file_access_denied` : ファイルは存在しますが、別のアプリまたはワークスペースに属しています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_access_denied": {
-                    "summary": "file_access_denied",
-                    "value": {
-                      "status": 403,
-                      "code": "file_access_denied",
-                      "message": "Access to the requested file is denied."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`file_not_found` : この ID のファイルは、このアプリのメッセージからは参照できません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_not_found": {
-                    "summary": "file_not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "file_not_found",
-                      "message": "The requested file was not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/files/download-file",
-          "metadata": {
-            "title": "ファイルをダウンロード",
-            "sidebarTitle": "ファイルをダウンロード"
-          }
-        }
-      }
-    },
-    "/end-users/{end_user_id}": {
-      "get": {
-        "summary": "エンドユーザー取得",
-        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nID を指定してエンドユーザーの詳細を返します。別のエンドポイントが返したエンドユーザー ID（例：[ファイルをアップロード](/ja/api-reference/files/upload-file) レスポンスの `created_by`）を解決するのに便利です。",
-        "operationId": "getEndUserChatJa",
-        "tags": [
-          "エンドユーザー"
-        ],
-        "parameters": [
-          {
-            "name": "end_user_id",
-            "in": "path",
-            "required": true,
-            "description": "照会するエンドユーザーの ID です。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "エンドユーザーを正常に取得しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EndUserDetail"
-                },
-                "examples": {
-                  "endUserDetail": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
-                      "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "type": "service-api",
-                      "external_user_id": "abc-123",
-                      "name": null,
-                      "is_anonymous": false,
-                      "session_id": "abc-123",
-                      "created_at": "2024-01-16T12:00:29Z",
-                      "updated_at": "2024-01-16T12:00:29Z"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`end_user_not_found` : エンドユーザーが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "end_user_not_found": {
-                    "summary": "end_user_not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "end_user_not_found",
-                      "message": "End user not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/end-users/get-end-user-info",
-          "metadata": {
-            "title": "エンドユーザー取得",
-            "sidebarTitle": "エンドユーザー取得"
-          }
-        }
-      }
-    },
-    "/messages/{message_id}/feedbacks": {
-      "post": {
-        "summary": "メッセージフィードバックを送信",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent、テキストジェネレーター。\n\nメッセージに `like` または `dislike` の評価と、任意のコメントを記録します。`rating` に `null` を送信すると、そのメッセージの既存のフィードバックを取り消します。",
-        "operationId": "postBasicChatMessageFeedbackJa",
-        "tags": [
-          "メッセージフィードバック"
-        ],
-        "parameters": [
-          {
-            "name": "message_id",
-            "in": "path",
-            "required": true,
-            "description": "フィードバックを送信するメッセージの ID です。メッセージ ID は [会話履歴メッセージ一覧を取得](/ja/api-reference/conversations/list-conversation-messages) から取得します。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MessageFeedbackRequest"
-              },
-              "examples": {
-                "likeFeedback": {
-                  "summary": "リクエスト例",
-                  "value": {
-                    "rating": "like",
-                    "user": "abc-123",
-                    "content": "This answer was very helpful!"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/SuccessResult"
-          },
-          "400": {
-            "description": "`invalid_param` : 必須の `user` フィールドが省略されているか、`rating` が `null` であるにもかかわらず取り消す既存のフィードバックがありません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : メッセージが存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "message_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Message Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/feedback/submit-message-feedback",
-          "metadata": {
-            "title": "メッセージフィードバックを送信",
-            "sidebarTitle": "メッセージフィードバックを送信"
-          }
-        }
-      }
-    },
-    "/app/feedbacks": {
-      "get": {
-        "summary": "アプリのフィードバック一覧を取得",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent、テキストジェネレーター。\n\nアプリのメッセージに対するすべてのフィードバックのページネーション付きリストを返します。エンドユーザーと管理者の両方の送信が含まれます。",
-        "operationId": "getBasicChatAppFeedbacksJa",
-        "tags": [
-          "メッセージフィードバック"
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "ページ番号。",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "1 ページあたりのフィードバック件数。",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 101
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "アプリケーションフィードバックのリスト。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppFeedbacksResponse"
-                },
-                "examples": {
-                  "feedbacksList": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
-                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                          "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
-                          "rating": "like",
-                          "content": "The response accurately answered my question about product specifications.",
-                          "from_source": "user",
-                          "from_end_user_id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                          "from_account_id": null,
-                          "created_at": "2025-01-16T14:30:29Z",
-                          "updated_at": "2025-01-16T14:30:29Z"
-                        },
-                        {
-                          "id": "c8f3a9b2-4d5e-6f70-8901-bcdef2345678",
-                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "conversation_id": "56812a93-9229-5cd6-9f0c-75673b666603",
-                          "message_id": "ae24b5c0-f814-584d-a493-5439e5d6b7b1",
-                          "rating": "dislike",
-                          "content": "The answer was too vague and did not address the specific pricing question.",
-                          "from_source": "user",
-                          "from_end_user_id": "d2c1b0a9-8765-4321-fedc-ba9876543210",
-                          "from_account_id": null,
-                          "created_at": "2025-01-15T09:12:45Z",
-                          "updated_at": "2025-01-15T09:12:45Z"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/feedback/list-app-feedbacks",
-          "metadata": {
-            "title": "アプリのフィードバック一覧を取得",
-            "sidebarTitle": "アプリのフィードバック一覧を取得"
-          }
-        }
-      }
-    },
-    "/conversations": {
-      "get": {
-        "summary": "会話一覧を取得",
-        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\nエンドユーザーの会話を、最近アクティブな順に一覧表示します。",
-        "operationId": "getBasicChatConversationsListJa",
-        "tags": [
-          "会話管理"
-        ],
-        "parameters": [
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "last_id",
-            "in": "query",
-            "required": false,
-            "description": "ページネーションカーソルです。現在のページの最後の会話の `id` を指定します。省略すると最初のページを取得します。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "返すレコード数です。",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          },
-          {
-            "name": "sort_by",
-            "in": "query",
-            "required": false,
-            "description": "並べ替えるフィールドです。降順にするには `-` を先頭に付けます。",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "created_at",
-                "-created_at",
-                "updated_at",
-                "-updated_at"
-              ],
-              "default": "-updated_at"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "会話リストの取得に成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationsListResponse"
-                },
-                "examples": {
-                  "conversationsList": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "limit": 20,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                          "name": "iPhone Specs Chat",
-                          "inputs": {
-                            "city": "San Francisco"
-                          },
-                          "status": "normal",
-                          "introduction": "Welcome! How can I help you today?",
-                          "created_at": 1705407629,
-                          "updated_at": 1705411229
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_chat_app` : アプリモードが API ルートと一致しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 前の会話が存在しません（無効な `last_id`）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "last_conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Last Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/conversations/list-conversations",
-          "metadata": {
-            "title": "会話一覧を取得",
-            "sidebarTitle": "会話一覧を取得"
-          }
-        }
-      }
-    },
-    "/messages": {
-      "get": {
-        "summary": "会話履歴メッセージ一覧を取得",
-        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\n会話のメッセージ履歴を新しい順に返します。`first_id` を渡すと、より古いメッセージへページをさかのぼれます。",
-        "operationId": "getBasicChatConversationHistoryJa",
-        "tags": [
-          "会話管理"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "query",
-            "required": true,
-            "description": "読み取る会話の ID です。会話 ID は [会話一覧を取得](/ja/api-reference/conversations/list-conversations) から取得します。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "first_id",
-            "in": "query",
-            "required": false,
-            "description": "ページネーションカーソルです。現在のページの最初のメッセージの `id` を指定します。渡すと前（より古い）ページを取得し、省略すると最新のメッセージを取得します。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "リクエストごとに返すチャット履歴メッセージの数です。",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "会話履歴の取得に成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationHistoryResponse"
-                },
-                "examples": {
-                  "conversationHistory": {
-                    "summary": "Response Example",
-                    "value": {
-                      "limit": 20,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "9da23599-e713-473b-982c-4328d4f5c78a",
-                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                          "parent_message_id": null,
-                          "inputs": {
-                            "city": "San Francisco"
-                          },
-                          "query": "What are the specs of the iPhone 13 Pro Max?",
-                          "answer": "iPhone 13 Pro Max specs are listed here:...",
-                          "status": "normal",
-                          "error": null,
-                          "message_files": [],
-                          "feedback": {
-                            "rating": "like"
-                          },
-                          "retriever_resources": [],
-                          "agent_thoughts": [],
-                          "created_at": 1705407629,
-                          "extra_contents": [],
-                          "message_tokens": 100,
-                          "answer_tokens": 58,
-                          "total_tokens": 158,
-                          "provider_response_latency": 1.234,
-                          "total_price": "0.0012825",
-                          "currency": "USD"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_chat_app` : アプリモードが API ルートと一致しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 会話が存在しません。\n- `not_found` : 最初のメッセージが存在しません（無効な `first_id`）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  },
-                  "first_message_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "First Message Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages?conversation_id={conversation_id}&user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
-        "x-mint": {
-          "href": "/ja/api-reference/conversations/list-conversation-messages",
-          "metadata": {
-            "title": "会話履歴メッセージ一覧を取得",
-            "sidebarTitle": "会話履歴メッセージ一覧を取得"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}/variables": {
-      "get": {
-        "summary": "会話変数の取得",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\n会話に保存された変数を一覧表示します。",
-        "operationId": "getBasicChatConversationVariablesJa",
-        "tags": [
-          "会話管理"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "変数を一覧表示する会話の ID です。会話 ID は [会話一覧を取得](/ja/api-reference/conversations/list-conversations) から取得します。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "last_id",
-            "in": "query",
-            "required": false,
-            "description": "ページネーションカーソルです。現在のページの最後の変数の `id` を指定します。省略すると最初のページを取得します。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "返すレコード数です。",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          },
-          {
-            "name": "variable_name",
-            "in": "query",
-            "required": false,
-            "description": "指定した名前で変数をフィルタリングします。",
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 255
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "会話変数の取得に成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationVariablesResponse"
-                },
-                "examples": {
-                  "conversationVariables": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "limit": 20,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "name": "user_preference",
-                          "value_type": "string",
-                          "value": "dark_mode",
-                          "description": "ユーザー設定",
-                          "created_at": 1705407629,
-                          "updated_at": 1705411229
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : アプリモードが API ルートと一致しません。\n- `invalid_param` : `last_id` がこの会話のどの変数にも一致しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "invalid_last_id": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 会話が存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/conversations/list-conversation-variables",
-          "metadata": {
-            "title": "会話変数の取得",
-            "sidebarTitle": "会話変数の取得"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}/name": {
-      "post": {
-        "summary": "会話の名前を変更",
-        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\n会話の名前を変更します。`auto_generate` が `true` の場合は、メッセージから名前を自動生成します。この名前は、複数会話のリストでクライアントが表示するものです。",
-        "operationId": "renameBasicChatConversationJa",
-        "tags": [
-          "会話管理"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "名前を変更する会話の ID です。会話 ID は [会話一覧を取得](/ja/api-reference/conversations/list-conversations) から取得します。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ConversationRenameRequest"
-              },
-              "examples": {
-                "renameExample": {
-                  "summary": "リクエスト例",
-                  "value": {
-                    "name": "iPhone Specs Chat",
-                    "user": "abc-123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "会話が正常に名前変更されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationListItem"
-                },
-                "examples": {
-                  "renamedConversation": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                      "name": "iPhone Specs Chat",
-                      "inputs": {
-                        "city": "San Francisco"
-                      },
-                      "status": "normal",
-                      "introduction": "Welcome! How can I help you today?",
-                      "created_at": 1705407629,
-                      "updated_at": 1705411229
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : アプリモードが API ルートと一致しません。\n- `invalid_param` : `auto_generate` が `true` ですが、名前を生成するためのメッセージが会話にありません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "no_messages": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 会話が存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/conversations/rename-conversation",
-          "metadata": {
-            "title": "会話の名前を変更",
-            "sidebarTitle": "会話の名前を変更"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}/variables/{variable_id}": {
-      "put": {
-        "summary": "会話変数を更新",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\n会話変数の値を更新します。新しい値は変数の既存の型と一致する必要があります。",
-        "operationId": "updateChatConversationVariableJa",
-        "tags": [
-          "会話管理"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "変数が属する会話の ID です。会話 ID は [会話一覧を取得](/ja/api-reference/conversations/list-conversations) から取得します。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "variable_id",
-            "in": "path",
-            "required": true,
-            "description": "更新する変数の ID です。変数 ID は [会話変数の取得](/ja/api-reference/conversations/list-conversation-variables) から取得します。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ConversationVariableUpdateRequest"
-              },
-              "examples": {
-                "updateStringVariable": {
-                  "summary": "リクエスト例",
-                  "value": {
-                    "value": "new value",
-                    "user": "abc-123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "変数が正常に更新されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationVariableItem"
-                },
-                "examples": {
-                  "updatedVariable": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "name": "user_preference",
-                      "value_type": "string",
-                      "value": "new value",
-                      "description": "ユーザー設定",
-                      "created_at": 1705407629,
-                      "updated_at": 1705411229
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : アプリモードが API ルートと一致しません。\n- `bad_request` : 変数値の型が一致しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "type_mismatch": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "Type mismatch: variable 'user_preference' expects string, but got number type"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 会話が存在しません。\n- `not_found` : 会話変数が存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  },
-                  "variable_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Variable Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/conversations/update-conversation-variable",
-          "metadata": {
-            "title": "会話変数を更新",
-            "sidebarTitle": "会話変数を更新"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}": {
-      "delete": {
-        "summary": "会話を削除",
-        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\n会話を削除します。",
-        "operationId": "deleteBasicChatConversationJa",
-        "tags": [
-          "会話管理"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "削除する会話の ID です。会話 ID は [会話一覧を取得](/ja/api-reference/conversations/list-conversations) から取得します。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "JSON ボディは常に必須です。`user` を省略する場合は `{}` を送信してください。",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。"
-                  }
-                }
-              },
-              "examples": {
-                "deleteExample": {
-                  "value": {
-                    "user": "abc-123"
-                  },
-                  "summary": "リクエスト例"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "会話の削除に成功しました。コンテンツは返されません。"
-          },
-          "400": {
-            "description": "`not_chat_app` : アプリモードが API ルートと一致しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 会話が存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/conversations/delete-conversation",
-          "metadata": {
-            "title": "会話を削除",
-            "sidebarTitle": "会話を削除"
-          }
-        }
-      }
-    },
-    "/audio-to-text": {
-      "post": {
-        "summary": "音声をテキストに変換",
-        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nワークスペースのデフォルト音声認識モデルを使用して、アップロードされた音声ファイルをテキストに文字起こしします。",
-        "operationId": "basicChatAudioToTextJa",
-        "tags": [
-          "音声・テキスト変換"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/AudioToTextRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "音声からテキストへの変換に成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AudioToTextResponse"
-                },
-                "examples": {
-                  "audioToTextSuccess": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "text": "Hello, I would like to know more about the iPhone 13 Pro Max."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_audio_uploaded` : 音声ファイルがアップロードされていません（`file` フィールドがありません）。\n- `speech_to_text_disabled` : このアプリでは音声からテキストへの変換が無効になっています。\n- `provider_not_support_speech_to_text` : モデルプロバイダーが音声認識をサポートしていません。\n- `provider_not_initialize` : 有効なモデルプロバイダーの認証情報が見つかりません。\n- `completion_request_error` : 音声認識リクエストに失敗しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_audio_uploaded": {
-                    "summary": "no_audio_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_audio_uploaded",
-                      "message": "Please upload your audio."
-                    }
-                  },
-                  "speech_to_text_disabled": {
-                    "summary": "speech_to_text_disabled",
-                    "value": {
-                      "status": 400,
-                      "code": "speech_to_text_disabled",
-                      "message": "Speech to text is disabled."
-                    }
-                  },
-                  "provider_not_support_speech_to_text": {
-                    "summary": "provider_not_support_speech_to_text",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_support_speech_to_text",
-                      "message": "Provider not support speech to text."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`audio_too_large` : 音声ファイルが `30 MB` のサイズ上限を超えています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "audio_too_large": {
-                    "summary": "audio_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "audio_too_large",
-                      "message": "Audio size larger than 30 mb"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_audio_type` : ファイルの MIME タイプが、受け付ける音声タイプのいずれでもありません（`file` フィールドを参照）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_audio_type": {
-                    "summary": "unsupported_audio_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_audio_type",
-                      "message": "Audio type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : 内部サーバーエラー。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/audio/convert-audio-to-text",
-          "metadata": {
-            "title": "音声をテキストに変換",
-            "sidebarTitle": "音声をテキストに変換"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/audio-to-text' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@meeting-question.mp3' \\\n  --form 'user={user}'"
-          }
-        ]
-      }
-    },
-    "/text-to-audio": {
-      "post": {
-        "summary": "テキストを音声に変換",
-        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nテキストを音声に変換します。任意のテキストを合成するには `text` を、既存のメッセージの回答を音声化するには `message_id` を渡します。",
-        "operationId": "basicChatTextToAudioJa",
-        "tags": [
-          "音声・テキスト変換"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TextToAudioRequest"
-              },
-              "examples": {
-                "textToAudioExample": {
-                  "summary": "リクエスト例",
-                  "value": {
-                    "text": "Hello, welcome to our service.",
-                    "user": "abc-123",
-                    "voice": "alloy",
-                    "streaming": false
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "生成された音声を返します。`Content-Type` ヘッダーはプロバイダーが返す音声コンテナ形式を反映し、認識可能な場合はレスポンスのバイト列から検証されます。\n\nレスポンスボディは AAC、FLAC、MP4、MP3、Ogg、WAV、WebM のいずれかです。認識できない出力には、プロバイダーが宣言した形式が設定されます。宣言がない場合は `audio/mpeg` になります。\n\nプロバイダーがストリームを返す場合はチャンク転送エンコーディングで配信されます。リクエストの `streaming` フィールドはこの動作を制御しません。",
-            "content": {
-              "audio/aac": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/flac": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/mp4": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/mpeg": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/ogg": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/wav": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/webm": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `app_unavailable` : アプリケーションが利用できないか、設定が正しくありません。\n- `invalid_param` : テキスト読み上げが有効になっていない、`text` が指定されていない、または利用可能な音声がありません。\n- `provider_not_initialize` : 有効なモデルプロバイダーの認証情報が見つかりません。\n- `provider_quota_exceeded` : モデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support` : 現在のモデルはこの操作をサポートしていません。\n- `completion_request_error` : テキスト読み上げリクエストに失敗しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "app_unavailable": {
-                    "summary": "app_unavailable",
-                    "value": {
-                      "status": 400,
-                      "code": "app_unavailable",
-                      "message": "App unavailable, please check your app configurations."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "TTS is not enabled"
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : 内部サーバーエラー。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/audio/convert-text-to-audio",
-          "metadata": {
-            "title": "テキストを音声に変換",
-            "sidebarTitle": "テキストを音声に変換"
-          }
-        }
-      }
-    },
-    "/info": {
-      "get": {
-        "summary": "アプリケーションの基本情報を取得",
-        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nアプリの基本情報（名前、説明、タグ、モード、作成者）を返します。",
-        "operationId": "getBasicChatAppInfoJa",
-        "tags": [
-          "アプリケーション設定"
-        ],
-        "responses": {
-          "200": {
-            "description": "アプリケーションの基本情報。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfoResponse"
-                },
-                "examples": {
-                  "appInfo": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "name": "My Chat App",
-                      "description": "便利なカスタマーサービスチャットボット。",
-                      "tags": [
-                        "customer-service",
-                        "chatbot"
-                      ],
-                      "mode": "chat",
-                      "author_name": "Dify Team"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/applications/get-app-info",
-          "metadata": {
-            "title": "アプリケーションの基本情報を取得",
-            "sidebarTitle": "アプリケーションの基本情報を取得"
-          }
-        }
-      }
-    },
-    "/parameters": {
-      "get": {
-        "summary": "アプリケーションのパラメータ情報を取得",
-        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nアプリのフロントエンド設定（開始文と推奨質問、機能トグル、ユーザー入力フォーム、ファイルアップロード上限）を返します。アプリの入力をレンダリングし、正しいアップロード上限を適用するために使用します。",
-        "operationId": "getBasicChatAppParametersJa",
-        "tags": [
-          "アプリケーション設定"
-        ],
-        "responses": {
-          "200": {
-            "description": "アプリケーションパラメータ情報。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppParametersResponse"
-                },
-                "examples": {
-                  "appParameters": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "opening_statement": "Hello! How can I help you today?",
-                      "suggested_questions": [
-                        "What can you do?",
-                        "Tell me about your features."
-                      ],
-                      "suggested_questions_after_answer": {
-                        "enabled": true
-                      },
-                      "speech_to_text": {
-                        "enabled": false
-                      },
-                      "text_to_speech": {
-                        "enabled": false,
-                        "voice": "alloy",
-                        "language": "en-US",
-                        "autoPlay": "disabled"
-                      },
-                      "retriever_resource": {
-                        "enabled": true
-                      },
-                      "annotation_reply": {
-                        "enabled": false
-                      },
-                      "more_like_this": {
-                        "enabled": false
-                      },
-                      "sensitive_word_avoidance": {
-                        "enabled": false
-                      },
-                      "user_input_form": [
-                        {
-                          "text-input": {
-                            "label": "City",
-                            "variable": "city",
-                            "required": true,
-                            "default": ""
-                          }
-                        }
-                      ],
-                      "file_upload": {
-                        "image": {
-                          "enabled": true,
-                          "number_limits": 3,
-                          "detail": "high",
-                          "transfer_methods": [
-                            "remote_url",
-                            "local_file"
-                          ]
-                        }
-                      },
-                      "system_parameters": {
-                        "file_size_limit": 15,
-                        "image_file_size_limit": 10,
-                        "audio_file_size_limit": 50,
-                        "video_file_size_limit": 100,
-                        "workflow_file_upload_limit": 10
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `app_unavailable` : アプリケーションが利用できないか、設定が正しくありません。\n- `agent_not_published` : バインドされた Agent が公開されていません。（新しい Agent アプリ）",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "app_unavailable": {
-                    "summary": "app_unavailable",
-                    "value": {
-                      "status": 400,
-                      "code": "app_unavailable",
-                      "message": "App unavailable, please check your app configurations."
-                    }
-                  },
-                  "agent_not_published": {
-                    "summary": "agent_not_published",
-                    "value": {
-                      "code": "agent_not_published",
-                      "message": "Agent has not been published. Please publish the Agent before using the API.",
-                      "status": 400
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/applications/get-app-parameters",
-          "metadata": {
-            "title": "アプリケーションのパラメータ情報を取得",
-            "sidebarTitle": "アプリケーションのパラメータ情報を取得"
-          }
-        }
-      }
-    },
-    "/meta": {
-      "get": {
-        "summary": "アプリケーションのメタ情報を取得",
-        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nこのアプリが使用するツールの表示アイコンを、ツール名をキーとして返します。",
-        "operationId": "getBasicChatAppMetaJa",
-        "tags": [
-          "アプリケーション設定"
-        ],
-        "responses": {
-          "200": {
-            "description": "アプリケーションのメタ情報を正常に取得しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppMetaResponse"
-                },
-                "examples": {
-                  "appMeta": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "tool_icons": {
-                        "dalle3": "https://example.com/icons/dalle3.png",
-                        "calculator": {
-                          "background": "#4A90D9",
-                          "content": "🧮"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/applications/get-app-meta",
-          "metadata": {
-            "title": "アプリケーションのメタ情報を取得",
-            "sidebarTitle": "アプリケーションのメタ情報を取得"
-          }
-        }
-      }
-    },
-    "/site": {
-      "get": {
-        "summary": "アプリの WebApp 設定を取得",
-        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nアプリのホスト型 Web アプリのブランディングと表示設定（タイトル、アイコン、テーマカラー、デフォルト言語など）を返します。",
-        "operationId": "getBasicChatWebAppSettingsJa",
-        "tags": [
-          "アプリケーション設定"
-        ],
-        "responses": {
-          "200": {
-            "description": "アプリケーションの Web アプリ設定。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WebAppSettingsResponse"
-                },
-                "examples": {
-                  "webAppSettings": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "title": "My Chat App",
-                      "chat_color_theme": "#4A90D9",
-                      "chat_color_theme_inverted": false,
-                      "icon_type": "emoji",
-                      "icon": "🤖",
-                      "icon_background": "#FFFFFF",
-                      "icon_url": null,
-                      "description": "便利なカスタマーサービスチャットボット。",
-                      "copyright": "2025 Dify",
-                      "privacy_policy": "https://example.com/privacy",
-                      "input_placeholder": "製品について何でもお尋ねください…",
-                      "custom_disclaimer": "",
-                      "default_language": "en-US",
-                      "show_workflow_steps": false,
-                      "use_icon_as_answer_icon": true
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : このアプリケーションのサイトが見つからないか、ワークスペースがアーカイブされています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/applications/get-app-webapp-settings",
-          "metadata": {
-            "title": "アプリの WebApp 設定を取得",
-            "sidebarTitle": "アプリの WebApp 設定を取得"
-          }
-        }
-      }
-    },
-    "/apps/annotations": {
-      "post": {
-        "summary": "アノテーションを作成",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\nアノテーションを作成します。アノテーションは、一致したときにアプリが新しい応答を生成する代わりに直接返す、事前定義された質問と回答のペアです。",
-        "operationId": "createChatAnnotationJa",
-        "tags": [
-          "アノテーション管理"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateAnnotationRequest"
-              },
-              "examples": {
-                "createAnnotation": {
-                  "summary": "リクエスト例",
-                  "value": {
-                    "question": "What is Dify?",
-                    "answer": "Dify is an open-source LLM application development platform."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "アノテーションが正常に作成されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnnotationItem"
-                },
-                "examples": {
-                  "createdAnnotation": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "question": "What is Dify?",
-                      "answer": "Dify is an open-source LLM application development platform.",
-                      "hit_count": 0,
-                      "created_at": 1705407629
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/annotations/create-annotation",
-          "metadata": {
-            "title": "アノテーションを作成",
-            "sidebarTitle": "アノテーションを作成"
-          }
-        }
-      },
-      "get": {
-        "summary": "アノテーションリストを取得",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\nアプリのアノテーションを、任意でキーワードでフィルタリングして一覧表示します。",
-        "operationId": "listChatAnnotationsJa",
-        "tags": [
-          "アノテーション管理"
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "ページ番号。",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "1 ページあたりのアイテム数。100 を超えるリクエストは 100 に制限されます。",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1
-            }
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "description": "質問または回答の内容でアノテーションをフィルタリングするためのキーワードです。",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "アノテーションリストの取得に成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnnotationListResponse"
-                },
-                "examples": {
-                  "annotationList": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "question": "What is Dify?",
-                          "answer": "Dify is an open-source LLM application development platform.",
-                          "hit_count": 5,
-                          "created_at": 1705407629
-                        }
-                      ],
-                      "has_more": false,
-                      "limit": 20,
-                      "total": 1,
-                      "page": 1
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/annotations/list-annotations",
-          "metadata": {
-            "title": "アノテーションリストを取得",
-            "sidebarTitle": "アノテーションリストを取得"
-          }
-        }
-      }
-    },
-    "/apps/annotations/{annotation_id}": {
-      "put": {
-        "summary": "アノテーションを更新",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\nアノテーションの質問と回答を更新します。",
-        "operationId": "updateChatAnnotationJa",
-        "tags": [
-          "アノテーション管理"
-        ],
-        "parameters": [
-          {
-            "name": "annotation_id",
-            "in": "path",
-            "required": true,
-            "description": "更新するアノテーションの ID です。アノテーション ID は [アノテーションリストを取得](/ja/api-reference/annotations/list-annotations) から取得します。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateAnnotationRequest"
-              },
-              "examples": {
-                "updateAnnotation": {
-                  "summary": "リクエスト例",
-                  "value": {
-                    "question": "What is Dify?",
-                    "answer": "Dify is an open-source LLM application development platform for building AI-powered apps."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "アノテーションが正常に更新されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnnotationItem"
-                },
-                "examples": {
-                  "updatedAnnotation": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "question": "What is Dify?",
-                      "answer": "Dify is an open-source LLM application development platform for building AI-powered apps.",
-                      "hit_count": 5,
-                      "created_at": 1705407629
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : アノテーションが存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Annotation not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/annotations/update-annotation",
-          "metadata": {
-            "title": "アノテーションを更新",
-            "sidebarTitle": "アノテーションを更新"
-          }
-        }
-      },
-      "delete": {
-        "summary": "アノテーションを削除",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\nアノテーションとその関連するヒット履歴を削除します。",
-        "operationId": "deleteChatAnnotationJa",
-        "tags": [
-          "アノテーション管理"
-        ],
-        "parameters": [
-          {
-            "name": "annotation_id",
-            "in": "path",
-            "required": true,
-            "description": "削除するアノテーションの ID です。アノテーション ID は [アノテーションリストを取得](/ja/api-reference/annotations/list-annotations) から取得します。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "アノテーションが正常に削除されました。"
-          },
-          "404": {
-            "description": "`not_found` : アノテーションが存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Annotation not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/annotations/delete-annotation",
-          "metadata": {
-            "title": "アノテーションを削除",
-            "sidebarTitle": "アノテーションを削除"
-          }
-        }
-      }
-    },
-    "/apps/annotation-reply/{action}": {
-      "post": {
-        "summary": "アノテーション返信を設定",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\nアプリのアノテーション返信を有効または無効にします。非同期で実行されます。進捗は [アノテーション返信の初期設定タスクステータスを取得](/ja/api-reference/annotations/get-annotation-reply-job-status) で追跡してください。\n\nリクエストボディはアクションの実行前に検証されるため、`disable` の場合でも `score_threshold`、`embedding_provider_name`、`embedding_model_name` が必須です。",
-        "operationId": "setChatAnnotationReplyJa",
-        "tags": [
-          "アノテーション管理"
-        ],
-        "parameters": [
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "description": "アノテーション返信を有効にするか無効にするかを指定します。",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InitialAnnotationReplySettingsRequest"
-              },
-              "examples": {
-                "enableAnnotationReply": {
-                  "summary": "リクエスト例",
-                  "value": {
-                    "score_threshold": 0.9,
-                    "embedding_provider_name": "openai",
-                    "embedding_model_name": "text-embedding-3-small"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "アノテーション返信設定タスクが開始されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InitialAnnotationReplySettingsResponse"
-                },
-                "examples": {
-                  "annotationReplyResponse": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "job_status": "waiting"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/annotations/configure-annotation-reply",
-          "metadata": {
-            "title": "アノテーション返信を設定",
-            "sidebarTitle": "アノテーション返信を設定"
-          }
-        }
-      }
-    },
-    "/apps/annotation-reply/{action}/status/{job_id}": {
-      "get": {
-        "summary": "アノテーション返信の初期設定タスクステータスを取得",
-        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\n[アノテーション返信を設定](/ja/api-reference/annotations/configure-annotation-reply) で開始されたアノテーション返信設定ジョブのステータスを返します。",
-        "operationId": "getChatAnnotationReplyStatusJa",
-        "tags": [
-          "アノテーション管理"
-        ],
-        "parameters": [
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "description": "アクションタイプです。[アノテーション返信を設定](/ja/api-reference/annotations/configure-annotation-reply) の呼び出しと一致する必要があります。",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            }
-          },
-          {
-            "name": "job_id",
-            "in": "path",
-            "required": true,
-            "description": "[アノテーション返信を設定](/ja/api-reference/annotations/configure-annotation-reply) から返されたジョブ ID です。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "タスクステータスの取得に成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InitialAnnotationReplySettingsStatusResponse"
-                },
-                "examples": {
-                  "jobStatus": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "job_status": "completed",
-                      "error_msg": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 指定されたジョブが存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "The job does not exist."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/annotations/get-annotation-reply-job-status",
-          "metadata": {
-            "title": "アノテーション返信の初期設定タスクステータスを取得",
-            "sidebarTitle": "アノテーション返信の初期設定タスクステータスを取得"
-          }
-        }
-      }
-    },
-    "/workflows/run/{workflow_run_id}": {
-      "get": {
-        "summary": "ワークフロー実行詳細を取得",
-        "description": "**対象アプリ**：Chatflow、Workflow。\n\n1 つのワークフロー実行のステータス、入力、出力、実行メトリクスを取得します。",
-        "operationId": "getWorkflowRunDetailJp",
-        "tags": [
-          "ワークフロー実行"
-        ],
-        "parameters": [
-          {
-            "name": "workflow_run_id",
-            "in": "path",
-            "required": true,
-            "description": "ワークフロー実行 ID です。[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) のレスポンスまたはストリーミングイベント、あるいは Chatflow アプリのメッセージメタデータから取得します。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "ワークフロー実行の詳細の取得に成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowRunDetailResponse"
-                },
-                "examples": {
-                  "workflowRunDetail": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                      "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
-                      "status": "succeeded",
-                      "inputs": "{\"query\": \"Translate this to French\"}",
-                      "outputs": {
-                        "result": "Traduisez ceci en francais"
-                      },
-                      "error": null,
-                      "total_steps": 3,
-                      "total_tokens": 150,
-                      "created_at": 1705407629,
-                      "finished_at": 1705407630,
-                      "elapsed_time": 1.23
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_workflow_app` : アプリモードが API ルートと一致しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ワークフロー実行記録が見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "workflow_run_not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Workflow run not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/workflow-runs/get-workflow-run-detail",
-          "metadata": {
-            "title": "ワークフロー実行詳細を取得",
-            "sidebarTitle": "ワークフロー実行詳細を取得"
-          }
-        }
-      }
-    },
-    "/workflows/logs": {
-      "get": {
-        "summary": "ワークフローログ一覧を取得",
-        "description": "**対象アプリ**：Chatflow、Workflow。\n\n過去のワークフロー実行を、任意のフィルターで一覧表示します。各エントリは実行単位のサマリー（ステータス、トークン使用量、ステップ数、所要時間）であり、ノードごとの実行ログではありません。\n\n実行のノードレベルのイベントを追跡するには、代わりにストリーミングを使用します。\n\n- **自分で開始する実行**：[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) をストリーミングモードで使用すると、実行の進行に応じて `node_started` と `node_finished` が送信されます。\n- **すでに進行中の実行**：[ワークフローイベントをストリーム](/ja/api-reference/workflow-runs/stream-workflow-events) を `include_state_snapshot=true` 付きで呼び出し、実行済み各ノードのステータスを再送してから、残りをストリーミングします。\n\n完了した実行のノードレベルのログは、サービス API 経由では取得できません。",
-        "operationId": "getWorkflowLogsJp",
-        "tags": [
-          "ワークフロー実行"
-        ],
-        "parameters": [
-          {
-            "name": "keyword",
-            "in": "query",
-            "description": "ログ内を検索するキーワードです。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "実行ステータスでフィルタリングします。",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "succeeded",
-                "failed",
-                "stopped"
-              ]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "ページ番号。",
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1,
-              "maximum": 99999
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "1 ページあたりの件数です。",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          },
-          {
-            "name": "created_at__before",
-            "in": "query",
-            "description": "この ISO 8601 タイムスタンプ以前に作成されたログをフィルタリングします。",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "created_at__after",
-            "in": "query",
-            "description": "この ISO 8601 タイムスタンプ以降に作成されたログをフィルタリングします。",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "created_by_end_user_session_id",
-            "in": "query",
-            "description": "エンドユーザーセッション ID でフィルタリングします。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "created_by_account",
-            "in": "query",
-            "description": "作成者のアカウントのメールアドレス（例：`name@example.com`）でフィルタリングします。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "ワークフローログの取得に成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowLogsResponse"
-                },
-                "examples": {
-                  "workflowLogs": {
-                    "summary": "Response Example",
-                    "value": {
-                      "page": 1,
-                      "limit": 20,
-                      "total": 1,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
-                          "workflow_run": {
-                            "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                            "version": "2025-01-16 12:00:00.000000",
-                            "status": "succeeded",
-                            "error": null,
-                            "elapsed_time": 1.23,
-                            "total_tokens": 150,
-                            "total_steps": 3,
-                            "created_at": 1705407629,
-                            "finished_at": 1705407630,
-                            "exceptions_count": 0,
-                            "triggered_from": "app-run"
-                          },
-                          "created_from": "service-api",
-                          "created_by_role": "end_user",
-                          "created_by_account": null,
-                          "created_by_end_user": {
-                            "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                            "type": "service-api",
-                            "is_anonymous": false,
-                            "session_id": "user_workflow_123"
-                          },
-                          "created_at": 1705407629
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : クエリパラメータが無効です。例：どのアカウントにも一致しない `created_by_account`、不正な形式の `created_at__before` や `created_at__after` のタイムスタンプ、範囲外の `page`、`limit`、`status` の値など。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Account not found: name@example.com"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/workflow-runs/list-workflow-logs",
-          "metadata": {
-            "title": "ワークフローログ一覧を取得",
-            "sidebarTitle": "ワークフローログ一覧を取得"
-          }
-        }
-      }
-    },
-    "/form/human_input/{form_token}": {
-      "get": {
-        "tags": [
-          "人間の入力"
-        ],
-        "summary": "人間の入力フォームを取得",
-        "description": "**対象アプリ**：Chatflow、Workflow。\n\n一時停止中の人間の入力フォームの内容を返します。Web アプリ配信が必要です。\n\n人間の入力を呼び出す一連の流れについては、[API 連携フロー](/ja/api-reference/guides/human-input-flow) を参照してください。",
-        "operationId": "getChatflowHumanInputForm",
-        "parameters": [
-          {
-            "name": "form_token",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "一時停止中のフォームへのアクセストークン。ストリーミングモードのワークフローを実行エンドポイントまたはチャットメッセージを送信エンドポイントが返す `human_input_required` イベントから取得します。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "フォーム内容の取得に成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "form_content": {
-                      "type": "string",
-                      "description": "ワークフロー変数を埋め込んだ、事前レンダリング済みのフォーム本文。"
-                    },
-                    "inputs": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "description": "フォーム入力コントロールの種類。利用可能な値： `paragraph` （複数行テキスト入力）、 `select` （リストからの単一選択）、 `file` （単一ファイルアップロード）、 `file-list` （複数ファイルアップロード）。"
-                          },
-                          "output_variable_name": {
-                            "type": "string",
-                            "description": "ワークフロー内でこの入力の送信値を参照する際の変数名。送信リクエストの `inputs` オブジェクトのキーに対応します。"
-                          },
-                          "default": {
-                            "type": "object",
-                            "nullable": true,
-                            "description": "`paragraph` 入力の生のデフォルト値設定。クライアントはこのフィールドを直接解決すべきではありません。デフォルトの表示には `resolved_default_values` を使用してください。その他の入力タイプ、またはデフォルト値が未設定の場合、このキーは含まれません。",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "description": "デフォルト値のソース。 `constant` は `value` をリテラル文字列として使用することを示します。 `variable` は `selector` がワークフロー変数を指すことを示します。"
-                              },
-                              "selector": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "`type` が `variable` の場合の変数参照パス（例： `[\"node_id\", \"var_name\"]`）。少なくとも 2 つの要素を含む必要があります。"
-                              },
-                              "value": {
-                                "type": "string",
-                                "description": "`type` が `constant` の場合のリテラルなデフォルト値。常に文字列です。"
-                              }
-                            }
-                          },
-                          "option_source": {
-                            "type": "object",
-                            "description": "`select` 入力の選択肢のソース。 `type` が `select` の場合のみ含まれます。",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "enum": [
-                                  "variable",
-                                  "constant"
-                                ],
-                                "description": "選択肢のソース。 `constant` は `value` に選択肢を直接列挙することを示します。 `variable` は `selector` が選択肢を提供する `array[string]` 型のワークフロー変数を指すことを示します。"
-                              },
-                              "selector": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "`type` が `variable` の場合の変数参照パス。"
-                              },
-                              "value": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "`type` が `constant` の場合のリテラルな選択肢リスト。"
-                              }
-                            }
-                          },
-                          "allowed_file_types": {
-                            "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": [
-                                "image",
-                                "document",
-                                "audio",
-                                "video",
-                                "custom"
-                              ]
-                            },
-                            "description": "受信者がアップロード可能なファイルカテゴリ。 `file` および `file-list` 入力に含まれます。値： `image`、 `document`、 `audio`、 `video`、 `custom`。"
-                          },
-                          "allowed_file_extensions": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            },
-                            "description": "`allowed_file_types` に `custom` が含まれる場合に許可されるファイル拡張子。各拡張子には先頭の `.` を含めてください。たとえば `.md` です。`file` および `file-list` 入力に含まれます。"
-                          },
-                          "allowed_file_upload_methods": {
-                            "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": [
-                                "local_file",
-                                "remote_url"
-                              ]
-                            },
-                            "description": "受信者が使用できるアップロード方法。値： `local_file`、 `remote_url`。 `file` および `file-list` 入力に含まれます。"
-                          },
-                          "number_limits": {
-                            "type": "integer",
-                            "description": "受信者がアップロードできるファイルの最大数。 `file-list` 入力のみに含まれます。"
-                          }
-                        }
-                      },
-                      "description": "フォーム入力フィールドの定義。"
-                    },
-                    "resolved_default_values": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      },
-                      "description": "フォームに表示するための事前計算済みデフォルト値。入力の `output_variable_name` をキーとします。デフォルト値がワークフロー変数から解決可能な `paragraph` 入力にのみ設定されます。解決可能なデフォルトがない入力では空になります。クライアントはこれらの値をそのまま表示してください。 `default` をクライアント側で再解決する必要はありません。すべての値は文字列化されています。"
-                    },
-                    "user_actions": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "maxLength": 20,
-                            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
-                            "description": "アクションボタンの識別子。受信者がこのボタンを選択したときに、[人間の入力フォームを送信](/ja/api-reference/human-input/submit-human-input-form) エンドポイントの `action` として渡します。"
-                          },
-                          "title": {
-                            "type": "string",
-                            "maxLength": 100,
-                            "description": "受信者に表示されるボタンのラベル。"
-                          },
-                          "button_style": {
-                            "type": "string",
-                            "description": "ボタンの視覚スタイル。利用可能な値： `primary`、 `default`、 `accent`、 `ghost`。"
-                          }
-                        }
-                      },
-                      "description": "利用可能な送信アクション。"
-                    },
-                    "expiration_time": {
-                      "type": "integer",
-                      "format": "int64",
-                      "description": "Unix タイムスタンプ（秒）。この時刻以降、フォームは送信できなくなります。",
-                      "nullable": true
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "form_content": "ドラフトを確認し、優先度を設定して、承認または修正を依頼してください。",
-                      "inputs": [
-                        {
-                          "type": "paragraph",
-                          "output_variable_name": "feedback",
-                          "default": {
-                            "type": "constant",
-                            "selector": [],
-                            "value": ""
-                          }
-                        },
-                        {
-                          "type": "select",
-                          "output_variable_name": "priority",
-                          "option_source": {
-                            "type": "constant",
-                            "selector": [],
-                            "value": [
-                              "low",
-                              "medium",
-                              "high"
-                            ]
-                          }
-                        },
-                        {
-                          "type": "file",
-                          "output_variable_name": "attachment",
-                          "allowed_file_types": [
-                            "image",
-                            "document"
-                          ],
-                          "allowed_file_extensions": [],
-                          "allowed_file_upload_methods": [
-                            "local_file",
-                            "remote_url"
-                          ]
-                        },
-                        {
-                          "type": "file-list",
-                          "output_variable_name": "attachments",
-                          "allowed_file_types": [
-                            "image",
-                            "document"
-                          ],
-                          "allowed_file_extensions": [],
-                          "allowed_file_upload_methods": [
-                            "local_file",
-                            "remote_url"
-                          ],
-                          "number_limits": 5
-                        }
-                      ],
-                      "resolved_default_values": {
-                        "feedback": ""
-                      },
-                      "user_actions": [
-                        {
-                          "id": "approve",
-                          "title": "承認",
-                          "button_style": "primary"
-                        },
-                        {
-                          "id": "reject",
-                          "title": "修正を依頼",
-                          "button_style": "default"
-                        }
-                      ],
-                      "expiration_time": 1745510400
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` ：フォームが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "フォームが見つかりません"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "412": {
-            "description": "- `human_input_form_submitted` ：フォームは送信済みです。フォームはワンショットで、最初の応答が有効になります（送信したユーザーは問いません）。\n- `human_input_form_expired` ：送信が到達する前にフォームの有効期限が切れています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "human_input_form_submitted": {
-                    "summary": "human_input_form_submitted",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_submitted",
-                      "message": "このフォームは他のユーザーによって送信済みです。form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  },
-                  "human_input_form_expired": {
-                    "summary": "human_input_form_expired",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_expired",
-                      "message": "このフォームは有効期限切れです。form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/human-input/get-human-input-form",
-          "metadata": {
-            "title": "人間の入力フォームを取得",
-            "sidebarTitle": "人間の入力フォームを取得"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "人間の入力"
-        ],
-        "summary": "人間の入力フォームを送信",
-        "description": "**対象アプリ**：Chatflow、Workflow。\n\n一時停止中の人間の入力フォームに、受信者の応答を送信します。受理されるとワークフローが再開されます。再開後の実行は [ワークフローイベントをストリーム](/ja/api-reference/workflow-runs/stream-workflow-events) で追跡してください。Web アプリ配信が必要です。",
-        "operationId": "submitChatflowHumanInputForm",
-        "parameters": [
-          {
-            "name": "form_token",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "一時停止中のフォームへのアクセストークン。ストリーミングモードのワークフローを実行エンドポイントまたはチャットメッセージを送信エンドポイントが返す `human_input_required` イベントから取得します。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "inputs",
-                  "action",
-                  "user"
-                ],
-                "properties": {
-                  "inputs": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "各入力の `output_variable_name` をキーとして送信する値。段落と選択の入力は文字列、`file` 入力は単一のファイルマッピング、`file-list` 入力はファイルマッピングの配列です。\n\nファイルマッピングは `{transfer_method: local_file, upload_file_id, type}` または `{transfer_method: remote_url, url, type}` で、`type` はそのフィールドの `allowed_file_types` のいずれかです。`local_file` の場合、`upload_file_id` は [ファイルをアップロード](/ja/api-reference/files/upload-file) が返す `id` です。\n\n実行、アップロード、送信の各呼び出しで一貫した `user` を使用してください。"
-                  },
-                  "action": {
-                    "type": "string",
-                    "description": "受信者が選択したアクションボタンの ID。フォームの `user_actions` リスト（[人間の入力フォームを取得](/ja/api-reference/human-input/get-human-input-form) エンドポイントから返される）にある `id` のいずれかと一致する必要があります。"
-                  },
-                  "user": {
-                    "type": "string",
-                    "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。サービス API と Web アプリのユーザー ID は、たとえ同じでも別物として扱われます。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。"
-                  }
-                }
-              },
-              "examples": {
-                "approve": {
-                  "summary": "リクエスト例",
-                  "value": {
-                    "inputs": {
-                      "feedback": "公開して問題ありません",
-                      "priority": "high",
-                      "attachment": {
-                        "transfer_method": "local_file",
-                        "upload_file_id": "3c8fa1b2-7d4e-4f9a-b0c1-d2e3f4a5b6c7",
-                        "type": "image"
-                      },
-                      "attachments": [
-                        {
-                          "transfer_method": "local_file",
-                          "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee",
-                          "type": "document"
-                        },
-                        {
-                          "transfer_method": "remote_url",
-                          "url": "https://example.com/report.pdf",
-                          "type": "document"
-                        }
-                      ]
-                    },
-                    "action": "approve",
-                    "user": "abc-123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "フォームの送信に成功しました。レスポンスボディは空のオブジェクトです。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {}
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `bad_request` ：フォーム受信者のタイプが無効です。\n- `invalid_form_data` ：送信内容がフォーム定義の検証に失敗しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "bad_request": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "フォーム受信者のタイプが無効です"
-                    }
-                  },
-                  "invalid_form_data": {
-                    "summary": "invalid_form_data",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_form_data",
-                      "message": "必須入力が不足しています：feedback"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` ：フォームが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "フォームが見つかりません"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "412": {
-            "description": "- `human_input_form_submitted` ：フォームは送信済みです。フォームはワンショットで、最初の応答が有効になります（送信したユーザーは問いません）。\n- `human_input_form_expired` ：送信が到達する前にフォームの有効期限が切れています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "human_input_form_submitted": {
-                    "summary": "human_input_form_submitted",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_submitted",
-                      "message": "このフォームは他のユーザーによって送信済みです。form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  },
-                  "human_input_form_expired": {
-                    "summary": "human_input_form_expired",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_expired",
-                      "message": "このフォームは有効期限切れです。form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/human-input/submit-human-input-form",
-          "metadata": {
-            "title": "人間の入力フォームを送信",
-            "sidebarTitle": "人間の入力フォームを送信"
-          }
-        }
-      }
-    },
-    "/workflow/{workflow_run_id}/events": {
-      "get": {
-        "tags": [
-          "ワークフロー実行"
-        ],
-        "summary": "ワークフローイベントをストリーム",
-        "description": "**対象アプリ**：Chatflow、Workflow。\n\n一時停止後または元の SSE 接続が切断された後にワークフロー実行の Server-Sent Events ストリームを再開します。すでに完了している実行に対しては、`workflow_finished` イベントを 1 つ送信してストリームを閉じます。\n\n進行中の実行のノードレベルのステータスと進捗を確認するには、`include_state_snapshot=true` を指定して呼び出します。ストリームは新しいイベントの送信前に、実行済み各ノードのステータスを再送します。",
-        "operationId": "streamWorkflowEvents",
-        "parameters": [
-          {
-            "name": "workflow_run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "イベントストリームを再開するワークフロー実行 ID です。[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) のレスポンスまたはストリーミングイベントから取得します。"
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。実行を開始した `user` と一致する必要があります。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。"
-          },
-          {
-            "name": "include_state_snapshot",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "`true` の場合、永続化された状態スナップショットからリプレイし、新しいイベントのストリーミング開始前に実行済みノードのステータスサマリーを含めます。"
-          },
-          {
-            "name": "continue_on_pause",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "`true` に設定すると、複数の `workflow_paused` イベントを跨いでストリームを開いたままにします（ワークフローに複数の人間の入力ノードが連続する場合に有用）。デフォルトでは最初の一時停止で閉じます。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Server-Sent Events ストリーム。ストリームはキープアライブの `event: ping` フレーム（`data:` なし）で始まり、その後もおよそ 10 秒ごとに届きます。それ以外のイベントは `data: {JSON}\\n\\n` として配信されます。イベントペイロードは元のストリーミングレスポンスと同じスキーマに従います。",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "再開されたワークフロー実行のイベントの SSE ストリームです。形式は [ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow)（Workflow アプリ）または [チャットメッセージを送信](/ja/api-reference/chat-messages/send-chat-message)（Chatflow アプリ）と同じです。再開された部分で `reasoning_format: separated` を指定した LLM ノードが実行される場合、このストリームには `reasoning_chunk` イベントも含まれます。"
-                },
-                "examples": {
-                  "resumedRun": {
-                    "summary": "レスポンス例 - 再開実行（Workflow）",
-                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"rendered_content\": \"ドラフトを確認してください。\", \"action_id\": \"approve\", \"action_text\": \"承認\", \"submitted_data\": {\"comment\": \"問題ありません。\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_2\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Approved, now translating.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour\"}, \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
-                  },
-                  "resumedRunChatflow": {
-                    "summary": "レスポンス例 - 再開実行（Chatflow）",
-                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"rendered_content\": \"ドラフトを確認してください。\", \"action_id\": \"approve\", \"action_text\": \"承認\", \"submitted_data\": {\"comment\": \"問題ありません。\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"The reviewer approved the draft.\", \"node_id\": \"node_llm_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"\", \"node_id\": \"node_llm_1\", \"is_final\": true}}\n\ndata: {\"event\": \"message\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"answer\": \"Approved\", \"created_at\": 1705407706}\n\ndata: {\"event\": \"node_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"status\": \"succeeded\", \"elapsed_time\": 1.2, \"created_at\": 1705407705, \"finished_at\": 1705407706}}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"metadata\": {\"usage\": {\"total_tokens\": 42, \"latency\": 1.3}}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_workflow_app` : Please check if your app mode matches the right API route.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Workflow run not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Workflow run not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "Resume stream",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          },
-          {
-            "lang": "bash",
-            "label": "With state snapshot",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}&include_state_snapshot=true' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
-        "x-mint": {
-          "href": "/ja/api-reference/workflow-runs/stream-workflow-events",
-          "metadata": {
-            "title": "ワークフローイベントをストリーム",
-            "sidebarTitle": "ワークフローイベントをストリーム"
-          }
-        }
-      }
-    },
-    "/workflows/run": {
-      "post": {
-        "summary": "ワークフローを実行",
-        "description": "**対象アプリ**：Workflow。\n\nアプリの公開済みワークフローを実行し、その出力を返します。単一の `blocking` レスポンス、または `streaming` の Server-Sent Events フィードのいずれかで返します。公開済みのワークフローが必要です。",
-        "operationId": "executeWorkflowJp",
-        "tags": [
-          "ワークフロー実行"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkflowExecutionRequest"
-              },
-              "examples": {
-                "streaming_example": {
-                  "summary": "リクエスト例 - ストリーミングモード",
-                  "value": {
-                    "inputs": {
-                      "query": "Summarize this text: The quick brown fox jumps over the lazy dog."
-                    },
-                    "response_mode": "streaming",
-                    "user": "user_workflow_123"
-                  }
-                },
-                "blocking_example": {
-                  "summary": "リクエスト例 - ブロッキングモード",
-                  "value": {
-                    "inputs": {
-                      "query": "Translate this to French: Hello world"
-                    },
-                    "response_mode": "blocking",
-                    "user": "user_workflow_456"
-                  }
-                },
-                "with_file_array_variable": {
-                  "summary": "Request Example - File array input",
-                  "value": {
-                    "inputs": {
-                      "my_documents": [
-                        {
-                          "type": "document",
-                          "transfer_method": "local_file",
-                          "upload_file_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab"
-                        },
-                        {
-                          "type": "image",
-                          "transfer_method": "remote_url",
-                          "url": "https://example.com/image.jpg"
-                        }
-                      ]
-                    },
-                    "response_mode": "blocking",
-                    "user": "user_workflow_789"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "リクエスト成功。コンテンツタイプと構造はリクエストの `response_mode` パラメータに依存します。\n\n- `response_mode` が `blocking` の場合、 `application/json` で `WorkflowBlockingResponse` オブジェクトを返します。\n- `response_mode` が `streaming` の場合、 `text/event-stream` で `ChunkWorkflowEvent` オブジェクトのストリームを返します。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
-                },
-                "examples": {
-                  "blockingResponse": {
-                    "summary": "レスポンス例 - ブロッキングモード",
-                    "value": {
-                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
-                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                      "data": {
-                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
-                        "status": "succeeded",
-                        "outputs": {
-                          "result": "Bonjour le monde"
-                        },
-                        "error": null,
-                        "elapsed_time": 1.23,
-                        "total_tokens": 150,
-                        "total_steps": 3,
-                        "created_at": 1705407629,
-                        "finished_at": 1705407630
-                      }
-                    }
-                  }
-                }
-              },
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "Server-Sent Events (SSE) のストリームです。解析は [ストリーミングレスポンスの処理](/ja/api-reference/guides/streaming) に従ってください：`data:` 行を読み取り、`event` フィールドで振り分け、`ping`（キープアライブ。ストリームは `ping` で始まり、その後およそ 10 秒ごとに届きます）は無視します。\n\n**ストリームライフサイクル**：`workflow_finished`、`workflow_paused`、または `error` イベントを受信するとストリームが閉じます。エラーはストリーム内の `error` イベントとして HTTP ステータス `200` で配信されます。ステータスコードではなくイベントペイロードを確認して詳細を取得してください。\n\n**推論イベント**：\n- `reasoning_chunk`：`reasoning_format` が `separated` の LLM ノードが発行する思考過程のデルタです。連続する `reasoning_chunk` イベントを連結すると、完全な推論を復元できます。`is_final: true` のイベントはノードの思考完了を示し、空の `reasoning` を伴う場合があります。ペイロードは `data` の下にあり、チャットアプリとは異なり `message_id` は `null` となり、`conversation_id` は含まれません。並行する `text_chunk` ストリームには `<think>` タグが含まれません。\n\n**人間の入力イベント**：\n- `human_input_required`：ワークフローが人間の入力ノードに到達した際に `workflow_paused` と同時に発行されます。ペイロードの `form_token` を使用して、[人間の入力 API](/ja/api-reference/human-input/get-human-input-form) でフォーム処理を進めます。\n- `human_input_form_filled`：受信者がフォームを送信し、ワークフロー実行が再開されます。\n- `human_input_form_timeout`：応答がないままフォームが期限切れ。タイムアウトのフォールバックエッジが定義されている場合、ワークフローはそのエッジを通って実行されます。"
-                },
-                "examples": {
-                  "streamingResponse": {
-                    "summary": "レスポンス例 - ストリーミングモード",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"Translate this\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Let me translate that.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
-                  },
-                  "humanInputPause": {
-                    "summary": "レスポンス例 - 人間の入力での一時停止",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"Hello\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"form_content\": \"ドラフトを確認してください。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"承認\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_workflow_app` : App mode does not match the API route.\n- `provider_not_initialize` : 有効なモデルプロバイダーの認証情報が見つかりません。\n- `provider_quota_exceeded` : モデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support` : 現在のモデルは利用できません。\n- `completion_request_error` : Workflow execution request failed.\n- `invalid_param` : リクエストパラメータが不足または無効です（`user` の欠落や未公開のワークフローなど）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "- `too_many_requests` : このアプリケーションへの同時リクエストが多すぎます。\n- `rate_limit_error` : このワークスペースの Dify Cloud のワークフロー実行クォータに達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "too_many_requests": {
-                    "summary": "too_many_requests",
-                    "value": {
-                      "status": 429,
-                      "code": "too_many_requests",
-                      "message": "Too many requests. Please try again later."
-                    }
-                  },
-                  "rate_limit_error": {
-                    "summary": "rate_limit_error",
-                    "value": {
-                      "status": 429,
-                      "code": "rate_limit_error",
-                      "message": "Rate Limit Error"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : 内部サーバーエラー。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "Internal Server Error."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/workflow-runs/run-workflow",
-          "metadata": {
-            "title": "ワークフローを実行",
-            "sidebarTitle": "ワークフローを実行"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl -N --request POST \\\n  --url 'https://{api_base_url}/workflows/run' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"inputs\": {\"query\": \"Summarize this text: The quick brown fox jumps over the lazy dog.\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
-      }
-    },
-    "/workflows/{workflow_id}/run": {
-      "post": {
-        "summary": "ID でワークフローを実行",
-        "description": "**対象アプリ**：Workflow。\n\n特定の公開済みワークフローバージョンを、パスの `workflow_id` で指定して実行します。リクエストボディ、レスポンス、ストリーミングの挙動は [ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) と同じで、実行されるバージョンだけが異なります。",
-        "operationId": "runWorkflowByIdJa",
-        "tags": [
-          "ワークフロー実行"
-        ],
-        "parameters": [
-          {
-            "name": "workflow_id",
-            "in": "path",
-            "required": true,
-            "description": "実行する公開済みワークフローバージョンです。[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) のレスポンスおよび [ワークフロー実行詳細を取得](/ja/api-reference/workflow-runs/get-workflow-run-detail) の `workflow_id` フィールドで返されます。公開済みバージョンを指定する必要があります。ドラフトバージョンの ID は `bad_request` で拒否されます。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkflowExecutionRequest"
-              },
-              "examples": {
-                "example": {
-                  "summary": "リクエスト例",
-                  "value": {
-                    "inputs": {
-                      "query": "Summarize this article"
-                    },
-                    "response_mode": "blocking",
-                    "user": "user_workflow_123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "リクエスト成功。コンテンツタイプと構造はリクエストの `response_mode` パラメータに依存します。\n\n- `response_mode` が `blocking` の場合、 `application/json` で `WorkflowBlockingResponse` オブジェクトを返します。\n- `response_mode` が `streaming` の場合、 `text/event-stream` で `ChunkWorkflowEvent` オブジェクトのストリームを返します。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
-                },
-                "examples": {
-                  "blockingResponse": {
-                    "summary": "レスポンス例 - ブロッキングモード",
-                    "value": {
-                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
-                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                      "data": {
-                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
-                        "status": "succeeded",
-                        "outputs": {
-                          "result": "Article summary here"
-                        },
-                        "error": null,
-                        "elapsed_time": 2.45,
-                        "total_tokens": 280,
-                        "total_steps": 4,
-                        "created_at": 1705407629,
-                        "finished_at": 1705407631
-                      }
-                    }
-                  }
-                }
-              },
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "Server-Sent Events (SSE) のストリームです。解析は [ストリーミングレスポンスの処理](/ja/api-reference/guides/streaming) に従ってください：`data:` 行を読み取り、`event` フィールドで振り分け、`ping`（キープアライブ。ストリームは `ping` で始まり、その後およそ 10 秒ごとに届きます）は無視します。\n\n**ストリームライフサイクル**：`workflow_finished`、`workflow_paused`、または `error` イベントを受信するとストリームが閉じます。エラーはストリーム内の `error` イベントとして HTTP ステータス `200` で配信されます。ステータスコードではなくイベントペイロードを確認して詳細を取得してください。\n\n**推論イベント**：\n- `reasoning_chunk`：`reasoning_format` が `separated` の LLM ノードが発行する思考過程のデルタです。連続する `reasoning_chunk` イベントを連結すると、完全な推論を復元できます。`is_final: true` のイベントはノードの思考完了を示し、空の `reasoning` を伴う場合があります。ペイロードは `data` の下にあり、チャットアプリとは異なり `message_id` は `null` となり、`conversation_id` は含まれません。並行する `text_chunk` ストリームには `<think>` タグが含まれません。\n\n**人間の入力イベント**：\n- `human_input_required`：ワークフローが人間の入力ノードに到達した際に `workflow_paused` と同時に発行されます。ペイロードの `form_token` を使用して、[人間の入力 API](/ja/api-reference/human-input/get-human-input-form) でフォーム処理を進めます。\n- `human_input_form_filled`：受信者がフォームを送信し、ワークフロー実行が再開されます。\n- `human_input_form_timeout`：応答がないままフォームが期限切れ。タイムアウトのフォールバックエッジが定義されている場合、ワークフローはそのエッジを通って実行されます。"
-                },
-                "examples": {
-                  "streamingResponse": {
-                    "summary": "レスポンス例 - ストリーミングモード",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"Translate this\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Let me translate that.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
-                  },
-                  "humanInputPause": {
-                    "summary": "レスポンス例 - 人間の入力での一時停止",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"Hello\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"form_content\": \"ドラフトを確認してください。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"承認\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_workflow_app` : App mode does not match the API route.\n- `bad_request` : Workflow is a draft or has an invalid ID format.\n- `provider_not_initialize` : 有効なモデルプロバイダーの認証情報が見つかりません。\n- `provider_quota_exceeded` : モデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support` : 現在のモデルは利用できません。\n- `completion_request_error` : Workflow execution request failed.\n- `invalid_param` : リクエストパラメータが不足または無効です（`user` の欠落など）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "bad_request": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "Cannot use draft workflow version. Workflow ID: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345. Please use a published workflow version or leave workflow_id empty."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`workflow_version_execution_not_allowed` : Dify Cloud の Sandbox プランでは、特定のワークフローバージョンを実行できません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "workflow_version_execution_not_allowed": {
-                    "summary": "workflow_version_execution_not_allowed",
-                    "value": {
-                      "status": 403,
-                      "code": "workflow_version_execution_not_allowed",
-                      "message": "Workflow version execution is not available on your current plan. Please upgrade to a paid plan."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ワークフローが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Workflow not found with id: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "- `too_many_requests` : このアプリケーションへの同時リクエストが多すぎます。\n- `rate_limit_error` : このワークスペースの Dify Cloud のワークフロー実行クォータに達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "too_many_requests": {
-                    "summary": "too_many_requests",
-                    "value": {
-                      "status": 429,
-                      "code": "too_many_requests",
-                      "message": "Too many requests. Please try again later."
-                    }
-                  },
-                  "rate_limit_error": {
-                    "summary": "rate_limit_error",
-                    "value": {
-                      "status": 429,
-                      "code": "rate_limit_error",
-                      "message": "Rate Limit Error"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : 内部サーバーエラー。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "Internal Server Error."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/workflow-runs/run-workflow-by-id",
-          "metadata": {
-            "title": "ID でワークフローを実行",
-            "sidebarTitle": "ID でワークフローを実行"
-          }
-        }
-      }
-    },
-    "/workflows/tasks/{task_id}/stop": {
-      "post": {
-        "summary": "ワークフロータスクを停止",
-        "description": "**対象アプリ**：Workflow。\n\n実行中のワークフロータスクを停止します。`streaming` モードでのみサポートされます。",
-        "operationId": "stopWorkflowTaskGenerationJp",
-        "tags": [
-          "ワークフロー実行"
-        ],
-        "parameters": [
-          {
-            "name": "task_id",
-            "in": "path",
-            "required": true,
-            "description": "タスク ID です。[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) のストリーミングイベントから取得します。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "user"
-                ],
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。実行を開始した `user` と一致する必要はありません。停止は `user` にかかわらずタスクに適用されます。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。"
-                  }
-                }
-              },
-              "examples": {
-                "example": {
-                  "summary": "リクエスト例",
-                  "value": {
-                    "user": "user_workflow_123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/SuccessResult"
-          },
-          "400": {
-            "description": "- `not_workflow_app` : アプリモードが API ルートと一致しません。\n- `invalid_param` : リクエストパラメータが不足または無効です（`user` の欠落など）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/workflow-runs/stop-workflow-task",
-          "metadata": {
-            "title": "ワークフロータスクを停止",
-            "sidebarTitle": "ワークフロータスクを停止"
-          }
-        }
-      }
-    },
     "/completion-messages": {
       "post": {
-        "summary": "完了メッセージを送信",
         "description": "**対象アプリ**：テキストジェネレーター。\n\nテキスト生成アプリにリクエストを送信し、生成されたテキストを返します。",
-        "operationId": "createCompletionMessageJp",
-        "tags": [
-          "完了メッセージ"
-        ],
+        "operationId": "createCompletionMessage",
         "requestBody": {
-          "description": "テキスト生成メッセージを作成するためのリクエストボディ。",
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CompletionRequest"
+                "$ref": "#/components/schemas/CompletionRequestPayloadWithUser"
               },
               "examples": {
                 "streaming_example": {
                   "summary": "リクエスト例 - ストリーミングモード",
                   "value": {
                     "inputs": {
-                      "city": "San Francisco"
+                      "city": "サンフランシスコ"
                     },
-                    "query": "Translate 'hello' to Spanish.",
+                    "query": "「こんにちは」をスペイン語に翻訳してください。",
                     "response_mode": "streaming",
                     "user": "abc-123",
                     "files": [
@@ -4391,24 +1632,25 @@
                   "summary": "リクエスト例 - ブロッキングモード",
                   "value": {
                     "inputs": {
-                      "city": "New York"
+                      "city": "ニューヨーク"
                     },
-                    "query": "Summarize the following text: ...",
+                    "query": "次の文章を要約してください：……",
                     "response_mode": "blocking",
                     "user": "def-456"
                   }
                 }
               }
             }
-          }
+          },
+          "required": true,
+          "description": "テキスト生成メッセージを作成するためのリクエストボディ。"
         },
         "responses": {
           "200": {
-            "description": "リクエスト成功。コンテンツタイプと構造はリクエストの `response_mode` パラメータに依存します。\n\n- `response_mode` が `blocking` の場合、 `application/json` で `CompletionResponse` オブジェクトを返します。\n- `response_mode` が `streaming` の場合、 `text/event-stream` で `ChunkCompletionEvent` オブジェクトのストリームを返します。",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CompletionResponse"
+                  "$ref": "#/components/schemas/CompletionBlockingResponse"
                 },
                 "examples": {
                   "blockingResponse": {
@@ -4419,7 +1661,7 @@
                       "id": "b01a39de-3480-4f3e-9f1e-4841a80f8e5e",
                       "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
                       "mode": "completion",
-                      "answer": "Hello World!...",
+                      "answer": "こんにちは、世界！……",
                       "metadata": {
                         "usage": {
                           "prompt_tokens": 1033,
@@ -4444,19 +1686,19 @@
               "text/event-stream": {
                 "schema": {
                   "type": "string",
-                  "description": "サーバー送信イベント (SSE) のストリームです。解析は [ストリーミングレスポンスの処理](/ja/api-reference/guides/streaming) に従ってください：`data:` 行を読み取り、`event` フィールドで振り分け、`ping`（10 秒ごとのキープアライブ）は無視します。イベント構造については `ChunkCompletionEvent` を参照してください。\n\n**ストリームライフサイクル**：応答は `message` チャンクとしてストリーミングされ、`message_end` で終了します。`error` イベントはストリームを早期に終了させます。HTTP ステータスは `200` のままなので、詳細はイベントペイロードを確認してください。"
+                  "description": "テキスト生成中に送信される Server-Sent Events（SSE）。"
                 },
                 "examples": {
                   "streamingResponse": {
                     "summary": "レスポンス例 - ストリーミングモード",
-                    "value": "data: {\"event\": \"message\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"answer\": \" I\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"answer\": \"'m\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"id\": \"5e52ce04-874b-4d27-9045-b3bc80def685\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"metadata\": {\"usage\": {\"prompt_tokens\": 1033, \"prompt_unit_price\": \"0.001\", \"prompt_price_unit\": \"0.001\", \"prompt_price\": \"0.0010330\", \"completion_tokens\": 135, \"completion_unit_price\": \"0.002\", \"completion_price_unit\": \"0.001\", \"completion_price\": \"0.0002700\", \"total_tokens\": 1168, \"total_price\": \"0.0013030\", \"currency\": \"USD\", \"latency\": 1.381760165997548}}}\n\n"
+                    "value": "data: {\"event\": \"message\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"answer\": \"私\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"answer\": \"'m\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"id\": \"5e52ce04-874b-4d27-9045-b3bc80def685\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"metadata\": {\"usage\": {\"prompt_tokens\": 1033, \"prompt_unit_price\": \"0.001\", \"prompt_price_unit\": \"0.001\", \"prompt_price\": \"0.0010330\", \"completion_tokens\": 135, \"completion_unit_price\": \"0.002\", \"completion_price_unit\": \"0.001\", \"completion_price\": \"0.0002700\", \"total_tokens\": 1168, \"total_price\": \"0.0013030\", \"currency\": \"USD\", \"latency\": 1.381760165997548}}}\n\n"
                   }
                 }
               }
-            }
+            },
+            "description": "成功レスポンス。`blocking` モードは `CompletionBlockingResponse` オブジェクトを含む `application/json`、`streaming` モードはテキスト生成のストリーミングイベントを含む `text/event-stream` を返します。"
           },
           "400": {
-            "description": "- `app_unavailable` : アプリケーションが利用できないか、設定が正しくありません。\n- `provider_not_initialize` : 有効なモデルプロバイダーの認証情報が見つかりません。\n- `provider_quota_exceeded` : モデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support` : 現在のモデルは利用できません。\n- `completion_request_error` : テキスト生成に失敗しました。\n- `invalid_param` : 必須の `user` フィールドがありません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4510,10 +1752,56 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `app_unavailable`：アプリケーションが利用できないか、設定が正しくありません。\n- `provider_not_initialize`：有効なモデルプロバイダーの認証情報が見つかりません。\n- `provider_quota_exceeded`：モデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support`：現在のモデルは利用できません。\n- `completion_request_error`：テキスト生成に失敗しました。\n- `invalid_param`：必須の `user` フィールドがありません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "エンドポイント宣言に残る互換性用レスポンスです。このテキスト生成リクエストは `conversation_id` を受け付けず、現在のランタイムも会話検索にこのレスポンスを使用しません。"
           },
           "429": {
-            "description": "`too_many_requests` : このアプリケーションへの同時リクエストが多すぎます。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4527,10 +1815,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`too_many_requests`：このアプリケーションへの同時リクエストが多すぎます。"
           },
           "500": {
-            "description": "`internal_server_error` : 内部サーバーエラー。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4544,59 +1832,51 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`internal_server_error`：内部サーバーエラー。"
           }
         },
+        "summary": "完了メッセージを送信",
+        "tags": [
+          "完了メッセージ"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/completion-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"inputs\": {\"city\": \"サンフランシスコ\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
+          }
+        ],
         "x-mint": {
           "href": "/ja/api-reference/completion-messages/send-completion-message",
           "metadata": {
             "title": "完了メッセージを送信",
             "sidebarTitle": "完了メッセージを送信"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/completion-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"inputs\": {\"city\": \"San Francisco\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/completion-messages/{task_id}/stop": {
       "post": {
-        "summary": "生成を停止",
         "description": "**対象アプリ**：テキストジェネレーター。\n\nテキスト生成メッセージ生成タスクを停止します。`streaming` モードでのみサポートされています。",
-        "operationId": "stopCompletionGenerationJp",
-        "tags": [
-          "完了メッセージ"
-        ],
+        "operationId": "stopGenerate",
         "parameters": [
           {
-            "name": "task_id",
-            "in": "path",
-            "required": true,
             "description": "タスク ID です。[完了メッセージを送信](/ja/api-reference/completion-messages/send-completion-message) のストリーミングイベントから取得します。",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
             "schema": {
+              "description": "テキスト生成メッセージ送信 API が返すストリーミングチャンクから取得するタスク ID。",
               "type": "string"
             }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "user"
-                ],
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。元のメッセージ送信時に渡した `user` と一致する必要があります。一致しない場合、停止は行われず、成功が返されます。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。"
-                  }
-                }
+                "$ref": "#/components/schemas/RequiredServiceApiUserPayload"
               },
               "examples": {
                 "example": {
@@ -4607,14 +1887,24 @@
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "$ref": "#/components/responses/SuccessResult"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "タスクを停止しました"
           },
           "400": {
-            "description": "- `app_unavailable` : アプリケーションが利用できないか、設定が正しくありません。\n- `invalid_param` : 必須の `user` フィールドがありません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4636,14 +1926,864 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `app_unavailable`：アプリケーションが利用できないか、設定が正しくありません。\n- `invalid_param`：必須の `user` フィールドがありません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "互換性のために予約されたレスポンスです。現在のランタイムは停止フラグを設定する前にタスクの存在を確認しないため、タスクがすでに実行中でなくても通常の `200` 結果を返します。"
           }
         },
+        "summary": "生成を停止",
+        "tags": [
+          "完了メッセージ"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/completion-messages/stop-completion-message-generation",
           "metadata": {
             "title": "生成を停止",
             "sidebarTitle": "生成を停止"
+          }
+        }
+      }
+    },
+    "/conversations": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\nエンドユーザーの会話を、最近アクティブな順に一覧表示します。",
+        "operationId": "getConversationsList",
+        "parameters": [
+          {
+            "description": "ページネーションカーソルです。現在のページの最後の会話の `id` を指定します。省略すると最初のページを取得します。",
+            "in": "query",
+            "name": "last_id",
+            "required": false,
+            "schema": {
+              "description": "現在のページの最後のレコード ID。次のページの取得に使用します。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "返すレコード数です。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "返すレコード数です。",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "並べ替えフィールド。降順にするには `-` 接頭辞を使用します。",
+            "in": "query",
+            "name": "sort_by",
+            "required": false,
+            "schema": {
+              "default": "-updated_at",
+              "description": "並べ替えフィールド。降順にするには `-` 接頭辞を使用します。",
+              "enum": [
+                "-created_at",
+                "-updated_at",
+                "created_at",
+                "updated_at"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "エンドユーザーコンテキストに使用するユーザー識別子。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationInfiniteScrollPagination"
+                },
+                "examples": {
+                  "conversationsList": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "limit": 20,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                          "name": "iPhone 仕様チャット",
+                          "inputs": {
+                            "city": "サンフランシスコ"
+                          },
+                          "status": "normal",
+                          "introduction": "ようこそ。本日はどのようなご用件でしょうか？",
+                          "created_at": 1705407629,
+                          "updated_at": 1705411229
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "会話リストの取得に成功しました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_chat_app`：アプリモードが API ルートと一致しません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "last_conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Last Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：前の会話が存在しません（無効な `last_id`）。"
+          }
+        },
+        "summary": "会話一覧を取得",
+        "tags": [
+          "会話管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/conversations/list-conversations",
+          "metadata": {
+            "title": "会話一覧を取得",
+            "sidebarTitle": "会話一覧を取得"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}": {
+      "delete": {
+        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\n会話を削除します。",
+        "operationId": "deleteConversation",
+        "parameters": [
+          {
+            "description": "削除する会話の ID です。会話 ID は [会話一覧を取得](/ja/api-reference/conversations/list-conversations) から取得します。",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "会話 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OptionalServiceApiUserPayload"
+              },
+              "examples": {
+                "deleteExample": {
+                  "value": {
+                    "user": "abc-123"
+                  },
+                  "summary": "リクエスト例"
+                }
+              }
+            }
+          },
+          "required": true,
+          "description": "JSON ボディは常に必須です。`user` を省略する場合は `{}` を送信してください。"
+        },
+        "responses": {
+          "204": {
+            "description": "会話の削除に成功しました。コンテンツは返されません。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_chat_app`：アプリモードが API ルートと一致しません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：会話が存在しません。"
+          }
+        },
+        "summary": "会話を削除",
+        "tags": [
+          "会話管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/conversations/delete-conversation",
+          "metadata": {
+            "title": "会話を削除",
+            "sidebarTitle": "会話を削除"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}/name": {
+      "post": {
+        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\n会話の名前を変更します。`auto_generate` が `true` の場合は、メッセージから名前を自動生成します。この名前は、複数会話のリストでクライアントが表示するものです。",
+        "operationId": "renameConversation",
+        "parameters": [
+          {
+            "description": "名前を変更する会話の ID です。会話 ID は [会話一覧を取得](/ja/api-reference/conversations/list-conversations) から取得します。",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "会話 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConversationRenamePayloadWithUser"
+              },
+              "examples": {
+                "renameExample": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "name": "iPhone 仕様チャット",
+                    "user": "abc-123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleConversation"
+                },
+                "examples": {
+                  "renamedConversation": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                      "name": "iPhone 仕様チャット",
+                      "inputs": {
+                        "city": "サンフランシスコ"
+                      },
+                      "status": "normal",
+                      "introduction": "ようこそ。本日はどのようなご用件でしょうか？",
+                      "created_at": 1705407629,
+                      "updated_at": 1705411229
+                    }
+                  }
+                }
+              }
+            },
+            "description": "会話が正常に名前変更されました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "no_messages": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app`：アプリモードが API ルートと一致しません。\n- `invalid_param`：`auto_generate` が `true` ですが、名前を生成するためのメッセージが会話にありません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：会話が存在しません。"
+          }
+        },
+        "summary": "会話の名前を変更",
+        "tags": [
+          "会話管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/conversations/rename-conversation",
+          "metadata": {
+            "title": "会話の名前を変更",
+            "sidebarTitle": "会話の名前を変更"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}/variables": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\n会話に保存された変数を一覧表示します。",
+        "operationId": "getConversationVariables",
+        "parameters": [
+          {
+            "description": "変数を一覧表示する会話の ID です。会話 ID は [会話一覧を取得](/ja/api-reference/conversations/list-conversations) から取得します。",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "会話 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ページネーションカーソルです。現在のページの最後の変数の `id` を指定します。省略すると最初のページを取得します。",
+            "in": "query",
+            "name": "last_id",
+            "required": false,
+            "schema": {
+              "description": "現在のページの最後のレコード ID。次のページの取得に使用します。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "返すレコード数です。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "返すレコード数です。",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "エンドユーザーコンテキストに使用するユーザー識別子。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "指定した名前で変数をフィルタリングします。",
+            "in": "query",
+            "name": "variable_name",
+            "required": false,
+            "schema": {
+              "description": "指定した名前で変数をフィルタリングします。",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationVariableInfiniteScrollPaginationResponse"
+                },
+                "examples": {
+                  "conversationVariables": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "limit": 20,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "name": "user_preference",
+                          "value_type": "string",
+                          "value": "dark_mode",
+                          "description": "ユーザー設定",
+                          "created_at": 1705407629,
+                          "updated_at": 1705411229
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "会話変数の取得に成功しました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "invalid_last_id": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app`：アプリモードが API ルートと一致しません。\n- `invalid_param`：`last_id` がこの会話のどの変数にも一致しません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：会話が存在しません。"
+          }
+        },
+        "summary": "会話変数の取得",
+        "tags": [
+          "会話管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/conversations/list-conversation-variables",
+          "metadata": {
+            "title": "会話変数の取得",
+            "sidebarTitle": "会話変数の取得"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}/variables/{variable_id}": {
+      "put": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent。\n\n会話変数の値を更新します。新しい値は変数の既存の型と一致する必要があります。",
+        "operationId": "updateChatConversationVariable",
+        "parameters": [
+          {
+            "description": "変数が属する会話の ID です。会話 ID は [会話一覧を取得](/ja/api-reference/conversations/list-conversations) から取得します。",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "会話 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "更新する変数の ID です。変数 ID は [会話変数の取得](/ja/api-reference/conversations/list-conversation-variables) から取得します。",
+            "in": "path",
+            "name": "variable_id",
+            "required": true,
+            "schema": {
+              "description": "変数 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConversationVariableUpdatePayloadWithUser"
+              },
+              "examples": {
+                "updateStringVariable": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "value": "新しい値",
+                    "user": "abc-123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationVariableResponse"
+                },
+                "examples": {
+                  "updatedVariable": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "name": "user_preference",
+                      "value_type": "string",
+                      "value": "新しい値",
+                      "description": "ユーザー設定",
+                      "created_at": 1705407629,
+                      "updated_at": 1705411229
+                    }
+                  }
+                }
+              }
+            },
+            "description": "変数が正常に更新されました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "type_mismatch": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "Type mismatch: variable 'user_preference' expects string, but got number type"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app`：アプリモードが API ルートと一致しません。\n- `bad_request`：変数値の型が一致しません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  },
+                  "variable_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Variable Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：会話が存在しません。\n- `not_found`：会話変数が存在しません。"
+          }
+        },
+        "summary": "会話変数を更新",
+        "tags": [
+          "会話管理"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/conversations/update-conversation-variable",
+          "metadata": {
+            "title": "会話変数を更新",
+            "sidebarTitle": "会話変数を更新"
           }
         }
       }
@@ -5042,6 +3182,645 @@
           "metadata": {
             "title": "ナレッジベースリストを取得",
             "sidebarTitle": "ナレッジベースリストを取得"
+          }
+        }
+      }
+    },
+    "/datasets/pipeline/file-upload": {
+      "post": {
+        "tags": [
+          "ナレッジパイプライン"
+        ],
+        "summary": "パイプラインファイルをアップロード",
+        "description": "ナレッジパイプラインで使用するファイルをアップロードします。返された `id` を [パイプラインを実行](/ja/api-reference/knowledge-pipeline/run-pipeline) の `local_file` アイテムの `reference` として使用します。",
+        "operationId": "uploadPipelineFileJa",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "アップロードするファイル。`multipart/form-data` の 1 パートとして送信します。ドキュメントファイルのデフォルト上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。\n\nDify Cloud の Professional と Team プランではドキュメントの上限が 50 MB になります。画像・音声・動画ファイルには別の上限があり、デフォルトはそれぞれ 10 MB、50 MB、100 MB です。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "ファイルが正常にアップロードされました。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "アップロードされたファイルの一意識別子です。"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "元のファイル名です。"
+                    },
+                    "size": {
+                      "type": "integer",
+                      "description": "ファイルサイズ（バイト）。"
+                    },
+                    "extension": {
+                      "type": "string",
+                      "description": "ファイル拡張子。"
+                    },
+                    "mime_type": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "ファイルの MIME タイプです。アップロードに MIME タイプが含まれない場合、`null` となることがあります。"
+                    },
+                    "created_by": {
+                      "type": "string",
+                      "description": "ファイルをアップロードしたユーザーの ID。"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "アップロードのタイムスタンプ（ISO 8601 形式）です。レコード作成中は `null` となることがあります。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "name": "report.pdf",
+                      "size": 524288,
+                      "extension": "pdf",
+                      "mime_type": "application/pdf",
+                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "created_at": "2025-03-06T12:00:00"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `no_file_uploaded` : リクエストにファイルが提供されていません。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "`file_too_large` : ファイルサイズの上限を超えています。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "`unsupported_file_type` : 許可されていないファイルタイプです。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/knowledge-pipeline/upload-pipeline-file",
+          "metadata": {
+            "title": "パイプラインファイルをアップロード",
+            "sidebarTitle": "パイプラインファイルをアップロード"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
+          }
+        ]
+      }
+    },
+    "/datasets/tags": {
+      "post": {
+        "tags": [
+          "タグ管理"
+        ],
+        "summary": "ナレッジベースタグを作成",
+        "description": "ナレッジベースを整理するためのタグを作成します。",
+        "operationId": "createKnowledgeTag",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50,
+                    "description": "タグ名です。ワークスペース内で一意である必要があります。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "タグが正常に作成されました。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "タグ識別子です。"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "タグの表示名です。"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
+                    },
+                    "binding_count": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "このタグにバインドされたナレッジベースの数です。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                      "name": "Product Docs",
+                      "type": "knowledge",
+                      "binding_count": "0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_param` : 同じ名前のナレッジタグが既に存在します。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Tag name already exists"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/tags/create-knowledge-tag",
+          "metadata": {
+            "title": "ナレッジベースタグを作成",
+            "sidebarTitle": "ナレッジベースタグを作成"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "タグ管理"
+        ],
+        "summary": "ナレッジベースタグリストを取得",
+        "description": "ワークスペース内のすべてのナレッジベースタグを返します。",
+        "operationId": "getKnowledgeTags",
+        "responses": {
+          "200": {
+            "description": "タグのリストです。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "タグ識別子です。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "タグの表示名です。"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
+                      },
+                      "binding_count": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "このタグにバインドされたナレッジベースの数です。"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": [
+                      {
+                        "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                        "name": "Product Docs",
+                        "type": "knowledge",
+                        "binding_count": "0"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/tags/list-knowledge-tags",
+          "metadata": {
+            "title": "ナレッジベースタグリストを取得",
+            "sidebarTitle": "ナレッジベースタグリストを取得"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "タグ管理"
+        ],
+        "summary": "ナレッジベースタグを変更",
+        "description": "ナレッジベースタグの名前を変更します。",
+        "operationId": "updateKnowledgeTag",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tag_id",
+                  "name"
+                ],
+                "properties": {
+                  "tag_id": {
+                    "type": "string",
+                    "description": "名前を変更するタグの ID です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。"
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50,
+                    "description": "タグの新しい名前です。ワークスペース内で一意である必要があります。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "タグが正常に更新されました。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "タグ識別子です。"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "タグの表示名です。"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
+                    },
+                    "binding_count": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "このタグにバインドされたナレッジベースの数です。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                      "name": "Product Docs",
+                      "type": "knowledge",
+                      "binding_count": "0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_param` : 同じ名前のナレッジタグが既に存在します。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Tag name already exists"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : 指定されたタグが存在しません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Tag not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/tags/update-knowledge-tag",
+          "metadata": {
+            "title": "ナレッジベースタグを変更",
+            "sidebarTitle": "ナレッジベースタグを変更"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "タグ管理"
+        ],
+        "summary": "ナレッジベースタグを削除",
+        "description": "ナレッジベースタグを完全に削除します。タグ付けされたナレッジベース自体は削除されません。",
+        "operationId": "deleteKnowledgeTag",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tag_id"
+                ],
+                "properties": {
+                  "tag_id": {
+                    "type": "string",
+                    "description": "削除するタグの ID です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "404": {
+            "description": "`not_found` : 指定されたタグが存在しません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Tag not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/tags/delete-knowledge-tag",
+          "metadata": {
+            "title": "ナレッジベースタグを削除",
+            "sidebarTitle": "ナレッジベースタグを削除"
+          }
+        }
+      }
+    },
+    "/datasets/tags/binding": {
+      "post": {
+        "tags": [
+          "タグ管理"
+        ],
+        "summary": "タグをナレッジベースにバインド",
+        "description": "ナレッジベースに 1 つ以上のタグをバインドします。ナレッジベースには複数のタグを設定できます。",
+        "operationId": "bindTagsToDataset",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tag_ids",
+                  "target_id"
+                ],
+                "properties": {
+                  "tag_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "description": "バインドするタグの ID です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。 不明なタグ ID はエラーにならず無視されます。"
+                  },
+                  "target_id": {
+                    "type": "string",
+                    "description": "タグをバインドするナレッジベースです。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "404": {
+            "description": "`not_found` : 対象のナレッジベースが存在しません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/tags/create-tag-binding",
+          "metadata": {
+            "title": "タグをナレッジベースにバインド",
+            "sidebarTitle": "タグをナレッジベースにバインド"
+          }
+        }
+      }
+    },
+    "/datasets/tags/unbinding": {
+      "post": {
+        "tags": [
+          "タグ管理"
+        ],
+        "summary": "タグとナレッジベースのバインドを解除",
+        "description": "ナレッジベースから 1 つまたは複数のタグを削除します。",
+        "operationId": "unbindTagFromDataset",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "target_id"
+                ],
+                "properties": {
+                  "tag_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "description": "バインド解除するタグ ID のリストです。旧版の `tag_id` を指定しない限り必須です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。"
+                  },
+                  "tag_id": {
+                    "type": "string",
+                    "deprecated": true,
+                    "description": "旧版の単一タグ用フィールドです。サーバーサイドで `tag_ids` に正規化されます。新規連携では `tag_ids` を使用してください。"
+                  },
+                  "target_id": {
+                    "type": "string",
+                    "description": "タグのバインドを解除するナレッジベースです。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "404": {
+            "description": "`not_found` : 対象のナレッジベースが存在しません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/tags/delete-tag-binding",
+          "metadata": {
+            "title": "タグとナレッジベースのバインドを解除",
+            "sidebarTitle": "タグとナレッジベースのバインドを解除"
           }
         }
       }
@@ -5496,6 +4275,275 @@
         }
       }
     },
+    "/datasets/{dataset_id}/document/create-by-file": {
+      "post": {
+        "tags": [
+          "ドキュメント"
+        ],
+        "summary": "ファイルからドキュメントを作成",
+        "description": "アップロードしたファイルからナレッジベースにドキュメントを作成します。PDF、TXT、DOCX などの一般的な形式をサポートします。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメント埋め込みステータス（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。",
+        "operationId": "createDocumentFromFile",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
+                  },
+                  "data": {
+                    "type": "string",
+                    "description": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。",
+                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ドキュメントが正常に作成されました。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "document": {
+                      "$ref": "#/components/schemas/Document"
+                    },
+                    "batch": {
+                      "type": "string",
+                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 0,
+                        "indexing_status": "indexing",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "indexing",
+                        "word_count": 0,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `no_file_uploaded` : リクエストにファイルが提供されていません。\n- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : ナレッジベースが外部です。`indexing_technique` が必須、または `process_rule` がありません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_external": {
+                    "summary": "invalid_param (external)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "External datasets are not supported."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (documents limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The number of documents has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : ナレッジベースが見つかりません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "`file_too_large` : ファイルサイズが上限を超えています。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "service_unavailable": {
+                    "summary": "service_unavailable",
+                    "value": {
+                      "status": 503,
+                      "code": "service_unavailable",
+                      "message": "Unable to verify vector space usage right now. Please try again later."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/documents/create-document-by-file",
+          "metadata": {
+            "title": "ファイルからドキュメントを作成",
+            "sidebarTitle": "ファイルからドキュメントを作成"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
+          }
+        ]
+      }
+    },
     "/datasets/{dataset_id}/document/create-by-text": {
       "post": {
         "tags": [
@@ -5818,275 +4866,6 @@
         }
       }
     },
-    "/datasets/{dataset_id}/document/create-by-file": {
-      "post": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ファイルからドキュメントを作成",
-        "description": "アップロードしたファイルからナレッジベースにドキュメントを作成します。PDF、TXT、DOCX などの一般的な形式をサポートします。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメント埋め込みステータス（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。",
-        "operationId": "createDocumentFromFile",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "file"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
-                  },
-                  "data": {
-                    "type": "string",
-                    "description": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。",
-                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "ドキュメントが正常に作成されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "document": {
-                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "position": 1,
-                        "data_source_type": "upload_file",
-                        "data_source_info": {
-                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                        },
-                        "data_source_detail_dict": {
-                          "upload_file": {
-                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                            "name": "guide.txt",
-                            "size": 2048,
-                            "extension": "txt",
-                            "mime_type": "text/plain",
-                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200
-                          }
-                        },
-                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
-                        "name": "guide.txt",
-                        "created_from": "api",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "tokens": 0,
-                        "indexing_status": "indexing",
-                        "error": null,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "archived": false,
-                        "display_status": "indexing",
-                        "word_count": 0,
-                        "hit_count": 0,
-                        "doc_form": "text_model",
-                        "doc_metadata": [],
-                        "summary_index_status": null,
-                        "need_summary": false
-                      },
-                      "batch": "20250306150245647595"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_file_uploaded` : リクエストにファイルが提供されていません。\n- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : ナレッジベースが外部です。`indexing_technique` が必須、または `process_rule` がありません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_file_uploaded": {
-                    "summary": "no_file_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_file_uploaded",
-                      "message": "Please upload your file."
-                    }
-                  },
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "invalid_param_external": {
-                    "summary": "invalid_param (external)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "External datasets are not supported."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (documents limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The number of documents has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : ファイルサイズが上限を超えています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": "File size exceeded."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/documents/create-document-by-file",
-          "metadata": {
-            "title": "ファイルからドキュメントを作成",
-            "sidebarTitle": "ファイルからドキュメントを作成"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
-          }
-        ]
-      }
-    },
     "/datasets/{dataset_id}/documents": {
       "get": {
         "tags": [
@@ -6277,6 +5056,664 @@
           "metadata": {
             "title": "ナレッジベースのドキュメントリストを取得",
             "sidebarTitle": "ナレッジベースのドキュメントリストを取得"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/download-zip": {
+      "post": {
+        "tags": [
+          "ドキュメント"
+        ],
+        "summary": "ドキュメントを一括ダウンロード（ZIP）",
+        "description": "1 つ以上のドキュメントを単一の ZIP アーカイブとしてダウンロードします。ファイルとしてアップロードされたドキュメントのみ含められます。",
+        "operationId": "downloadDocumentsZipJa",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "document_ids"
+                ],
+                "properties": {
+                  "document_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "description": "アーカイブに含めるドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "リクエストされたドキュメントを含む ZIP アーカイブです。",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary",
+                  "description": "ZIP アーカイブのバイナリストリームです。"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden` : このナレッジベースにアクセスする権限がありません。\n- `forbidden` : リクエストされたドキュメントのいずれかにアクセスする権限がありません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (dataset permission)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You do not have permission to access this dataset."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden (document permission)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "No permission."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "- `not_found` : ドキュメントが見つかりません。\n- `not_found` : ナレッジベースが見つかりません。 リクエストしたドキュメントにアップロード済みファイルがない場合は \"Only uploaded-file documents can be downloaded as ZIP.\" が返ります。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found_3",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Only uploaded-file documents can be downloaded as ZIP."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/documents/download-documents-as-zip",
+          "metadata": {
+            "title": "ドキュメントを一括ダウンロード（ZIP）",
+            "sidebarTitle": "ドキュメントを一括ダウンロード（ZIP）"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/metadata": {
+      "post": {
+        "tags": [
+          "メタデータ"
+        ],
+        "summary": "ドキュメントメタデータを一括更新",
+        "description": "複数のドキュメントのメタデータ値を 1 回のリクエストで更新します。",
+        "operationId": "batchUpdateDocumentMetadataJa",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "operation_data"
+                ],
+                "properties": {
+                  "operation_data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "document_id",
+                        "metadata_list"
+                      ],
+                      "properties": {
+                        "document_id": {
+                          "type": "string",
+                          "description": "更新するドキュメントの ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) を参照してください。"
+                        },
+                        "metadata_list": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "id",
+                              "name"
+                            ],
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "メタデータフィールド ID です。[メタデータフィールドリストを取得](/ja/api-reference/metadata/list-metadata-fields) を参照してください。"
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "メタデータフィールド名です。"
+                              },
+                              "value": {
+                                "description": "メタデータ値。文字列、数値、または `null` を指定できます。"
+                              }
+                            }
+                          },
+                          "description": "ドキュメントに設定するメタデータフィールドです。"
+                        },
+                        "partial_update": {
+                          "type": "boolean",
+                          "default": false,
+                          "description": "メタデータを部分的に更新し、未指定フィールドの既存の値を保持するかどうかです。"
+                        }
+                      }
+                    },
+                    "description": "ドキュメントメタデータの更新操作です。ドキュメントごとに 1 エントリです。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ドキュメントメタデータが正常に更新されました。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "description": "操作結果です。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "result": "success"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_param` : このリクエスト内のドキュメントで別のメタデータ操作が実行中です。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Another document metadata operation is running, please wait a moment."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : `operation_data` で参照されたドキュメントがこのナレッジベースに存在しません。\n- `not_found` : `metadata_list` で参照されたメタデータフィールドがこのナレッジベースに存在しません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found (knowledge base)",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found (document)",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found (metadata)",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Metadata not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/metadata/update-document-metadata-in-batch",
+          "metadata": {
+            "title": "ドキュメントメタデータを一括更新",
+            "sidebarTitle": "ドキュメントメタデータを一括更新"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/status/{action}": {
+      "patch": {
+        "tags": [
+          "ドキュメント"
+        ],
+        "summary": "ドキュメントステータスを一括更新",
+        "description": "複数のドキュメントを 1 回のリクエストで有効化、無効化、アーカイブ、またはアーカイブ解除します。",
+        "operationId": "batchUpdateDocumentStatus",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+          },
+          {
+            "name": "action",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enable",
+                "disable",
+                "archive",
+                "un_archive"
+              ]
+            },
+            "description": "`enable` はドキュメントを検索対象として有効化し、`disable` は無効化し、`archive` はアーカイブに移動し、`un_archive` はアーカイブから復元します。"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "document_ids"
+                ],
+                "properties": {
+                  "document_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "更新するドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ドキュメントが正常に更新されました。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "description": "操作結果です。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "result": "success"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_action` : アクションが無効です。またはドキュメントがアクションを許可しない状態です（インデックス中、または未完了など）。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_action": {
+                    "summary": "invalid_action",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_action",
+                      "message": "Invalid action."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : ナレッジベースが見つかりません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/documents/update-document-status-in-batch",
+          "metadata": {
+            "title": "ドキュメントステータスを一括更新",
+            "sidebarTitle": "ドキュメントステータスを一括更新"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{batch}/indexing-status": {
+      "get": {
+        "tags": [
+          "ドキュメント"
+        ],
+        "summary": "ドキュメント埋め込みステータス（進捗）を取得",
+        "description": "バッチ内のすべてのドキュメントのインデックス進捗（現在の段階とチャンク完了数）を返します。各 `indexing_status` が `completed` または `error` に達するまでポーリングします。ステータスは `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed` の順に進みます。",
+        "operationId": "getDocumentIndexingStatus",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+          },
+          {
+            "name": "batch",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ドキュメントの作成時または更新時に返されるバッチ ID です。"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "バッチ内のドキュメントのインデックス状態です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "ドキュメント識別子です。"
+                          },
+                          "indexing_status": {
+                            "type": "string",
+                            "description": "現在のインデックスステータスです：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、または `error`。"
+                          },
+                          "processing_started_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "処理開始時の Unix タイムスタンプです。"
+                          },
+                          "parsing_completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "解析完了時の Unix タイムスタンプです。"
+                          },
+                          "cleaning_completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "クリーニング完了時の Unix タイムスタンプです。"
+                          },
+                          "splitting_completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "分割完了時の Unix タイムスタンプです。"
+                          },
+                          "completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "インデックス完了時の Unix タイムスタンプです。"
+                          },
+                          "paused_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "インデキシングが一時停止されたタイムスタンプ。一時停止されていない場合は `null`。"
+                          },
+                          "error": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "インデキシングが失敗した場合のエラーメッセージ。エラーがない場合は `null`。"
+                          },
+                          "stopped_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "インデキシングが停止されたタイムスタンプ。停止されていない場合は `null`。"
+                          },
+                          "completed_segments": {
+                            "type": "integer",
+                            "description": "インデックス済みのチャンク数です。"
+                          },
+                          "total_segments": {
+                            "type": "integer",
+                            "description": "インデックス対象のチャンクの合計数です。"
+                          }
+                        }
+                      },
+                      "description": "インデキシングステータスエントリのリスト。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                          "indexing_status": "completed",
+                          "processing_started_at": 1741267200,
+                          "parsing_completed_at": 1741267200,
+                          "cleaning_completed_at": 1741267200,
+                          "splitting_completed_at": 1741267200,
+                          "completed_at": 1741267200,
+                          "paused_at": null,
+                          "error": null,
+                          "stopped_at": null,
+                          "completed_segments": 5,
+                          "total_segments": 5
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "documents_not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Documents not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/documents/get-document-indexing-status",
+          "metadata": {
+            "title": "ドキュメント埋め込みステータス（進捗）を取得",
+            "sidebarTitle": "ドキュメント埋め込みステータス（進捗）を取得"
           }
         }
       }
@@ -7167,1068 +6604,6 @@
           "metadata": {
             "title": "ドキュメントをダウンロード",
             "sidebarTitle": "ドキュメントをダウンロード"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{batch}/indexing-status": {
-      "get": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ドキュメント埋め込みステータス（進捗）を取得",
-        "description": "バッチ内のすべてのドキュメントのインデックス進捗（現在の段階とチャンク完了数）を返します。各 `indexing_status` が `completed` または `error` に達するまでポーリングします。ステータスは `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed` の順に進みます。",
-        "operationId": "getDocumentIndexingStatus",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "batch",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "ドキュメントの作成時または更新時に返されるバッチ ID です。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "バッチ内のドキュメントのインデックス状態です。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "ドキュメント識別子です。"
-                          },
-                          "indexing_status": {
-                            "type": "string",
-                            "description": "現在のインデックスステータスです：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、または `error`。"
-                          },
-                          "processing_started_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "処理開始時の Unix タイムスタンプです。"
-                          },
-                          "parsing_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "解析完了時の Unix タイムスタンプです。"
-                          },
-                          "cleaning_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "クリーニング完了時の Unix タイムスタンプです。"
-                          },
-                          "splitting_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "分割完了時の Unix タイムスタンプです。"
-                          },
-                          "completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "インデックス完了時の Unix タイムスタンプです。"
-                          },
-                          "paused_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "インデキシングが一時停止されたタイムスタンプ。一時停止されていない場合は `null`。"
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "インデキシングが失敗した場合のエラーメッセージ。エラーがない場合は `null`。"
-                          },
-                          "stopped_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "インデキシングが停止されたタイムスタンプ。停止されていない場合は `null`。"
-                          },
-                          "completed_segments": {
-                            "type": "integer",
-                            "description": "インデックス済みのチャンク数です。"
-                          },
-                          "total_segments": {
-                            "type": "integer",
-                            "description": "インデックス対象のチャンクの合計数です。"
-                          }
-                        }
-                      },
-                      "description": "インデキシングステータスエントリのリスト。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                          "indexing_status": "completed",
-                          "processing_started_at": 1741267200,
-                          "parsing_completed_at": 1741267200,
-                          "cleaning_completed_at": 1741267200,
-                          "splitting_completed_at": 1741267200,
-                          "completed_at": 1741267200,
-                          "paused_at": null,
-                          "error": null,
-                          "stopped_at": null,
-                          "completed_segments": 5,
-                          "total_segments": 5
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "dataset_not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "documents_not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Documents not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/documents/get-document-indexing-status",
-          "metadata": {
-            "title": "ドキュメント埋め込みステータス（進捗）を取得",
-            "sidebarTitle": "ドキュメント埋め込みステータス（進捗）を取得"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/update-by-text": {
-      "post": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "テキストでドキュメントを更新",
-        "description": "ドキュメントのテキスト内容、名前、または処理設定を更新します。テキストが変更されると、ドキュメントを再インデックスします。",
-        "operationId": "updateDocumentByText",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "ドキュメント名です。`text` を指定する場合は必須です。"
-                  },
-                  "text": {
-                    "type": "string",
-                    "description": "ドキュメントのテキスト内容です。"
-                  },
-                  "process_rule": {
-                    "type": "object",
-                    "description": "チャンキングの処理ルールです。",
-                    "required": [
-                      "mode"
-                    ],
-                    "properties": {
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "automatic",
-                          "custom",
-                          "hierarchical"
-                        ],
-                        "description": "`automatic` は組み込みルールを使用、`custom` は手動設定が可能、`hierarchical` は親子チャンク構造を有効にします（`doc_form: hierarchical_model` と組み合わせて使用）。"
-                      },
-                      "rules": {
-                        "type": "object",
-                        "properties": {
-                          "pre_processing_rules": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "enum": [
-                                    "remove_stopwords",
-                                    "remove_extra_spaces",
-                                    "remove_urls_emails"
-                                  ],
-                                  "description": "ルール識別子です。"
-                                },
-                                "enabled": {
-                                  "type": "boolean",
-                                  "description": "この前処理ルールが有効かどうかです。"
-                                }
-                              }
-                            }
-                          },
-                          "segmentation": {
-                            "type": "object",
-                            "properties": {
-                              "separator": {
-                                "type": "string",
-                                "default": "\n",
-                                "description": "テキスト分割用のカスタムセパレーターです。"
-                              },
-                              "max_tokens": {
-                                "type": "integer",
-                                "description": "チャンクあたりの最大トークン数です。"
-                              },
-                              "chunk_overlap": {
-                                "type": "integer",
-                                "default": 0,
-                                "description": "チャンク間のトークンオーバーラップです。"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "doc_form": {
-                    "type": "string",
-                    "enum": [
-                      "text_model",
-                      "hierarchical_model",
-                      "qa_model"
-                    ],
-                    "default": "text_model",
-                    "description": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。"
-                  },
-                  "doc_language": {
-                    "type": "string",
-                    "default": "English",
-                    "description": "処理最適化のためのドキュメント言語です。"
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "このナレッジベースをクエリする際のチャンクの検索方法とランキング方法を制御します。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "ドキュメントが正常に更新されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "document": {
-                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "position": 1,
-                        "data_source_type": "upload_file",
-                        "data_source_info": {
-                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                        },
-                        "data_source_detail_dict": {
-                          "upload_file": {
-                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                            "name": "guide.txt",
-                            "size": 2048,
-                            "extension": "txt",
-                            "mime_type": "text/plain",
-                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200
-                          }
-                        },
-                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
-                        "name": "guide.txt",
-                        "created_from": "api",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "tokens": 512,
-                        "indexing_status": "completed",
-                        "error": null,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "archived": false,
-                        "display_status": "available",
-                        "word_count": 350,
-                        "hit_count": 0,
-                        "doc_form": "text_model",
-                        "doc_metadata": [],
-                        "summary_index_status": null,
-                        "need_summary": false
-                      },
-                      "batch": "20250306150245647595"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : `text` を指定する場合は `name` が必須です。または `doc_form` が無効です。\n- `invalid_param` : ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "invalid_param_name": {
-                    "summary": "invalid_param (name required)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "name is required when text is provided."
-                    }
-                  },
-                  "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Document is not available"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/documents/update-document-by-text",
-          "metadata": {
-            "title": "テキストでドキュメントを更新",
-            "sidebarTitle": "テキストでドキュメントを更新"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/update-by-file": {
-      "post": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ファイルでドキュメントを更新",
-        "description": "非推奨です。代わりに [ドキュメントを更新](/ja/api-reference/documents/update-document) を使用してください。新しいファイルをアップロードしてドキュメントを更新し、再インデックスします。",
-        "operationId": "updateDocumentByFile",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
-                  },
-                  "data": {
-                    "type": "string",
-                    "description": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。",
-                    "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "ドキュメントが正常に更新されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "document": {
-                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "position": 1,
-                        "data_source_type": "upload_file",
-                        "data_source_info": {
-                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                        },
-                        "data_source_detail_dict": {
-                          "upload_file": {
-                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                            "name": "guide.txt",
-                            "size": 2048,
-                            "extension": "txt",
-                            "mime_type": "text/plain",
-                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200
-                          }
-                        },
-                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
-                        "name": "guide.txt",
-                        "created_from": "api",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "tokens": 512,
-                        "indexing_status": "completed",
-                        "error": null,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "archived": false,
-                        "display_status": "available",
-                        "word_count": 350,
-                        "hit_count": 0,
-                        "doc_form": "text_model",
-                        "doc_metadata": [],
-                        "summary_index_status": null,
-                        "need_summary": false
-                      },
-                      "batch": "20250306150245647595"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Document is not available"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : ファイルサイズが上限を超えています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": "File size exceeded."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_file_type` : 許可されていないファイルタイプです。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_file_type": {
-                    "summary": "unsupported_file_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_file_type",
-                      "message": "File type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "deprecated": true,
-        "x-mint": {
-          "href": "/ja/api-reference/documents/update-document-by-file",
-          "metadata": {
-            "title": "ファイルでドキュメントを更新",
-            "sidebarTitle": "ファイルでドキュメントを更新"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/download-zip": {
-      "post": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ドキュメントを一括ダウンロード（ZIP）",
-        "description": "1 つ以上のドキュメントを単一の ZIP アーカイブとしてダウンロードします。ファイルとしてアップロードされたドキュメントのみ含められます。",
-        "operationId": "downloadDocumentsZipJa",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 100,
-                    "items": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "description": "アーカイブに含めるドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "リクエストされたドキュメントを含む ZIP アーカイブです。",
-            "content": {
-              "application/zip": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary",
-                  "description": "ZIP アーカイブのバイナリストリームです。"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden` : このナレッジベースにアクセスする権限がありません。\n- `forbidden` : リクエストされたドキュメントのいずれかにアクセスする権限がありません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (dataset permission)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "You do not have permission to access this dataset."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (document permission)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "No permission."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : ドキュメントが見つかりません。\n- `not_found` : ナレッジベースが見つかりません。 リクエストしたドキュメントにアップロード済みファイルがない場合は \"Only uploaded-file documents can be downloaded as ZIP.\" が返ります。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found_3",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Only uploaded-file documents can be downloaded as ZIP."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/documents/download-documents-as-zip",
-          "metadata": {
-            "title": "ドキュメントを一括ダウンロード（ZIP）",
-            "sidebarTitle": "ドキュメントを一括ダウンロード（ZIP）"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/status/{action}": {
-      "patch": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ドキュメントステータスを一括更新",
-        "description": "複数のドキュメントを 1 回のリクエストで有効化、無効化、アーカイブ、またはアーカイブ解除します。",
-        "operationId": "batchUpdateDocumentStatus",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable",
-                "archive",
-                "un_archive"
-              ]
-            },
-            "description": "`enable` はドキュメントを検索対象として有効化し、`disable` は無効化し、`archive` はアーカイブに移動し、`un_archive` はアーカイブから復元します。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "更新するドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "ドキュメントが正常に更新されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作結果です。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "result": "success"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_action` : アクションが無効です。またはドキュメントがアクションを許可しない状態です（インデックス中、または未完了など）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_action": {
-                    "summary": "invalid_action",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_action",
-                      "message": "Invalid action."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/documents/update-document-status-in-batch",
-          "metadata": {
-            "title": "ドキュメントステータスを一括更新",
-            "sidebarTitle": "ドキュメントステータスを一括更新"
           }
         }
       }
@@ -10117,14 +8492,14 @@
         }
       }
     },
-    "/datasets/{dataset_id}/retrieve": {
+    "/datasets/{dataset_id}/documents/{document_id}/update-by-file": {
       "post": {
         "tags": [
-          "ナレッジベース"
+          "ドキュメント"
         ],
-        "summary": "ナレッジベースからチャンクを取得 / テスト検索",
-        "description": "ナレッジベースを検索し、クエリに最も関連性の高いチャンクを返します。本番環境の検索とテスト検索の両方に使用できます。",
-        "operationId": "retrieveSegments",
+        "summary": "ファイルでドキュメントを更新",
+        "description": "非推奨です。代わりに [ドキュメントを更新](/ja/api-reference/documents/update-document) を使用してください。新しいファイルをアップロードしてドキュメントを更新し、再インデックスします。",
+        "operationId": "updateDocumentByFile",
         "parameters": [
           {
             "name": "dataset_id",
@@ -10135,52 +8510,34 @@
               "format": "uuid"
             },
             "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+          },
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "query"
-                ],
                 "properties": {
-                  "query": {
+                  "file": {
                     "type": "string",
-                    "maxLength": 250,
-                    "description": "検索クエリテキストです。"
+                    "format": "binary",
+                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
                   },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "検索モデルの設定です。このナレッジベースをクエリする際のチャンクの検索方法とランキング方法を制御します。"
-                  },
-                  "attachment_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true,
-                    "description": "検索コンテキストに含める添付ファイル ID のリストです。"
-                  },
-                  "external_retrieval_model": {
-                    "type": "object",
-                    "description": "外部ナレッジベースの検索設定です。",
-                    "properties": {
-                      "top_k": {
-                        "type": "integer",
-                        "description": "返す結果の最大数です。"
-                      },
-                      "score_threshold": {
-                        "type": "number",
-                        "description": "結果をフィルタリングするための最小類似度スコアのしきい値です。"
-                      },
-                      "score_threshold_enabled": {
-                        "type": "boolean",
-                        "description": "スコアしきい値によるフィルタリングを有効にするかどうか。"
-                      }
-                    }
+                  "data": {
+                    "type": "string",
+                    "description": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。",
+                    "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
                   }
                 }
               }
@@ -10189,233 +8546,18 @@
         },
         "responses": {
           "200": {
-            "description": "検索結果です。",
+            "description": "ドキュメントが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "query": {
-                      "type": "object",
-                      "description": "元のクエリオブジェクトです。",
-                      "properties": {
-                        "content": {
-                          "type": "string",
-                          "description": "クエリテキストです。"
-                        }
-                      }
+                    "document": {
+                      "$ref": "#/components/schemas/Document"
                     },
-                    "records": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "segment": {
-                            "type": "object",
-                            "description": "ナレッジベースから一致したチャンクです。",
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "チャンクの一意識別子です。"
-                              },
-                              "position": {
-                                "type": "integer",
-                                "description": "ドキュメント内のチャンクの位置。"
-                              },
-                              "document_id": {
-                                "type": "string",
-                                "description": "このチャンクが属するドキュメントの ID です。"
-                              },
-                              "content": {
-                                "type": "string",
-                                "description": "チャンクのテキスト内容です。"
-                              },
-                              "sign_content": {
-                                "type": "string",
-                                "description": "整合性検証用の署名付きコンテンツハッシュです。"
-                              },
-                              "answer": {
-                                "type": "string",
-                                "description": "回答コンテンツです。Q&A モードのドキュメントで使用されます。"
-                              },
-                              "word_count": {
-                                "type": "integer",
-                                "description": "チャンク内容の単語数です。"
-                              },
-                              "tokens": {
-                                "type": "integer",
-                                "description": "チャンク内容のトークン数です。"
-                              },
-                              "keywords": {
-                                "type": "array",
-                                "description": "キーワードベースの検索のためにこのチャンクに関連付けられたキーワードです。",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "index_node_id": {
-                                "type": "string",
-                                "description": "ベクトルストア内のインデックスノードの ID です。"
-                              },
-                              "index_node_hash": {
-                                "type": "string",
-                                "description": "インデックスされたコンテンツのハッシュです。変更の検出に使用されます。"
-                              },
-                              "hit_count": {
-                                "type": "integer",
-                                "description": "このチャンクが検索クエリでマッチした回数です。"
-                              },
-                              "enabled": {
-                                "type": "boolean",
-                                "description": "このチャンクが検索に対して有効かどうかです。"
-                              },
-                              "disabled_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "チャンクが無効化されたタイムスタンプです。有効な場合は `null` です。"
-                              },
-                              "disabled_by": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "チャンクを無効化したユーザーの ID です。有効な場合は `null` です。"
-                              },
-                              "status": {
-                                "type": "string",
-                                "description": "チャンクのインデックスステータスです。"
-                              },
-                              "created_by": {
-                                "type": "string",
-                                "description": "チャンクを作成したユーザーの ID です。"
-                              },
-                              "created_at": {
-                                "type": "number",
-                                "description": "作成タイムスタンプ（Unix エポック、秒単位）です。"
-                              },
-                              "indexing_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "インデックス作成が開始されたタイムスタンプです。まだ開始されていない場合は `null` です。"
-                              },
-                              "completed_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "インデックス作成が完了したタイムスタンプです。まだ完了していない場合は `null` です。"
-                              },
-                              "error": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "インデックス作成が失敗した場合のエラーメッセージです。エラーなしの場合は `null` です。"
-                              },
-                              "stopped_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "インデックス作成が停止されたタイムスタンプです。停止されていない場合は `null` です。"
-                              },
-                              "document": {
-                                "type": "object",
-                                "description": "マッチしたチャンクの親ドキュメント情報です。",
-                                "properties": {
-                                  "id": {
-                                    "type": "string",
-                                    "description": "ドキュメントの一意識別子です。"
-                                  },
-                                  "data_source_type": {
-                                    "type": "string",
-                                    "description": "ドキュメントの作成方法です。"
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "ドキュメント名です。"
-                                  },
-                                  "doc_type": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "ドキュメントタイプの分類です。未設定の場合は `null` です。"
-                                  },
-                                  "doc_metadata": {
-                                    "type": "object",
-                                    "nullable": true,
-                                    "description": "ドキュメントのメタデータ値です。メタデータが設定されていない場合は `null` です。"
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "child_chunks": {
-                            "type": "array",
-                            "description": "階層インデックスを使用している場合、チャンク内でマッチした子チャンクです。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "子チャンクの一意識別子です。"
-                                },
-                                "content": {
-                                  "type": "string",
-                                  "description": "子チャンクのテキスト内容です。"
-                                },
-                                "position": {
-                                  "type": "integer",
-                                  "description": "親チャンク内の子チャンクの位置です。"
-                                },
-                                "score": {
-                                  "type": "number",
-                                  "description": "子チャンクの関連性スコアです。"
-                                }
-                              }
-                            }
-                          },
-                          "score": {
-                            "type": "number",
-                            "description": "関連性スコアです。"
-                          },
-                          "tsne_position": {
-                            "type": "object",
-                            "nullable": true,
-                            "description": "t-SNE 可視化の位置です。"
-                          },
-                          "files": {
-                            "type": "array",
-                            "description": "このチャンクに添付されたファイルです。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "添付ファイルの識別子です。"
-                                },
-                                "name": {
-                                  "type": "string",
-                                  "description": "元のファイル名です。"
-                                },
-                                "size": {
-                                  "type": "integer",
-                                  "description": "ファイルサイズ（バイト）。"
-                                },
-                                "extension": {
-                                  "type": "string",
-                                  "description": "ファイル拡張子。"
-                                },
-                                "mime_type": {
-                                  "type": "string",
-                                  "description": "ファイルの MIME タイプ。"
-                                },
-                                "source_url": {
-                                  "type": "string",
-                                  "description": "添付ファイルにアクセスする URL です。"
-                                }
-                              }
-                            }
-                          },
-                          "summary": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "要約インデックス経由で取得された場合の要約コンテンツです。"
-                          }
-                        }
-                      },
-                      "description": "一致した検索レコードのリスト。"
+                    "batch": {
+                      "type": "string",
+                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
                     }
                   }
                 },
@@ -10423,53 +8565,45 @@
                   "success": {
                     "summary": "レスポンス例",
                     "value": {
-                      "query": {
-                        "content": "What is Dify?"
-                      },
-                      "records": [
-                        {
-                          "segment": {
-                            "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                            "position": 1,
-                            "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                            "content": "Dify is an open-source LLM app development platform.",
-                            "sign_content": "",
-                            "answer": "",
-                            "word_count": 9,
-                            "tokens": 12,
-                            "keywords": [
-                              "dify",
-                              "platform",
-                              "llm"
-                            ],
-                            "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
-                            "index_node_hash": "abc123def456",
-                            "hit_count": 1,
-                            "enabled": true,
-                            "disabled_at": null,
-                            "disabled_by": null,
-                            "status": "completed",
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
                             "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200,
-                            "indexing_at": 1741267200,
-                            "completed_at": 1741267200,
-                            "error": null,
-                            "stopped_at": null,
-                            "document": {
-                              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                              "data_source_type": "upload_file",
-                              "name": "guide.txt",
-                              "doc_type": null,
-                              "doc_metadata": null
-                            }
-                          },
-                          "child_chunks": [],
-                          "score": 0.92,
-                          "tsne_position": null,
-                          "files": [],
-                          "summary": null
-                        }
-                      ]
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
                     }
                   }
                 }
@@ -10477,16 +8611,24 @@
             }
           },
           "400": {
-            "description": "- `dataset_not_initialized` : ナレッジベースはまだ初期化中またはインデキシング中です。\n- `provider_not_initialize` : モデルプロバイダーに有効な認証情報が設定されていません。\n- `provider_quota_exceeded` : Dify がホストするモデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support` : 選択したモデルは現在サポートされていません。\n- `completion_request_error` : モデルへのリクエストに失敗しました。\n- `invalid_param` : リクエストパラメータが無効です。",
+            "description": "- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。",
             "content": {
               "application/json": {
                 "examples": {
-                  "dataset_not_initialized": {
-                    "summary": "dataset_not_initialized",
+                  "too_many_files": {
+                    "summary": "too_many_files",
                     "value": {
                       "status": 400,
-                      "code": "dataset_not_initialized",
-                      "message": "The dataset is still being initialized or indexing. Please wait a moment."
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
                     }
                   },
                   "provider_not_initialize": {
@@ -10497,36 +8639,12 @@
                       "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
                     }
                   },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
+                  "invalid_param_not_available": {
+                    "summary": "invalid_param (not available)",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
-                      "message": "Invalid parameter value."
+                      "message": "Document is not available"
                     }
                   }
                 }
@@ -10534,7 +8652,7 @@
             }
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
+            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10547,6 +8665,14 @@
                     }
                   },
                   "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
                     "summary": "forbidden (rate limit)",
                     "value": {
                       "status": 403,
@@ -10559,33 +8685,75 @@
             }
           },
           "404": {
-            "description": "`not_found` : `dataset_id` に一致するナレッジベースがありません。",
+            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
-                  "not_found": {
+                  "not_found_1": {
                     "summary": "not_found",
                     "value": {
                       "status": 404,
                       "code": "not_found",
                       "message": "Dataset not found."
                     }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
                   }
                 }
               }
             }
           },
-          "500": {
-            "description": "`internal_server_error` : 検索中に内部エラーが発生しました。",
+          "413": {
+            "description": "`file_too_large` : ファイルサイズが上限を超えています。",
             "content": {
               "application/json": {
                 "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
+                  "file_too_large": {
+                    "summary": "file_too_large",
                     "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "An internal error occurred."
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "`unsupported_file_type` : 許可されていないファイルタイプです。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "service_unavailable": {
+                    "summary": "service_unavailable",
+                    "value": {
+                      "status": 503,
+                      "code": "service_unavailable",
+                      "message": "Unable to verify vector space usage right now. Please try again later."
                     }
                   }
                 }
@@ -10593,493 +8761,24 @@
             }
           }
         },
+        "deprecated": true,
         "x-mint": {
-          "href": "/ja/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
+          "href": "/ja/api-reference/documents/update-document-by-file",
           "metadata": {
-            "title": "ナレッジベースからチャンクを取得 / テスト検索",
-            "sidebarTitle": "ナレッジベースからチャンクを取得 / テスト検索"
+            "title": "ファイルでドキュメントを更新",
+            "sidebarTitle": "ファイルでドキュメントを更新"
           }
         }
       }
     },
-    "/datasets/tags": {
+    "/datasets/{dataset_id}/documents/{document_id}/update-by-text": {
       "post": {
         "tags": [
-          "タグ管理"
+          "ドキュメント"
         ],
-        "summary": "ナレッジベースタグを作成",
-        "description": "ナレッジベースを整理するためのタグを作成します。",
-        "operationId": "createKnowledgeTag",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "タグ名です。ワークスペース内で一意である必要があります。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "タグが正常に作成されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "タグ識別子です。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "タグの表示名です。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "このタグにバインドされたナレッジベースの数です。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
-                      "type": "knowledge",
-                      "binding_count": "0"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 同じ名前のナレッジタグが既に存在します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Tag name already exists"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/tags/create-knowledge-tag",
-          "metadata": {
-            "title": "ナレッジベースタグを作成",
-            "sidebarTitle": "ナレッジベースタグを作成"
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "ナレッジベースタグリストを取得",
-        "description": "ワークスペース内のすべてのナレッジベースタグを返します。",
-        "operationId": "getKnowledgeTags",
-        "responses": {
-          "200": {
-            "description": "タグのリストです。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "description": "タグ識別子です。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "description": "タグの表示名です。"
-                      },
-                      "type": {
-                        "type": "string",
-                        "description": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
-                      },
-                      "binding_count": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "このタグにバインドされたナレッジベースの数です。"
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": [
-                      {
-                        "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                        "name": "Product Docs",
-                        "type": "knowledge",
-                        "binding_count": "0"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/tags/list-knowledge-tags",
-          "metadata": {
-            "title": "ナレッジベースタグリストを取得",
-            "sidebarTitle": "ナレッジベースタグリストを取得"
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "ナレッジベースタグを変更",
-        "description": "ナレッジベースタグの名前を変更します。",
-        "operationId": "updateKnowledgeTag",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id",
-                  "name"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "名前を変更するタグの ID です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。"
-                  },
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "タグの新しい名前です。ワークスペース内で一意である必要があります。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "タグが正常に更新されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "タグ識別子です。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "タグの表示名です。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "このタグにバインドされたナレッジベースの数です。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
-                      "type": "knowledge",
-                      "binding_count": "0"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 同じ名前のナレッジタグが既に存在します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Tag name already exists"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 指定されたタグが存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Tag not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/tags/update-knowledge-tag",
-          "metadata": {
-            "title": "ナレッジベースタグを変更",
-            "sidebarTitle": "ナレッジベースタグを変更"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "ナレッジベースタグを削除",
-        "description": "ナレッジベースタグを完全に削除します。タグ付けされたナレッジベース自体は削除されません。",
-        "operationId": "deleteKnowledgeTag",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "削除するタグの ID です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : 指定されたタグが存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Tag not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/tags/delete-knowledge-tag",
-          "metadata": {
-            "title": "ナレッジベースタグを削除",
-            "sidebarTitle": "ナレッジベースタグを削除"
-          }
-        }
-      }
-    },
-    "/datasets/tags/binding": {
-      "post": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "タグをナレッジベースにバインド",
-        "description": "ナレッジベースに 1 つ以上のタグをバインドします。ナレッジベースには複数のタグを設定できます。",
-        "operationId": "bindTagsToDataset",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "tag_ids",
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "バインドするタグの ID です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。 不明なタグ ID はエラーにならず無視されます。"
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "タグをバインドするナレッジベースです。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : 対象のナレッジベースが存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/tags/create-tag-binding",
-          "metadata": {
-            "title": "タグをナレッジベースにバインド",
-            "sidebarTitle": "タグをナレッジベースにバインド"
-          }
-        }
-      }
-    },
-    "/datasets/tags/unbinding": {
-      "post": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "タグとナレッジベースのバインドを解除",
-        "description": "ナレッジベースから 1 つまたは複数のタグを削除します。",
-        "operationId": "unbindTagFromDataset",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "バインド解除するタグ ID のリストです。旧版の `tag_id` を指定しない限り必須です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。"
-                  },
-                  "tag_id": {
-                    "type": "string",
-                    "deprecated": true,
-                    "description": "旧版の単一タグ用フィールドです。サーバーサイドで `tag_ids` に正規化されます。新規連携では `tag_ids` を使用してください。"
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "タグのバインドを解除するナレッジベースです。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : 対象のナレッジベースが存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/tags/delete-tag-binding",
-          "metadata": {
-            "title": "タグとナレッジベースのバインドを解除",
-            "sidebarTitle": "タグとナレッジベースのバインドを解除"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/tags": {
-      "get": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "ナレッジベースにバインドされたタグを取得",
-        "description": "ナレッジベースにバインドされたタグを返します。",
-        "operationId": "queryDatasetTags",
+        "summary": "テキストでドキュメントを更新",
+        "description": "ドキュメントのテキスト内容、名前、または処理設定を更新します。テキストが変更されると、ドキュメントを再インデックスします。",
+        "operationId": "updateDocumentByText",
         "parameters": [
           {
             "name": "dataset_id",
@@ -11089,37 +8788,135 @@
               "type": "string",
               "format": "uuid"
             },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+          },
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "ドキュメント名です。`text` を指定する場合は必須です。"
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "ドキュメントのテキスト内容です。"
+                  },
+                  "process_rule": {
+                    "type": "object",
+                    "description": "チャンキングの処理ルールです。",
+                    "required": [
+                      "mode"
+                    ],
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "automatic",
+                          "custom",
+                          "hierarchical"
+                        ],
+                        "description": "`automatic` は組み込みルールを使用、`custom` は手動設定が可能、`hierarchical` は親子チャンク構造を有効にします（`doc_form: hierarchical_model` と組み合わせて使用）。"
+                      },
+                      "rules": {
+                        "type": "object",
+                        "properties": {
+                          "pre_processing_rules": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "enum": [
+                                    "remove_stopwords",
+                                    "remove_extra_spaces",
+                                    "remove_urls_emails"
+                                  ],
+                                  "description": "ルール識別子です。"
+                                },
+                                "enabled": {
+                                  "type": "boolean",
+                                  "description": "この前処理ルールが有効かどうかです。"
+                                }
+                              }
+                            }
+                          },
+                          "segmentation": {
+                            "type": "object",
+                            "properties": {
+                              "separator": {
+                                "type": "string",
+                                "default": "\n",
+                                "description": "テキスト分割用のカスタムセパレーターです。"
+                              },
+                              "max_tokens": {
+                                "type": "integer",
+                                "description": "チャンクあたりの最大トークン数です。"
+                              },
+                              "chunk_overlap": {
+                                "type": "integer",
+                                "default": 0,
+                                "description": "チャンク間のトークンオーバーラップです。"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "doc_form": {
+                    "type": "string",
+                    "enum": [
+                      "text_model",
+                      "hierarchical_model",
+                      "qa_model"
+                    ],
+                    "default": "text_model",
+                    "description": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。"
+                  },
+                  "doc_language": {
+                    "type": "string",
+                    "default": "English",
+                    "description": "処理最適化のためのドキュメント言語です。"
+                  },
+                  "retrieval_model": {
+                    "$ref": "#/components/schemas/RetrievalModel",
+                    "description": "このナレッジベースをクエリする際のチャンクの検索方法とランキング方法を制御します。"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "ナレッジベースにバインドされたタグです。",
+            "description": "ドキュメントが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "タグ識別子です。"
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "タグの表示名です。"
-                          }
-                        }
-                      },
-                      "description": "このナレッジベースにバインドされたタグのリスト。"
+                    "document": {
+                      "$ref": "#/components/schemas/Document"
                     },
-                    "total": {
-                      "type": "integer",
-                      "description": "このナレッジベースにバインドされたタグの合計数です。"
+                    "batch": {
+                      "type": "string",
+                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
                     }
                   }
                 },
@@ -11127,13 +8924,78 @@
                   "success": {
                     "summary": "レスポンス例",
                     "value": {
-                      "data": [
-                        {
-                          "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                          "name": "Product Docs"
-                        }
-                      ],
-                      "total": 1
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : `text` を指定する場合は `name` が必須です。または `doc_form` が無効です。\n- `invalid_param` : ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_name": {
+                    "summary": "invalid_param (name required)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "name is required when text is provided."
+                    }
+                  },
+                  "invalid_param_not_available": {
+                    "summary": "invalid_param (not available)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Document is not available"
                     }
                   }
                 }
@@ -11141,16 +9003,32 @@
             }
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
+            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
-                  "forbidden": {
+                  "forbidden_1": {
                     "summary": "forbidden (api access)",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
                       "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
                     }
                   }
                 }
@@ -11158,16 +9036,41 @@
             }
           },
           "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
+            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
-                  "not_found": {
+                  "not_found_1": {
                     "summary": "not_found",
                     "value": {
                       "status": 404,
                       "code": "not_found",
                       "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "service_unavailable": {
+                    "summary": "service_unavailable",
+                    "value": {
+                      "status": 503,
+                      "code": "service_unavailable",
+                      "message": "Unable to verify vector space usage right now. Please try again later."
                     }
                   }
                 }
@@ -11176,10 +9079,10 @@
           }
         },
         "x-mint": {
-          "href": "/ja/api-reference/tags/get-knowledge-base-tags",
+          "href": "/ja/api-reference/documents/update-document-by-text",
           "metadata": {
-            "title": "ナレッジベースにバインドされたタグを取得",
-            "sidebarTitle": "ナレッジベースにバインドされたタグを取得"
+            "title": "テキストでドキュメントを更新",
+            "sidebarTitle": "テキストでドキュメントを更新"
           }
         }
       }
@@ -11457,6 +9360,239 @@
         }
       }
     },
+    "/datasets/{dataset_id}/metadata/built-in": {
+      "get": {
+        "tags": [
+          "メタデータ"
+        ],
+        "summary": "組み込みメタデータフィールドを取得",
+        "description": "システムが提供する組み込みメタデータフィールドを返します。",
+        "operationId": "getBuiltInMetadataFieldsJa",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "組み込みメタデータフィールドです。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fields": {
+                      "type": "array",
+                      "description": "システム提供のメタデータフィールドのリストです。",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "組み込みフィールド識別子です。`document_name` はドキュメントタイトル、`uploader` は作成者、`upload_date` は作成日時、`last_update_date` は最終更新日時、`source` はドキュメントの出典を示します。"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "フィールドのデータ型です。テキスト値の場合は `string`、日時値の場合は `time` です。"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "fields": [
+                        {
+                          "name": "document_name",
+                          "type": "string"
+                        },
+                        {
+                          "name": "uploader",
+                          "type": "string"
+                        },
+                        {
+                          "name": "upload_date",
+                          "type": "time"
+                        },
+                        {
+                          "name": "last_update_date",
+                          "type": "time"
+                        },
+                        {
+                          "name": "source",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : ナレッジベースが見つかりません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/metadata/get-built-in-metadata-fields",
+          "metadata": {
+            "title": "組み込みメタデータフィールドを取得",
+            "sidebarTitle": "組み込みメタデータフィールドを取得"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/metadata/built-in/{action}": {
+      "post": {
+        "tags": [
+          "メタデータ"
+        ],
+        "summary": "組み込みメタデータフィールドを更新",
+        "description": "ナレッジベースの組み込みメタデータフィールドを有効または無効にします。",
+        "operationId": "toggleBuiltInMetadataFieldJa",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+          },
+          {
+            "name": "action",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enable",
+                "disable"
+              ]
+            },
+            "description": "`enable` で内蔵メタデータフィールドを有効化、`disable` で無効化します。"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "組み込みメタデータフィールドの切り替えに成功しました。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "description": "操作結果です。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "result": "success"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : ナレッジベースが見つかりません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/metadata/update-built-in-metadata-field",
+          "metadata": {
+            "title": "組み込みメタデータフィールドを更新",
+            "sidebarTitle": "組み込みメタデータフィールドを更新"
+          }
+        }
+      }
+    },
     "/datasets/{dataset_id}/metadata/{metadata_id}": {
       "patch": {
         "tags": [
@@ -11692,815 +9828,6 @@
             "sidebarTitle": "メタデータフィールドを削除"
           }
         }
-      }
-    },
-    "/datasets/{dataset_id}/metadata/built-in": {
-      "get": {
-        "tags": [
-          "メタデータ"
-        ],
-        "summary": "組み込みメタデータフィールドを取得",
-        "description": "システムが提供する組み込みメタデータフィールドを返します。",
-        "operationId": "getBuiltInMetadataFieldsJa",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "組み込みメタデータフィールドです。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "fields": {
-                      "type": "array",
-                      "description": "システム提供のメタデータフィールドのリストです。",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "組み込みフィールド識別子です。`document_name` はドキュメントタイトル、`uploader` は作成者、`upload_date` は作成日時、`last_update_date` は最終更新日時、`source` はドキュメントの出典を示します。"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "フィールドのデータ型です。テキスト値の場合は `string`、日時値の場合は `time` です。"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "fields": [
-                        {
-                          "name": "document_name",
-                          "type": "string"
-                        },
-                        {
-                          "name": "uploader",
-                          "type": "string"
-                        },
-                        {
-                          "name": "upload_date",
-                          "type": "time"
-                        },
-                        {
-                          "name": "last_update_date",
-                          "type": "time"
-                        },
-                        {
-                          "name": "source",
-                          "type": "string"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/metadata/get-built-in-metadata-fields",
-          "metadata": {
-            "title": "組み込みメタデータフィールドを取得",
-            "sidebarTitle": "組み込みメタデータフィールドを取得"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/metadata/built-in/{action}": {
-      "post": {
-        "tags": [
-          "メタデータ"
-        ],
-        "summary": "組み込みメタデータフィールドを更新",
-        "description": "ナレッジベースの組み込みメタデータフィールドを有効または無効にします。",
-        "operationId": "toggleBuiltInMetadataFieldJa",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
-          },
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            },
-            "description": "`enable` で内蔵メタデータフィールドを有効化、`disable` で無効化します。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "組み込みメタデータフィールドの切り替えに成功しました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作結果です。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "result": "success"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/metadata/update-built-in-metadata-field",
-          "metadata": {
-            "title": "組み込みメタデータフィールドを更新",
-            "sidebarTitle": "組み込みメタデータフィールドを更新"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/metadata": {
-      "post": {
-        "tags": [
-          "メタデータ"
-        ],
-        "summary": "ドキュメントメタデータを一括更新",
-        "description": "複数のドキュメントのメタデータ値を 1 回のリクエストで更新します。",
-        "operationId": "batchUpdateDocumentMetadataJa",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "operation_data"
-                ],
-                "properties": {
-                  "operation_data": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "document_id",
-                        "metadata_list"
-                      ],
-                      "properties": {
-                        "document_id": {
-                          "type": "string",
-                          "description": "更新するドキュメントの ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) を参照してください。"
-                        },
-                        "metadata_list": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "id",
-                              "name"
-                            ],
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "メタデータフィールド ID です。[メタデータフィールドリストを取得](/ja/api-reference/metadata/list-metadata-fields) を参照してください。"
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "メタデータフィールド名です。"
-                              },
-                              "value": {
-                                "description": "メタデータ値。文字列、数値、または `null` を指定できます。"
-                              }
-                            }
-                          },
-                          "description": "ドキュメントに設定するメタデータフィールドです。"
-                        },
-                        "partial_update": {
-                          "type": "boolean",
-                          "default": false,
-                          "description": "メタデータを部分的に更新し、未指定フィールドの既存の値を保持するかどうかです。"
-                        }
-                      }
-                    },
-                    "description": "ドキュメントメタデータの更新操作です。ドキュメントごとに 1 エントリです。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "ドキュメントメタデータが正常に更新されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作結果です。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "result": "success"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : このリクエスト内のドキュメントで別のメタデータ操作が実行中です。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Another document metadata operation is running, please wait a moment."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : `operation_data` で参照されたドキュメントがこのナレッジベースに存在しません。\n- `not_found` : `metadata_list` で参照されたメタデータフィールドがこのナレッジベースに存在しません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found (knowledge base)",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found (document)",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found (metadata)",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Metadata not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/metadata/update-document-metadata-in-batch",
-          "metadata": {
-            "title": "ドキュメントメタデータを一括更新",
-            "sidebarTitle": "ドキュメントメタデータを一括更新"
-          }
-        }
-      }
-    },
-    "/workspaces/current/models/model-types/{model_type}": {
-      "get": {
-        "tags": [
-          "モデル"
-        ],
-        "summary": "利用可能なモデルを取得",
-        "description": "指定したタイプの利用可能なモデルを返します。ナレッジベースに設定する `text-embedding` モデルと `rerank` モデルを見つけるために使用します。",
-        "operationId": "getAvailableModelsJa",
-        "parameters": [
-          {
-            "name": "model_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "text-embedding",
-                "rerank",
-                "llm",
-                "tts",
-                "speech2text",
-                "moderation"
-              ]
-            },
-            "description": "取得するモデルのタイプです。ナレッジベースの設定には、埋め込みモデルの場合は `text-embedding`、リランキングモデルの場合は `rerank` を使用します。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "指定された種類で利用可能なモデルです。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "利用可能なモデルを持つモデルプロバイダーのリストです。",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "provider": {
-                            "type": "string",
-                            "description": "モデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。以前のプロバイダーでは短縮形（例：`openai`）が返される場合があります。"
-                          },
-                          "label": {
-                            "type": "object",
-                            "description": "プロバイダーのローカライズ表示名です。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "英語表示名。"
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "中国語表示名。"
-                              }
-                            }
-                          },
-                          "icon_small": {
-                            "type": "object",
-                            "description": "プロバイダーの小アイコンの URL です。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "小アイコン URL。"
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "中国語アイコンの URL。"
-                              }
-                            }
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "プロバイダーのステータスです。認証情報が設定済みで有効な場合は `active` です。"
-                          },
-                          "models": {
-                            "type": "array",
-                            "description": "このプロバイダーから利用可能なモデルのリストです。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "model": {
-                                  "type": "string",
-                                  "description": "モデル識別子です。ナレッジベースの作成または更新時に `embedding_model` の値として使用します。"
-                                },
-                                "label": {
-                                  "type": "object",
-                                  "description": "モデルのローカライズ表示名です。",
-                                  "properties": {
-                                    "en_US": {
-                                      "type": "string",
-                                      "description": "英語モデル名。"
-                                    },
-                                    "zh_Hans": {
-                                      "type": "string",
-                                      "description": "中国語モデル名。"
-                                    }
-                                  }
-                                },
-                                "model_type": {
-                                  "type": "string",
-                                  "description": "モデルのタイプです。`model_type` パスパラメータと一致します。"
-                                },
-                                "features": {
-                                  "type": "array",
-                                  "nullable": true,
-                                  "description": "モデルがサポートする機能です。なしの場合は `null` です。",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "fetch_from": {
-                                  "type": "string",
-                                  "description": "モデル定義の取得元です。`predefined-model` は組み込みモデル、`customizable-model` はユーザー設定モデルを示します。"
-                                },
-                                "model_properties": {
-                                  "type": "object",
-                                  "description": "`context_size` などのモデル固有のプロパティです。"
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "description": "モデルの利用可能ステータスです。使用可能な場合は `active` です。"
-                                },
-                                "deprecated": {
-                                  "type": "boolean",
-                                  "description": "モデルが非推奨かどうか。"
-                                },
-                                "load_balancing_enabled": {
-                                  "type": "boolean",
-                                  "description": "モデルのロードバランシングが有効かどうか。"
-                                },
-                                "has_invalid_load_balancing_configs": {
-                                  "type": "boolean",
-                                  "description": "モデルに無効なロードバランシング設定があるかどうか。"
-                                }
-                              }
-                            }
-                          },
-                          "tenant_id": {
-                            "type": "string",
-                            "description": "このプロバイダー設定が属するワークスペース ID。"
-                          },
-                          "icon_small_dark": {
-                            "type": "object",
-                            "description": "ダークモード用アイコンの URL。プロバイダーにない場合は `null`。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string"
-                              },
-                              "zh_Hans": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "data": [
-                        {
-                          "provider": "langgenius/openai/openai",
-                          "label": {
-                            "en_US": "OpenAI",
-                            "zh_Hans": "OpenAI"
-                          },
-                          "icon_small": {
-                            "en_US": "https://example.com/openai-small.svg",
-                            "zh_Hans": "https://example.com/openai-small.svg"
-                          },
-                          "status": "active",
-                          "models": [
-                            {
-                              "model": "text-embedding-3-small",
-                              "label": {
-                                "en_US": "text-embedding-3-small",
-                                "zh_Hans": "text-embedding-3-small"
-                              },
-                              "model_type": "text-embedding",
-                              "features": null,
-                              "fetch_from": "predefined-model",
-                              "model_properties": {
-                                "context_size": 8191
-                              },
-                              "status": "active",
-                              "deprecated": false,
-                              "load_balancing_enabled": false,
-                              "has_invalid_load_balancing_configs": false
-                            }
-                          ],
-                          "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
-                          "icon_small_dark": null
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/models/get-available-models",
-          "metadata": {
-            "title": "利用可能なモデルを取得",
-            "sidebarTitle": "利用可能なモデルを取得"
-          }
-        }
-      }
-    },
-    "/datasets/pipeline/file-upload": {
-      "post": {
-        "tags": [
-          "ナレッジパイプライン"
-        ],
-        "summary": "パイプラインファイルをアップロード",
-        "description": "ナレッジパイプラインで使用するファイルをアップロードします。返された `id` を [パイプラインを実行](/ja/api-reference/knowledge-pipeline/run-pipeline) の `local_file` アイテムの `reference` として使用します。",
-        "operationId": "uploadPipelineFileJa",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "file"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "アップロードするファイル。`multipart/form-data` の 1 パートとして送信します。ドキュメントファイルのデフォルト上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。\n\nDify Cloud の Professional と Team プランではドキュメントの上限が 50 MB になります。画像・音声・動画ファイルには別の上限があり、デフォルトはそれぞれ 10 MB、50 MB、100 MB です。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "ファイルが正常にアップロードされました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "アップロードされたファイルの一意識別子です。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "元のファイル名です。"
-                    },
-                    "size": {
-                      "type": "integer",
-                      "description": "ファイルサイズ（バイト）。"
-                    },
-                    "extension": {
-                      "type": "string",
-                      "description": "ファイル拡張子。"
-                    },
-                    "mime_type": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "ファイルの MIME タイプです。アップロードに MIME タイプが含まれない場合、`null` となることがあります。"
-                    },
-                    "created_by": {
-                      "type": "string",
-                      "description": "ファイルをアップロードしたユーザーの ID。"
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "アップロードのタイムスタンプ（ISO 8601 形式）です。レコード作成中は `null` となることがあります。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                      "name": "report.pdf",
-                      "size": 524288,
-                      "extension": "pdf",
-                      "mime_type": "application/pdf",
-                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "created_at": "2025-03-06T12:00:00"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_file_uploaded` : リクエストにファイルが提供されていません。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_file_uploaded": {
-                    "summary": "no_file_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_file_uploaded",
-                      "message": "Please upload your file."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : ファイルサイズの上限を超えています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": "File size exceeded."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_file_type` : 許可されていないファイルタイプです。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_file_type": {
-                    "summary": "unsupported_file_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_file_type",
-                      "message": "File type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/knowledge-pipeline/upload-pipeline-file",
-          "metadata": {
-            "title": "パイプラインファイルをアップロード",
-            "sidebarTitle": "パイプラインファイルをアップロード"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
-          }
-        ]
       }
     },
     "/datasets/{dataset_id}/pipeline/datasource-plugins": {
@@ -13193,6 +10520,3909 @@
           "metadata": {
             "title": "パイプラインを実行",
             "sidebarTitle": "パイプラインを実行"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/retrieve": {
+      "post": {
+        "tags": [
+          "ナレッジベース"
+        ],
+        "summary": "ナレッジベースからチャンクを取得 / テスト検索",
+        "description": "ナレッジベースを検索し、クエリに最も関連性の高いチャンクを返します。本番環境の検索とテスト検索の両方に使用できます。",
+        "operationId": "retrieveSegments",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "maxLength": 250,
+                    "description": "検索クエリテキストです。"
+                  },
+                  "retrieval_model": {
+                    "$ref": "#/components/schemas/RetrievalModel",
+                    "description": "検索モデルの設定です。このナレッジベースをクエリする際のチャンクの検索方法とランキング方法を制御します。"
+                  },
+                  "attachment_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "description": "検索コンテキストに含める添付ファイル ID のリストです。"
+                  },
+                  "external_retrieval_model": {
+                    "type": "object",
+                    "description": "外部ナレッジベースの検索設定です。",
+                    "properties": {
+                      "top_k": {
+                        "type": "integer",
+                        "description": "返す結果の最大数です。"
+                      },
+                      "score_threshold": {
+                        "type": "number",
+                        "description": "結果をフィルタリングするための最小類似度スコアのしきい値です。"
+                      },
+                      "score_threshold_enabled": {
+                        "type": "boolean",
+                        "description": "スコアしきい値によるフィルタリングを有効にするかどうか。"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "検索結果です。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "query": {
+                      "type": "object",
+                      "description": "元のクエリオブジェクトです。",
+                      "properties": {
+                        "content": {
+                          "type": "string",
+                          "description": "クエリテキストです。"
+                        }
+                      }
+                    },
+                    "records": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "segment": {
+                            "type": "object",
+                            "description": "ナレッジベースから一致したチャンクです。",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "チャンクの一意識別子です。"
+                              },
+                              "position": {
+                                "type": "integer",
+                                "description": "ドキュメント内のチャンクの位置。"
+                              },
+                              "document_id": {
+                                "type": "string",
+                                "description": "このチャンクが属するドキュメントの ID です。"
+                              },
+                              "content": {
+                                "type": "string",
+                                "description": "チャンクのテキスト内容です。"
+                              },
+                              "sign_content": {
+                                "type": "string",
+                                "description": "整合性検証用の署名付きコンテンツハッシュです。"
+                              },
+                              "answer": {
+                                "type": "string",
+                                "description": "回答コンテンツです。Q&A モードのドキュメントで使用されます。"
+                              },
+                              "word_count": {
+                                "type": "integer",
+                                "description": "チャンク内容の単語数です。"
+                              },
+                              "tokens": {
+                                "type": "integer",
+                                "description": "チャンク内容のトークン数です。"
+                              },
+                              "keywords": {
+                                "type": "array",
+                                "description": "キーワードベースの検索のためにこのチャンクに関連付けられたキーワードです。",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "index_node_id": {
+                                "type": "string",
+                                "description": "ベクトルストア内のインデックスノードの ID です。"
+                              },
+                              "index_node_hash": {
+                                "type": "string",
+                                "description": "インデックスされたコンテンツのハッシュです。変更の検出に使用されます。"
+                              },
+                              "hit_count": {
+                                "type": "integer",
+                                "description": "このチャンクが検索クエリでマッチした回数です。"
+                              },
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "このチャンクが検索に対して有効かどうかです。"
+                              },
+                              "disabled_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "チャンクが無効化されたタイムスタンプです。有効な場合は `null` です。"
+                              },
+                              "disabled_by": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "チャンクを無効化したユーザーの ID です。有効な場合は `null` です。"
+                              },
+                              "status": {
+                                "type": "string",
+                                "description": "チャンクのインデックスステータスです。"
+                              },
+                              "created_by": {
+                                "type": "string",
+                                "description": "チャンクを作成したユーザーの ID です。"
+                              },
+                              "created_at": {
+                                "type": "number",
+                                "description": "作成タイムスタンプ（Unix エポック、秒単位）です。"
+                              },
+                              "indexing_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "インデックス作成が開始されたタイムスタンプです。まだ開始されていない場合は `null` です。"
+                              },
+                              "completed_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "インデックス作成が完了したタイムスタンプです。まだ完了していない場合は `null` です。"
+                              },
+                              "error": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "インデックス作成が失敗した場合のエラーメッセージです。エラーなしの場合は `null` です。"
+                              },
+                              "stopped_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "インデックス作成が停止されたタイムスタンプです。停止されていない場合は `null` です。"
+                              },
+                              "document": {
+                                "type": "object",
+                                "description": "マッチしたチャンクの親ドキュメント情報です。",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ドキュメントの一意識別子です。"
+                                  },
+                                  "data_source_type": {
+                                    "type": "string",
+                                    "description": "ドキュメントの作成方法です。"
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "ドキュメント名です。"
+                                  },
+                                  "doc_type": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "ドキュメントタイプの分類です。未設定の場合は `null` です。"
+                                  },
+                                  "doc_metadata": {
+                                    "type": "object",
+                                    "nullable": true,
+                                    "description": "ドキュメントのメタデータ値です。メタデータが設定されていない場合は `null` です。"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "child_chunks": {
+                            "type": "array",
+                            "description": "階層インデックスを使用している場合、チャンク内でマッチした子チャンクです。",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "子チャンクの一意識別子です。"
+                                },
+                                "content": {
+                                  "type": "string",
+                                  "description": "子チャンクのテキスト内容です。"
+                                },
+                                "position": {
+                                  "type": "integer",
+                                  "description": "親チャンク内の子チャンクの位置です。"
+                                },
+                                "score": {
+                                  "type": "number",
+                                  "description": "子チャンクの関連性スコアです。"
+                                }
+                              }
+                            }
+                          },
+                          "score": {
+                            "type": "number",
+                            "description": "関連性スコアです。"
+                          },
+                          "tsne_position": {
+                            "type": "object",
+                            "nullable": true,
+                            "description": "t-SNE 可視化の位置です。"
+                          },
+                          "files": {
+                            "type": "array",
+                            "description": "このチャンクに添付されたファイルです。",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "添付ファイルの識別子です。"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "元のファイル名です。"
+                                },
+                                "size": {
+                                  "type": "integer",
+                                  "description": "ファイルサイズ（バイト）。"
+                                },
+                                "extension": {
+                                  "type": "string",
+                                  "description": "ファイル拡張子。"
+                                },
+                                "mime_type": {
+                                  "type": "string",
+                                  "description": "ファイルの MIME タイプ。"
+                                },
+                                "source_url": {
+                                  "type": "string",
+                                  "description": "添付ファイルにアクセスする URL です。"
+                                }
+                              }
+                            }
+                          },
+                          "summary": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "要約インデックス経由で取得された場合の要約コンテンツです。"
+                          }
+                        }
+                      },
+                      "description": "一致した検索レコードのリスト。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "query": {
+                        "content": "What is Dify?"
+                      },
+                      "records": [
+                        {
+                          "segment": {
+                            "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                            "position": 1,
+                            "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                            "content": "Dify is an open-source LLM app development platform.",
+                            "sign_content": "",
+                            "answer": "",
+                            "word_count": 9,
+                            "tokens": 12,
+                            "keywords": [
+                              "dify",
+                              "platform",
+                              "llm"
+                            ],
+                            "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                            "index_node_hash": "abc123def456",
+                            "hit_count": 1,
+                            "enabled": true,
+                            "disabled_at": null,
+                            "disabled_by": null,
+                            "status": "completed",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200,
+                            "indexing_at": 1741267200,
+                            "completed_at": 1741267200,
+                            "error": null,
+                            "stopped_at": null,
+                            "document": {
+                              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                              "data_source_type": "upload_file",
+                              "name": "guide.txt",
+                              "doc_type": null,
+                              "doc_metadata": null
+                            }
+                          },
+                          "child_chunks": [],
+                          "score": 0.92,
+                          "tsne_position": null,
+                          "files": [],
+                          "summary": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `dataset_not_initialized` : ナレッジベースはまだ初期化中またはインデキシング中です。\n- `provider_not_initialize` : モデルプロバイダーに有効な認証情報が設定されていません。\n- `provider_quota_exceeded` : Dify がホストするモデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support` : 選択したモデルは現在サポートされていません。\n- `completion_request_error` : モデルへのリクエストに失敗しました。\n- `invalid_param` : リクエストパラメータが無効です。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_not_initialized": {
+                    "summary": "dataset_not_initialized",
+                    "value": {
+                      "status": 400,
+                      "code": "dataset_not_initialized",
+                      "message": "The dataset is still being initialized or indexing. Please wait a moment."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Invalid parameter value."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : `dataset_id` に一致するナレッジベースがありません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "`internal_server_error` : 検索中に内部エラーが発生しました。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "An internal error occurred."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
+          "metadata": {
+            "title": "ナレッジベースからチャンクを取得 / テスト検索",
+            "sidebarTitle": "ナレッジベースからチャンクを取得 / テスト検索"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/tags": {
+      "get": {
+        "tags": [
+          "タグ管理"
+        ],
+        "summary": "ナレッジベースにバインドされたタグを取得",
+        "description": "ナレッジベースにバインドされたタグを返します。",
+        "operationId": "queryDatasetTags",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ナレッジベースにバインドされたタグです。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "タグ識別子です。"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "タグの表示名です。"
+                          }
+                        }
+                      },
+                      "description": "このナレッジベースにバインドされたタグのリスト。"
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "このナレッジベースにバインドされたタグの合計数です。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                          "name": "Product Docs"
+                        }
+                      ],
+                      "total": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : ナレッジベースが見つかりません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/tags/get-knowledge-base-tags",
+          "metadata": {
+            "title": "ナレッジベースにバインドされたタグを取得",
+            "sidebarTitle": "ナレッジベースにバインドされたタグを取得"
+          }
+        }
+      }
+    },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nID を指定してエンドユーザーの詳細を返します。別のエンドポイントが返したエンドユーザー ID（例：[ファイルをアップロード](/ja/api-reference/files/upload-file) レスポンスの `created_by`）を解決するのに便利です。",
+        "operationId": "getEndUserChat",
+        "parameters": [
+          {
+            "description": "照会するエンドユーザーの ID です。",
+            "in": "path",
+            "name": "end_user_id",
+            "required": true,
+            "schema": {
+              "description": "エンドユーザー ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndUserDetail"
+                },
+                "examples": {
+                  "endUserDetail": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                      "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "type": "service-api",
+                      "external_user_id": "abc-123",
+                      "name": null,
+                      "is_anonymous": false,
+                      "session_id": "abc-123",
+                      "created_at": "2024-01-16T12:00:29Z",
+                      "updated_at": "2024-01-16T12:00:29Z"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "エンドユーザーを正常に取得しました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "end_user_not_found": {
+                    "summary": "end_user_not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "end_user_not_found",
+                      "message": "End user not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`end_user_not_found`：エンドユーザーが見つかりません。"
+          }
+        },
+        "summary": "エンドユーザー取得",
+        "tags": [
+          "エンドユーザー"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/end-users/get-end-user-info",
+          "metadata": {
+            "title": "エンドユーザー取得",
+            "sidebarTitle": "エンドユーザー取得"
+          }
+        }
+      }
+    },
+    "/files/upload": {
+      "post": {
+        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nファイルをアップロードし、後続のリクエストから参照するための `id` を返します。ファイルはアップロードしたエンドユーザーに属し、同じ `user` を持つリクエストだけがそのファイルを参照できます。\n\nアプリが実際に扱えるファイル種別は、アプリのファイルアップロード設定によって決まります。[アプリケーションのパラメータ情報を取得](/ja/api-reference/applications/get-app-parameters) で確認できます。",
+        "operationId": "uploadChatFile",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "description": "アップロードするファイル。`multipart/form-data` の 1 パートとして送信します。ファイル名に `/` や `\\` は使えません。\n\nデプロイの安全ブラックリスト（`UPLOAD_FILE_EXTENSION_BLACKLIST`、デフォルトは空）にある拡張子を除き、任意の拡張子を受け付けます。\n\nサイズ上限はカテゴリごとに適用されます：画像 10 MB、音声 50 MB、動画 100 MB、その他のファイル 15 MB（デフォルト値。Dify Cloud はデフォルト値を使用）。セルフホスト環境では `UPLOAD_*_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "user": {
+                    "description": "このアップロードが属するエンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。省略すると、共有の `DEFAULT-USER` に帰属します。同じ `user` を持つ後続のリクエストだけがこのファイルを参照できます。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true,
+          "description": "ファイルアップロードリクエスト。multipart/form-data 形式が必要です。"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileResponse"
+                },
+                "examples": {
+                  "uploadSuccess": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "reference": null,
+                      "name": "product-photo.png",
+                      "size": 204800,
+                      "extension": "png",
+                      "mime_type": "image/png",
+                      "created_by": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                      "created_at": 1705407629,
+                      "preview_url": null,
+                      "source_url": "https://upload.dify.ai/files/a1b2c3d4-5678-90ab-cdef-1234567890ab/file-preview?timestamp=1705407629&nonce=8b3e26a5&sign=rN5DXW3xkVGwGE5MSvptu_BhQVXpMbXWmVJ0ib0LMzI=",
+                      "original_url": null,
+                      "user_id": null,
+                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                      "conversation_id": null,
+                      "file_key": null
+                    }
+                  }
+                }
+              }
+            },
+            "description": "ファイルが正常にアップロードされました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "File extension '.exe' is not allowed for security reasons"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `no_file_uploaded`：リクエストにファイルが提供されていません。\n- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `invalid_param`：ファイル名に `/` または `\\` が含まれているか、ファイルの拡張子がデプロイのブラックリストにあります。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_too_large`：ファイルがカテゴリごとのサイズ上限（`file` フィールドを参照）を超えています。現在、実行時の `message` は空文字列で返ります（既知のバックエンドの問題）。`code` とステータスコードで判定してください。"
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`unsupported_file_type`：アップロードされた `file` パートに MIME タイプが宣言されていません。"
+          }
+        },
+        "summary": "ファイルをアップロード",
+        "tags": [
+          "ファイル操作"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/files/upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@product-photo.png' \\\n  --form 'user={user}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/files/upload-file",
+          "metadata": {
+            "title": "ファイルをアップロード",
+            "sidebarTitle": "ファイルをアップロード"
+          }
+        }
+      }
+    },
+    "/files/{file_id}/preview": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent、テキストジェネレーター。\n\n以前 [ファイルをアップロード](/ja/api-reference/files/upload-file) が返したファイルの生のバイト列を返します。ファイルには、そのメッセージが参照しているアプリからのみアクセスできます。",
+        "operationId": "previewChatFile",
+        "parameters": [
+          {
+            "description": "ダウンロードするファイルの ID です。ファイルアップロードのレスポンスから取得します。",
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "description": "プレビューするファイルの一意な識別子。[ファイルをアップロード](/ja/api-reference/files/upload-file) API のレスポンスから取得します。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "`true` の場合、ファイルはブラウザでインライン表示される代わりに、添付ファイルとしてダウンロードされます。",
+            "in": "query",
+            "name": "as_attachment",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "`true` の場合、ブラウザでプレビューせず、ファイルを添付ファイルとして強制的にダウンロードします。",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。ここではファイルアクセスに影響しません。アクセスは `user` ではなくアプリとメッセージによってスコープされます。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "エンドユーザーコンテキストに使用するユーザー識別子。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "生のファイルコンテンツを返します。`Content-Type` ヘッダーはファイルの MIME タイプに設定されます。`as_attachment` が `true` の場合、ファイルは `Content-Disposition: attachment` としてダウンロード形式で返されます。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_access_denied": {
+                    "summary": "file_access_denied",
+                    "value": {
+                      "status": 403,
+                      "code": "file_access_denied",
+                      "message": "Access to the requested file is denied."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_access_denied`：ファイルは存在しますが、別のアプリまたはワークスペースに属しています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_not_found": {
+                    "summary": "file_not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "file_not_found",
+                      "message": "The requested file was not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_not_found`：この ID のファイルは、このアプリのメッセージからは参照できません。"
+          }
+        },
+        "summary": "ファイルをダウンロード",
+        "tags": [
+          "ファイル操作"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/files/download-file",
+          "metadata": {
+            "title": "ファイルをダウンロード",
+            "sidebarTitle": "ファイルをダウンロード"
+          }
+        }
+      }
+    },
+    "/form/human_input/{form_token}": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、Workflow。\n\n一時停止中の人間の入力フォームの内容を返します。人間の入力ノードで **Web アプリ**配信方法を有効にしてください。これによりスタンドアロン Web アプリの受信者が作成され、その `form_token` をこれらの Service API エンドポイントで使用できます。メールのみ、またはコンソールのみの配信では使用できません。\n\n人間の入力を呼び出す一連の流れについては、[API 連携フロー](/ja/api-reference/guides/human-input-flow) を参照してください。",
+        "operationId": "getChatflowHumanInputForm",
+        "parameters": [
+          {
+            "description": "一時停止中のフォームへのアクセストークン。ストリーミングモードのワークフローを実行エンドポイントまたはチャットメッセージを送信エンドポイントが返す `human_input_required` イベントから取得します。",
+            "in": "path",
+            "name": "form_token",
+            "required": true,
+            "schema": {
+              "description": "人工入力フォームトークン",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumanInputFormDefinitionResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "form_content": "ドラフトを確認し、優先度を設定して、承認または修正を依頼してください。",
+                      "inputs": [
+                        {
+                          "type": "paragraph",
+                          "output_variable_name": "feedback",
+                          "default": {
+                            "type": "constant",
+                            "selector": [],
+                            "value": ""
+                          }
+                        },
+                        {
+                          "type": "select",
+                          "output_variable_name": "priority",
+                          "option_source": {
+                            "type": "constant",
+                            "selector": [],
+                            "value": [
+                              "low",
+                              "medium",
+                              "high"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "file",
+                          "output_variable_name": "attachment",
+                          "allowed_file_types": [
+                            "image",
+                            "document"
+                          ],
+                          "allowed_file_extensions": [],
+                          "allowed_file_upload_methods": [
+                            "local_file",
+                            "remote_url"
+                          ]
+                        },
+                        {
+                          "type": "file-list",
+                          "output_variable_name": "attachments",
+                          "allowed_file_types": [
+                            "image",
+                            "document"
+                          ],
+                          "allowed_file_extensions": [],
+                          "allowed_file_upload_methods": [
+                            "local_file",
+                            "remote_url"
+                          ],
+                          "number_limits": 5
+                        }
+                      ],
+                      "resolved_default_values": {
+                        "feedback": ""
+                      },
+                      "user_actions": [
+                        {
+                          "id": "approve",
+                          "title": "承認",
+                          "button_style": "primary"
+                        },
+                        {
+                          "id": "reject",
+                          "title": "修正を依頼",
+                          "button_style": "default"
+                        }
+                      ],
+                      "expiration_time": 1745510400
+                    }
+                  }
+                }
+              }
+            },
+            "description": "フォーム内容の取得に成功しました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "フォームが見つかりません"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` ：フォームが見つかりません。"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "human_input_form_submitted": {
+                    "summary": "human_input_form_submitted",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_submitted",
+                      "message": "このフォームは他のユーザーによって送信済みです。form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  },
+                  "human_input_form_expired": {
+                    "summary": "human_input_form_expired",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_expired",
+                      "message": "このフォームは有効期限切れです。form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `human_input_form_submitted` ：フォームは送信済みです。フォームはワンショットで、最初の応答が有効になります（送信したユーザーは問いません）。\n- `human_input_form_expired` ：送信が到達する前にフォームの有効期限が切れています。"
+          }
+        },
+        "summary": "人間の入力フォームを取得",
+        "tags": [
+          "人間の入力"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/human-input/get-human-input-form",
+          "metadata": {
+            "title": "人間の入力フォームを取得",
+            "sidebarTitle": "人間の入力フォームを取得"
+          }
+        }
+      },
+      "post": {
+        "description": "**対象アプリ**：Chatflow、Workflow。\n\n一時停止中の人間の入力フォームに、受信者の応答を送信します。受理されるとワークフローが再開されます。再開後の実行は [ワークフローイベントをストリーム](/ja/api-reference/workflow-runs/stream-workflow-events) で追跡してください。人間の入力ノードで **Web アプリ**配信方法を有効にしてください。メールのみ、またはコンソールのみの配信では、このフォームはこれらの Service API エンドポイントに公開されません。",
+        "operationId": "submitChatflowHumanInputForm",
+        "parameters": [
+          {
+            "description": "一時停止中のフォームへのアクセストークン。ストリーミングモードのワークフローを実行エンドポイントまたはチャットメッセージを送信エンドポイントが返す `human_input_required` イベントから取得します。",
+            "in": "path",
+            "name": "form_token",
+            "required": true,
+            "schema": {
+              "description": "人工入力フォームトークン",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HumanInputFormSubmitPayloadWithUser"
+              },
+              "examples": {
+                "approve": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "inputs": {
+                      "feedback": "公開して問題ありません",
+                      "priority": "high",
+                      "attachment": {
+                        "transfer_method": "local_file",
+                        "upload_file_id": "3c8fa1b2-7d4e-4f9a-b0c1-d2e3f4a5b6c7",
+                        "type": "image"
+                      },
+                      "attachments": [
+                        {
+                          "transfer_method": "local_file",
+                          "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee",
+                          "type": "document"
+                        },
+                        {
+                          "transfer_method": "remote_url",
+                          "url": "https://example.com/report.pdf",
+                          "type": "document"
+                        }
+                      ]
+                    },
+                    "action": "approve",
+                    "user": "abc-123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumanInputFormSubmitResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {}
+                  }
+                }
+              }
+            },
+            "description": "フォームの送信に成功しました。レスポンスボディは空のオブジェクトです。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "bad_request": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "フォーム受信者のタイプが無効です"
+                    }
+                  },
+                  "invalid_form_data": {
+                    "summary": "invalid_form_data",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_form_data",
+                      "message": "必須入力が不足しています：feedback"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `bad_request` ：フォーム受信者のタイプが無効です。\n- `invalid_form_data` ：送信内容がフォーム定義の検証に失敗しました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "フォームが見つかりません"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` ：フォームが見つかりません。"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "human_input_form_submitted": {
+                    "summary": "human_input_form_submitted",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_submitted",
+                      "message": "このフォームは他のユーザーによって送信済みです。form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  },
+                  "human_input_form_expired": {
+                    "summary": "human_input_form_expired",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_expired",
+                      "message": "このフォームは有効期限切れです。form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `human_input_form_submitted` ：フォームは送信済みです。フォームはワンショットで、最初の応答が有効になります（送信したユーザーは問いません）。\n- `human_input_form_expired` ：送信が到達する前にフォームの有効期限が切れています。"
+          }
+        },
+        "summary": "人間の入力フォームを送信",
+        "tags": [
+          "人間の入力"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/human-input/submit-human-input-form",
+          "metadata": {
+            "title": "人間の入力フォームを送信",
+            "sidebarTitle": "人間の入力フォームを送信"
+          }
+        }
+      }
+    },
+    "/info": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nアプリの基本情報（名前、説明、タグ、モード、作成者）を返します。",
+        "operationId": "getChatAppInfo",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfoResponse"
+                },
+                "examples": {
+                  "appInfo": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "name": "マイチャットアプリ",
+                      "description": "便利なカスタマーサービスチャットボット。",
+                      "tags": [
+                        "customer-service",
+                        "chatbot"
+                      ],
+                      "mode": "chat",
+                      "author_name": "Dify Team"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "アプリケーションの基本情報。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "アプリケーションが見つかりません"
+          }
+        },
+        "summary": "アプリケーションの基本情報を取得",
+        "tags": [
+          "アプリケーション設定"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl -X GET 'https://{api_base_url}/info' \\\n  -H 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/applications/get-app-info",
+          "metadata": {
+            "title": "アプリケーションの基本情報を取得",
+            "sidebarTitle": "アプリケーションの基本情報を取得"
+          }
+        }
+      }
+    },
+    "/messages": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\n会話のメッセージ履歴を新しい順に返します。`first_id` を渡すと、より古いメッセージへページをさかのぼれます。",
+        "operationId": "getConversationHistory",
+        "parameters": [
+          {
+            "description": "読み取る会話の ID です。会話 ID は [会話一覧を取得](/ja/api-reference/conversations/list-conversations) から取得します。",
+            "in": "query",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "会話 ID。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ページネーションカーソルです。現在のページの最初のメッセージの `id` を指定します。渡すと前（より古い）ページを取得し、省略すると最新のメッセージを取得します。",
+            "in": "query",
+            "name": "first_id",
+            "required": false,
+            "schema": {
+              "description": "現在のページの最初のチャットレコード ID。最新メッセージを取得する場合は省略します。次のページでは、現在のリストの最初のメッセージ ID を使って古いメッセージを取得します。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "リクエストごとに返すチャット履歴メッセージの数です。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "リクエストごとに返すチャット履歴メッセージの数です。",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "エンドユーザーコンテキストに使用するユーザー識別子。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageInfiniteScrollPagination"
+                },
+                "examples": {
+                  "conversationHistory": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "limit": 20,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "9da23599-e713-473b-982c-4328d4f5c78a",
+                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                          "parent_message_id": null,
+                          "inputs": {
+                            "city": "サンフランシスコ"
+                          },
+                          "query": "iPhone 13 Pro Max の仕様を教えてください。",
+                          "answer": "iPhone 13 Pro Max の仕様は次のとおりです……",
+                          "status": "normal",
+                          "error": null,
+                          "message_files": [],
+                          "feedback": {
+                            "rating": "like"
+                          },
+                          "retriever_resources": [],
+                          "agent_thoughts": [],
+                          "created_at": 1705407629,
+                          "extra_contents": [],
+                          "message_tokens": 100,
+                          "answer_tokens": 58,
+                          "total_tokens": 158,
+                          "provider_response_latency": 1.234,
+                          "total_price": "0.0012825",
+                          "currency": "USD"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "会話履歴の取得に成功しました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_chat_app`：アプリモードが API ルートと一致しません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  },
+                  "first_message_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "First Message Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：会話が存在しません。\n- `not_found`：最初のメッセージが存在しません（無効な `first_id`）。"
+          }
+        },
+        "summary": "会話履歴メッセージ一覧を取得",
+        "tags": [
+          "会話管理"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages?conversation_id={conversation_id}&user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/conversations/list-conversation-messages",
+          "metadata": {
+            "title": "会話履歴メッセージ一覧を取得",
+            "sidebarTitle": "会話履歴メッセージ一覧を取得"
+          }
+        }
+      }
+    },
+    "/messages/{message_id}/feedbacks": {
+      "post": {
+        "description": "**対象アプリ**：Chatflow、チャットボット、Agent、テキストジェネレーター。\n\nメッセージに `like` または `dislike` の評価と、任意のコメントを記録します。`rating` に `null` を送信すると、そのメッセージの既存のフィードバックを取り消します。",
+        "operationId": "postChatMessageFeedback",
+        "parameters": [
+          {
+            "description": "フィードバックを送信するメッセージの ID です。メッセージ ID は [会話履歴メッセージ一覧を取得](/ja/api-reference/conversations/list-conversation-messages) から取得します。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "メッセージ ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MessageFeedbackPayloadWithUser"
+              },
+              "examples": {
+                "likeFeedback": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "rating": "like",
+                    "user": "abc-123",
+                    "content": "この回答はとても役に立ちました！"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "フィードバックを送信しました"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：必須の `user` フィールドが省略されているか、`rating` が `null` であるにもかかわらず取り消す既存のフィードバックがありません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "message_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Message Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：メッセージが存在しません。"
+          }
+        },
+        "summary": "メッセージフィードバックを送信",
+        "tags": [
+          "メッセージフィードバック"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/feedback/submit-message-feedback",
+          "metadata": {
+            "title": "メッセージフィードバックを送信",
+            "sidebarTitle": "メッセージフィードバックを送信"
+          }
+        }
+      }
+    },
+    "/messages/{message_id}/suggested": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、新しい Agent、チャットボット、Agent。\n\nメッセージに対して提案されたフォローアップ質問を返します。",
+        "operationId": "getSuggestedQuestions",
+        "parameters": [
+          {
+            "description": "推奨質問を取得するメッセージの ID です。チャットのレスポンス、または [会話履歴メッセージ一覧を取得](/ja/api-reference/conversations/list-conversation-messages) から取得します。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "メッセージ ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "description": "エンドユーザーコンテキストに使用するユーザー識別子。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultStringListResponse"
+                },
+                "examples": {
+                  "suggestedQuestions": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "result": "success",
+                      "data": [
+                        "iPhone 13 Pro Max にはどの色がありますか？",
+                        "バッテリーは iPhone 12 と比べてどうですか？",
+                        "価格帯を教えてください。"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "提案された質問の取得に成功しました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "bad_request": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "Suggested Questions Is Disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app`：アプリモードが API ルートと一致しません。\n- `bad_request`：推奨質問機能が無効です。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "message_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Message Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：メッセージが存在しません。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：内部サーバーエラー。"
+          }
+        },
+        "summary": "次の推奨質問を取得",
+        "tags": [
+          "チャットメッセージ"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages/{message_id}/suggested?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/chat-messages/get-next-suggested-questions",
+          "metadata": {
+            "title": "次の推奨質問を取得",
+            "sidebarTitle": "次の推奨質問を取得"
+          }
+        }
+      }
+    },
+    "/meta": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nこのアプリが使用するツールの表示アイコンを、ツール名をキーとして返します。",
+        "operationId": "getChatAppMeta",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppMetaResponse"
+                },
+                "examples": {
+                  "appMeta": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "tool_icons": {
+                        "dalle3": "https://example.com/icons/dalle3.png",
+                        "calculator": {
+                          "background": "#4A90D9",
+                          "content": "🧮"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "アプリケーションのメタ情報を正常に取得しました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "アプリケーションが見つかりません"
+          }
+        },
+        "summary": "アプリケーションのメタ情報を取得",
+        "tags": [
+          "アプリケーション設定"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/applications/get-app-meta",
+          "metadata": {
+            "title": "アプリケーションのメタ情報を取得",
+            "sidebarTitle": "アプリケーションのメタ情報を取得"
+          }
+        }
+      }
+    },
+    "/parameters": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nアプリのフロントエンド設定（開始文と推奨質問、機能トグル、ユーザー入力フォーム、ファイルアップロード上限）を返します。アプリの入力をレンダリングし、正しいアップロード上限を適用するために使用します。",
+        "operationId": "getChatAppParameters",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Parameters"
+                },
+                "examples": {
+                  "appParameters": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "opening_statement": "こんにちは。本日はどのようなご用件でしょうか？",
+                      "suggested_questions": [
+                        "何ができますか？",
+                        "機能について教えてください。"
+                      ],
+                      "suggested_questions_after_answer": {
+                        "enabled": true
+                      },
+                      "speech_to_text": {
+                        "enabled": false
+                      },
+                      "text_to_speech": {
+                        "enabled": false,
+                        "voice": "alloy",
+                        "language": "en-US",
+                        "autoPlay": "disabled"
+                      },
+                      "retriever_resource": {
+                        "enabled": true
+                      },
+                      "annotation_reply": {
+                        "enabled": false
+                      },
+                      "more_like_this": {
+                        "enabled": false
+                      },
+                      "sensitive_word_avoidance": {
+                        "enabled": false
+                      },
+                      "user_input_form": [
+                        {
+                          "text-input": {
+                            "label": "都市",
+                            "variable": "city",
+                            "required": true,
+                            "default": ""
+                          }
+                        }
+                      ],
+                      "file_upload": {
+                        "image": {
+                          "enabled": true,
+                          "number_limits": 3,
+                          "detail": "high",
+                          "transfer_methods": [
+                            "remote_url",
+                            "local_file"
+                          ]
+                        }
+                      },
+                      "system_parameters": {
+                        "file_size_limit": 15,
+                        "image_file_size_limit": 10,
+                        "audio_file_size_limit": 50,
+                        "video_file_size_limit": 100,
+                        "workflow_file_upload_limit": 10
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "アプリケーションパラメータ情報。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "app_unavailable": {
+                    "summary": "app_unavailable",
+                    "value": {
+                      "status": 400,
+                      "code": "app_unavailable",
+                      "message": "App unavailable, please check your app configurations."
+                    }
+                  },
+                  "agent_not_published": {
+                    "summary": "agent_not_published",
+                    "value": {
+                      "code": "agent_not_published",
+                      "message": "Agent has not been published. Please publish the Agent before using the API.",
+                      "status": 400
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `app_unavailable`：アプリケーションが利用できないか、設定が正しくありません。\n- `agent_not_published`：バインドされた Agent が公開されていません。（新しい Agent アプリ）"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "アプリケーションが見つかりません"
+          }
+        },
+        "summary": "アプリケーションのパラメータ情報を取得",
+        "tags": [
+          "アプリケーション設定"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/applications/get-app-parameters",
+          "metadata": {
+            "title": "アプリケーションのパラメータ情報を取得",
+            "sidebarTitle": "アプリケーションのパラメータ情報を取得"
+          }
+        }
+      }
+    },
+    "/site": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nアプリのホスト型 Web アプリのブランディングと表示設定（タイトル、アイコン、テーマカラー、デフォルト言語など）を返します。",
+        "operationId": "getChatWebAppSettings",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Site"
+                },
+                "examples": {
+                  "webAppSettings": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "title": "マイチャットアプリ",
+                      "chat_color_theme": "#4A90D9",
+                      "chat_color_theme_inverted": false,
+                      "icon_type": "emoji",
+                      "icon": "🤖",
+                      "icon_background": "#FFFFFF",
+                      "icon_url": null,
+                      "description": "便利なカスタマーサービスチャットボット。",
+                      "copyright": "2025 Dify",
+                      "privacy_policy": "https://example.com/privacy",
+                      "input_placeholder": "製品について何でもお尋ねください…",
+                      "custom_disclaimer": "",
+                      "default_language": "en-US",
+                      "show_workflow_steps": false,
+                      "use_icon_as_answer_icon": true
+                    }
+                  }
+                }
+              }
+            },
+            "description": "アプリケーションの Web アプリ設定。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このアプリケーションのサイトが見つからないか、ワークスペースがアーカイブされています。"
+          }
+        },
+        "summary": "アプリの WebApp 設定を取得",
+        "tags": [
+          "アプリケーション設定"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/applications/get-app-webapp-settings",
+          "metadata": {
+            "title": "アプリの WebApp 設定を取得",
+            "sidebarTitle": "アプリの WebApp 設定を取得"
+          }
+        }
+      }
+    },
+    "/text-to-audio": {
+      "post": {
+        "description": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nテキストを音声に変換します。`text` または `message_id` の少なくとも一方を指定してください。`text` では任意の内容を合成し、`message_id` では既存メッセージの回答を音声化します。両方を指定した場合は `message_id` が優先されます。生成された schema はこのフィールド間制約をまだ表現していないため、クライアント側で送信前に検証してください。",
+        "operationId": "textToAudioChat",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TextToAudioPayloadWithUser"
+              },
+              "examples": {
+                "textToAudioExample": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "text": "こんにちは。サービスへようこそ。",
+                    "user": "abc-123",
+                    "voice": "alloy",
+                    "streaming": false
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "audio/aac": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/flac": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/mp4": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/mpeg": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/ogg": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/wav": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/webm": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "生成された音声を返します。`Content-Type` ヘッダーはプロバイダーが返す音声コンテナ形式を反映し、認識可能な場合はレスポンスのバイト列から検証されます。\n\nレスポンスボディは AAC、FLAC、MP4、MP3、Ogg、WAV、WebM のいずれかです。認識できない出力には、プロバイダーが宣言した形式が設定されます。宣言がない場合は `audio/mpeg` になります。\n\nプロバイダーがストリームを返す場合はチャンク転送エンコーディングで配信されます。リクエストの `streaming` フィールドはこの動作を制御しません。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "app_unavailable": {
+                    "summary": "app_unavailable",
+                    "value": {
+                      "status": 400,
+                      "code": "app_unavailable",
+                      "message": "App unavailable, please check your app configurations."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "TTS is not enabled"
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `app_unavailable`：アプリケーションが利用できないか、設定が正しくありません。\n- `invalid_param`：テキスト読み上げが有効になっていない、`text` と `message_id` のどちらも指定されていない、または利用可能な音声がありません。\n- `provider_not_initialize`：有効なモデルプロバイダーの認証情報が見つかりません。\n- `provider_quota_exceeded`：モデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support`：現在のモデルはこの操作をサポートしていません。\n- `completion_request_error`：テキスト読み上げリクエストに失敗しました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：内部サーバーエラー。"
+          }
+        },
+        "summary": "テキストを音声に変換",
+        "tags": [
+          "音声・テキスト変換"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/audio/convert-text-to-audio",
+          "metadata": {
+            "title": "テキストを音声に変換",
+            "sidebarTitle": "テキストを音声に変換"
+          }
+        }
+      }
+    },
+    "/workflow/{workflow_run_id}/events": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、Workflow。\n\n一時停止後または元の SSE 接続が切断された後にワークフロー実行の Server-Sent Events ストリームを再開します。すでに完了している実行に対しては、`workflow_finished` イベントを 1 つ送信してストリームを閉じます。\n\n進行中の実行のノードレベルのステータスと進捗を確認するには、`include_state_snapshot=true` を指定して呼び出します。ストリームは新しいイベントの送信前に、実行済み各ノードのステータスを再送します。",
+        "operationId": "streamWorkflowEvents",
+        "parameters": [
+          {
+            "description": "イベントストリームを再開するワークフロー実行 ID です。[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) のレスポンスまたはストリーミングイベントから取得します。",
+            "in": "path",
+            "name": "workflow_run_id",
+            "required": true,
+            "schema": {
+              "description": "元のワークフロー実行リクエストが返したワークフロー実行 ID。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "`true` に設定すると、複数の `workflow_paused` イベントを跨いでストリームを開いたままにします（ワークフローに複数の人間の入力ノードが連続する場合に有用）。デフォルトでは最初の一時停止で閉じます。",
+            "in": "query",
+            "name": "continue_on_pause",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "`true` にすると、複数の `workflow_paused` イベントにまたがってストリームを開いたままにします。複数の人工入力ノードが連続するワークフローで便利です。デフォルトでは最初の一時停止後にストリームを閉じます。",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "`true` の場合、永続化された状態スナップショットからリプレイし、新しいイベントのストリーミング開始前に実行済みノードのステータスサマリーを含めます。",
+            "in": "query",
+            "name": "include_state_snapshot",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "`true` の場合、永続化された状態スナップショットからリプレイし、新しいイベントのストリーミング開始前に実行済みノードのステータスサマリーを含めます。",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "エンドユーザーの識別子。アプリ側で定義し、アプリ内で一意にします。実行を開始した `user` と一致する必要があります。[エンドユーザーの識別](/ja/api-reference/guides/end-user-identity) を参照してください。",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "description": "最初に実行をトリガーしたエンドユーザー識別子。実行の作成者と一致する必要があります。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "再開されたワークフロー実行のイベントの SSE ストリームです。形式は [ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow)（Workflow アプリ）または [チャットメッセージを送信](/ja/api-reference/chat-messages/send-chat-message)（Chatflow アプリ）と同じです。再開された部分で `reasoning_format: separated` を指定した LLM ノードが実行される場合、このストリームには `reasoning_chunk` イベントも含まれます。"
+                },
+                "examples": {
+                  "resumedRun": {
+                    "summary": "レスポンス例 - 再開実行（Workflow）",
+                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"承認\", \"rendered_content\": \"ドラフトを確認してください。\", \"action_id\": \"approve\", \"action_text\": \"承認\", \"submitted_data\": {\"comment\": \"問題ありません。\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_2\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM ノード\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"承認されました。翻訳を開始します。\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour\"}, \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
+                  },
+                  "resumedRunChatflow": {
+                    "summary": "レスポンス例 - 再開実行（Chatflow）",
+                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"承認\", \"rendered_content\": \"ドラフトを確認してください。\", \"action_id\": \"approve\", \"action_text\": \"承認\", \"submitted_data\": {\"comment\": \"問題ありません。\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"レビュアーがドラフトを承認しました。\", \"node_id\": \"node_llm_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"\", \"node_id\": \"node_llm_1\", \"is_final\": true}}\n\ndata: {\"event\": \"message\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"answer\": \"承認済み\", \"created_at\": 1705407706}\n\ndata: {\"event\": \"node_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"status\": \"succeeded\", \"elapsed_time\": 1.2, \"created_at\": 1705407705, \"finished_at\": 1705407706}}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"metadata\": {\"usage\": {\"total_tokens\": 42, \"latency\": 1.3}}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
+                  }
+                }
+              }
+            },
+            "description": "Server-Sent Events ストリーム。ストリームはキープアライブの `event: ping` フレーム（`data:` なし）で始まり、その後もおよそ 10 秒ごとに届きます。それ以外のイベントは `data: {JSON}\\n\\n` として配信されます。イベントペイロードは元のストリーミングレスポンスと同じスキーマに従います。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_workflow_app`：アプリモードがこの API ルートに対応しているか確認してください。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Workflow run not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：ワークフロー実行が見つかりません。"
+          }
+        },
+        "summary": "ワークフローイベントをストリーム",
+        "tags": [
+          "ワークフロー実行"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "ストリームを再開",
+            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
+          },
+          {
+            "lang": "bash",
+            "label": "状態スナップショット付き",
+            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}&include_state_snapshot=true' \\\n  --header 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/workflow-runs/stream-workflow-events",
+          "metadata": {
+            "title": "ワークフローイベントをストリーム",
+            "sidebarTitle": "ワークフローイベントをストリーム"
+          }
+        }
+      }
+    },
+    "/workflows/logs": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、Workflow。\n\n過去のワークフロー実行を、任意のフィルターで一覧表示します。各エントリは実行単位のサマリー（ステータス、トークン使用量、ステップ数、所要時間）であり、ノードごとの実行ログではありません。\n\n実行のノードレベルのイベントを追跡するには、代わりにストリーミングを使用します。\n\n- **自分で開始する実行**：[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) をストリーミングモードで使用すると、実行の進行に応じて `node_started` と `node_finished` が送信されます。\n- **すでに進行中の実行**：[ワークフローイベントをストリーム](/ja/api-reference/workflow-runs/stream-workflow-events) を `include_state_snapshot=true` 付きで呼び出し、実行済み各ノードのステータスを再送してから、残りをストリーミングします。\n\n完了した実行のノードレベルのログは、サービス API 経由では取得できません。",
+        "operationId": "getWorkflowLogs",
+        "parameters": [
+          {
+            "description": "この ISO 8601 タイムスタンプ以降に作成されたログをフィルタリングします。",
+            "in": "query",
+            "name": "created_at__after",
+            "required": false,
+            "schema": {
+              "description": "この ISO 8601 タイムスタンプ以降に作成されたログをフィルタリングします。",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "この ISO 8601 タイムスタンプ以前に作成されたログをフィルタリングします。",
+            "in": "query",
+            "name": "created_at__before",
+            "required": false,
+            "schema": {
+              "description": "この ISO 8601 タイムスタンプ以前に作成されたログをフィルタリングします。",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "アカウント ID で絞り込みます。",
+            "in": "query",
+            "name": "created_by_account",
+            "required": false,
+            "schema": {
+              "description": "アカウント ID で絞り込みます。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "エンドユーザーセッション ID でフィルタリングします。",
+            "in": "query",
+            "name": "created_by_end_user_session_id",
+            "required": false,
+            "schema": {
+              "description": "エンドユーザーセッション ID でフィルタリングします。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ログ内を検索するキーワードです。",
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "description": "ログ内を検索するキーワードです。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "1 ページあたりの件数です。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "1 ページあたりの件数です。",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "ページネーションのページ番号。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "ページネーションのページ番号。",
+              "maximum": 99999,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "実行ステータスでフィルタリングします。",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "実行ステータスでフィルタリングします。",
+              "enum": [
+                "failed",
+                "stopped",
+                "succeeded"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowAppLogPaginationResponse"
+                },
+                "examples": {
+                  "workflowLogs": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "page": 1,
+                      "limit": 20,
+                      "total": 1,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
+                          "workflow_run": {
+                            "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                            "version": "2025-01-16 12:00:00.000000",
+                            "status": "succeeded",
+                            "error": null,
+                            "elapsed_time": 1.23,
+                            "total_tokens": 150,
+                            "total_steps": 3,
+                            "created_at": 1705407629,
+                            "finished_at": 1705407630,
+                            "exceptions_count": 0,
+                            "triggered_from": "app-run"
+                          },
+                          "created_from": "service-api",
+                          "created_by_role": "end_user",
+                          "created_by_account": null,
+                          "created_by_end_user": {
+                            "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                            "type": "service-api",
+                            "is_anonymous": false,
+                            "session_id": "user_workflow_123"
+                          },
+                          "created_at": 1705407629
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "ワークフローログの取得に成功しました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Account not found: name@example.com"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：クエリパラメータが無効です。例：どのアカウントにも一致しない `created_by_account`、不正な形式の `created_at__before` や `created_at__after` のタイムスタンプ、範囲外の `page`、`limit`、`status` の値など。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          }
+        },
+        "summary": "ワークフローログ一覧を取得",
+        "tags": [
+          "ワークフロー実行"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/workflow-runs/list-workflow-logs",
+          "metadata": {
+            "title": "ワークフローログ一覧を取得",
+            "sidebarTitle": "ワークフローログ一覧を取得"
+          }
+        }
+      }
+    },
+    "/workflows/run": {
+      "post": {
+        "description": "**対象アプリ**：Workflow。\n\nアプリの公開済みワークフローを実行し、その出力を返します。単一の `blocking` レスポンス、または `streaming` の Server-Sent Events フィードのいずれかで返します。公開済みのワークフローが必要です。バージョン ID を省略すると、アプリの現在の公開済みワークフローを実行します。ドラフトはエディター内にだけ存在し、Service API からは呼び出せません。公開すると、そのドラフトが現在の公開済みバージョンになります。以前に公開した `workflow_id` を実行する場合だけ[ID でワークフローを実行](/ja/api-reference/workflow-runs/run-workflow-by-id)を使用してください。",
+        "operationId": "executeWorkflow",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowRunPayloadWithUser"
+              },
+              "examples": {
+                "streaming_example": {
+                  "summary": "リクエスト例 - ストリーミングモード",
+                  "value": {
+                    "inputs": {
+                      "query": "次の文章を要約してください：素早い茶色のキツネが怠け者の犬を飛び越えます。"
+                    },
+                    "response_mode": "streaming",
+                    "user": "user_workflow_123"
+                  }
+                },
+                "blocking_example": {
+                  "summary": "リクエスト例 - ブロッキングモード",
+                  "value": {
+                    "inputs": {
+                      "query": "次の文をフランス語に翻訳してください：こんにちは、世界"
+                    },
+                    "response_mode": "blocking",
+                    "user": "user_workflow_456"
+                  }
+                },
+                "with_file_array_variable": {
+                  "summary": "リクエスト例 — ファイル配列入力",
+                  "value": {
+                    "inputs": {
+                      "my_documents": [
+                        {
+                          "type": "document",
+                          "transfer_method": "local_file",
+                          "upload_file_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+                        },
+                        {
+                          "type": "image",
+                          "transfer_method": "remote_url",
+                          "url": "https://example.com/image.jpg"
+                        }
+                      ]
+                    },
+                    "response_mode": "blocking",
+                    "user": "user_workflow_789"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
+                },
+                "examples": {
+                  "blockingResponse": {
+                    "summary": "レスポンス例 - ブロッキングモード",
+                    "value": {
+                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
+                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "data": {
+                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "status": "succeeded",
+                        "outputs": {
+                          "result": "Bonjour le monde"
+                        },
+                        "error": null,
+                        "elapsed_time": 1.23,
+                        "total_tokens": 150,
+                        "total_steps": 3,
+                        "created_at": 1705407629,
+                        "finished_at": 1705407630
+                      }
+                    }
+                  }
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "Server-Sent Events (SSE) のストリームです。解析は [ストリーミングレスポンスの処理](/ja/api-reference/guides/streaming) に従ってください：`data:` 行を読み取り、`event` フィールドで振り分け、`ping`（キープアライブ。ストリームは `ping` で始まり、その後およそ 10 秒ごとに届きます）は無視します。\n\n**ストリームライフサイクル**：`workflow_finished`、`workflow_paused`、または `error` イベントを受信するとストリームが閉じます。エラーはストリーム内の `error` イベントとして HTTP ステータス `200` で配信されます。ステータスコードではなくイベントペイロードを確認して詳細を取得してください。\n\n**推論イベント**：\n- `reasoning_chunk`：`reasoning_format` が `separated` の LLM ノードが発行する思考過程のデルタです。連続する `reasoning_chunk` イベントを連結すると、完全な推論を復元できます。`is_final: true` のイベントはノードの思考完了を示し、空の `reasoning` を伴う場合があります。ペイロードは `data` の下にあり、チャットアプリとは異なり `message_id` は `null` となり、`conversation_id` は含まれません。並行する `text_chunk` ストリームには `<think>` タグが含まれません。\n\n**人間の入力イベント**：\n- `human_input_required`：ワークフローが人間の入力ノードに到達した際に `workflow_paused` と同時に発行されます。ペイロードの `form_token` を使用して、[人間の入力 API](/ja/api-reference/human-input/get-human-input-form) でフォーム処理を進めます。\n- `human_input_form_filled`：受信者がフォームを送信し、ワークフロー実行が再開されます。\n- `human_input_form_timeout`：応答がないままフォームが期限切れ。タイムアウトのフォールバックエッジが定義されている場合、ワークフローはそのエッジを通って実行されます。"
+                },
+                "examples": {
+                  "streamingResponse": {
+                    "summary": "レスポンス例 - ストリーミングモード",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"この文章を翻訳\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM ノード\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"翻訳します。\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
+                  },
+                  "humanInputPause": {
+                    "summary": "レスポンス例 - 人間の入力での一時停止",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"こんにちは\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"承認\", \"form_content\": \"ドラフトを確認してください。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"承認\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
+                  }
+                }
+              }
+            },
+            "description": "成功レスポンス。`blocking` モードは `WorkflowBlockingResponse` オブジェクトを含む `application/json`、`streaming` モードはワークフローイベントを含む `text/event-stream` を返します。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_workflow_app`：アプリモードが API ルートと一致しません。\n- `provider_not_initialize`：有効なモデルプロバイダーの認証情報が見つかりません。\n- `provider_quota_exceeded`：モデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support`：現在のモデルは利用できません。\n- `completion_request_error`：ワークフロー実行リクエストに失敗しました。\n- `invalid_param`：リクエストパラメータが不足または無効です（`user` の欠落や未公開のワークフローなど）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "ワークフローが見つかりません"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "too_many_requests": {
+                    "summary": "too_many_requests",
+                    "value": {
+                      "status": 429,
+                      "code": "too_many_requests",
+                      "message": "Too many requests. Please try again later."
+                    }
+                  },
+                  "rate_limit_error": {
+                    "summary": "rate_limit_error",
+                    "value": {
+                      "status": 429,
+                      "code": "rate_limit_error",
+                      "message": "Rate Limit Error"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `too_many_requests`：このアプリケーションへの同時リクエストが多すぎます。\n- `rate_limit_error`：このワークスペースの Dify Cloud のワークフロー実行クォータに達しました。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "Internal Server Error."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：内部サーバーエラー。"
+          }
+        },
+        "summary": "ワークフローを実行",
+        "tags": [
+          "ワークフロー実行"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl -N --request POST \\\n  --url 'https://{api_base_url}/workflows/run' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"inputs\": {\"query\": \"次の文章を要約してください：素早い茶色のキツネが怠け者の犬を飛び越えます。\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/workflow-runs/run-workflow",
+          "metadata": {
+            "title": "ワークフローを実行",
+            "sidebarTitle": "ワークフローを実行"
+          }
+        }
+      }
+    },
+    "/workflows/run/{workflow_run_id}": {
+      "get": {
+        "description": "**対象アプリ**：Chatflow、Workflow。\n\n1 つのワークフロー実行のステータス、入力、出力、実行メトリクスを取得します。",
+        "operationId": "getWorkflowRunDetail",
+        "parameters": [
+          {
+            "description": "ワークフロー実行 ID です。[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) のレスポンスまたはストリーミングイベント、あるいは Chatflow アプリのメッセージメタデータから取得します。",
+            "in": "path",
+            "name": "workflow_run_id",
+            "required": true,
+            "schema": {
+              "description": "ワークフロー実行レスポンスまたはストリーミングイベントから取得するワークフロー実行 ID。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowRunResponse"
+                },
+                "examples": {
+                  "workflowRunDetail": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                      "status": "succeeded",
+                      "inputs": "{\"query\": \"次の文をフランス語に翻訳してください\"}",
+                      "outputs": {
+                        "result": "Traduisez ceci en francais"
+                      },
+                      "error": null,
+                      "total_steps": 3,
+                      "total_tokens": 150,
+                      "created_at": 1705407629,
+                      "finished_at": 1705407630,
+                      "elapsed_time": 1.23
+                    }
+                  }
+                }
+              }
+            },
+            "description": "ワークフロー実行の詳細の取得に成功しました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_workflow_app`：アプリモードが API ルートと一致しません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "workflow_run_not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Workflow run not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：ワークフロー実行記録が見つかりません。"
+          }
+        },
+        "summary": "ワークフロー実行詳細を取得",
+        "tags": [
+          "ワークフロー実行"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/workflow-runs/get-workflow-run-detail",
+          "metadata": {
+            "title": "ワークフロー実行詳細を取得",
+            "sidebarTitle": "ワークフロー実行詳細を取得"
+          }
+        }
+      }
+    },
+    "/workflows/tasks/{task_id}/stop": {
+      "post": {
+        "description": "**対象アプリ**：Workflow。\n\n実行中のワークフロータスクを停止します。`streaming` モードでのみサポートされます。",
+        "operationId": "stopWorkflowTaskGeneration",
+        "parameters": [
+          {
+            "description": "タスク ID です。[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) のストリーミングイベントから取得します。",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "description": "ワークフロー実行 API が返すストリーミングチャンクから取得するタスク ID。",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RequiredServiceApiUserPayload"
+              },
+              "examples": {
+                "example": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "user": "user_workflow_123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "タスクを停止しました"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_workflow_app`：アプリモードが API ルートと一致しません。\n- `invalid_param`：リクエストパラメータが不足または無効です（`user` の欠落など）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：アプリ API が無効、アプリの状態が異常、またはワークスペースがアーカイブされています。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "互換性のために予約されたレスポンスです。現在のランタイムは停止フラグを設定する前にタスクの存在を確認しないため、タスクがすでに実行中でなくても通常の `200` 結果を返します。"
+          }
+        },
+        "summary": "ワークフロータスクを停止",
+        "tags": [
+          "ワークフロー実行"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/workflow-runs/stop-workflow-task",
+          "metadata": {
+            "title": "ワークフロータスクを停止",
+            "sidebarTitle": "ワークフロータスクを停止"
+          }
+        }
+      }
+    },
+    "/workflows/{workflow_id}/run": {
+      "post": {
+        "description": "**対象アプリ**：Workflow。\n\n特定の公開済みワークフローバージョンを、パスの `workflow_id` で指定して実行します。リクエストボディ、レスポンス、ストリーミングの挙動は [ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) と同じで、実行されるバージョンだけが異なります。",
+        "operationId": "runWorkflowById",
+        "parameters": [
+          {
+            "description": "実行する公開済みワークフローバージョンです。[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow) のレスポンスおよび [ワークフロー実行詳細を取得](/ja/api-reference/workflow-runs/get-workflow-run-detail) の `workflow_id` フィールドで返されます。公開済みバージョンを指定する必要があります。ドラフトバージョンの ID は `bad_request` で拒否されます。",
+            "in": "path",
+            "name": "workflow_id",
+            "required": true,
+            "schema": {
+              "description": "実行する特定バージョンのワークフロー ID。この値はワークフロー実行レスポンスの `workflow_id` フィールドで返されます。",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowRunPayloadWithUser"
+              },
+              "examples": {
+                "example": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "inputs": {
+                      "query": "この記事を要約してください"
+                    },
+                    "response_mode": "blocking",
+                    "user": "user_workflow_123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
+                },
+                "examples": {
+                  "blockingResponse": {
+                    "summary": "レスポンス例 - ブロッキングモード",
+                    "value": {
+                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
+                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "data": {
+                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "status": "succeeded",
+                        "outputs": {
+                          "result": "記事の要約がここに入ります"
+                        },
+                        "error": null,
+                        "elapsed_time": 2.45,
+                        "total_tokens": 280,
+                        "total_steps": 4,
+                        "created_at": 1705407629,
+                        "finished_at": 1705407631
+                      }
+                    }
+                  }
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "Server-Sent Events (SSE) のストリームです。解析は [ストリーミングレスポンスの処理](/ja/api-reference/guides/streaming) に従ってください：`data:` 行を読み取り、`event` フィールドで振り分け、`ping`（キープアライブ。ストリームは `ping` で始まり、その後およそ 10 秒ごとに届きます）は無視します。\n\n**ストリームライフサイクル**：`workflow_finished`、`workflow_paused`、または `error` イベントを受信するとストリームが閉じます。エラーはストリーム内の `error` イベントとして HTTP ステータス `200` で配信されます。ステータスコードではなくイベントペイロードを確認して詳細を取得してください。\n\n**推論イベント**：\n- `reasoning_chunk`：`reasoning_format` が `separated` の LLM ノードが発行する思考過程のデルタです。連続する `reasoning_chunk` イベントを連結すると、完全な推論を復元できます。`is_final: true` のイベントはノードの思考完了を示し、空の `reasoning` を伴う場合があります。ペイロードは `data` の下にあり、チャットアプリとは異なり `message_id` は `null` となり、`conversation_id` は含まれません。並行する `text_chunk` ストリームには `<think>` タグが含まれません。\n\n**人間の入力イベント**：\n- `human_input_required`：ワークフローが人間の入力ノードに到達した際に `workflow_paused` と同時に発行されます。ペイロードの `form_token` を使用して、[人間の入力 API](/ja/api-reference/human-input/get-human-input-form) でフォーム処理を進めます。\n- `human_input_form_filled`：受信者がフォームを送信し、ワークフロー実行が再開されます。\n- `human_input_form_timeout`：応答がないままフォームが期限切れ。タイムアウトのフォールバックエッジが定義されている場合、ワークフローはそのエッジを通って実行されます。"
+                },
+                "examples": {
+                  "streamingResponse": {
+                    "summary": "レスポンス例 - ストリーミングモード",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"この文章を翻訳\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM ノード\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"翻訳します。\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
+                  },
+                  "humanInputPause": {
+                    "summary": "レスポンス例 - 人間の入力での一時停止",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"こんにちは\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"承認\", \"form_content\": \"ドラフトを確認してください。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"承認\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
+                  }
+                }
+              }
+            },
+            "description": "成功レスポンス。`blocking` モードは `WorkflowBlockingResponse` オブジェクトを含む `application/json`、`streaming` モードはワークフローイベントを含む `text/event-stream` を返します。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "bad_request": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "ドラフトのワークフローバージョンは使用できません。 Workflow ID: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345. Please use a published workflow version or leave workflow_id empty."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_workflow_app`：アプリモードが API ルートと一致しません。\n- `bad_request`：ワークフローがドラフトであるか、ID の形式が無効です。\n- `provider_not_initialize`：有効なモデルプロバイダーの認証情報が見つかりません。\n- `provider_quota_exceeded`：モデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support`：現在のモデルは利用できません。\n- `completion_request_error`：ワークフロー実行リクエストに失敗しました。\n- `invalid_param`：リクエストパラメータが不足または無効です（`user` の欠落など）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "workflow_version_execution_not_allowed": {
+                    "summary": "workflow_version_execution_not_allowed",
+                    "value": {
+                      "status": 403,
+                      "code": "workflow_version_execution_not_allowed",
+                      "message": "Workflow version execution is not available on your current plan. Please upgrade to a paid plan."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`workflow_version_execution_not_allowed`：Dify Cloud の Sandbox プランでは、特定のワークフローバージョンを実行できません。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Workflow not found with id: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：ワークフローが見つかりません。"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "too_many_requests": {
+                    "summary": "too_many_requests",
+                    "value": {
+                      "status": 429,
+                      "code": "too_many_requests",
+                      "message": "Too many requests. Please try again later."
+                    }
+                  },
+                  "rate_limit_error": {
+                    "summary": "rate_limit_error",
+                    "value": {
+                      "status": 429,
+                      "code": "rate_limit_error",
+                      "message": "Rate Limit Error"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `too_many_requests`：このアプリケーションへの同時リクエストが多すぎます。\n- `rate_limit_error`：このワークスペースの Dify Cloud のワークフロー実行クォータに達しました。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "Internal Server Error."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：内部サーバーエラー。"
+          }
+        },
+        "summary": "ID でワークフローを実行",
+        "tags": [
+          "ワークフロー実行"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/workflow-runs/run-workflow-by-id",
+          "metadata": {
+            "title": "ID でワークフローを実行",
+            "sidebarTitle": "ID でワークフローを実行"
+          }
+        }
+      }
+    },
+    "/workspaces/current/models/model-types/{model_type}": {
+      "get": {
+        "tags": [
+          "モデル"
+        ],
+        "summary": "利用可能なモデルを取得",
+        "description": "指定したタイプの利用可能なモデルを返します。ナレッジベースに設定する `text-embedding` モデルと `rerank` モデルを見つけるために使用します。",
+        "operationId": "getAvailableModelsJa",
+        "parameters": [
+          {
+            "name": "model_type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "text-embedding",
+                "rerank",
+                "llm",
+                "tts",
+                "speech2text",
+                "moderation"
+              ]
+            },
+            "description": "取得するモデルのタイプです。ナレッジベースの設定には、埋め込みモデルの場合は `text-embedding`、リランキングモデルの場合は `rerank` を使用します。"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "指定された種類で利用可能なモデルです。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "description": "利用可能なモデルを持つモデルプロバイダーのリストです。",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "provider": {
+                            "type": "string",
+                            "description": "モデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。以前のプロバイダーでは短縮形（例：`openai`）が返される場合があります。"
+                          },
+                          "label": {
+                            "type": "object",
+                            "description": "プロバイダーのローカライズ表示名です。",
+                            "properties": {
+                              "en_US": {
+                                "type": "string",
+                                "description": "英語表示名。"
+                              },
+                              "zh_Hans": {
+                                "type": "string",
+                                "description": "中国語表示名。"
+                              }
+                            }
+                          },
+                          "icon_small": {
+                            "type": "object",
+                            "description": "プロバイダーの小アイコンの URL です。",
+                            "properties": {
+                              "en_US": {
+                                "type": "string",
+                                "description": "小アイコン URL。"
+                              },
+                              "zh_Hans": {
+                                "type": "string",
+                                "description": "中国語アイコンの URL。"
+                              }
+                            }
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "プロバイダーのステータスです。認証情報が設定済みで有効な場合は `active` です。"
+                          },
+                          "models": {
+                            "type": "array",
+                            "description": "このプロバイダーから利用可能なモデルのリストです。",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string",
+                                  "description": "モデル識別子です。ナレッジベースの作成または更新時に `embedding_model` の値として使用します。"
+                                },
+                                "label": {
+                                  "type": "object",
+                                  "description": "モデルのローカライズ表示名です。",
+                                  "properties": {
+                                    "en_US": {
+                                      "type": "string",
+                                      "description": "英語モデル名。"
+                                    },
+                                    "zh_Hans": {
+                                      "type": "string",
+                                      "description": "中国語モデル名。"
+                                    }
+                                  }
+                                },
+                                "model_type": {
+                                  "type": "string",
+                                  "description": "モデルのタイプです。`model_type` パスパラメータと一致します。"
+                                },
+                                "features": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "description": "モデルがサポートする機能です。なしの場合は `null` です。",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "fetch_from": {
+                                  "type": "string",
+                                  "description": "モデル定義の取得元です。`predefined-model` は組み込みモデル、`customizable-model` はユーザー設定モデルを示します。"
+                                },
+                                "model_properties": {
+                                  "type": "object",
+                                  "description": "`context_size` などのモデル固有のプロパティです。"
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "description": "モデルの利用可能ステータスです。使用可能な場合は `active` です。"
+                                },
+                                "deprecated": {
+                                  "type": "boolean",
+                                  "description": "モデルが非推奨かどうか。"
+                                },
+                                "load_balancing_enabled": {
+                                  "type": "boolean",
+                                  "description": "モデルのロードバランシングが有効かどうか。"
+                                },
+                                "has_invalid_load_balancing_configs": {
+                                  "type": "boolean",
+                                  "description": "モデルに無効なロードバランシング設定があるかどうか。"
+                                }
+                              }
+                            }
+                          },
+                          "tenant_id": {
+                            "type": "string",
+                            "description": "このプロバイダー設定が属するワークスペース ID。"
+                          },
+                          "icon_small_dark": {
+                            "type": "object",
+                            "description": "ダークモード用アイコンの URL。プロバイダーにない場合は `null`。",
+                            "properties": {
+                              "en_US": {
+                                "type": "string"
+                              },
+                              "zh_Hans": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "data": [
+                        {
+                          "provider": "langgenius/openai/openai",
+                          "label": {
+                            "en_US": "OpenAI",
+                            "zh_Hans": "OpenAI"
+                          },
+                          "icon_small": {
+                            "en_US": "https://example.com/openai-small.svg",
+                            "zh_Hans": "https://example.com/openai-small.svg"
+                          },
+                          "status": "active",
+                          "models": [
+                            {
+                              "model": "text-embedding-3-small",
+                              "label": {
+                                "en_US": "text-embedding-3-small",
+                                "zh_Hans": "text-embedding-3-small"
+                              },
+                              "model_type": "text-embedding",
+                              "features": null,
+                              "fetch_from": "predefined-model",
+                              "model_properties": {
+                                "context_size": 8191
+                              },
+                              "status": "active",
+                              "deprecated": false,
+                              "load_balancing_enabled": false,
+                              "has_invalid_load_balancing_configs": false
+                            }
+                          ],
+                          "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                          "icon_small_dark": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/ja/api-reference/models/get-available-models",
+          "metadata": {
+            "title": "利用可能なモデルを取得",
+            "sidebarTitle": "利用可能なモデルを取得"
           }
         }
       }

--- a/zh/api-reference/openapi_service.json
+++ b/zh/api-reference/openapi_service.json
@@ -91,30 +91,1048 @@
     }
   ],
   "paths": {
-    "/chat-messages": {
-      "post": {
-        "summary": "发送对话消息",
-        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n向对话型应用发送一条消息并返回助手的回复。流式响应中的事件因应用类型而异。",
-        "operationId": "sendBasicChatMessageCn",
+    "/": {
+      "get": {
+        "operationId": "get_index_api",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexInfoResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "成功",
+                    "value": {
+                      "welcome": "Dify OpenAPI",
+                      "api_version": "v1",
+                      "server_version": "1.17.0"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Service API 与服务器版本信息。"
+          }
+        },
+        "security": [],
+        "summary": "获取 API 信息",
         "tags": [
-          "对话消息"
+          "应用配置"
+        ],
+        "description": "返回 Service API 版本和服务器版本。",
+        "x-mint": {
+          "href": "/zh/api-reference/applications/get-api-information",
+          "metadata": {
+            "title": "获取 API 信息",
+            "sidebarTitle": "获取 API 信息"
+          }
+        }
+      }
+    },
+    "/app/feedbacks": {
+      "get": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent、文本生成应用。\n\n返回此应用所有消息反馈的分页列表，包括终端用户和管理员提交的反馈。\n\n按页列出反馈记录。响应不含总数或 `has_more` 字段；当 `data` 为空或记录数少于请求的 `limit` 时停止翻页。",
+        "operationId": "getChatAppFeedbacks",
+        "parameters": [
+          {
+            "description": "每页反馈条数。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "每页记录数。",
+              "maximum": 101,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "页码。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "分页页码。",
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppFeedbackListResponse"
+                },
+                "examples": {
+                  "feedbacksList": {
+                    "summary": "响应示例",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
+                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                          "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
+                          "rating": "like",
+                          "content": "该回答准确解答了我关于产品规格的问题。",
+                          "from_source": "user",
+                          "from_end_user_id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                          "from_account_id": null,
+                          "created_at": "2025-01-16T14:30:29Z",
+                          "updated_at": "2025-01-16T14:30:29Z"
+                        },
+                        {
+                          "id": "c8f3a9b2-4d5e-6f70-8901-bcdef2345678",
+                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "conversation_id": "56812a93-9229-5cd6-9f0c-75673b666603",
+                          "message_id": "ae24b5c0-f814-584d-a493-5439e5d6b7b1",
+                          "rating": "dislike",
+                          "content": "该回答过于笼统，没有解答具体的价格问题。",
+                          "from_source": "user",
+                          "from_end_user_id": "d2c1b0a9-8765-4321-fedc-ba9876543210",
+                          "from_account_id": null,
+                          "created_at": "2025-01-15T09:12:45Z",
+                          "updated_at": "2025-01-15T09:12:45Z"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "应用反馈列表。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          }
+        },
+        "summary": "获取应用的消息反馈",
+        "tags": [
+          "消息反馈"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/feedback/list-app-feedbacks",
+          "metadata": {
+            "title": "获取应用的消息反馈",
+            "sidebarTitle": "获取应用的消息反馈"
+          }
+        }
+      }
+    },
+    "/apps/annotation-reply/{action}": {
+      "post": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n为应用启用或禁用标注回复。异步执行；使用 [查询标注回复配置任务状态](/zh/api-reference/annotations/get-annotation-reply-job-status) 跟踪进度。\n\n请求体在执行操作前校验，因此即使是 `disable` 也必须提供 `score_threshold`、`embedding_provider_name` 和 `embedding_model_name`。请调用 [获取可用模型](/zh/api-reference/models/get-available-models) 并传入 `model_type=text-embedding`，复制响应中的 `provider` 和 `model` 值；请求示例使用 `openai` 和 `text-embedding-3-small`。",
+        "operationId": "initialAnnotationReplySettings",
+        "parameters": [
+          {
+            "description": "要执行的操作：`enable` 或 `disable`。",
+            "in": "path",
+            "name": "action",
+            "required": true,
+            "schema": {
+              "description": "要执行的操作：`enable` 或 `disable`。",
+              "enum": [
+                "disable",
+                "enable"
+              ],
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
-          "description": "发送对话消息的请求体。",
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ChatRequest"
+                "$ref": "#/components/schemas/AnnotationReplyActionPayload"
+              },
+              "examples": {
+                "enableAnnotationReply": {
+                  "summary": "请求示例",
+                  "value": {
+                    "score_threshold": 0.9,
+                    "embedding_provider_name": "openai",
+                    "embedding_model_name": "text-embedding-3-small"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationJobStatusResponse"
+                },
+                "examples": {
+                  "annotationReplyResponse": {
+                    "summary": "响应示例",
+                    "value": {
+                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "job_status": "waiting"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "标注回复设置任务已启动。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          }
+        },
+        "summary": "配置标注回复",
+        "tags": [
+          "标注管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/annotations/configure-annotation-reply",
+          "metadata": {
+            "title": "配置标注回复",
+            "sidebarTitle": "配置标注回复"
+          }
+        }
+      }
+    },
+    "/apps/annotation-reply/{action}/status/{job_id}": {
+      "get": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n返回由 [配置标注回复](/zh/api-reference/annotations/configure-annotation-reply) 发起的标注回复配置任务的状态。",
+        "operationId": "getInitialAnnotationReplySettingsStatus",
+        "parameters": [
+          {
+            "description": "要执行的操作：`enable` 或 `disable`。",
+            "in": "path",
+            "name": "action",
+            "required": true,
+            "schema": {
+              "description": "要执行的操作：`enable` 或 `disable`。",
+              "enum": [
+                "disable",
+                "enable"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "由 [配置标注回复](/zh/api-reference/annotations/configure-annotation-reply) 接口返回的任务 ID。",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "由[配置标注回复](/zh/api-reference/annotations/configure-annotation-reply)返回的任务 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationJobStatusDetailResponse"
+                },
+                "examples": {
+                  "jobStatus": {
+                    "summary": "响应示例",
+                    "value": {
+                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "job_status": "completed",
+                      "error_msg": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "成功获取任务状态。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "The job does not exist."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：任务不存在。当前运行时会为未知或已过期的任务 ID 返回此状态。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "保留的兼容响应。当前运行时对未知或已过期任务返回 `400 invalid_param`，而不是 `404`。"
+          }
+        },
+        "summary": "查询标注回复配置任务状态",
+        "tags": [
+          "标注管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/annotations/get-annotation-reply-job-status",
+          "metadata": {
+            "title": "查询标注回复配置任务状态",
+            "sidebarTitle": "查询标注回复配置任务状态"
+          }
+        }
+      }
+    },
+    "/apps/annotations": {
+      "get": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n列出应用的标注，可按关键词筛选。",
+        "operationId": "getAnnotationList",
+        "parameters": [
+          {
+            "description": "按问题或回答内容筛选标注的关键词。",
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "按问题或回答内容筛选标注的关键词。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "每页条目数。超过 100 的请求会被限制为 100。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "每页条目数。",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "页码。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "分页页码。",
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationList"
+                },
+                "examples": {
+                  "annotationList": {
+                    "summary": "响应示例",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "question": "什么是 Dify？",
+                          "answer": "Dify 是一个开源的 LLM 应用开发平台。",
+                          "hit_count": 5,
+                          "created_at": 1705407629
+                        }
+                      ],
+                      "has_more": false,
+                      "limit": 20,
+                      "total": 1,
+                      "page": 1
+                    }
+                  }
+                }
+              }
+            },
+            "description": "成功获取标注列表。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          }
+        },
+        "summary": "获取标注列表",
+        "tags": [
+          "标注管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/annotations/list-annotations",
+          "metadata": {
+            "title": "获取标注列表",
+            "sidebarTitle": "获取标注列表"
+          }
+        }
+      },
+      "post": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n创建标注。标注是预定义的问答对，命中时应用直接返回，而不再生成新回复。",
+        "operationId": "createAnnotation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationCreatePayload"
+              },
+              "examples": {
+                "createAnnotation": {
+                  "summary": "请求示例",
+                  "value": {
+                    "question": "什么是 Dify？",
+                    "answer": "Dify 是一个开源的 LLM 应用开发平台。"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                },
+                "examples": {
+                  "createdAnnotation": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "question": "什么是 Dify？",
+                      "answer": "Dify 是一个开源的 LLM 应用开发平台。",
+                      "hit_count": 0,
+                      "created_at": 1705407629
+                    }
+                  }
+                }
+              }
+            },
+            "description": "标注创建成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          }
+        },
+        "summary": "创建标注",
+        "tags": [
+          "标注管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/annotations/create-annotation",
+          "metadata": {
+            "title": "创建标注",
+            "sidebarTitle": "创建标注"
+          }
+        }
+      }
+    },
+    "/apps/annotations/{annotation_id}": {
+      "delete": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n删除标注及其关联的命中历史。",
+        "operationId": "deleteAnnotation",
+        "parameters": [
+          {
+            "description": "要删除的标注 ID。标注 ID 从 [获取标注列表](/zh/api-reference/annotations/list-annotations) 获取。",
+            "in": "path",
+            "name": "annotation_id",
+            "required": true,
+            "schema": {
+              "description": "要删除的标注唯一标识符。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "标注删除成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Annotation not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：标注不存在。"
+          }
+        },
+        "summary": "删除标注",
+        "tags": [
+          "标注管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/annotations/delete-annotation",
+          "metadata": {
+            "title": "删除标注",
+            "sidebarTitle": "删除标注"
+          }
+        }
+      },
+      "put": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n更新标注的问题和答案。",
+        "operationId": "updateAnnotation",
+        "parameters": [
+          {
+            "description": "要更新的标注 ID。标注 ID 从 [获取标注列表](/zh/api-reference/annotations/list-annotations) 获取。",
+            "in": "path",
+            "name": "annotation_id",
+            "required": true,
+            "schema": {
+              "description": "要更新的标注唯一标识符。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationCreatePayload"
+              },
+              "examples": {
+                "updateAnnotation": {
+                  "summary": "请求示例",
+                  "value": {
+                    "question": "什么是 Dify？",
+                    "answer": "Dify 是一个用于构建 AI 应用的开源 LLM 应用开发平台。"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                },
+                "examples": {
+                  "updatedAnnotation": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "question": "什么是 Dify？",
+                      "answer": "Dify 是一个用于构建 AI 应用的开源 LLM 应用开发平台。",
+                      "hit_count": 5,
+                      "created_at": 1705407629
+                    }
+                  }
+                }
+              }
+            },
+            "description": "标注更新成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Annotation not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：标注不存在。"
+          }
+        },
+        "summary": "更新标注",
+        "tags": [
+          "标注管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/annotations/update-annotation",
+          "metadata": {
+            "title": "更新标注",
+            "sidebarTitle": "更新标注"
+          }
+        }
+      }
+    },
+    "/audio-to-text": {
+      "post": {
+        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n使用工作空间的默认语音转文字模型，将上传的音频文件转写为文字。",
+        "operationId": "audioToText",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "description": "要转写的音频文件。支持的 MIME 类型包括 `audio/mp3`、`audio/mpga`、`audio/m4a`、`audio/x-m4a`、`audio/wav` 和 `audio/amr`。文件大小上限为 `30 MB`。",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "user": {
+                    "description": "应用内唯一的用户标识符。该标识符用于限定数据访问范围；使用某个 `user` 值创建的资源，仅在查询时使用相同 `user` 值才可见。",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AudioTranscriptResponse"
+                },
+                "examples": {
+                  "audioToTextSuccess": {
+                    "summary": "响应示例",
+                    "value": {
+                      "text": "你好，我想进一步了解 iPhone 13 Pro Max。"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "语音转文字成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_audio_uploaded": {
+                    "summary": "no_audio_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_audio_uploaded",
+                      "message": "Please upload your audio."
+                    }
+                  },
+                  "speech_to_text_disabled": {
+                    "summary": "speech_to_text_disabled",
+                    "value": {
+                      "status": 400,
+                      "code": "speech_to_text_disabled",
+                      "message": "Speech to text is disabled."
+                    }
+                  },
+                  "provider_not_support_speech_to_text": {
+                    "summary": "provider_not_support_speech_to_text",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_support_speech_to_text",
+                      "message": "Provider not support speech to text."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `no_audio_uploaded`：未上传音频文件（`file` 字段缺失）。\n- `speech_to_text_disabled`：此应用未启用语音转文本。\n- `provider_not_support_speech_to_text`：模型供应商不支持语音转文字。\n- `provider_not_initialize`：未配置有效的模型供应商凭据。\n- `completion_request_error`：语音识别请求失败。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "audio_too_large": {
+                    "summary": "audio_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "audio_too_large",
+                      "message": "Audio size larger than 30 mb"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`audio_too_large`：音频文件超出 `30 MB` 大小限制。"
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_audio_type": {
+                    "summary": "unsupported_audio_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_audio_type",
+                      "message": "Audio type not allowed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`unsupported_audio_type`：文件的 MIME 类型不在接受的音频类型之列（见 `file` 字段）。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：内部服务器错误。"
+          }
+        },
+        "summary": "语音转文字",
+        "tags": [
+          "语音与文字转换"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/audio-to-text' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@meeting-question.mp3' \\\n  --form 'user={user}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/audio/convert-audio-to-text",
+          "metadata": {
+            "title": "语音转文字",
+            "sidebarTitle": "语音转文字"
+          }
+        }
+      }
+    },
+    "/chat-messages": {
+      "post": {
+        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n向对话型应用发送一条消息并返回助手的回复。流式响应中的事件因应用类型而异。",
+        "operationId": "sendChatMessage",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequestPayloadWithUser"
               },
               "examples": {
                 "streaming_example": {
                   "summary": "请求示例 - 流式模式",
                   "value": {
                     "inputs": {
-                      "city": "San Francisco"
+                      "city": "旧金山"
                     },
-                    "query": "What are the specs of the iPhone 13 Pro Max?",
+                    "query": "iPhone 13 Pro Max 的规格是什么？",
                     "response_mode": "streaming",
                     "conversation_id": "",
                     "user": "abc-123",
@@ -131,7 +1149,7 @@
                   "summary": "请求示例 - 阻塞模式",
                   "value": {
                     "inputs": {},
-                    "query": "What are the specs of the iPhone 13 Pro Max?",
+                    "query": "iPhone 13 Pro Max 的规格是什么？",
                     "response_mode": "blocking",
                     "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
                     "user": "abc-123"
@@ -139,15 +1157,16 @@
                 }
               }
             }
-          }
+          },
+          "required": true,
+          "description": "发送对话消息的请求体。"
         },
         "responses": {
           "200": {
-            "description": "请求成功。内容类型和结构取决于请求中的 `response_mode` 参数。\n\n- 如果 `response_mode` 为 `blocking`，返回 `application/json` 和 `ChatCompletionResponse` 对象。\n- 如果 `response_mode` 为 `streaming`，返回 `text/event-stream` 和服务器发送事件流。",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChatCompletionResponse"
+                  "$ref": "#/components/schemas/ChatBlockingResponse"
                 },
                 "examples": {
                   "blockingResponse": {
@@ -159,7 +1178,7 @@
                       "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
                       "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
                       "mode": "chat",
-                      "answer": "iPhone 13 Pro Max specs are listed here:...",
+                      "answer": "iPhone 13 Pro Max 的规格如下：……",
                       "metadata": {
                         "usage": {
                           "prompt_tokens": 1033,
@@ -181,10 +1200,10 @@
                             "dataset_id": "101b4c97-fc2e-463c-90b1-5261a4cdcafb",
                             "dataset_name": "iPhone",
                             "document_id": "8dd1ad74-0b5f-4175-b735-7d98bbbb4e00",
-                            "document_name": "iPhone List",
+                            "document_name": "iPhone 列表",
                             "segment_id": "ed599c7f-2766-4294-9d1d-e5235a61270a",
                             "score": 0.98457545,
-                            "content": "\"Model\",\"Release Date\",\"Display Size\",\"Resolution\",\"Processor\",\"RAM\",\"Storage\",\"Camera\",\"Battery\",\"Operating System\" \"iPhone 13 Pro Max\",\"September 24, 2021\",\"6.7 inch\",\"1284 x 2778\",\"Hexa-core (2x3.23 GHz Avalanche + 4x1.82 GHz Blizzard)\",\"6 GB\",\"128, 256, 512 GB, 1TB\",\"12 MP\",\"4352 mAh\",\"iOS 15\""
+                            "content": "\"型号\",\"发布日期\",\"屏幕尺寸\",\"分辨率\",\"处理器\",\"内存\",\"存储空间\",\"相机\",\"电池\",\"操作系统\" \"iPhone 13 Pro Max\",\"2021 年 9 月 24 日\",\"6.7 英寸\",\"1284 x 2778\",\"六核处理器\",\"6 GB\",\"128、256、512 GB、1 TB\",\"1200 万像素\",\"4352 mAh\",\"iOS 15\""
                           }
                         ]
                       },
@@ -200,27 +1219,27 @@
                 },
                 "examples": {
                   "streamingResponseBasic": {
-                    "summary": "Response Example - Streaming (Basic)",
-                    "value": "data: {\"event\": \"message\", \"task_id\": \"mock_task_id\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"conversation_id\": \"45701982-8118-4bc5-8e9b-64562b4555f2\", \"answer\": \" I\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"mock_task_id\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"conversation_id\": \"45701982-8118-4bc5-8e9b-64562b4555f2\", \"created_at\": 1679586595, \"metadata\": {\"usage\": {\"total_tokens\": 10, \"latency\": 1.0}}}"
+                    "summary": "响应示例——基础流式响应",
+                    "value": "data: {\"event\": \"message\", \"task_id\": \"mock_task_id\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"conversation_id\": \"45701982-8118-4bc5-8e9b-64562b4555f2\", \"answer\": \"我\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"mock_task_id\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"conversation_id\": \"45701982-8118-4bc5-8e9b-64562b4555f2\", \"created_at\": 1679586595, \"metadata\": {\"usage\": {\"total_tokens\": 10, \"latency\": 1.0}}}"
                   },
                   "streamingResponseAgent": {
-                    "summary": "Response Example - Streaming (Agent)",
-                    "value": "data: {\"event\": \"agent_thought\", \"id\": \"agent_thought_id_1\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"position\": 1, \"thought\": \"Thinking about calling a tool...\", \"tool\": \"dalle3\", \"tool_input\": \"{\\\"dalle3\\\": {\\\"prompt\\\": \\\"a cute cat\\\"}}\", \"created_at\": 1705395332}\n\ndata: {\"event\": \"message_file\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"id\": \"file_id_1\", \"type\": \"image\", \"belongs_to\": \"assistant\", \"url\": \"https://example.com/cat.png\", \"created_at\": 1705395332}\n\ndata: {\"event\": \"agent_message\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"answer\": \"Here is the image: \", \"created_at\": 1705395333}\n\ndata: {\"event\": \"message_end\", \"task_id\":\"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"metadata\": {\"usage\": {\"total_tokens\": 50, \"latency\": 2.5}}}"
+                    "summary": "响应示例——Agent 流式响应",
+                    "value": "data: {\"event\": \"agent_thought\", \"id\": \"agent_thought_id_1\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"position\": 1, \"thought\": \"正在考虑调用工具……\", \"tool\": \"dalle3\", \"tool_input\": \"{\\\"dalle3\\\": {\\\"prompt\\\": \\\"一只可爱的猫\\\"}}\", \"created_at\": 1705395332}\n\ndata: {\"event\": \"message_file\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"id\": \"file_id_1\", \"type\": \"image\", \"belongs_to\": \"assistant\", \"url\": \"https://example.com/cat.png\", \"created_at\": 1705395332}\n\ndata: {\"event\": \"agent_message\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"answer\": \"图片如下：\", \"created_at\": 1705395333}\n\ndata: {\"event\": \"message_end\", \"task_id\":\"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"metadata\": {\"usage\": {\"total_tokens\": 50, \"latency\": 2.5}}}"
                   },
                   "streamingResponseWorkflow": {
-                    "summary": "Response Example - Streaming (工作流)",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395332, \"data\": {\"id\": \"wfr_abc123\", \"workflow_id\": \"wf_def456\", \"inputs\": {\"city\": \"San Francisco\"}, \"created_at\": 1705395332}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395332, \"data\": {\"id\": \"ne_001\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 1, \"created_at\": 1705395332}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395333, \"data\": {\"message_id\": \"msg123\", \"reasoning\": \"The user greeted me, so\", \"node_id\": \"node_llm_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395333, \"data\": {\"message_id\": \"msg123\", \"reasoning\": \"\", \"node_id\": \"node_llm_1\", \"is_final\": true}}\n\ndata: {\"event\": \"message\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"answer\": \" I\", \"created_at\": 1705395333}\n\ndata: {\"event\": \"node_finished\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395334, \"data\": {\"id\": \"ne_001\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 1, \"status\": \"succeeded\", \"elapsed_time\": 1.5, \"created_at\": 1705395332, \"finished_at\": 1705395334}}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395334, \"metadata\": {\"usage\": {\"total_tokens\": 50, \"latency\": 2.5}}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395335, \"data\": {\"id\": \"wfr_abc123\", \"workflow_id\": \"wf_def456\", \"status\": \"succeeded\", \"elapsed_time\": 2.5, \"total_tokens\": 50, \"total_steps\": 2, \"created_at\": 1705395332, \"finished_at\": 1705395335}}"
+                    "summary": "响应示例 - 流式（Workflow）",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395332, \"data\": {\"id\": \"wfr_abc123\", \"workflow_id\": \"wf_def456\", \"inputs\": {\"city\": \"旧金山\"}, \"created_at\": 1705395332}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395332, \"data\": {\"id\": \"ne_001\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 1, \"created_at\": 1705395332}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395333, \"data\": {\"message_id\": \"msg123\", \"reasoning\": \"用户向我打招呼，因此\", \"node_id\": \"node_llm_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395333, \"data\": {\"message_id\": \"msg123\", \"reasoning\": \"\", \"node_id\": \"node_llm_1\", \"is_final\": true}}\n\ndata: {\"event\": \"message\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"answer\": \"我\", \"created_at\": 1705395333}\n\ndata: {\"event\": \"node_finished\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395334, \"data\": {\"id\": \"ne_001\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 1, \"status\": \"succeeded\", \"elapsed_time\": 1.5, \"created_at\": 1705395332, \"finished_at\": 1705395334}}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"task123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395334, \"metadata\": {\"usage\": {\"total_tokens\": 50, \"latency\": 2.5}}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"task123\", \"workflow_run_id\": \"wfr_abc123\", \"message_id\": \"msg123\", \"conversation_id\": \"conv123\", \"created_at\": 1705395335, \"data\": {\"id\": \"wfr_abc123\", \"workflow_id\": \"wf_def456\", \"status\": \"succeeded\", \"elapsed_time\": 2.5, \"total_tokens\": 50, \"total_steps\": 2, \"created_at\": 1705395332, \"finished_at\": 1705395335}}"
                   },
                   "humanInputPause": {
                     "summary": "响应示例 - 人工介入暂停",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"Hello\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"form_content\": \"请审阅草稿。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"批准\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"paused_nodes\": [\"approval_node\"], \"outputs\": {}, \"reasons\": [{\"TYPE\": \"human_input_required\", \"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_content\": \"请审阅草稿。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"批准\", \"button_style\": \"primary\"}], \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"resolved_default_values\": {\"comment\": \"\"}, \"form_token\": \"tok_abc123\", \"expiration_time\": 1705494029}], \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5, \"total_tokens\": 0, \"total_steps\": 1}}"
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"你好\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"审批\", \"form_content\": \"请审阅草稿。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"批准\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407629, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"paused_nodes\": [\"approval_node\"], \"outputs\": {}, \"reasons\": [{\"TYPE\": \"human_input_required\", \"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_content\": \"请审阅草稿。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"批准\", \"button_style\": \"primary\"}], \"node_id\": \"approval_node\", \"node_title\": \"审批\", \"resolved_default_values\": {\"comment\": \"\"}, \"form_token\": \"tok_abc123\", \"expiration_time\": 1705494029}], \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5, \"total_tokens\": 0, \"total_steps\": 1}}"
                   }
                 }
               }
-            }
+            },
+            "description": "成功响应。`blocking` 模式返回包含 `ChatBlockingResponse` 对象的 `application/json`；`streaming` 模式返回包含服务器发送事件（SSE）的 `text/event-stream`。"
           },
           "400": {
-            "description": "- `app_unavailable` : 应用不可用或配置错误。\n- `not_chat_app` : App mode does not match the API route.\n- `provider_not_initialize` : 未找到有效的模型供应商凭据。\n- `provider_quota_exceeded` : 模型供应商配额已用尽。\n- `model_currently_not_support` : 当前模型不可用。\n- `completion_request_error` : 文本生成失败。\n- `bad_request` : Cannot use draft 工作流 version.\n- `bad_request` : Invalid `workflow_id` format.\n- `bad_request` : 新 Agent 应用使用了 `blocking` 响应模式。\n- `invalid_param` : 新 Agent 应用未绑定 Agent。\n- `agent_not_published` : 绑定的 Agent 尚未发布。（新 Agent 应用）\n- `conversation_completed` : 会话已结束，省略 `conversation_id` 以开启新会话。",
             "content": {
               "application/json": {
                 "examples": {
@@ -322,10 +1341,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `app_unavailable`：应用不可用或配置错误。\n- `not_chat_app`：应用模式与此 API 路由不匹配。\n- `provider_not_initialize`：未找到有效的模型供应商凭据。\n- `provider_quota_exceeded`：模型供应商配额已用尽。\n- `model_currently_not_support`：当前模型不可用。\n- `completion_request_error`：文本生成失败。\n- `bad_request`：不能使用工作流草稿版本。\n- `bad_request`：`workflow_id` 格式无效。\n- `bad_request`：新 Agent 应用使用了 `blocking` 响应模式。\n- `invalid_param`：新 Agent 应用未绑定 Agent。\n- `agent_not_published`：绑定的 Agent 尚未发布。（新 Agent 应用）\n- `conversation_completed`：会话已结束，省略 `conversation_id` 以开启新会话。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`workflow_version_execution_not_allowed` : Chatflow 请求在 Dify Cloud Sandbox 套餐下通过 `workflow_id` 指定了工作流版本。",
             "content": {
               "application/json": {
                 "examples": {
@@ -339,10 +1375,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`workflow_version_execution_not_allowed`：Chatflow 请求在 Dify Cloud Sandbox 套餐下通过 `workflow_id` 指定了工作流版本。"
           },
           "404": {
-            "description": "- `not_found` : Conversation does not exist.\n- `not_found` : 工作流 not found with the specified `workflow_id`.",
             "content": {
               "application/json": {
                 "examples": {
@@ -364,10 +1400,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：会话不存在。\n- `not_found`：未找到指定 `workflow_id` 的工作流。"
           },
           "429": {
-            "description": "- `too_many_requests` : 该应用的并发请求过多。\n- `rate_limit_error` : 工作空间在 Dify Cloud 的工作流执行配额已用尽。",
             "content": {
               "application/json": {
                 "examples": {
@@ -389,10 +1425,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `too_many_requests`：该应用的并发请求过多。\n- `rate_limit_error`：工作空间在 Dify Cloud 的工作流执行配额已用尽。"
           },
           "500": {
-            "description": "`internal_server_error` : 内部服务器错误。",
             "content": {
               "application/json": {
                 "examples": {
@@ -406,59 +1442,51 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`internal_server_error`：内部服务器错误。"
           }
         },
+        "summary": "发送对话消息",
+        "tags": [
+          "对话消息"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/chat-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"query\": \"iPhone 13 Pro Max 的规格是什么？\", \"inputs\": {}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
+          }
+        ],
         "x-mint": {
           "href": "/zh/api-reference/chat-messages/send-chat-message",
           "metadata": {
             "title": "发送对话消息",
             "sidebarTitle": "发送对话消息"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/chat-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"query\": \"What are the specs of the iPhone 13 Pro Max?\", \"inputs\": {}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/chat-messages/{task_id}/stop": {
       "post": {
-        "summary": "停止响应",
         "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n停止聊天消息生成任务。仅在 `streaming` 模式下支持。",
-        "operationId": "stopBasicChatMessageGenerationCn",
-        "tags": [
-          "对话消息"
-        ],
+        "operationId": "stopChatMessageGeneration",
         "parameters": [
           {
-            "name": "task_id",
-            "in": "path",
-            "required": true,
             "description": "任务 ID，来自 [发送对话消息](/zh/api-reference/chat-messages/send-chat-message) 的流式事件。",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
             "schema": {
+              "description": "任务 ID，可从发送聊天消息 API 返回的流式分块中获取。",
               "type": "string"
             }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "user"
-                ],
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "终端用户标识，由你的应用定义，需在应用内唯一。必须与发送原始消息时的 `user` 一致；不一致时停止不会生效，但仍返回成功。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。"
-                  }
-                }
+                "$ref": "#/components/schemas/RequiredServiceApiUserPayload"
               },
               "examples": {
                 "example": {
@@ -469,14 +1497,24 @@
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "$ref": "#/components/responses/SuccessResult"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "任务已成功停止"
           },
           "400": {
-            "description": "- `not_chat_app` : 应用模式与 API 路由不匹配。\n- `invalid_param` : 缺少必填的 `user` 字段。",
             "content": {
               "application/json": {
                 "examples": {
@@ -498,9 +1536,60 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_chat_app`：应用模式与 API 路由不匹配。\n- `invalid_param`：缺少必填的 `user` 字段。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "保留的兼容响应。当前运行时在设置停止标记前不会校验任务是否存在；即使任务已不再运行，也会返回正常的 `200` 结果。"
           }
         },
+        "summary": "停止响应",
+        "tags": [
+          "对话消息"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/chat-messages/stop-chat-message-generation",
           "metadata": {
@@ -510,3872 +1599,24 @@
         }
       }
     },
-    "/messages/{message_id}/suggested": {
-      "get": {
-        "summary": "获取下一轮建议问题列表",
-        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n返回为某条消息推荐的追问问题。",
-        "operationId": "getBasicChatSuggestedQuestionsCn",
-        "tags": [
-          "对话消息"
-        ],
-        "parameters": [
-          {
-            "name": "message_id",
-            "in": "path",
-            "required": true,
-            "description": "要获取建议问题的消息 ID。可从对话响应或 [获取会话历史消息](/zh/api-reference/conversations/list-conversation-messages) 获取。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": true,
-            "description": "终端用户标识，由你的应用定义，需在应用内唯一。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "成功获取建议问题。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SuggestedQuestionsResponse"
-                },
-                "examples": {
-                  "suggestedQuestions": {
-                    "summary": "响应示例",
-                    "value": {
-                      "result": "success",
-                      "data": [
-                        "What colors does the iPhone 13 Pro Max come in?",
-                        "How does the battery compare to iPhone 12?",
-                        "What is the price range?"
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : 应用模式与 API 路由不匹配。\n- `bad_request` : 建议问题功能已禁用。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "bad_request": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "Suggested Questions Is Disabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 消息不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "message_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Message Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : 内部服务器错误。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages/{message_id}/suggested?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
-        "x-mint": {
-          "href": "/zh/api-reference/chat-messages/get-next-suggested-questions",
-          "metadata": {
-            "title": "获取下一轮建议问题列表",
-            "sidebarTitle": "获取下一轮建议问题列表"
-          }
-        }
-      }
-    },
-    "/files/upload": {
-      "post": {
-        "summary": "上传文件",
-        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n上传文件并返回其 `id`，供后续请求引用。文件归上传它的终端用户所有：只有携带相同 `user` 的请求才能引用该文件。\n\n应用实际能使用哪些文件类型，取决于它的文件上传设置；可通过 [获取应用参数](/zh/api-reference/applications/get-app-parameters) 读取。",
-        "operationId": "uploadBasicChatFileCn",
-        "tags": [
-          "文件操作"
-        ],
-        "requestBody": {
-          "description": "文件上传请求。需要 multipart/form-data 格式。",
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "file"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "要上传的文件，作为 `multipart/form-data` 的一个部分。文件名不能包含 `/` 或 `\\`。\n\n除部署安全黑名单（`UPLOAD_FILE_EXTENSION_BLACKLIST`，默认为空）中的扩展名外，任何文件类型都可上传。\n\n文件大小按类别限制：图片 10 MB、音频 50 MB、视频 100 MB、其他文件 15 MB（默认值，Dify Cloud 使用默认值）。自部署可通过 `UPLOAD_*_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。"
-                  },
-                  "user": {
-                    "type": "string",
-                    "description": "该上传所属的终端用户标识，由你的应用定义，需在应用内唯一。省略时上传归属于共享的 `DEFAULT-USER`。只有携带相同 `user` 的后续请求才能引用该文件。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "文件上传成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileUploadResponse"
-                },
-                "examples": {
-                  "uploadSuccess": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "reference": null,
-                      "name": "product-photo.png",
-                      "size": 204800,
-                      "extension": "png",
-                      "mime_type": "image/png",
-                      "created_by": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                      "created_at": 1705407629,
-                      "preview_url": null,
-                      "source_url": "https://upload.dify.ai/files/a1b2c3d4-5678-90ab-cdef-1234567890ab/file-preview?timestamp=1705407629&nonce=8b3e26a5&sign=rN5DXW3xkVGwGE5MSvptu_BhQVXpMbXWmVJ0ib0LMzI=",
-                      "original_url": null,
-                      "user_id": null,
-                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
-                      "conversation_id": null,
-                      "file_key": null
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_file_uploaded` : 请求中未提供文件。\n- `too_many_files` : 每次请求仅允许上传一个文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `invalid_param` : 文件名包含 `/` 或 `\\`，或文件扩展名在部署的黑名单中。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_file_uploaded": {
-                    "summary": "no_file_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_file_uploaded",
-                      "message": "Please upload your file."
-                    }
-                  },
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "File extension '.exe' is not allowed for security reasons"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : 文件超过其类别的大小限制（见 `file` 字段）。目前运行时返回的 `message` 为空字符串（已知的后端问题），请以 `code` 和状态码为准。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_file_type` : 上传的 `file` 部分未声明 MIME 类型。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_file_type": {
-                    "summary": "unsupported_file_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_file_type",
-                      "message": "File type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/files/upload-file",
-          "metadata": {
-            "title": "上传文件",
-            "sidebarTitle": "上传文件"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/files/upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@product-photo.png' \\\n  --form 'user={user}'"
-          }
-        ]
-      }
-    },
-    "/files/{file_id}/preview": {
-      "get": {
-        "summary": "下载文件",
-        "description": "**适用于**：Chatflow、聊天助手、Agent、文本生成应用。\n\n返回此前由 [上传文件](/zh/api-reference/files/upload-file) 返回的文件的原始字节。文件仅可通过引用它的消息所属的应用访问。",
-        "operationId": "previewBasicChatFileCn",
-        "tags": [
-          "文件操作"
-        ],
-        "parameters": [
-          {
-            "name": "file_id",
-            "in": "path",
-            "required": true,
-            "description": "要下载的文件 ID，来自上传文件的响应。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "as_attachment",
-            "in": "query",
-            "required": false,
-            "description": "为 `true` 时，文件以附件形式下载，而不是在浏览器中内联渲染。",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "终端用户标识，由你的应用定义，需在应用内唯一。此处对文件访问没有影响，文件访问按应用和消息（而非 `user`）限定。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "返回原始文件内容。`Content-Type` 头设置为文件的 MIME 类型。如果 `as_attachment` 为 `true`，文件将以 `Content-Disposition: attachment` 方式作为下载返回。",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`file_access_denied` : 文件存在，但属于其他应用或工作空间。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_access_denied": {
-                    "summary": "file_access_denied",
-                    "value": {
-                      "status": 403,
-                      "code": "file_access_denied",
-                      "message": "Access to the requested file is denied."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`file_not_found` : 此 ID 对应的文件无法通过本应用的消息访问。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_not_found": {
-                    "summary": "file_not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "file_not_found",
-                      "message": "The requested file was not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/files/download-file",
-          "metadata": {
-            "title": "下载文件",
-            "sidebarTitle": "下载文件"
-          }
-        }
-      }
-    },
-    "/end-users/{end_user_id}": {
-      "get": {
-        "summary": "获取终端用户信息",
-        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n根据 ID 返回终端用户的详细信息。当需要解析其他接口返回的终端用户 ID（例如 [上传文件](/zh/api-reference/files/upload-file) 响应中的 `created_by`）时很有用。",
-        "operationId": "getEndUserChatCn",
-        "tags": [
-          "终端用户"
-        ],
-        "parameters": [
-          {
-            "name": "end_user_id",
-            "in": "path",
-            "required": true,
-            "description": "要查询的终端用户 ID。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "成功获取终端用户。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EndUserDetail"
-                },
-                "examples": {
-                  "endUserDetail": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
-                      "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "type": "service-api",
-                      "external_user_id": "abc-123",
-                      "name": null,
-                      "is_anonymous": false,
-                      "session_id": "abc-123",
-                      "created_at": "2024-01-16T12:00:29Z",
-                      "updated_at": "2024-01-16T12:00:29Z"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`end_user_not_found` : 未找到终端用户。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "end_user_not_found": {
-                    "summary": "end_user_not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "end_user_not_found",
-                      "message": "End user not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/end-users/get-end-user-info",
-          "metadata": {
-            "title": "获取终端用户信息",
-            "sidebarTitle": "获取终端用户信息"
-          }
-        }
-      }
-    },
-    "/messages/{message_id}/feedbacks": {
-      "post": {
-        "summary": "提交消息反馈",
-        "description": "**适用于**：Chatflow、聊天助手、Agent、文本生成应用。\n\n为消息记录 `like` 或 `dislike` 评价，并可附带可选评论。将 `rating` 设为 `null` 可撤销该消息的已有反馈。",
-        "operationId": "postBasicChatMessageFeedbackCn",
-        "tags": [
-          "消息反馈"
-        ],
-        "parameters": [
-          {
-            "name": "message_id",
-            "in": "path",
-            "required": true,
-            "description": "要反馈的消息 ID。消息 ID 从 [获取会话历史消息](/zh/api-reference/conversations/list-conversation-messages) 获取。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MessageFeedbackRequest"
-              },
-              "examples": {
-                "likeFeedback": {
-                  "summary": "请求示例",
-                  "value": {
-                    "rating": "like",
-                    "user": "abc-123",
-                    "content": "This answer was very helpful!"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/SuccessResult"
-          },
-          "400": {
-            "description": "`invalid_param` : 缺少必填的 `user` 字段，或 `rating` 为 `null` 但没有可撤销的已有反馈。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 消息不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "message_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Message Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/feedback/submit-message-feedback",
-          "metadata": {
-            "title": "提交消息反馈",
-            "sidebarTitle": "提交消息反馈"
-          }
-        }
-      }
-    },
-    "/app/feedbacks": {
-      "get": {
-        "summary": "获取应用的消息反馈",
-        "description": "**适用于**：Chatflow、聊天助手、Agent、文本生成应用。\n\n返回此应用所有消息反馈的分页列表，包括终端用户和管理员提交的反馈。",
-        "operationId": "getBasicChatAppFeedbacksCn",
-        "tags": [
-          "消息反馈"
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "页码。",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "每页反馈条数。",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 101
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "应用反馈列表。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppFeedbacksResponse"
-                },
-                "examples": {
-                  "feedbacksList": {
-                    "summary": "响应示例",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
-                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                          "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
-                          "rating": "like",
-                          "content": "The response accurately answered my question about product specifications.",
-                          "from_source": "user",
-                          "from_end_user_id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                          "from_account_id": null,
-                          "created_at": "2025-01-16T14:30:29Z",
-                          "updated_at": "2025-01-16T14:30:29Z"
-                        },
-                        {
-                          "id": "c8f3a9b2-4d5e-6f70-8901-bcdef2345678",
-                          "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "conversation_id": "56812a93-9229-5cd6-9f0c-75673b666603",
-                          "message_id": "ae24b5c0-f814-584d-a493-5439e5d6b7b1",
-                          "rating": "dislike",
-                          "content": "The answer was too vague and did not address the specific pricing question.",
-                          "from_source": "user",
-                          "from_end_user_id": "d2c1b0a9-8765-4321-fedc-ba9876543210",
-                          "from_account_id": null,
-                          "created_at": "2025-01-15T09:12:45Z",
-                          "updated_at": "2025-01-15T09:12:45Z"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/feedback/list-app-feedbacks",
-          "metadata": {
-            "title": "获取应用的消息反馈",
-            "sidebarTitle": "获取应用的消息反馈"
-          }
-        }
-      }
-    },
-    "/conversations": {
-      "get": {
-        "summary": "获取会话列表",
-        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n列出某个终端用户的会话，按最近活跃时间排序。",
-        "operationId": "getBasicChatConversationsListCn",
-        "tags": [
-          "会话管理"
-        ],
-        "parameters": [
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "终端用户标识，由你的应用定义，需在应用内唯一。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "last_id",
-            "in": "query",
-            "required": false,
-            "description": "分页游标：当前页最后一个会话的 `id`。省略则获取第一页。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "返回的记录数。",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          },
-          {
-            "name": "sort_by",
-            "in": "query",
-            "required": false,
-            "description": "排序字段。加 `-` 前缀表示降序。",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "created_at",
-                "-created_at",
-                "updated_at",
-                "-updated_at"
-              ],
-              "default": "-updated_at"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "成功获取会话列表。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationsListResponse"
-                },
-                "examples": {
-                  "conversationsList": {
-                    "summary": "响应示例",
-                    "value": {
-                      "limit": 20,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                          "name": "iPhone Specs Chat",
-                          "inputs": {
-                            "city": "San Francisco"
-                          },
-                          "status": "normal",
-                          "introduction": "Welcome! How can I help you today?",
-                          "created_at": 1705407629,
-                          "updated_at": 1705411229
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_chat_app` : 应用模式与 API 路由不匹配。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 上一个会话不存在（无效的 `last_id`）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "last_conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Last Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/conversations/list-conversations",
-          "metadata": {
-            "title": "获取会话列表",
-            "sidebarTitle": "获取会话列表"
-          }
-        }
-      }
-    },
-    "/messages": {
-      "get": {
-        "summary": "获取会话历史消息",
-        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n返回会话的消息历史，按时间倒序（最新在前）。传入 `first_id` 可向前翻页获取更早的消息。",
-        "operationId": "getBasicChatConversationHistoryCn",
-        "tags": [
-          "会话管理"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "query",
-            "required": true,
-            "description": "要读取的会话 ID。会话 ID 从 [获取会话列表](/zh/api-reference/conversations/list-conversations) 获取。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "终端用户标识，由你的应用定义，需在应用内唯一。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "first_id",
-            "in": "query",
-            "required": false,
-            "description": "分页游标：当前页第一条消息的 `id`。传入它可获取上一页（更早的消息）；省略则获取最新消息。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "每次请求返回的聊天历史消息数量。",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "成功获取会话历史。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationHistoryResponse"
-                },
-                "examples": {
-                  "conversationHistory": {
-                    "summary": "响应示例",
-                    "value": {
-                      "limit": 20,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "9da23599-e713-473b-982c-4328d4f5c78a",
-                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                          "parent_message_id": null,
-                          "inputs": {
-                            "city": "San Francisco"
-                          },
-                          "query": "What are the specs of the iPhone 13 Pro Max?",
-                          "answer": "iPhone 13 Pro Max specs are listed here:...",
-                          "status": "normal",
-                          "error": null,
-                          "message_files": [],
-                          "feedback": {
-                            "rating": "like"
-                          },
-                          "retriever_resources": [],
-                          "agent_thoughts": [],
-                          "created_at": 1705407629,
-                          "extra_contents": [],
-                          "message_tokens": 100,
-                          "answer_tokens": 58,
-                          "total_tokens": 158,
-                          "provider_response_latency": 1.234,
-                          "total_price": "0.0012825",
-                          "currency": "USD"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_chat_app` : 应用模式与 API 路由不匹配。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 会话不存在。\n- `not_found` : 第一条消息不存在（`first_id` 无效）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  },
-                  "first_message_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "First Message Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages?conversation_id={conversation_id}&user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
-        "x-mint": {
-          "href": "/zh/api-reference/conversations/list-conversation-messages",
-          "metadata": {
-            "title": "获取会话历史消息",
-            "sidebarTitle": "获取会话历史消息"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}/variables": {
-      "get": {
-        "summary": "获取对话变量",
-        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n列出会话中存储的变量。",
-        "operationId": "getBasicChatConversationVariablesCn",
-        "tags": [
-          "会话管理"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "要列出变量的会话 ID。会话 ID 从 [获取会话列表](/zh/api-reference/conversations/list-conversations) 获取。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": false,
-            "description": "终端用户标识，由你的应用定义，需在应用内唯一。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "last_id",
-            "in": "query",
-            "required": false,
-            "description": "分页游标：当前页最后一个变量的 `id`。省略则获取第一页。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "返回的记录数。",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          },
-          {
-            "name": "variable_name",
-            "in": "query",
-            "required": false,
-            "description": "按指定名称筛选变量。",
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 255
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "成功获取会话变量。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationVariablesResponse"
-                },
-                "examples": {
-                  "conversationVariables": {
-                    "summary": "响应示例",
-                    "value": {
-                      "limit": 20,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "name": "user_preference",
-                          "value_type": "string",
-                          "value": "dark_mode",
-                          "description": "用户偏好设置",
-                          "created_at": 1705407629,
-                          "updated_at": 1705411229
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : 应用模式与 API 路由不匹配。\n- `invalid_param` : `last_id` 未匹配到此会话中的任何变量。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "invalid_last_id": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 会话不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/conversations/list-conversation-variables",
-          "metadata": {
-            "title": "获取对话变量",
-            "sidebarTitle": "获取对话变量"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}/name": {
-      "post": {
-        "summary": "重命名会话",
-        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n重命名会话；当 `auto_generate` 为 `true` 时，根据会话消息自动生成名称。该名称用于客户端的多会话列表显示。",
-        "operationId": "renameBasicChatConversationCn",
-        "tags": [
-          "会话管理"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "要重命名的会话 ID。会话 ID 从 [获取会话列表](/zh/api-reference/conversations/list-conversations) 获取。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ConversationRenameRequest"
-              },
-              "examples": {
-                "renameExample": {
-                  "summary": "请求示例",
-                  "value": {
-                    "name": "iPhone Specs Chat",
-                    "user": "abc-123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "会话重命名成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationListItem"
-                },
-                "examples": {
-                  "renamedConversation": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
-                      "name": "iPhone Specs Chat",
-                      "inputs": {
-                        "city": "San Francisco"
-                      },
-                      "status": "normal",
-                      "introduction": "Welcome! How can I help you today?",
-                      "created_at": 1705407629,
-                      "updated_at": 1705411229
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : 应用模式与 API 路由不匹配。\n- `invalid_param` : `auto_generate` 为 `true`，但会话中没有可用于生成名称的消息。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "no_messages": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 会话不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/conversations/rename-conversation",
-          "metadata": {
-            "title": "重命名会话",
-            "sidebarTitle": "重命名会话"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}/variables/{variable_id}": {
-      "put": {
-        "summary": "更新对话变量",
-        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n更新会话变量的值。新值必须与该变量的现有类型匹配。",
-        "operationId": "updateChatConversationVariableZh",
-        "tags": [
-          "会话管理"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "变量所属的会话 ID。会话 ID 从 [获取会话列表](/zh/api-reference/conversations/list-conversations) 获取。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "variable_id",
-            "in": "path",
-            "required": true,
-            "description": "要更新的变量 ID。变量 ID 从 [获取对话变量](/zh/api-reference/conversations/list-conversation-variables) 获取。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ConversationVariableUpdateRequest"
-              },
-              "examples": {
-                "updateStringVariable": {
-                  "summary": "请求示例",
-                  "value": {
-                    "value": "new value",
-                    "user": "abc-123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "变量更新成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationVariableItem"
-                },
-                "examples": {
-                  "updatedVariable": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "name": "user_preference",
-                      "value_type": "string",
-                      "value": "new value",
-                      "description": "用户偏好设置",
-                      "created_at": 1705407629,
-                      "updated_at": 1705411229
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_chat_app` : 应用模式与 API 路由不匹配。\n- `bad_request` : 变量值类型不匹配。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "type_mismatch": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "Type mismatch: variable 'user_preference' expects string, but got number type"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 会话不存在。\n- `not_found` : 会话变量不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  },
-                  "variable_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Variable Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/conversations/update-conversation-variable",
-          "metadata": {
-            "title": "更新对话变量",
-            "sidebarTitle": "更新对话变量"
-          }
-        }
-      }
-    },
-    "/conversations/{conversation_id}": {
-      "delete": {
-        "summary": "删除会话",
-        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n删除会话。",
-        "operationId": "deleteBasicChatConversationCn",
-        "tags": [
-          "会话管理"
-        ],
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "description": "要删除的会话 ID。会话 ID 从 [获取会话列表](/zh/api-reference/conversations/list-conversations) 获取。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "JSON 请求体始终必填；不传 `user` 时发送 `{}`。",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "终端用户标识，由你的应用定义，需在应用内唯一。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。"
-                  }
-                }
-              },
-              "examples": {
-                "deleteExample": {
-                  "value": {
-                    "user": "abc-123"
-                  },
-                  "summary": "请求示例"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "会话删除成功。无返回内容。"
-          },
-          "400": {
-            "description": "`not_chat_app` : 应用模式与 API 路由不匹配。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_chat_app": {
-                    "summary": "not_chat_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_chat_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 会话不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "conversation_not_exists": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Conversation Not Exists."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/conversations/delete-conversation",
-          "metadata": {
-            "title": "删除会话",
-            "sidebarTitle": "删除会话"
-          }
-        }
-      }
-    },
-    "/audio-to-text": {
-      "post": {
-        "summary": "语音转文字",
-        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n使用工作空间的默认语音转文字模型，将上传的音频文件转写为文字。",
-        "operationId": "basicChatAudioToTextCn",
-        "tags": [
-          "语音与文字转换"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/AudioToTextRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "语音转文字成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AudioToTextResponse"
-                },
-                "examples": {
-                  "audioToTextSuccess": {
-                    "summary": "响应示例",
-                    "value": {
-                      "text": "Hello, I would like to know more about the iPhone 13 Pro Max."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_audio_uploaded` : 未上传音频文件（`file` 字段缺失）。\n- `speech_to_text_disabled` : 此应用未启用语音转文本。\n- `provider_not_support_speech_to_text` : 模型供应商不支持语音转文字。\n- `provider_not_initialize` : 未配置有效的模型供应商凭据。\n- `completion_request_error` : 语音识别请求失败。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_audio_uploaded": {
-                    "summary": "no_audio_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_audio_uploaded",
-                      "message": "Please upload your audio."
-                    }
-                  },
-                  "speech_to_text_disabled": {
-                    "summary": "speech_to_text_disabled",
-                    "value": {
-                      "status": 400,
-                      "code": "speech_to_text_disabled",
-                      "message": "Speech to text is disabled."
-                    }
-                  },
-                  "provider_not_support_speech_to_text": {
-                    "summary": "provider_not_support_speech_to_text",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_support_speech_to_text",
-                      "message": "Provider not support speech to text."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`audio_too_large` : 音频文件超出 `30 MB` 大小限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "audio_too_large": {
-                    "summary": "audio_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "audio_too_large",
-                      "message": "Audio size larger than 30 mb"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_audio_type` : 文件的 MIME 类型不在接受的音频类型之列（见 `file` 字段）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_audio_type": {
-                    "summary": "unsupported_audio_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_audio_type",
-                      "message": "Audio type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : 内部服务器错误。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/audio/convert-audio-to-text",
-          "metadata": {
-            "title": "语音转文字",
-            "sidebarTitle": "语音转文字"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/audio-to-text' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@meeting-question.mp3' \\\n  --form 'user={user}'"
-          }
-        ]
-      }
-    },
-    "/text-to-audio": {
-      "post": {
-        "summary": "文字转语音",
-        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n将文本转换为语音音频。传入 `text` 可合成任意文本，或传入 `message_id` 为已有消息的答案配音。",
-        "operationId": "basicChatTextToAudioCn",
-        "tags": [
-          "语音与文字转换"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TextToAudioRequest"
-              },
-              "examples": {
-                "textToAudioExample": {
-                  "summary": "请求示例",
-                  "value": {
-                    "text": "Hello, welcome to our service.",
-                    "user": "abc-123",
-                    "voice": "alloy",
-                    "streaming": false
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "返回生成的音频。`Content-Type` 响应头反映供应商实际返回的音频容器格式，可识别时会根据响应字节校验。\n\n响应体可能是 AAC、FLAC、MP4、MP3、Ogg、WAV 或 WebM。无法识别的输出按供应商声明的类型标注；未声明时标注为 `audio/mpeg`。\n\n供应商流式返回时按分块传输编码交付；请求中的 `streaming` 字段不控制此行为。",
-            "content": {
-              "audio/aac": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/flac": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/mp4": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/mpeg": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/ogg": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/wav": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              },
-              "audio/webm": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `app_unavailable` : 应用不可用或配置错误。\n- `invalid_param` : 未启用文字转语音、缺少 `text` 或没有可用音色。\n- `provider_not_initialize` : 未配置有效的模型供应商凭据。\n- `provider_quota_exceeded` : 模型供应商配额已用尽。\n- `model_currently_not_support` : 当前模型不支持此操作。\n- `completion_request_error` : 文字转语音请求失败。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "app_unavailable": {
-                    "summary": "app_unavailable",
-                    "value": {
-                      "status": 400,
-                      "code": "app_unavailable",
-                      "message": "App unavailable, please check your app configurations."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "TTS is not enabled"
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : 内部服务器错误。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/audio/convert-text-to-audio",
-          "metadata": {
-            "title": "文字转语音",
-            "sidebarTitle": "文字转语音"
-          }
-        }
-      }
-    },
-    "/info": {
-      "get": {
-        "summary": "获取应用基本信息",
-        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n返回应用的基本信息：名称、描述、标签、模式和作者。",
-        "operationId": "getBasicChatAppInfoCn",
-        "tags": [
-          "应用配置"
-        ],
-        "responses": {
-          "200": {
-            "description": "应用的基本信息。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfoResponse"
-                },
-                "examples": {
-                  "appInfo": {
-                    "summary": "响应示例",
-                    "value": {
-                      "name": "My Chat App",
-                      "description": "一个有用的客服聊天机器人。",
-                      "tags": [
-                        "customer-service",
-                        "chatbot"
-                      ],
-                      "mode": "chat",
-                      "author_name": "Dify Team"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/applications/get-app-info",
-          "metadata": {
-            "title": "获取应用基本信息",
-            "sidebarTitle": "获取应用基本信息"
-          }
-        }
-      }
-    },
-    "/parameters": {
-      "get": {
-        "summary": "获取应用参数",
-        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n返回应用的前端配置：开场白和建议问题、功能开关、用户输入表单，以及文件上传限制。用它来渲染应用的输入项并应用正确的上传限制。",
-        "operationId": "getBasicChatAppParametersCn",
-        "tags": [
-          "应用配置"
-        ],
-        "responses": {
-          "200": {
-            "description": "应用参数信息。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppParametersResponse"
-                },
-                "examples": {
-                  "appParameters": {
-                    "summary": "响应示例",
-                    "value": {
-                      "opening_statement": "Hello! How can I help you today?",
-                      "suggested_questions": [
-                        "What can you do?",
-                        "Tell me about your features."
-                      ],
-                      "suggested_questions_after_answer": {
-                        "enabled": true
-                      },
-                      "speech_to_text": {
-                        "enabled": false
-                      },
-                      "text_to_speech": {
-                        "enabled": false,
-                        "voice": "alloy",
-                        "language": "en-US",
-                        "autoPlay": "disabled"
-                      },
-                      "retriever_resource": {
-                        "enabled": true
-                      },
-                      "annotation_reply": {
-                        "enabled": false
-                      },
-                      "more_like_this": {
-                        "enabled": false
-                      },
-                      "sensitive_word_avoidance": {
-                        "enabled": false
-                      },
-                      "user_input_form": [
-                        {
-                          "text-input": {
-                            "label": "City",
-                            "variable": "city",
-                            "required": true,
-                            "default": ""
-                          }
-                        }
-                      ],
-                      "file_upload": {
-                        "image": {
-                          "enabled": true,
-                          "number_limits": 3,
-                          "detail": "high",
-                          "transfer_methods": [
-                            "remote_url",
-                            "local_file"
-                          ]
-                        }
-                      },
-                      "system_parameters": {
-                        "file_size_limit": 15,
-                        "image_file_size_limit": 10,
-                        "audio_file_size_limit": 50,
-                        "video_file_size_limit": 100,
-                        "workflow_file_upload_limit": 10
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `app_unavailable` : 应用不可用或配置错误。\n- `agent_not_published` : 应用的 Agent 尚无已发布版本。（新 Agent 应用）",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "app_unavailable": {
-                    "summary": "app_unavailable",
-                    "value": {
-                      "status": 400,
-                      "code": "app_unavailable",
-                      "message": "App unavailable, please check your app configurations."
-                    }
-                  },
-                  "agent_not_published": {
-                    "summary": "agent_not_published",
-                    "value": {
-                      "code": "agent_not_published",
-                      "message": "Agent has not been published. Please publish the Agent before using the API.",
-                      "status": 400
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/applications/get-app-parameters",
-          "metadata": {
-            "title": "获取应用参数",
-            "sidebarTitle": "获取应用参数"
-          }
-        }
-      }
-    },
-    "/meta": {
-      "get": {
-        "summary": "获取应用元数据",
-        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n返回此应用所用工具的展示图标，以工具名为键。",
-        "operationId": "getBasicChatAppMetaCn",
-        "tags": [
-          "应用配置"
-        ],
-        "responses": {
-          "200": {
-            "description": "成功获取应用元数据。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppMetaResponse"
-                },
-                "examples": {
-                  "appMeta": {
-                    "summary": "响应示例",
-                    "value": {
-                      "tool_icons": {
-                        "dalle3": "https://example.com/icons/dalle3.png",
-                        "calculator": {
-                          "background": "#4A90D9",
-                          "content": "🧮"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/applications/get-app-meta",
-          "metadata": {
-            "title": "获取应用元数据",
-            "sidebarTitle": "获取应用元数据"
-          }
-        }
-      }
-    },
-    "/site": {
-      "get": {
-        "summary": "获取应用 WebApp 设置",
-        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n返回应用托管 Web 应用的品牌与展示设置，如标题、图标、主题色和默认语言。",
-        "operationId": "getBasicChatWebAppSettingsCn",
-        "tags": [
-          "应用配置"
-        ],
-        "responses": {
-          "200": {
-            "description": "应用的 Web 应用设置。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WebAppSettingsResponse"
-                },
-                "examples": {
-                  "webAppSettings": {
-                    "summary": "响应示例",
-                    "value": {
-                      "title": "My Chat App",
-                      "chat_color_theme": "#4A90D9",
-                      "chat_color_theme_inverted": false,
-                      "icon_type": "emoji",
-                      "icon": "🤖",
-                      "icon_background": "#FFFFFF",
-                      "icon_url": null,
-                      "description": "一个有用的客服聊天机器人。",
-                      "copyright": "2025 Dify",
-                      "privacy_policy": "https://example.com/privacy",
-                      "input_placeholder": "有任何关于我们产品的问题都可以问我……",
-                      "custom_disclaimer": "",
-                      "default_language": "en-US",
-                      "show_workflow_steps": false,
-                      "use_icon_as_answer_icon": true
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : 未找到此应用的站点或工作空间已归档。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/applications/get-app-webapp-settings",
-          "metadata": {
-            "title": "获取应用 WebApp 设置",
-            "sidebarTitle": "获取应用 WebApp 设置"
-          }
-        }
-      }
-    },
-    "/apps/annotations": {
-      "post": {
-        "summary": "创建标注",
-        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n创建标注。标注是预定义的问答对，命中时应用直接返回，而不再生成新回复。",
-        "operationId": "createChatAnnotationZh",
-        "tags": [
-          "标注管理"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateAnnotationRequest"
-              },
-              "examples": {
-                "createAnnotation": {
-                  "summary": "请求示例",
-                  "value": {
-                    "question": "What is Dify?",
-                    "answer": "Dify is an open-source LLM application development platform."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "标注创建成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnnotationItem"
-                },
-                "examples": {
-                  "createdAnnotation": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "question": "What is Dify?",
-                      "answer": "Dify is an open-source LLM application development platform.",
-                      "hit_count": 0,
-                      "created_at": 1705407629
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/annotations/create-annotation",
-          "metadata": {
-            "title": "创建标注",
-            "sidebarTitle": "创建标注"
-          }
-        }
-      },
-      "get": {
-        "summary": "获取标注列表",
-        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n列出应用的标注，可按关键词筛选。",
-        "operationId": "listChatAnnotationsZh",
-        "tags": [
-          "标注管理"
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "页码。",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "每页条目数。超过 100 的请求会被限制为 100。",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1
-            }
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "description": "按问题或回答内容筛选标注的关键词。",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "成功获取标注列表。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnnotationListResponse"
-                },
-                "examples": {
-                  "annotationList": {
-                    "summary": "响应示例",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                          "question": "What is Dify?",
-                          "answer": "Dify is an open-source LLM application development platform.",
-                          "hit_count": 5,
-                          "created_at": 1705407629
-                        }
-                      ],
-                      "has_more": false,
-                      "limit": 20,
-                      "total": 1,
-                      "page": 1
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/annotations/list-annotations",
-          "metadata": {
-            "title": "获取标注列表",
-            "sidebarTitle": "获取标注列表"
-          }
-        }
-      }
-    },
-    "/apps/annotations/{annotation_id}": {
-      "put": {
-        "summary": "更新标注",
-        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n更新标注的问题和答案。",
-        "operationId": "updateChatAnnotationZh",
-        "tags": [
-          "标注管理"
-        ],
-        "parameters": [
-          {
-            "name": "annotation_id",
-            "in": "path",
-            "required": true,
-            "description": "要更新的标注 ID。标注 ID 从 [获取标注列表](/zh/api-reference/annotations/list-annotations) 获取。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateAnnotationRequest"
-              },
-              "examples": {
-                "updateAnnotation": {
-                  "summary": "请求示例",
-                  "value": {
-                    "question": "What is Dify?",
-                    "answer": "Dify is an open-source LLM application development platform for building AI-powered apps."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "标注更新成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnnotationItem"
-                },
-                "examples": {
-                  "updatedAnnotation": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "question": "What is Dify?",
-                      "answer": "Dify is an open-source LLM application development platform for building AI-powered apps.",
-                      "hit_count": 5,
-                      "created_at": 1705407629
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 标注不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Annotation not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/annotations/update-annotation",
-          "metadata": {
-            "title": "更新标注",
-            "sidebarTitle": "更新标注"
-          }
-        }
-      },
-      "delete": {
-        "summary": "删除标注",
-        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n删除标注及其关联的命中历史。",
-        "operationId": "deleteChatAnnotationZh",
-        "tags": [
-          "标注管理"
-        ],
-        "parameters": [
-          {
-            "name": "annotation_id",
-            "in": "path",
-            "required": true,
-            "description": "要删除的标注 ID。标注 ID 从 [获取标注列表](/zh/api-reference/annotations/list-annotations) 获取。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "标注删除成功。"
-          },
-          "404": {
-            "description": "`not_found` : 标注不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Annotation not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/annotations/delete-annotation",
-          "metadata": {
-            "title": "删除标注",
-            "sidebarTitle": "删除标注"
-          }
-        }
-      }
-    },
-    "/apps/annotation-reply/{action}": {
-      "post": {
-        "summary": "配置标注回复",
-        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n为应用启用或禁用标注回复。异步执行；使用 [查询标注回复配置任务状态](/zh/api-reference/annotations/get-annotation-reply-job-status) 跟踪进度。\n\n请求体在执行操作前校验，因此即使是 `disable` 也必须提供 `score_threshold`、`embedding_provider_name` 和 `embedding_model_name`。",
-        "operationId": "setChatAnnotationReplyZh",
-        "tags": [
-          "标注管理"
-        ],
-        "parameters": [
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "description": "启用还是禁用标注回复。",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InitialAnnotationReplySettingsRequest"
-              },
-              "examples": {
-                "enableAnnotationReply": {
-                  "summary": "请求示例",
-                  "value": {
-                    "score_threshold": 0.9,
-                    "embedding_provider_name": "openai",
-                    "embedding_model_name": "text-embedding-3-small"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "标注回复设置任务已启动。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InitialAnnotationReplySettingsResponse"
-                },
-                "examples": {
-                  "annotationReplyResponse": {
-                    "summary": "响应示例",
-                    "value": {
-                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "job_status": "waiting"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/annotations/configure-annotation-reply",
-          "metadata": {
-            "title": "配置标注回复",
-            "sidebarTitle": "配置标注回复"
-          }
-        }
-      }
-    },
-    "/apps/annotation-reply/{action}/status/{job_id}": {
-      "get": {
-        "summary": "查询标注回复配置任务状态",
-        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n返回由 [配置标注回复](/zh/api-reference/annotations/configure-annotation-reply) 发起的标注回复配置任务的状态。",
-        "operationId": "getChatAnnotationReplyStatusZh",
-        "tags": [
-          "标注管理"
-        ],
-        "parameters": [
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "description": "操作类型，必须与 [配置标注回复](/zh/api-reference/annotations/configure-annotation-reply) 调用中的一致。",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            }
-          },
-          {
-            "name": "job_id",
-            "in": "path",
-            "required": true,
-            "description": "由 [配置标注回复](/zh/api-reference/annotations/configure-annotation-reply) 接口返回的任务 ID。",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "成功获取任务状态。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InitialAnnotationReplySettingsStatusResponse"
-                },
-                "examples": {
-                  "jobStatus": {
-                    "summary": "响应示例",
-                    "value": {
-                      "job_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                      "job_status": "completed",
-                      "error_msg": ""
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 指定的任务不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "The job does not exist."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/annotations/get-annotation-reply-job-status",
-          "metadata": {
-            "title": "查询标注回复配置任务状态",
-            "sidebarTitle": "查询标注回复配置任务状态"
-          }
-        }
-      }
-    },
-    "/workflows/run/{workflow_run_id}": {
-      "get": {
-        "summary": "获取工作流执行情况",
-        "description": "**适用于**：Chatflow、Workflow。\n\n获取单次工作流运行的状态、输入、输出和执行指标。",
-        "operationId": "getWorkflowRunDetailCn",
-        "tags": [
-          "工作流运行"
-        ],
-        "parameters": [
-          {
-            "name": "workflow_run_id",
-            "in": "path",
-            "required": true,
-            "description": "工作流运行 ID，来自 [执行工作流](/zh/api-reference/workflow-runs/run-workflow) 的响应或流式事件，或 Chatflow 应用的消息元数据。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "成功获取工作流运行详情。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowRunDetailResponse"
-                },
-                "examples": {
-                  "workflowRunDetail": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                      "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
-                      "status": "succeeded",
-                      "inputs": "{\"query\": \"Translate this to French\"}",
-                      "outputs": {
-                        "result": "Traduisez ceci en francais"
-                      },
-                      "error": null,
-                      "total_steps": 3,
-                      "total_tokens": 150,
-                      "created_at": 1705407629,
-                      "finished_at": 1705407630,
-                      "elapsed_time": 1.23
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_workflow_app` : 应用模式与 API 路由不匹配。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到工作流运行记录。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "workflow_run_not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Workflow run not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/workflow-runs/get-workflow-run-detail",
-          "metadata": {
-            "title": "获取工作流执行情况",
-            "sidebarTitle": "获取工作流执行情况"
-          }
-        }
-      }
-    },
-    "/workflows/logs": {
-      "get": {
-        "summary": "获取工作流日志",
-        "description": "**适用于**：Chatflow、Workflow。\n\n列出过往的工作流运行，支持可选筛选。每条记录是运行级摘要（状态、Token 用量、步数和耗时），而非逐节点的执行日志。\n\n如需跟踪某次运行的节点级事件，请改用流式方式：\n\n- **自行发起的运行**：以流式模式调用 [执行工作流](/zh/api-reference/workflow-runs/run-workflow)，运行执行时会发送 `node_started` 和 `node_finished` 事件。\n- **已在进行中的运行**：调用 [流式获取工作流事件](/zh/api-reference/workflow-runs/stream-workflow-events) 并附带 `include_state_snapshot=true`，先重放各已执行节点的状态，再流式发送其余事件。\n\n已结束运行的节点级日志无法通过服务 API 获取。",
-        "operationId": "getWorkflowLogsCn",
-        "tags": [
-          "工作流运行"
-        ],
-        "parameters": [
-          {
-            "name": "keyword",
-            "in": "query",
-            "description": "在日志中搜索的关键词。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "按执行状态筛选。",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "succeeded",
-                "failed",
-                "stopped"
-              ]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "页码。",
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1,
-              "maximum": 99999
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "每页条目数。",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 100
-            }
-          },
-          {
-            "name": "created_at__before",
-            "in": "query",
-            "description": "筛选在此 ISO 8601 时间戳之前创建的日志。",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "created_at__after",
-            "in": "query",
-            "description": "筛选在此 ISO 8601 时间戳之后创建的日志。",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "created_by_end_user_session_id",
-            "in": "query",
-            "description": "按终端用户会话 ID 筛选。",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "created_by_account",
-            "in": "query",
-            "description": "按创建者的账户邮箱筛选（例如 `name@example.com`）。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "成功获取工作流日志。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowLogsResponse"
-                },
-                "examples": {
-                  "workflowLogs": {
-                    "summary": "响应示例",
-                    "value": {
-                      "page": 1,
-                      "limit": 20,
-                      "total": 1,
-                      "has_more": false,
-                      "data": [
-                        {
-                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
-                          "workflow_run": {
-                            "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                            "version": "2025-01-16 12:00:00.000000",
-                            "status": "succeeded",
-                            "error": null,
-                            "elapsed_time": 1.23,
-                            "total_tokens": 150,
-                            "total_steps": 3,
-                            "created_at": 1705407629,
-                            "finished_at": 1705407630,
-                            "exceptions_count": 0,
-                            "triggered_from": "app-run"
-                          },
-                          "created_from": "service-api",
-                          "created_by_role": "end_user",
-                          "created_by_account": null,
-                          "created_by_end_user": {
-                            "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
-                            "type": "service-api",
-                            "is_anonymous": false,
-                            "session_id": "user_workflow_123"
-                          },
-                          "created_at": 1705407629
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 某个查询参数无效，例如 `created_by_account` 未匹配到任何账户、`created_at__before` 或 `created_at__after` 时间戳格式错误，或 `page`、`limit`、`status` 超出有效范围。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Account not found: name@example.com"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/workflow-runs/list-workflow-logs",
-          "metadata": {
-            "title": "获取工作流日志",
-            "sidebarTitle": "获取工作流日志"
-          }
-        }
-      }
-    },
-    "/form/human_input/{form_token}": {
-      "get": {
-        "tags": [
-          "人工介入"
-        ],
-        "summary": "获取人工介入表单",
-        "description": "**适用于**：Chatflow、Workflow。\n\n返回暂停中的人工介入表单内容。需要 Web 应用提交方式。\n\n人工介入调用的完整流程，参见 [人工介入流程](/zh/api-reference/guides/human-input-flow)。",
-        "operationId": "getChatflowHumanInputForm",
-        "parameters": [
-          {
-            "name": "form_token",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "暂停表单的访问令牌，由流式模式下执行工作流或发送对话消息接口返回的 `human_input_required` 事件提供。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "表单内容获取成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "form_content": {
-                      "type": "string",
-                      "description": "已替换工作流变量的预渲染表单正文。"
-                    },
-                    "inputs": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "description": "表单输入控件类型。可用值：`paragraph`（多行文本输入）、`select`（从列表中单选）、`file`（单个文件上传）和 `file-list`（多个文件上传）。"
-                          },
-                          "output_variable_name": {
-                            "type": "string",
-                            "description": "引用该输入提交值在工作流中使用的变量名。对应提交 `inputs` 对象中的键。"
-                          },
-                          "default": {
-                            "type": "object",
-                            "nullable": true,
-                            "description": "`paragraph` 输入的原始默认值配置。客户端不应直接解析此字段，请使用 `resolved_default_values` 来展示默认值。其他输入类型或未配置默认值时，不包含该键。",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "description": "默认值来源。`constant` 表示将 `value` 作为字面字符串；`variable` 表示 `selector` 指向工作流变量。"
-                              },
-                              "selector": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "当 `type` 为 `variable` 时的变量引用路径（例如 `[\"node_id\", \"var_name\"]`）。至少包含两个元素。"
-                              },
-                              "value": {
-                                "type": "string",
-                                "description": "当 `type` 为 `constant` 时的字面默认值。始终为字符串。"
-                              }
-                            }
-                          },
-                          "option_source": {
-                            "type": "object",
-                            "description": "`select` 输入的选项来源。仅当 `type` 为 `select` 时出现。",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "enum": [
-                                  "variable",
-                                  "constant"
-                                ],
-                                "description": "选项来源。`constant` 表示 `value` 直接列出选项；`variable` 表示 `selector` 指向提供选项的 `array[string]` 工作流变量。"
-                              },
-                              "selector": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "当 `type` 为 `variable` 时的变量引用路径。"
-                              },
-                              "value": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "当 `type` 为 `constant` 时的字面选项列表。"
-                              }
-                            }
-                          },
-                          "allowed_file_types": {
-                            "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": [
-                                "image",
-                                "document",
-                                "audio",
-                                "video",
-                                "custom"
-                              ]
-                            },
-                            "description": "接收人可上传的文件类别。`file` 和 `file-list` 输入会包含此字段。可用值：`image`、`document`、`audio`、`video`、`custom`。"
-                          },
-                          "allowed_file_extensions": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            },
-                            "description": "当 `allowed_file_types` 包含 `custom` 时允许的文件扩展名。每个扩展名都需要包含前导 `.`，例如 `.md`。`file` 和 `file-list` 输入会包含此字段。"
-                          },
-                          "allowed_file_upload_methods": {
-                            "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": [
-                                "local_file",
-                                "remote_url"
-                              ]
-                            },
-                            "description": "接收人可使用的上传方式。可用值：`local_file`、`remote_url`。`file` 和 `file-list` 输入会包含此字段。"
-                          },
-                          "number_limits": {
-                            "type": "integer",
-                            "description": "接收人可上传的最大文件数。仅 `file-list` 输入会包含此字段。"
-                          }
-                        }
-                      },
-                      "description": "表单输入字段定义。"
-                    },
-                    "resolved_default_values": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      },
-                      "description": "用于在表单中展示的预渲染默认值，按输入的 `output_variable_name` 分组。仅当 `paragraph` 输入的默认值可由工作流变量解析时填充；无可解析默认值的输入为空。客户端请直接展示这些值，无需在前端再次解析 `default`。所有值均为字符串。"
-                    },
-                    "user_actions": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "maxLength": 20,
-                            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
-                            "description": "操作按钮的标识。当接收人选择该按钮时，作为 `action` 传入 [提交人工介入表单](/zh/api-reference/human-input/submit-human-input-form)。"
-                          },
-                          "title": {
-                            "type": "string",
-                            "maxLength": 100,
-                            "description": "显示给接收人的按钮文本。"
-                          },
-                          "button_style": {
-                            "type": "string",
-                            "description": "按钮的视觉样式。可用值：`primary`、`default`、`accent`、`ghost`。"
-                          }
-                        }
-                      },
-                      "description": "可用的提交操作。"
-                    },
-                    "expiration_time": {
-                      "type": "integer",
-                      "format": "int64",
-                      "description": "Unix 时间戳（秒），超过该时间后表单将不可提交。",
-                      "nullable": true
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "form_content": "请审阅草稿，设置优先级，然后确认或提出修改。",
-                      "inputs": [
-                        {
-                          "type": "paragraph",
-                          "output_variable_name": "feedback",
-                          "default": {
-                            "type": "constant",
-                            "selector": [],
-                            "value": ""
-                          }
-                        },
-                        {
-                          "type": "select",
-                          "output_variable_name": "priority",
-                          "option_source": {
-                            "type": "constant",
-                            "selector": [],
-                            "value": [
-                              "low",
-                              "medium",
-                              "high"
-                            ]
-                          }
-                        },
-                        {
-                          "type": "file",
-                          "output_variable_name": "attachment",
-                          "allowed_file_types": [
-                            "image",
-                            "document"
-                          ],
-                          "allowed_file_extensions": [],
-                          "allowed_file_upload_methods": [
-                            "local_file",
-                            "remote_url"
-                          ]
-                        },
-                        {
-                          "type": "file-list",
-                          "output_variable_name": "attachments",
-                          "allowed_file_types": [
-                            "image",
-                            "document"
-                          ],
-                          "allowed_file_extensions": [],
-                          "allowed_file_upload_methods": [
-                            "local_file",
-                            "remote_url"
-                          ],
-                          "number_limits": 5
-                        }
-                      ],
-                      "resolved_default_values": {
-                        "feedback": ""
-                      },
-                      "user_actions": [
-                        {
-                          "id": "approve",
-                          "title": "批准",
-                          "button_style": "primary"
-                        },
-                        {
-                          "id": "reject",
-                          "title": "请求修改",
-                          "button_style": "default"
-                        }
-                      ],
-                      "expiration_time": 1745510400
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found`：未找到表单。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "未找到表单"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "412": {
-            "description": "- `human_input_form_submitted`：表单已被提交。表单为一次性使用；无论由哪位用户提交，首个响应即生效。\n- `human_input_form_expired`：在提交到达之前表单已过期。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "human_input_form_submitted": {
-                    "summary": "human_input_form_submitted",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_submitted",
-                      "message": "该表单已被其他用户提交，form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  },
-                  "human_input_form_expired": {
-                    "summary": "human_input_form_expired",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_expired",
-                      "message": "该表单已过期，form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/human-input/get-human-input-form",
-          "metadata": {
-            "title": "获取人工介入表单",
-            "sidebarTitle": "获取人工介入表单"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "人工介入"
-        ],
-        "summary": "提交人工介入表单",
-        "description": "**适用于**：Chatflow、Workflow。\n\n向暂停中的人工介入表单提交接收人的响应。接受后工作流将恢复；可通过 [流式获取工作流事件](/zh/api-reference/workflow-runs/stream-workflow-events) 跟踪恢复后的运行。需要 Web 应用提交方式。",
-        "operationId": "submitChatflowHumanInputForm",
-        "parameters": [
-          {
-            "name": "form_token",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "暂停表单的访问令牌，由流式模式下执行工作流或发送对话消息接口返回的 `human_input_required` 事件提供。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "inputs",
-                  "action",
-                  "user"
-                ],
-                "properties": {
-                  "inputs": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "按各输入的 `output_variable_name` 作为键提交的值。段落和下拉选项输入为字符串；`file` 输入为单个文件映射；`file-list` 输入为文件映射数组。\n\n文件映射为 `{transfer_method: local_file, upload_file_id, type}` 或 `{transfer_method: remote_url, url, type}`，其中 `type` 为该字段 `allowed_file_types` 中的一种。对于 `local_file`，`upload_file_id` 为 [上传文件](/zh/api-reference/files/upload-file) 返回的 `id`。\n\n在执行、上传和提交各次调用中使用一致的 `user`。"
-                  },
-                  "action": {
-                    "type": "string",
-                    "description": "接收人选择的操作按钮 ID。必须与表单的 `user_actions` 列表（由 [获取人工介入表单](/zh/api-reference/human-input/get-human-input-form) 接口返回）中的某个 `id` 值匹配。"
-                  },
-                  "user": {
-                    "type": "string",
-                    "description": "终端用户标识，由你的应用定义，需在应用内唯一。Service API 与 Web 应用的用户 ID 相互独立，即使取值相同也不指向同一用户。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。"
-                  }
-                }
-              },
-              "examples": {
-                "approve": {
-                  "summary": "请求示例",
-                  "value": {
-                    "inputs": {
-                      "feedback": "可以发布",
-                      "priority": "high",
-                      "attachment": {
-                        "transfer_method": "local_file",
-                        "upload_file_id": "3c8fa1b2-7d4e-4f9a-b0c1-d2e3f4a5b6c7",
-                        "type": "image"
-                      },
-                      "attachments": [
-                        {
-                          "transfer_method": "local_file",
-                          "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee",
-                          "type": "document"
-                        },
-                        {
-                          "transfer_method": "remote_url",
-                          "url": "https://example.com/report.pdf",
-                          "type": "document"
-                        }
-                      ]
-                    },
-                    "action": "approve",
-                    "user": "abc-123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "表单提交成功。响应体为空对象。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {}
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `bad_request`：表单接收人类型无效。\n- `invalid_form_data`：提交内容未通过表单定义的校验。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "bad_request": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "表单接收人类型无效"
-                    }
-                  },
-                  "invalid_form_data": {
-                    "summary": "invalid_form_data",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_form_data",
-                      "message": "缺少必填输入：feedback"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found`：未找到表单。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "未找到表单"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "412": {
-            "description": "- `human_input_form_submitted`：表单已被提交。表单为一次性使用；无论由哪位用户提交，首个响应即生效。\n- `human_input_form_expired`：在提交到达之前表单已过期。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "human_input_form_submitted": {
-                    "summary": "human_input_form_submitted",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_submitted",
-                      "message": "该表单已被其他用户提交，form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  },
-                  "human_input_form_expired": {
-                    "summary": "human_input_form_expired",
-                    "value": {
-                      "status": 412,
-                      "code": "human_input_form_expired",
-                      "message": "该表单已过期，form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/human-input/submit-human-input-form",
-          "metadata": {
-            "title": "提交人工介入表单",
-            "sidebarTitle": "提交人工介入表单"
-          }
-        }
-      }
-    },
-    "/workflow/{workflow_run_id}/events": {
-      "get": {
-        "tags": [
-          "工作流运行"
-        ],
-        "summary": "流式获取工作流事件",
-        "description": "**适用于**：Chatflow、Workflow。\n\n在工作流运行暂停或原始 SSE 连接断开后恢复 Server-Sent Events 流。对于已结束的运行，流仅发送单个 `workflow_finished` 事件后关闭。\n\n如需查看进行中运行的节点级状态与进度，可在调用时附带 `include_state_snapshot=true`：流会先重放各已执行节点的状态，再流式发送新事件。",
-        "operationId": "streamWorkflowEvents",
-        "parameters": [
-          {
-            "name": "workflow_run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "要恢复事件流的工作流运行 ID，来自 [执行工作流](/zh/api-reference/workflow-runs/run-workflow) 的响应或流式事件。"
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "终端用户标识，由你的应用定义，需在应用内唯一。必须与发起该运行的 `user` 一致。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。"
-          },
-          {
-            "name": "include_state_snapshot",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "为 `true` 时，从持久化状态快照重放，在流式发送新事件前附带已执行节点的状态摘要。"
-          },
-          {
-            "name": "continue_on_pause",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "设为 `true` 时，流会在多次 `workflow_paused` 事件之间保持打开（适用于工作流包含多个连续人工介入节点的场景）。默认在首次暂停时关闭流。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Server-Sent Events 流。流以保活用的 `event: ping` 帧（不带 `data:`）开头，之后约每 10 秒到达一次；其余事件以 `data: {JSON}\\n\\n` 形式送达。事件载荷结构与原始流式响应一致。",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "已恢复工作流运行的事件 SSE 流，格式与 [执行工作流](/zh/api-reference/workflow-runs/run-workflow)（Workflow 应用）或 [发送对话消息](/zh/api-reference/chat-messages/send-chat-message)（Chatflow 应用）相同。当恢复部分运行设置 `reasoning_format: separated` 的 LLM 节点时，本流还会携带 `reasoning_chunk` 事件。"
-                },
-                "examples": {
-                  "resumedRun": {
-                    "summary": "响应示例 - 恢复运行（Workflow）",
-                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"rendered_content\": \"请审阅草稿。\", \"action_id\": \"approve\", \"action_text\": \"批准\", \"submitted_data\": {\"comment\": \"没问题，可以发布。\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_2\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Approved, now translating.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour\"}, \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
-                  },
-                  "resumedRunChatflow": {
-                    "summary": "响应示例 - 恢复运行（Chatflow）",
-                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"rendered_content\": \"请审阅草稿。\", \"action_id\": \"approve\", \"action_text\": \"批准\", \"submitted_data\": {\"comment\": \"没问题，可以发布。\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"The reviewer approved the draft.\", \"node_id\": \"node_llm_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"\", \"node_id\": \"node_llm_1\", \"is_final\": true}}\n\ndata: {\"event\": \"message\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"answer\": \"Approved\", \"created_at\": 1705407706}\n\ndata: {\"event\": \"node_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"status\": \"succeeded\", \"elapsed_time\": 1.2, \"created_at\": 1705407705, \"finished_at\": 1705407706}}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"metadata\": {\"usage\": {\"total_tokens\": 42, \"latency\": 1.3}}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`not_workflow_app` : Please check if your app mode matches the right API route.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Workflow run not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Workflow run not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "恢复事件流",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          },
-          {
-            "lang": "bash",
-            "label": "附带状态快照",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}&include_state_snapshot=true' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
-        "x-mint": {
-          "href": "/zh/api-reference/workflow-runs/stream-workflow-events",
-          "metadata": {
-            "title": "流式获取工作流事件",
-            "sidebarTitle": "流式获取工作流事件"
-          }
-        }
-      }
-    },
-    "/workflows/run": {
-      "post": {
-        "summary": "执行工作流",
-        "description": "**适用于**：Workflow。\n\n运行应用已发布的工作流并返回其输出，可以是单次 `blocking` 响应，也可以是 `streaming` 的 Server-Sent Events 流。需要已发布的工作流。",
-        "operationId": "executeWorkflowCn",
-        "tags": [
-          "工作流运行"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkflowExecutionRequest"
-              },
-              "examples": {
-                "streaming_example": {
-                  "summary": "请求示例 - 流式模式",
-                  "value": {
-                    "inputs": {
-                      "query": "Summarize this text: The quick brown fox jumps over the lazy dog."
-                    },
-                    "response_mode": "streaming",
-                    "user": "user_workflow_123"
-                  }
-                },
-                "blocking_example": {
-                  "summary": "请求示例 - 阻塞模式",
-                  "value": {
-                    "inputs": {
-                      "query": "Translate this to French: Hello world"
-                    },
-                    "response_mode": "blocking",
-                    "user": "user_workflow_456"
-                  }
-                },
-                "with_file_array_variable": {
-                  "summary": "Request Example - File array input",
-                  "value": {
-                    "inputs": {
-                      "my_documents": [
-                        {
-                          "type": "document",
-                          "transfer_method": "local_file",
-                          "upload_file_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab"
-                        },
-                        {
-                          "type": "image",
-                          "transfer_method": "remote_url",
-                          "url": "https://example.com/image.jpg"
-                        }
-                      ]
-                    },
-                    "response_mode": "blocking",
-                    "user": "user_workflow_789"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "请求成功。内容类型和结构取决于请求中的 `response_mode` 参数。\n\n- 如果 `response_mode` 为 `blocking`，返回 `application/json` 和 `WorkflowBlockingResponse` 对象。\n- 如果 `response_mode` 为 `streaming`，返回 `text/event-stream` 和 `ChunkWorkflowEvent` 对象流。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
-                },
-                "examples": {
-                  "blockingResponse": {
-                    "summary": "响应示例 - 阻塞模式",
-                    "value": {
-                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
-                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                      "data": {
-                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
-                        "status": "succeeded",
-                        "outputs": {
-                          "result": "Bonjour le monde"
-                        },
-                        "error": null,
-                        "elapsed_time": 1.23,
-                        "total_tokens": 150,
-                        "total_steps": 3,
-                        "created_at": 1705407629,
-                        "finished_at": 1705407630
-                      }
-                    }
-                  }
-                }
-              },
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "Server-Sent Events (SSE) 流。按 [SSE 流式传输指南](/zh/api-reference/guides/streaming) 解析：读取 `data:` 行，根据 `event` 字段分派，忽略 `ping`（保活；流以 `ping` 开头，之后约每 10 秒到达一次）。\n\n**流生命周期**：收到 `workflow_finished`、`workflow_paused` 或 `error` 事件时流关闭。错误以流内 `error` 事件的形式返回，HTTP 状态码始终为 `200`；请检查事件载荷获取详情，不要依赖状态码判断。\n\n**推理事件**：\n- `reasoning_chunk`：来自 `reasoning_format` 为 `separated` 的 LLM 节点的推理内容增量。拼接连续的 `reasoning_chunk` 事件即可还原完整推理内容；`is_final: true` 的事件标志该节点思考结束（且 `reasoning` 可能为空）。载荷位于 `data` 下，与对话应用不同，`message_id` 为 `null`，且不含 `conversation_id`。并行的 `text_chunk` 流不含 `<think>` 标签。\n\n**人工介入事件**：\n- `human_input_required`：工作流到达人工介入节点时与 `workflow_paused` 一同触发。使用载荷中的 `form_token` 通过 [人工介入 API](/zh/api-reference/human-input/get-human-input-form) 处理表单。\n- `human_input_form_filled`：接收者提交了表单，工作流恢复执行。\n- `human_input_form_timeout`：表单超时未响应。如定义了超时回退分支，工作流将沿该分支执行。"
-                },
-                "examples": {
-                  "streamingResponse": {
-                    "summary": "响应示例 - 流式模式",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"Translate this\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Let me translate that.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
-                  },
-                  "humanInputPause": {
-                    "summary": "响应示例 - 人工介入暂停",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"Hello\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"form_content\": \"请审阅草稿。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"批准\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_workflow_app` : 应用模式与 API 路由不匹配。\n- `provider_not_initialize` : 未找到有效的模型供应商凭据。\n- `provider_quota_exceeded` : 模型供应商配额已用尽。\n- `model_currently_not_support` : 当前模型不可用。\n- `completion_request_error` : 工作流执行请求失败。\n- `invalid_param` : 请求参数缺失或无效，例如缺少 `user` 或工作流未发布。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "- `too_many_requests` : 该应用的并发请求过多。\n- `rate_limit_error` : 此工作空间在 Dify Cloud 的工作流执行配额已达上限。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "too_many_requests": {
-                    "summary": "too_many_requests",
-                    "value": {
-                      "status": 429,
-                      "code": "too_many_requests",
-                      "message": "Too many requests. Please try again later."
-                    }
-                  },
-                  "rate_limit_error": {
-                    "summary": "rate_limit_error",
-                    "value": {
-                      "status": 429,
-                      "code": "rate_limit_error",
-                      "message": "Rate Limit Error"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : 内部服务器错误。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "Internal Server Error."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/workflow-runs/run-workflow",
-          "metadata": {
-            "title": "执行工作流",
-            "sidebarTitle": "执行工作流"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl -N --request POST \\\n  --url 'https://{api_base_url}/workflows/run' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"inputs\": {\"query\": \"Summarize this text: The quick brown fox jumps over the lazy dog.\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
-      }
-    },
-    "/workflows/{workflow_id}/run": {
-      "post": {
-        "summary": "按 ID 执行工作流",
-        "description": "**适用于**：Workflow。\n\n运行指定的已发布工作流版本，由路径中的 `workflow_id` 指定。请求体、响应和流式行为与 [执行工作流](/zh/api-reference/workflow-runs/run-workflow) 相同，仅执行的版本不同。",
-        "operationId": "runWorkflowByIdZh",
-        "tags": [
-          "工作流运行"
-        ],
-        "parameters": [
-          {
-            "name": "workflow_id",
-            "in": "path",
-            "required": true,
-            "description": "要运行的已发布工作流版本。在 [执行工作流](/zh/api-reference/workflow-runs/run-workflow) 响应和 [获取工作流运行详情](/zh/api-reference/workflow-runs/get-workflow-run-detail) 的 `workflow_id` 字段中返回。必须指向已发布版本；草稿版本 ID 会返回 `bad_request`。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkflowExecutionRequest"
-              },
-              "examples": {
-                "example": {
-                  "summary": "请求示例",
-                  "value": {
-                    "inputs": {
-                      "query": "Summarize this article"
-                    },
-                    "response_mode": "blocking",
-                    "user": "user_workflow_123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "请求成功。内容类型和结构取决于请求中的 `response_mode` 参数。\n\n- 如果 `response_mode` 为 `blocking`，返回 `application/json` 和 `WorkflowBlockingResponse` 对象。\n- 如果 `response_mode` 为 `streaming`，返回 `text/event-stream` 和 `ChunkWorkflowEvent` 对象流。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
-                },
-                "examples": {
-                  "blockingResponse": {
-                    "summary": "响应示例 - 阻塞模式",
-                    "value": {
-                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
-                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                      "data": {
-                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
-                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
-                        "status": "succeeded",
-                        "outputs": {
-                          "result": "Article summary here"
-                        },
-                        "error": null,
-                        "elapsed_time": 2.45,
-                        "total_tokens": 280,
-                        "total_steps": 4,
-                        "created_at": 1705407629,
-                        "finished_at": 1705407631
-                      }
-                    }
-                  }
-                }
-              },
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "Server-Sent Events (SSE) 流。按 [SSE 流式传输指南](/zh/api-reference/guides/streaming) 解析：读取 `data:` 行，根据 `event` 字段分派，忽略 `ping`（保活；流以 `ping` 开头，之后约每 10 秒到达一次）。\n\n**流生命周期**：收到 `workflow_finished`、`workflow_paused` 或 `error` 事件时流关闭。错误以流内 `error` 事件的形式返回，HTTP 状态码始终为 `200`；请检查事件载荷获取详情，不要依赖状态码判断。\n\n**推理事件**：\n- `reasoning_chunk`：来自 `reasoning_format` 为 `separated` 的 LLM 节点的推理内容增量。拼接连续的 `reasoning_chunk` 事件即可还原完整推理内容；`is_final: true` 的事件标志该节点思考结束（且 `reasoning` 可能为空）。载荷位于 `data` 下，与对话应用不同，`message_id` 为 `null`，且不含 `conversation_id`。并行的 `text_chunk` 流不含 `<think>` 标签。\n\n**人工介入事件**：\n- `human_input_required`：工作流到达人工介入节点时与 `workflow_paused` 一同触发。使用载荷中的 `form_token` 通过 [人工介入 API](/zh/api-reference/human-input/get-human-input-form) 处理表单。\n- `human_input_form_filled`：接收者提交了表单，工作流恢复执行。\n- `human_input_form_timeout`：表单超时未响应。如定义了超时回退分支，工作流将沿该分支执行。"
-                },
-                "examples": {
-                  "streamingResponse": {
-                    "summary": "响应示例 - 流式模式",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"Translate this\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM Node\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"Let me translate that.\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
-                  },
-                  "humanInputPause": {
-                    "summary": "响应示例 - 人工介入暂停",
-                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"Hello\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"Approval\", \"form_content\": \"请审阅草稿。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"批准\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `not_workflow_app` : 应用模式与 API 路由不匹配。\n- `bad_request` : 工作流为草稿或 ID 格式无效。\n- `provider_not_initialize` : 未找到有效的模型供应商凭据。\n- `provider_quota_exceeded` : 模型供应商配额已用尽。\n- `model_currently_not_support` : 当前模型不可用。\n- `completion_request_error` : 工作流执行请求失败。\n- `invalid_param` : 请求参数缺失或无效，例如缺少 `user`。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "bad_request": {
-                    "summary": "bad_request",
-                    "value": {
-                      "status": 400,
-                      "code": "bad_request",
-                      "message": "Cannot use draft workflow version. Workflow ID: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345. Please use a published workflow version or leave workflow_id empty."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`workflow_version_execution_not_allowed` : Dify Cloud Sandbox 套餐无法执行指定的工作流版本。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "workflow_version_execution_not_allowed": {
-                    "summary": "workflow_version_execution_not_allowed",
-                    "value": {
-                      "status": 403,
-                      "code": "workflow_version_execution_not_allowed",
-                      "message": "Workflow version execution is not available on your current plan. Please upgrade to a paid plan."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 工作流 not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Workflow not found with id: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "- `too_many_requests` : 该应用的并发请求过多。\n- `rate_limit_error` : 此工作空间在 Dify Cloud 的工作流执行配额已达上限。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "too_many_requests": {
-                    "summary": "too_many_requests",
-                    "value": {
-                      "status": 429,
-                      "code": "too_many_requests",
-                      "message": "Too many requests. Please try again later."
-                    }
-                  },
-                  "rate_limit_error": {
-                    "summary": "rate_limit_error",
-                    "value": {
-                      "status": 429,
-                      "code": "rate_limit_error",
-                      "message": "Rate Limit Error"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "`internal_server_error` : 内部服务器错误。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
-                    "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "Internal Server Error."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/workflow-runs/run-workflow-by-id",
-          "metadata": {
-            "title": "按 ID 执行工作流",
-            "sidebarTitle": "按 ID 执行工作流"
-          }
-        }
-      }
-    },
-    "/workflows/tasks/{task_id}/stop": {
-      "post": {
-        "summary": "停止工作流任务",
-        "description": "**适用于**：Workflow。\n\n停止正在运行的工作流任务。仅在 `streaming` 模式下支持。",
-        "operationId": "stopWorkflowTaskGenerationCn",
-        "tags": [
-          "工作流运行"
-        ],
-        "parameters": [
-          {
-            "name": "task_id",
-            "in": "path",
-            "required": true,
-            "description": "任务 ID，来自 [执行工作流](/zh/api-reference/workflow-runs/run-workflow) 的流式事件。",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "user"
-                ],
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "终端用户标识，由你的应用定义，需在应用内唯一。无需与发起该运行的 `user` 一致；停止对该任务始终生效。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。"
-                  }
-                }
-              },
-              "examples": {
-                "example": {
-                  "summary": "请求示例",
-                  "value": {
-                    "user": "user_workflow_123"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/SuccessResult"
-          },
-          "400": {
-            "description": "- `not_workflow_app` : 应用模式与 API 路由不匹配。\n- `invalid_param` : 请求参数缺失或无效，例如缺少 `user`。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_workflow_app": {
-                    "summary": "not_workflow_app",
-                    "value": {
-                      "status": 400,
-                      "code": "not_workflow_app",
-                      "message": "Please check if your app mode matches the right API route."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Arg user must be provided."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/workflow-runs/stop-workflow-task",
-          "metadata": {
-            "title": "停止工作流任务",
-            "sidebarTitle": "停止工作流任务"
-          }
-        }
-      }
-    },
     "/completion-messages": {
       "post": {
-        "summary": "发送消息",
         "description": "**适用于**：文本生成应用。\n\n向文本生成型应用发送请求并返回生成的文本。",
         "operationId": "createCompletionMessage",
-        "tags": [
-          "文本生成消息"
-        ],
         "requestBody": {
-          "description": "创建文本生成消息的请求体。",
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CompletionRequest"
+                "$ref": "#/components/schemas/CompletionRequestPayloadWithUser"
               },
               "examples": {
                 "streaming_example": {
                   "summary": "请求示例 - 流式模式",
                   "value": {
                     "inputs": {
-                      "city": "San Francisco"
+                      "city": "旧金山"
                     },
-                    "query": "Translate 'hello' to Spanish.",
+                    "query": "将“你好”翻译成西班牙语。",
                     "response_mode": "streaming",
                     "user": "abc-123",
                     "files": [
@@ -4391,24 +1632,25 @@
                   "summary": "请求示例 - 阻塞模式",
                   "value": {
                     "inputs": {
-                      "city": "New York"
+                      "city": "纽约"
                     },
-                    "query": "Summarize the following text: ...",
+                    "query": "总结以下文本：……",
                     "response_mode": "blocking",
                     "user": "def-456"
                   }
                 }
               }
             }
-          }
+          },
+          "required": true,
+          "description": "创建文本生成消息的请求体。"
         },
         "responses": {
           "200": {
-            "description": "请求成功。内容类型和结构取决于请求中的 `response_mode` 参数。\n\n- 如果 `response_mode` 为 `blocking`，返回 `application/json` 和 `CompletionResponse` 对象。\n- 如果 `response_mode` 为 `streaming`，返回 `text/event-stream` 和 `ChunkCompletionEvent` 对象流。",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CompletionResponse"
+                  "$ref": "#/components/schemas/CompletionBlockingResponse"
                 },
                 "examples": {
                   "blockingResponse": {
@@ -4419,7 +1661,7 @@
                       "id": "b01a39de-3480-4f3e-9f1e-4841a80f8e5e",
                       "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
                       "mode": "completion",
-                      "answer": "Hello World!...",
+                      "answer": "你好，世界！……",
                       "metadata": {
                         "usage": {
                           "prompt_tokens": 1033,
@@ -4444,19 +1686,19 @@
               "text/event-stream": {
                 "schema": {
                   "type": "string",
-                  "description": "Server-Sent Events (SSE) 流。按 [SSE 流式传输指南](/zh/api-reference/guides/streaming) 解析：读取 `data:` 行，根据 `event` 字段分派，忽略 `ping`（每 10 秒保持连接）。事件结构参见 `ChunkCompletionEvent`。\n\n**流生命周期**：回复以 `message` 片段流式返回，并以 `message_end` 结束。`error` 事件会提前结束流；此时 HTTP 状态码仍为 `200`，请检查事件载荷获取详情。"
+                  "description": "文本生成期间发送的服务器发送事件（SSE）。"
                 },
                 "examples": {
                   "streamingResponse": {
                     "summary": "响应示例 - 流式模式",
-                    "value": "data: {\"event\": \"message\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"answer\": \" I\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"answer\": \"'m\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"id\": \"5e52ce04-874b-4d27-9045-b3bc80def685\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"metadata\": {\"usage\": {\"prompt_tokens\": 1033, \"prompt_unit_price\": \"0.001\", \"prompt_price_unit\": \"0.001\", \"prompt_price\": \"0.0010330\", \"completion_tokens\": 135, \"completion_unit_price\": \"0.002\", \"completion_price_unit\": \"0.001\", \"completion_price\": \"0.0002700\", \"total_tokens\": 1168, \"total_price\": \"0.0013030\", \"currency\": \"USD\", \"latency\": 1.381760165997548}}}\n\n"
+                    "value": "data: {\"event\": \"message\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"answer\": \"我\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"answer\": \"'m\", \"created_at\": 1679586595}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"900bbd43-dc0b-4383-a372-aa6e6c414227\", \"id\": \"5e52ce04-874b-4d27-9045-b3bc80def685\", \"message_id\": \"5ad4cb98-f0c7-4085-b384-88c403be6290\", \"metadata\": {\"usage\": {\"prompt_tokens\": 1033, \"prompt_unit_price\": \"0.001\", \"prompt_price_unit\": \"0.001\", \"prompt_price\": \"0.0010330\", \"completion_tokens\": 135, \"completion_unit_price\": \"0.002\", \"completion_price_unit\": \"0.001\", \"completion_price\": \"0.0002700\", \"total_tokens\": 1168, \"total_price\": \"0.0013030\", \"currency\": \"USD\", \"latency\": 1.381760165997548}}}\n\n"
                   }
                 }
               }
-            }
+            },
+            "description": "成功响应。`blocking` 模式返回包含 `CompletionBlockingResponse` 对象的 `application/json`；`streaming` 模式返回包含文本生成流式事件的 `text/event-stream`。"
           },
           "400": {
-            "description": "- `app_unavailable` : 应用不可用或配置错误。\n- `provider_not_initialize` : 未找到有效的模型供应商凭据。\n- `provider_quota_exceeded` : 模型供应商配额已用尽。\n- `model_currently_not_support` : 当前模型不可用。\n- `completion_request_error` : 文本生成失败。\n- `invalid_param` : 缺少必填的 `user` 字段。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4510,10 +1752,56 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `app_unavailable`：应用不可用或配置错误。\n- `provider_not_initialize`：未找到有效的模型供应商凭据。\n- `provider_quota_exceeded`：模型供应商配额已用尽。\n- `model_currently_not_support`：当前模型不可用。\n- `completion_request_error`：文本生成失败。\n- `invalid_param`：缺少必填的 `user` 字段。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "端点声明中保留的兼容响应。此文本生成请求不接受 `conversation_id`，当前运行时也不会通过此响应查询会话。"
           },
           "429": {
-            "description": "`too_many_requests` : 该应用的并发请求过多。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4527,10 +1815,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`too_many_requests`：该应用的并发请求过多。"
           },
           "500": {
-            "description": "`internal_server_error` : 内部服务器错误。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4544,59 +1832,51 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`internal_server_error`：内部服务器错误。"
           }
         },
+        "summary": "发送消息",
+        "tags": [
+          "文本生成消息"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/completion-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"inputs\": {\"city\": \"旧金山\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
+          }
+        ],
         "x-mint": {
           "href": "/zh/api-reference/completion-messages/send-completion-message",
           "metadata": {
             "title": "发送消息",
             "sidebarTitle": "发送消息"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/completion-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"inputs\": {\"city\": \"San Francisco\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/completion-messages/{task_id}/stop": {
       "post": {
-        "summary": "停止响应",
-        "description": "**适用于**：文本生成应用。\n\n停止文本生成消息生成任务。仅在 `streaming` 模式下支持。",
-        "operationId": "stopCompletionGeneration",
-        "tags": [
-          "文本生成消息"
-        ],
+        "description": "停止文本生成任务。仅支持 `streaming` 模式。",
+        "operationId": "stopGenerate",
         "parameters": [
           {
-            "name": "task_id",
-            "in": "path",
-            "required": true,
             "description": "任务 ID，来自 [发送消息](/zh/api-reference/completion-messages/send-completion-message) 的流式事件。",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
             "schema": {
+              "description": "任务 ID，可从发送文本生成消息 API 返回的流式分块中获取。",
               "type": "string"
             }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "user"
-                ],
-                "properties": {
-                  "user": {
-                    "type": "string",
-                    "description": "终端用户标识，由你的应用定义，需在应用内唯一。必须与发送原始消息时的 `user` 一致；不一致时停止不会生效，但仍返回成功。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。"
-                  }
-                }
+                "$ref": "#/components/schemas/RequiredServiceApiUserPayload"
               },
               "examples": {
                 "example": {
@@ -4607,14 +1887,24 @@
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "$ref": "#/components/responses/SuccessResult"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "任务已成功停止"
           },
           "400": {
-            "description": "- `app_unavailable` : 应用不可用或配置错误。\n- `invalid_param` : 缺少必填的 `user` 字段。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4636,14 +1926,864 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `app_unavailable`：应用不可用或配置错误。\n- `invalid_param`：缺少必填的 `user` 字段。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "保留的兼容响应。当前运行时在设置停止标记前不会校验任务是否存在；即使任务已不再运行，也会返回正常的 `200` 结果。"
           }
         },
+        "summary": "停止响应",
+        "tags": [
+          "文本生成消息"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/completion-messages/stop-completion-message-generation",
           "metadata": {
             "title": "停止响应",
             "sidebarTitle": "停止响应"
+          }
+        }
+      }
+    },
+    "/conversations": {
+      "get": {
+        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n列出某个终端用户的会话，按最近活跃时间排序。",
+        "operationId": "getConversationsList",
+        "parameters": [
+          {
+            "description": "分页游标：当前页最后一个会话的 `id`。省略则获取第一页。",
+            "in": "query",
+            "name": "last_id",
+            "required": false,
+            "schema": {
+              "description": "当前页面最后一条记录的 ID，用于获取下一页。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "返回的记录数。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "返回的记录数。",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "排序字段。使用 `-` 前缀表示降序。",
+            "in": "query",
+            "name": "sort_by",
+            "required": false,
+            "schema": {
+              "default": "-updated_at",
+              "description": "排序字段。使用 `-` 前缀表示降序。",
+              "enum": [
+                "-created_at",
+                "-updated_at",
+                "created_at",
+                "updated_at"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "终端用户标识，由你的应用定义，需在应用内唯一。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "用于终端用户上下文的用户标识符。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationInfiniteScrollPagination"
+                },
+                "examples": {
+                  "conversationsList": {
+                    "summary": "响应示例",
+                    "value": {
+                      "limit": 20,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                          "name": "iPhone 规格对话",
+                          "inputs": {
+                            "city": "旧金山"
+                          },
+                          "status": "normal",
+                          "introduction": "欢迎！今天有什么可以帮你？",
+                          "created_at": 1705407629,
+                          "updated_at": 1705411229
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "成功获取会话列表。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_chat_app`：应用模式与 API 路由不匹配。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "last_conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Last Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：上一个会话不存在（无效的 `last_id`）。"
+          }
+        },
+        "summary": "获取会话列表",
+        "tags": [
+          "会话管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/conversations/list-conversations",
+          "metadata": {
+            "title": "获取会话列表",
+            "sidebarTitle": "获取会话列表"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}": {
+      "delete": {
+        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n删除会话。",
+        "operationId": "deleteConversation",
+        "parameters": [
+          {
+            "description": "要删除的会话 ID。会话 ID 从 [获取会话列表](/zh/api-reference/conversations/list-conversations) 获取。",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "会话 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OptionalServiceApiUserPayload"
+              },
+              "examples": {
+                "deleteExample": {
+                  "value": {
+                    "user": "abc-123"
+                  },
+                  "summary": "请求示例"
+                }
+              }
+            }
+          },
+          "required": true,
+          "description": "JSON 请求体始终必填；不传 `user` 时发送 `{}`。"
+        },
+        "responses": {
+          "204": {
+            "description": "会话删除成功。无返回内容。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_chat_app`：应用模式与 API 路由不匹配。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：会话不存在。"
+          }
+        },
+        "summary": "删除会话",
+        "tags": [
+          "会话管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/conversations/delete-conversation",
+          "metadata": {
+            "title": "删除会话",
+            "sidebarTitle": "删除会话"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}/name": {
+      "post": {
+        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n重命名会话；当 `auto_generate` 为 `true` 时，根据会话消息自动生成名称。该名称用于客户端的多会话列表显示。",
+        "operationId": "renameConversation",
+        "parameters": [
+          {
+            "description": "要重命名的会话 ID。会话 ID 从 [获取会话列表](/zh/api-reference/conversations/list-conversations) 获取。",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "会话 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConversationRenamePayloadWithUser"
+              },
+              "examples": {
+                "renameExample": {
+                  "summary": "请求示例",
+                  "value": {
+                    "name": "iPhone 规格对话",
+                    "user": "abc-123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleConversation"
+                },
+                "examples": {
+                  "renamedConversation": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                      "name": "iPhone 规格对话",
+                      "inputs": {
+                        "city": "旧金山"
+                      },
+                      "status": "normal",
+                      "introduction": "欢迎！今天有什么可以帮你？",
+                      "created_at": 1705407629,
+                      "updated_at": 1705411229
+                    }
+                  }
+                }
+              }
+            },
+            "description": "会话重命名成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "no_messages": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app`：应用模式与 API 路由不匹配。\n- `invalid_param`：`auto_generate` 为 `true`，但会话中没有可用于生成名称的消息。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：会话不存在。"
+          }
+        },
+        "summary": "重命名会话",
+        "tags": [
+          "会话管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/conversations/rename-conversation",
+          "metadata": {
+            "title": "重命名会话",
+            "sidebarTitle": "重命名会话"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}/variables": {
+      "get": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n列出会话中存储的变量。",
+        "operationId": "getConversationVariables",
+        "parameters": [
+          {
+            "description": "要列出变量的会话 ID。会话 ID 从 [获取会话列表](/zh/api-reference/conversations/list-conversations) 获取。",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "会话 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "分页游标：当前页最后一个变量的 `id`。省略则获取第一页。",
+            "in": "query",
+            "name": "last_id",
+            "required": false,
+            "schema": {
+              "description": "当前页面最后一条记录的 ID，用于获取下一页。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "返回的记录数。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "返回的记录数。",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "终端用户标识，由你的应用定义，需在应用内唯一。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "用于终端用户上下文的用户标识符。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "按指定名称筛选变量。",
+            "in": "query",
+            "name": "variable_name",
+            "required": false,
+            "schema": {
+              "description": "按指定名称筛选变量。",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationVariableInfiniteScrollPaginationResponse"
+                },
+                "examples": {
+                  "conversationVariables": {
+                    "summary": "响应示例",
+                    "value": {
+                      "limit": 20,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                          "name": "user_preference",
+                          "value_type": "string",
+                          "value": "dark_mode",
+                          "description": "用户偏好设置",
+                          "created_at": 1705407629,
+                          "updated_at": 1705411229
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "成功获取会话变量。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "invalid_last_id": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app`：应用模式与 API 路由不匹配。\n- `invalid_param`：`last_id` 未匹配到此会话中的任何变量。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：会话不存在。"
+          }
+        },
+        "summary": "获取对话变量",
+        "tags": [
+          "会话管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/conversations/list-conversation-variables",
+          "metadata": {
+            "title": "获取对话变量",
+            "sidebarTitle": "获取对话变量"
+          }
+        }
+      }
+    },
+    "/conversations/{conversation_id}/variables/{variable_id}": {
+      "put": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent。\n\n更新会话变量的值。新值必须与该变量的现有类型匹配。",
+        "operationId": "updateChatConversationVariable",
+        "parameters": [
+          {
+            "description": "变量所属的会话 ID。会话 ID 从 [获取会话列表](/zh/api-reference/conversations/list-conversations) 获取。",
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "会话 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "要更新的变量 ID。变量 ID 从 [获取对话变量](/zh/api-reference/conversations/list-conversation-variables) 获取。",
+            "in": "path",
+            "name": "variable_id",
+            "required": true,
+            "schema": {
+              "description": "变量 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConversationVariableUpdatePayloadWithUser"
+              },
+              "examples": {
+                "updateStringVariable": {
+                  "summary": "请求示例",
+                  "value": {
+                    "value": "新值",
+                    "user": "abc-123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationVariableResponse"
+                },
+                "examples": {
+                  "updatedVariable": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "name": "user_preference",
+                      "value_type": "string",
+                      "value": "新值",
+                      "description": "用户偏好设置",
+                      "created_at": 1705407629,
+                      "updated_at": 1705411229
+                    }
+                  }
+                }
+              }
+            },
+            "description": "变量更新成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "type_mismatch": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "Type mismatch: variable 'user_preference' expects string, but got number type"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app`：应用模式与 API 路由不匹配。\n- `bad_request`：变量值类型不匹配。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  },
+                  "variable_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Variable Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：会话不存在。\n- `not_found`：会话变量不存在。"
+          }
+        },
+        "summary": "更新对话变量",
+        "tags": [
+          "会话管理"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/conversations/update-conversation-variable",
+          "metadata": {
+            "title": "更新对话变量",
+            "sidebarTitle": "更新对话变量"
           }
         }
       }
@@ -5042,6 +3182,645 @@
           "metadata": {
             "title": "获取知识库列表",
             "sidebarTitle": "获取知识库列表"
+          }
+        }
+      }
+    },
+    "/datasets/pipeline/file-upload": {
+      "post": {
+        "tags": [
+          "知识流水线"
+        ],
+        "summary": "上传流水线文件",
+        "description": "上传文件以在知识流水线中使用。将返回的 `id` 用作 [运行流水线](/zh/api-reference/knowledge-pipeline/run-pipeline) 中 `local_file` 项的 `reference`。",
+        "operationId": "uploadPipelineFileZh",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "要上传的文件，作为 `multipart/form-data` 的一个部分。文档文件默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。\n\nDify Cloud 的 Professional 和 Team 套餐的文档上限为 50 MB。图片、音频、视频文件各有独立上限，默认分别为 10 MB、50 MB、100 MB。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "文件上传成功。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "已上传文件的唯一标识符。"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "原始文件名。"
+                    },
+                    "size": {
+                      "type": "integer",
+                      "description": "文件大小（字节）。"
+                    },
+                    "extension": {
+                      "type": "string",
+                      "description": "文件扩展名。"
+                    },
+                    "mime_type": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "文件的 MIME 类型。若上传未包含 MIME 类型则可能为 `null`。"
+                    },
+                    "created_by": {
+                      "type": "string",
+                      "description": "上传文件的用户 ID。"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "上传时间戳（ISO 8601 格式）。在记录创建过程中可能为 `null`。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "name": "report.pdf",
+                      "size": 524288,
+                      "extension": "pdf",
+                      "mime_type": "application/pdf",
+                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "created_at": "2025-03-06T12:00:00"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `no_file_uploaded` : 请求中未提供文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `too_many_files` : 每次请求仅允许一个文件。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "`file_too_large` : 文件超出上传大小限制。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "`unsupported_file_type` : 不支持的文件类型。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/knowledge-pipeline/upload-pipeline-file",
+          "metadata": {
+            "title": "上传流水线文件",
+            "sidebarTitle": "上传流水线文件"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
+          }
+        ]
+      }
+    },
+    "/datasets/tags": {
+      "post": {
+        "tags": [
+          "标签"
+        ],
+        "summary": "创建知识库标签",
+        "description": "创建用于组织知识库的标签。",
+        "operationId": "createKnowledgeTag",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50,
+                    "description": "标签名称。在工作空间内必须唯一。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "标签创建成功。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "标签标识符。"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "标签显示名称。"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "标签类型。知识库标签始终为 `knowledge`。"
+                    },
+                    "binding_count": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "绑定到该标签的知识库数量。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                      "name": "Product Docs",
+                      "type": "knowledge",
+                      "binding_count": "0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_param` : 已存在同名的知识库标签。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Tag name already exists"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/tags/create-knowledge-tag",
+          "metadata": {
+            "title": "创建知识库标签",
+            "sidebarTitle": "创建知识库标签"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "标签"
+        ],
+        "summary": "获取知识库标签列表",
+        "description": "返回工作空间中所有的知识库标签。",
+        "operationId": "getKnowledgeTags",
+        "responses": {
+          "200": {
+            "description": "标签列表。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "标签标识符。"
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "标签显示名称。"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "标签类型。知识库标签始终为 `knowledge`。"
+                      },
+                      "binding_count": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "绑定到该标签的知识库数量。"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": [
+                      {
+                        "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                        "name": "Product Docs",
+                        "type": "knowledge",
+                        "binding_count": "0"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/tags/list-knowledge-tags",
+          "metadata": {
+            "title": "获取知识库标签列表",
+            "sidebarTitle": "获取知识库标签列表"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "标签"
+        ],
+        "summary": "修改知识库标签",
+        "description": "重命名知识库标签。",
+        "operationId": "updateKnowledgeTag",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tag_id",
+                  "name"
+                ],
+                "properties": {
+                  "tag_id": {
+                    "type": "string",
+                    "description": "要重命名的标签 ID。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。"
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50,
+                    "description": "标签的新名称。在工作空间内必须唯一。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "标签更新成功。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "标签标识符。"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "标签显示名称。"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "标签类型。知识库标签始终为 `knowledge`。"
+                    },
+                    "binding_count": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "绑定到该标签的知识库数量。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                      "name": "Product Docs",
+                      "type": "knowledge",
+                      "binding_count": "0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_param` : 已存在同名的知识库标签。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Tag name already exists"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : 指定的标签不存在。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Tag not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/tags/update-knowledge-tag",
+          "metadata": {
+            "title": "修改知识库标签",
+            "sidebarTitle": "修改知识库标签"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "标签"
+        ],
+        "summary": "删除知识库标签",
+        "description": "永久删除知识库标签。不会删除已被标记的知识库。",
+        "operationId": "deleteKnowledgeTag",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tag_id"
+                ],
+                "properties": {
+                  "tag_id": {
+                    "type": "string",
+                    "description": "要删除的标签 ID。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "404": {
+            "description": "`not_found` : 指定的标签不存在。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Tag not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/tags/delete-knowledge-tag",
+          "metadata": {
+            "title": "删除知识库标签",
+            "sidebarTitle": "删除知识库标签"
+          }
+        }
+      }
+    },
+    "/datasets/tags/binding": {
+      "post": {
+        "tags": [
+          "标签"
+        ],
+        "summary": "绑定标签到知识库",
+        "description": "将一个或多个标签绑定到知识库。一个知识库可以有多个标签。",
+        "operationId": "bindTagsToDataset",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tag_ids",
+                  "target_id"
+                ],
+                "properties": {
+                  "tag_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "description": "要绑定的标签 ID。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。 未知的标签 ID 会被忽略，不会报错。"
+                  },
+                  "target_id": {
+                    "type": "string",
+                    "description": "要绑定标签的知识库。参见 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases)。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "404": {
+            "description": "`not_found` : 目标知识库不存在。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/tags/create-tag-binding",
+          "metadata": {
+            "title": "绑定标签到知识库",
+            "sidebarTitle": "绑定标签到知识库"
+          }
+        }
+      }
+    },
+    "/datasets/tags/unbinding": {
+      "post": {
+        "tags": [
+          "标签"
+        ],
+        "summary": "解除标签与知识库的绑定",
+        "description": "从知识库中移除一个或多个标签。",
+        "operationId": "unbindTagFromDataset",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "target_id"
+                ],
+                "properties": {
+                  "tag_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "description": "要解绑的标签 ID 列表。未提供旧版 `tag_id` 时必填。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。"
+                  },
+                  "tag_id": {
+                    "type": "string",
+                    "deprecated": true,
+                    "description": "旧版单标签字段。服务端将其归一化为 `tag_ids`。新接入应使用 `tag_ids`。"
+                  },
+                  "target_id": {
+                    "type": "string",
+                    "description": "要解绑标签的知识库。参见 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases)。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "404": {
+            "description": "`not_found` : 目标知识库不存在。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/tags/delete-tag-binding",
+          "metadata": {
+            "title": "解除标签与知识库的绑定",
+            "sidebarTitle": "解除标签与知识库的绑定"
           }
         }
       }
@@ -5496,6 +4275,275 @@
         }
       }
     },
+    "/datasets/{dataset_id}/document/create-by-file": {
+      "post": {
+        "tags": [
+          "文档"
+        ],
+        "summary": "从文件创建文档",
+        "description": "在知识库中通过上传文件创建文档。支持 PDF、TXT、DOCX 等常见格式。索引异步进行；使用返回的 `batch` ID 通过 [获取文档嵌入状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。",
+        "operationId": "createDocumentFromFile",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
+                  },
+                  "data": {
+                    "type": "string",
+                    "description": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。",
+                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "文档创建成功。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "document": {
+                      "$ref": "#/components/schemas/Document"
+                    },
+                    "batch": {
+                      "type": "string",
+                      "description": "用于跟踪索引进度的批次 ID。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 0,
+                        "indexing_status": "indexing",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "indexing",
+                        "word_count": 0,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `no_file_uploaded` : 请求中未提供文件。\n- `too_many_files` : 每次请求仅允许一个文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 该知识库为外部知识库、缺少 `indexing_technique`，或缺少 `process_rule`。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_external": {
+                    "summary": "invalid_param (external)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "External datasets are not supported."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 文档数量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (documents limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The number of documents has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : 未找到知识库。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "`file_too_large` : 上传的文件超出最大大小限制。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "service_unavailable": {
+                    "summary": "service_unavailable",
+                    "value": {
+                      "status": 503,
+                      "code": "service_unavailable",
+                      "message": "Unable to verify vector space usage right now. Please try again later."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/documents/create-document-by-file",
+          "metadata": {
+            "title": "从文件创建文档",
+            "sidebarTitle": "从文件创建文档"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
+          }
+        ]
+      }
+    },
     "/datasets/{dataset_id}/document/create-by-text": {
       "post": {
         "tags": [
@@ -5818,275 +4866,6 @@
         }
       }
     },
-    "/datasets/{dataset_id}/document/create-by-file": {
-      "post": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "从文件创建文档",
-        "description": "在知识库中通过上传文件创建文档。支持 PDF、TXT、DOCX 等常见格式。索引异步进行；使用返回的 `batch` ID 通过 [获取文档嵌入状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。",
-        "operationId": "createDocumentFromFile",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "file"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
-                  },
-                  "data": {
-                    "type": "string",
-                    "description": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。",
-                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "文档创建成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "用于跟踪索引进度的批次 ID。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "document": {
-                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "position": 1,
-                        "data_source_type": "upload_file",
-                        "data_source_info": {
-                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                        },
-                        "data_source_detail_dict": {
-                          "upload_file": {
-                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                            "name": "guide.txt",
-                            "size": 2048,
-                            "extension": "txt",
-                            "mime_type": "text/plain",
-                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200
-                          }
-                        },
-                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
-                        "name": "guide.txt",
-                        "created_from": "api",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "tokens": 0,
-                        "indexing_status": "indexing",
-                        "error": null,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "archived": false,
-                        "display_status": "indexing",
-                        "word_count": 0,
-                        "hit_count": 0,
-                        "doc_form": "text_model",
-                        "doc_metadata": [],
-                        "summary_index_status": null,
-                        "need_summary": false
-                      },
-                      "batch": "20250306150245647595"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_file_uploaded` : 请求中未提供文件。\n- `too_many_files` : 每次请求仅允许一个文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 该知识库为外部知识库、缺少 `indexing_technique`，或缺少 `process_rule`。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_file_uploaded": {
-                    "summary": "no_file_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_file_uploaded",
-                      "message": "Please upload your file."
-                    }
-                  },
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "invalid_param_external": {
-                    "summary": "invalid_param (external)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "External datasets are not supported."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 文档数量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (documents limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The number of documents has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : 上传的文件超出最大大小限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": "File size exceeded."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/documents/create-document-by-file",
-          "metadata": {
-            "title": "从文件创建文档",
-            "sidebarTitle": "从文件创建文档"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
-          }
-        ]
-      }
-    },
     "/datasets/{dataset_id}/documents": {
       "get": {
         "tags": [
@@ -6277,6 +5056,664 @@
           "metadata": {
             "title": "获取知识库的文档列表",
             "sidebarTitle": "获取知识库的文档列表"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/download-zip": {
+      "post": {
+        "tags": [
+          "文档"
+        ],
+        "summary": "批量下载文档（ZIP）",
+        "description": "将一个或多个文档下载为单个 ZIP 压缩包。仅可包含以文件形式上传的文档。",
+        "operationId": "downloadDocumentsZipZh",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "document_ids"
+                ],
+                "properties": {
+                  "document_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "description": "要包含在压缩包中的文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "包含所请求文档的 ZIP 压缩包。",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary",
+                  "description": "ZIP 压缩包二进制流。"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。\n- `forbidden` : 你没有访问此知识库的权限。\n- `forbidden` : 你对请求的某个文档没有访问权限。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (dataset permission)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You do not have permission to access this dataset."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden (document permission)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "No permission."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "- `not_found` : 未找到文档。\n- `not_found` : 未找到知识库。 请求的文档没有已上传的文件时，也会返回 \"Only uploaded-file documents can be downloaded as ZIP.\"。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found_3",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Only uploaded-file documents can be downloaded as ZIP."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/documents/download-documents-as-zip",
+          "metadata": {
+            "title": "批量下载文档（ZIP）",
+            "sidebarTitle": "批量下载文档（ZIP）"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/metadata": {
+      "post": {
+        "tags": [
+          "元数据"
+        ],
+        "summary": "批量更新文档元数据",
+        "description": "在一次请求中批量更新多个文档的元数据值。",
+        "operationId": "batchUpdateDocumentMetadataZh",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "operation_data"
+                ],
+                "properties": {
+                  "operation_data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "document_id",
+                        "metadata_list"
+                      ],
+                      "properties": {
+                        "document_id": {
+                          "type": "string",
+                          "description": "要更新的文档 ID。参见 [获取知识库的文档列表](/zh/api-reference/documents/list-documents)。"
+                        },
+                        "metadata_list": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "id",
+                              "name"
+                            ],
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "元数据字段 ID。参见 [获取元数据字段列表](/zh/api-reference/metadata/list-metadata-fields)。"
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "元数据字段名称。"
+                              },
+                              "value": {
+                                "description": "元数据值。可以是字符串、数字或 `null`。"
+                              }
+                            }
+                          },
+                          "description": "要设置到文档的元数据字段。"
+                        },
+                        "partial_update": {
+                          "type": "boolean",
+                          "default": false,
+                          "description": "是否部分更新元数据，保留未指定字段的现有值。"
+                        }
+                      }
+                    },
+                    "description": "文档元数据更新操作，每个文档一个条目。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "文档元数据更新成功。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "description": "操作结果。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "result": "success"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_param` : 本次请求中的文档已有另一个元数据操作正在进行。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Another document metadata operation is running, please wait a moment."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "- `not_found` : 未找到知识库。\n- `not_found` : `operation_data` 中引用的文档在该知识库中不存在。\n- `not_found` : `metadata_list` 中引用的元数据字段在该知识库中不存在。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found (knowledge base)",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found (document)",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found (metadata)",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Metadata not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/metadata/update-document-metadata-in-batch",
+          "metadata": {
+            "title": "批量更新文档元数据",
+            "sidebarTitle": "批量更新文档元数据"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/status/{action}": {
+      "patch": {
+        "tags": [
+          "文档"
+        ],
+        "summary": "批量更新文档状态",
+        "description": "在一次请求中批量启用、禁用、归档或取消归档多个文档。",
+        "operationId": "batchUpdateDocumentStatus",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          },
+          {
+            "name": "action",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enable",
+                "disable",
+                "archive",
+                "un_archive"
+              ]
+            },
+            "description": "`enable` 启用文档以供检索，`disable` 停用，`archive` 移入归档，`un_archive` 从归档中恢复。"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "document_ids"
+                ],
+                "properties": {
+                  "document_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "要更新的文档 ID。文档 ID 从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "文档更新成功。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "description": "操作结果。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "result": "success"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_action` : 操作无效，或某个文档处于不允许该操作的状态（例如仍在索引中或尚未处理完成）。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_action": {
+                    "summary": "invalid_action",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_action",
+                      "message": "Invalid action."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : 该知识库未启用 API 访问。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : 知识库未找到。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/documents/update-document-status-in-batch",
+          "metadata": {
+            "title": "批量更新文档状态",
+            "sidebarTitle": "批量更新文档状态"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{batch}/indexing-status": {
+      "get": {
+        "tags": [
+          "文档"
+        ],
+        "summary": "获取文档嵌入状态（进度）",
+        "description": "返回批次中每个文档的索引进度：当前阶段和分段完成计数。轮询直到每个 `indexing_status` 变为 `completed` 或 `error`。状态按 `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed` 推进。",
+        "operationId": "getDocumentIndexingStatus",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          },
+          {
+            "name": "batch",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "创建或更新文档时返回的批次 ID。"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "批次中文档的索引状态。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "文档标识符。"
+                          },
+                          "indexing_status": {
+                            "type": "string",
+                            "description": "当前索引状态：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed` 或 `error`。"
+                          },
+                          "processing_started_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "处理开始的 Unix 时间戳。"
+                          },
+                          "parsing_completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "解析完成的 Unix 时间戳。"
+                          },
+                          "cleaning_completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "清洗完成的 Unix 时间戳。"
+                          },
+                          "splitting_completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "拆分完成的 Unix 时间戳。"
+                          },
+                          "completed_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "索引完成的 Unix 时间戳。"
+                          },
+                          "paused_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "索引暂停的时间戳。未暂停时为 `null`。"
+                          },
+                          "error": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "索引失败时的错误信息。无错误时为 `null`。"
+                          },
+                          "stopped_at": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "索引停止的时间戳。未停止时为 `null`。"
+                          },
+                          "completed_segments": {
+                            "type": "integer",
+                            "description": "已索引的分段数。"
+                          },
+                          "total_segments": {
+                            "type": "integer",
+                            "description": "待索引的分段总数。"
+                          }
+                        }
+                      },
+                      "description": "索引状态条目列表。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                          "indexing_status": "completed",
+                          "processing_started_at": 1741267200,
+                          "parsing_completed_at": 1741267200,
+                          "cleaning_completed_at": 1741267200,
+                          "splitting_completed_at": 1741267200,
+                          "completed_at": 1741267200,
+                          "paused_at": null,
+                          "error": null,
+                          "stopped_at": null,
+                          "completed_segments": 5,
+                          "total_segments": 5
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : 该知识库未启用 API 访问。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "documents_not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Documents not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/documents/get-document-indexing-status",
+          "metadata": {
+            "title": "获取文档嵌入状态（进度）",
+            "sidebarTitle": "获取文档嵌入状态（进度）"
           }
         }
       }
@@ -7167,1068 +6604,6 @@
           "metadata": {
             "title": "下载文档",
             "sidebarTitle": "下载文档"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{batch}/indexing-status": {
-      "get": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "获取文档嵌入状态（进度）",
-        "description": "返回批次中每个文档的索引进度：当前阶段和分段完成计数。轮询直到每个 `indexing_status` 变为 `completed` 或 `error`。状态按 `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed` 推进。",
-        "operationId": "getDocumentIndexingStatus",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "batch",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "创建或更新文档时返回的批次 ID。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "批次中文档的索引状态。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "文档标识符。"
-                          },
-                          "indexing_status": {
-                            "type": "string",
-                            "description": "当前索引状态：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed` 或 `error`。"
-                          },
-                          "processing_started_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "处理开始的 Unix 时间戳。"
-                          },
-                          "parsing_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "解析完成的 Unix 时间戳。"
-                          },
-                          "cleaning_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "清洗完成的 Unix 时间戳。"
-                          },
-                          "splitting_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "拆分完成的 Unix 时间戳。"
-                          },
-                          "completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "索引完成的 Unix 时间戳。"
-                          },
-                          "paused_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "索引暂停的时间戳。未暂停时为 `null`。"
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "索引失败时的错误信息。无错误时为 `null`。"
-                          },
-                          "stopped_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "索引停止的时间戳。未停止时为 `null`。"
-                          },
-                          "completed_segments": {
-                            "type": "integer",
-                            "description": "已索引的分段数。"
-                          },
-                          "total_segments": {
-                            "type": "integer",
-                            "description": "待索引的分段总数。"
-                          }
-                        }
-                      },
-                      "description": "索引状态条目列表。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                          "indexing_status": "completed",
-                          "processing_started_at": 1741267200,
-                          "parsing_completed_at": 1741267200,
-                          "cleaning_completed_at": 1741267200,
-                          "splitting_completed_at": 1741267200,
-                          "completed_at": 1741267200,
-                          "paused_at": null,
-                          "error": null,
-                          "stopped_at": null,
-                          "completed_segments": 5,
-                          "total_segments": 5
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "dataset_not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "documents_not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Documents not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/documents/get-document-indexing-status",
-          "metadata": {
-            "title": "获取文档嵌入状态（进度）",
-            "sidebarTitle": "获取文档嵌入状态（进度）"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/update-by-text": {
-      "post": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "用文本更新文档",
-        "description": "更新文档的文本内容、名称或处理配置。文本变更时会重新索引文档。",
-        "operationId": "updateDocumentByText",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "文档名称。当提供 `text` 时必填。"
-                  },
-                  "text": {
-                    "type": "string",
-                    "description": "文档文本内容。"
-                  },
-                  "process_rule": {
-                    "type": "object",
-                    "description": "分块处理规则。",
-                    "required": [
-                      "mode"
-                    ],
-                    "properties": {
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "automatic",
-                          "custom",
-                          "hierarchical"
-                        ],
-                        "description": "`automatic` 使用内置规则，`custom` 允许手动配置，`hierarchical` 启用父子分段结构（配合 `doc_form: hierarchical_model` 使用）。"
-                      },
-                      "rules": {
-                        "type": "object",
-                        "properties": {
-                          "pre_processing_rules": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "enum": [
-                                    "remove_stopwords",
-                                    "remove_extra_spaces",
-                                    "remove_urls_emails"
-                                  ],
-                                  "description": "规则标识符。"
-                                },
-                                "enabled": {
-                                  "type": "boolean",
-                                  "description": "该预处理规则是否启用。"
-                                }
-                              }
-                            }
-                          },
-                          "segmentation": {
-                            "type": "object",
-                            "properties": {
-                              "separator": {
-                                "type": "string",
-                                "default": "\n",
-                                "description": "用于拆分文本的自定义分隔符。"
-                              },
-                              "max_tokens": {
-                                "type": "integer",
-                                "description": "每个分段的最大令牌数。"
-                              },
-                              "chunk_overlap": {
-                                "type": "integer",
-                                "default": 0,
-                                "description": "分段之间的令牌重叠数。"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "doc_form": {
-                    "type": "string",
-                    "enum": [
-                      "text_model",
-                      "hierarchical_model",
-                      "qa_model"
-                    ],
-                    "default": "text_model",
-                    "description": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。"
-                  },
-                  "doc_language": {
-                    "type": "string",
-                    "default": "English",
-                    "description": "用于处理优化的文档语言。"
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "控制查询此知识库时如何搜索和排序分段。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "文档更新成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "用于跟踪索引进度的批次 ID。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "document": {
-                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "position": 1,
-                        "data_source_type": "upload_file",
-                        "data_source_info": {
-                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                        },
-                        "data_source_detail_dict": {
-                          "upload_file": {
-                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                            "name": "guide.txt",
-                            "size": 2048,
-                            "extension": "txt",
-                            "mime_type": "text/plain",
-                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200
-                          }
-                        },
-                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
-                        "name": "guide.txt",
-                        "created_from": "api",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "tokens": 512,
-                        "indexing_status": "completed",
-                        "error": null,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "archived": false,
-                        "display_status": "available",
-                        "word_count": 350,
-                        "hit_count": 0,
-                        "doc_form": "text_model",
-                        "doc_metadata": [],
-                        "summary_index_status": null,
-                        "need_summary": false
-                      },
-                      "batch": "20250306150245647595"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 提供 `text` 时必须提供 `name`，或 `doc_form` 无效。\n- `invalid_param` : 文档不可用，无法更新（仅可更新处于可用状态的文档）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "invalid_param_name": {
-                    "summary": "invalid_param (name required)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "name is required when text is provided."
-                    }
-                  },
-                  "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Document is not available"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/documents/update-document-by-text",
-          "metadata": {
-            "title": "用文本更新文档",
-            "sidebarTitle": "用文本更新文档"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/update-by-file": {
-      "post": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "用文件更新文档",
-        "description": "已弃用。改用 [更新文档](/zh/api-reference/documents/update-document)。通过上传新文件更新文档，然后重新索引。",
-        "operationId": "updateDocumentByFile",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
-                  },
-                  "data": {
-                    "type": "string",
-                    "description": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。",
-                    "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "文档更新成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "用于跟踪索引进度的批次 ID。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "document": {
-                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "position": 1,
-                        "data_source_type": "upload_file",
-                        "data_source_info": {
-                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                        },
-                        "data_source_detail_dict": {
-                          "upload_file": {
-                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                            "name": "guide.txt",
-                            "size": 2048,
-                            "extension": "txt",
-                            "mime_type": "text/plain",
-                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200
-                          }
-                        },
-                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
-                        "name": "guide.txt",
-                        "created_from": "api",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "tokens": 512,
-                        "indexing_status": "completed",
-                        "error": null,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "archived": false,
-                        "display_status": "available",
-                        "word_count": 350,
-                        "hit_count": 0,
-                        "doc_form": "text_model",
-                        "doc_metadata": [],
-                        "summary_index_status": null,
-                        "need_summary": false
-                      },
-                      "batch": "20250306150245647595"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `too_many_files` : 每次请求仅允许一个文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 文档不可用，无法更新（仅可更新处于可用状态的文档）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
-                    }
-                  },
-                  "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Document is not available"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : 上传的文件超出最大大小限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": "File size exceeded."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_file_type` : 上传文件的类型不受支持。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_file_type": {
-                    "summary": "unsupported_file_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_file_type",
-                      "message": "File type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "deprecated": true,
-        "x-mint": {
-          "href": "/zh/api-reference/documents/update-document-by-file",
-          "metadata": {
-            "title": "用文件更新文档",
-            "sidebarTitle": "用文件更新文档"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/download-zip": {
-      "post": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "批量下载文档（ZIP）",
-        "description": "将一个或多个文档下载为单个 ZIP 压缩包。仅可包含以文件形式上传的文档。",
-        "operationId": "downloadDocumentsZipZh",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 100,
-                    "items": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "description": "要包含在压缩包中的文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "包含所请求文档的 ZIP 压缩包。",
-            "content": {
-              "application/zip": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary",
-                  "description": "ZIP 压缩包二进制流。"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。\n- `forbidden` : 你没有访问此知识库的权限。\n- `forbidden` : 你对请求的某个文档没有访问权限。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (dataset permission)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "You do not have permission to access this dataset."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (document permission)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "No permission."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 未找到文档。\n- `not_found` : 未找到知识库。 请求的文档没有已上传的文件时，也会返回 \"Only uploaded-file documents can be downloaded as ZIP.\"。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found_3",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Only uploaded-file documents can be downloaded as ZIP."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/documents/download-documents-as-zip",
-          "metadata": {
-            "title": "批量下载文档（ZIP）",
-            "sidebarTitle": "批量下载文档（ZIP）"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/status/{action}": {
-      "patch": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "批量更新文档状态",
-        "description": "在一次请求中批量启用、禁用、归档或取消归档多个文档。",
-        "operationId": "batchUpdateDocumentStatus",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable",
-                "archive",
-                "un_archive"
-              ]
-            },
-            "description": "`enable` 启用文档以供检索，`disable` 停用，`archive` 移入归档，`un_archive` 从归档中恢复。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "要更新的文档 ID。文档 ID 从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "文档更新成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作结果。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "result": "success"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_action` : 操作无效，或某个文档处于不允许该操作的状态（例如仍在索引中或尚未处理完成）。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_action": {
-                    "summary": "invalid_action",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_action",
-                      "message": "Invalid action."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 知识库未找到。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/documents/update-document-status-in-batch",
-          "metadata": {
-            "title": "批量更新文档状态",
-            "sidebarTitle": "批量更新文档状态"
           }
         }
       }
@@ -10117,14 +8492,14 @@
         }
       }
     },
-    "/datasets/{dataset_id}/retrieve": {
+    "/datasets/{dataset_id}/documents/{document_id}/update-by-file": {
       "post": {
         "tags": [
-          "知识库"
+          "文档"
         ],
-        "summary": "从知识库检索分段 / 测试检索",
-        "description": "搜索知识库，返回与查询最相关的分段，可用于生产环境检索和测试检索。",
-        "operationId": "retrieveSegments",
+        "summary": "用文件更新文档",
+        "description": "已弃用。改用 [更新文档](/zh/api-reference/documents/update-document)。通过上传新文件更新文档，然后重新索引。",
+        "operationId": "updateDocumentByFile",
         "parameters": [
           {
             "name": "dataset_id",
@@ -10135,52 +8510,34 @@
               "format": "uuid"
             },
             "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          },
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "query"
-                ],
                 "properties": {
-                  "query": {
+                  "file": {
                     "type": "string",
-                    "maxLength": 250,
-                    "description": "搜索查询文本。"
+                    "format": "binary",
+                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
                   },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "检索模型配置。控制查询此知识库时如何搜索和排序分段。"
-                  },
-                  "attachment_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true,
-                    "description": "要包含在检索上下文中的附件 ID 列表。"
-                  },
-                  "external_retrieval_model": {
-                    "type": "object",
-                    "description": "外部知识库的检索设置。",
-                    "properties": {
-                      "top_k": {
-                        "type": "integer",
-                        "description": "返回结果的最大数量。"
-                      },
-                      "score_threshold": {
-                        "type": "number",
-                        "description": "用于过滤结果的最小相似度分数阈值。"
-                      },
-                      "score_threshold_enabled": {
-                        "type": "boolean",
-                        "description": "是否启用分数阈值过滤。"
-                      }
-                    }
+                  "data": {
+                    "type": "string",
+                    "description": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。",
+                    "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
                   }
                 }
               }
@@ -10189,233 +8546,18 @@
         },
         "responses": {
           "200": {
-            "description": "检索结果。",
+            "description": "文档更新成功。",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "query": {
-                      "type": "object",
-                      "description": "原始查询对象。",
-                      "properties": {
-                        "content": {
-                          "type": "string",
-                          "description": "查询文本。"
-                        }
-                      }
+                    "document": {
+                      "$ref": "#/components/schemas/Document"
                     },
-                    "records": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "segment": {
-                            "type": "object",
-                            "description": "从知识库中匹配的分段。",
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "分段的唯一标识符。"
-                              },
-                              "position": {
-                                "type": "integer",
-                                "description": "分段在文档中的位置。"
-                              },
-                              "document_id": {
-                                "type": "string",
-                                "description": "该分段所属文档的 ID。"
-                              },
-                              "content": {
-                                "type": "string",
-                                "description": "分段的文本内容。"
-                              },
-                              "sign_content": {
-                                "type": "string",
-                                "description": "用于完整性验证的签名内容哈希。"
-                              },
-                              "answer": {
-                                "type": "string",
-                                "description": "回答内容，用于问答模式文档。"
-                              },
-                              "word_count": {
-                                "type": "integer",
-                                "description": "分段内容的字数。"
-                              },
-                              "tokens": {
-                                "type": "integer",
-                                "description": "分段内容的令牌数。"
-                              },
-                              "keywords": {
-                                "type": "array",
-                                "description": "与该分段关联的关键词，用于基于关键词的检索。",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "index_node_id": {
-                                "type": "string",
-                                "description": "向量存储中索引节点的 ID。"
-                              },
-                              "index_node_hash": {
-                                "type": "string",
-                                "description": "索引内容的哈希值，用于检测变更。"
-                              },
-                              "hit_count": {
-                                "type": "integer",
-                                "description": "该分段在检索查询中被匹配的次数。"
-                              },
-                              "enabled": {
-                                "type": "boolean",
-                                "description": "该分段是否启用检索。"
-                              },
-                              "disabled_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "分段被禁用的时间戳。启用时为 `null`。"
-                              },
-                              "disabled_by": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "禁用该分段的用户 ID。启用时为 `null`。"
-                              },
-                              "status": {
-                                "type": "string",
-                                "description": "分段的索引状态。"
-                              },
-                              "created_by": {
-                                "type": "string",
-                                "description": "创建该分段的用户 ID。"
-                              },
-                              "created_at": {
-                                "type": "number",
-                                "description": "创建时间戳（Unix 纪元，单位为秒）。"
-                              },
-                              "indexing_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "索引开始的时间戳。尚未开始时为 `null`。"
-                              },
-                              "completed_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "索引完成的时间戳。尚未完成时为 `null`。"
-                              },
-                              "error": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "索引失败时的错误消息。无错误时为 `null`。"
-                              },
-                              "stopped_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "索引停止的时间戳。未停止时为 `null`。"
-                              },
-                              "document": {
-                                "type": "object",
-                                "description": "匹配分段的父文档信息。",
-                                "properties": {
-                                  "id": {
-                                    "type": "string",
-                                    "description": "文档的唯一标识符。"
-                                  },
-                                  "data_source_type": {
-                                    "type": "string",
-                                    "description": "文档的创建方式。"
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "文档名称。"
-                                  },
-                                  "doc_type": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "文档类型分类。未设置时为 `null`。"
-                                  },
-                                  "doc_metadata": {
-                                    "type": "object",
-                                    "nullable": true,
-                                    "description": "文档的元数据值。未配置元数据时为 `null`。"
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "child_chunks": {
-                            "type": "array",
-                            "description": "使用分层索引时，分段内匹配的子分段。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "子分段的唯一标识符。"
-                                },
-                                "content": {
-                                  "type": "string",
-                                  "description": "子分段的文本内容。"
-                                },
-                                "position": {
-                                  "type": "integer",
-                                  "description": "子分段在父分段中的位置。"
-                                },
-                                "score": {
-                                  "type": "number",
-                                  "description": "子分段的相关性得分。"
-                                }
-                              }
-                            }
-                          },
-                          "score": {
-                            "type": "number",
-                            "description": "相关性得分。"
-                          },
-                          "tsne_position": {
-                            "type": "object",
-                            "nullable": true,
-                            "description": "t-SNE 可视化位置。"
-                          },
-                          "files": {
-                            "type": "array",
-                            "description": "附加到该分段的文件。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "附件文件标识符。"
-                                },
-                                "name": {
-                                  "type": "string",
-                                  "description": "原始文件名。"
-                                },
-                                "size": {
-                                  "type": "integer",
-                                  "description": "文件大小（字节）。"
-                                },
-                                "extension": {
-                                  "type": "string",
-                                  "description": "文件扩展名。"
-                                },
-                                "mime_type": {
-                                  "type": "string",
-                                  "description": "文件的 MIME 类型。"
-                                },
-                                "source_url": {
-                                  "type": "string",
-                                  "description": "访问附件的 URL。"
-                                }
-                              }
-                            }
-                          },
-                          "summary": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "通过摘要索引检索到的摘要内容。"
-                          }
-                        }
-                      },
-                      "description": "匹配的检索记录列表。"
+                    "batch": {
+                      "type": "string",
+                      "description": "用于跟踪索引进度的批次 ID。"
                     }
                   }
                 },
@@ -10423,53 +8565,45 @@
                   "success": {
                     "summary": "响应示例",
                     "value": {
-                      "query": {
-                        "content": "What is Dify?"
-                      },
-                      "records": [
-                        {
-                          "segment": {
-                            "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                            "position": 1,
-                            "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                            "content": "Dify is an open-source LLM app development platform.",
-                            "sign_content": "",
-                            "answer": "",
-                            "word_count": 9,
-                            "tokens": 12,
-                            "keywords": [
-                              "dify",
-                              "platform",
-                              "llm"
-                            ],
-                            "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
-                            "index_node_hash": "abc123def456",
-                            "hit_count": 1,
-                            "enabled": true,
-                            "disabled_at": null,
-                            "disabled_by": null,
-                            "status": "completed",
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
                             "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                            "created_at": 1741267200,
-                            "indexing_at": 1741267200,
-                            "completed_at": 1741267200,
-                            "error": null,
-                            "stopped_at": null,
-                            "document": {
-                              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                              "data_source_type": "upload_file",
-                              "name": "guide.txt",
-                              "doc_type": null,
-                              "doc_metadata": null
-                            }
-                          },
-                          "child_chunks": [],
-                          "score": 0.92,
-                          "tsne_position": null,
-                          "files": [],
-                          "summary": null
-                        }
-                      ]
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
                     }
                   }
                 }
@@ -10477,16 +8611,24 @@
             }
           },
           "400": {
-            "description": "- `dataset_not_initialized` : 知识库仍在初始化或索引中。\n- `provider_not_initialize` : 模型供应商未配置有效凭据。\n- `provider_quota_exceeded` : Dify 托管的模型供应商配额已用尽。\n- `model_currently_not_support` : 所选模型当前不受支持。\n- `completion_request_error` : 模型请求失败。\n- `invalid_param` : 请求参数无效。",
+            "description": "- `too_many_files` : 每次请求仅允许一个文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 文档不可用，无法更新（仅可更新处于可用状态的文档）。",
             "content": {
               "application/json": {
                 "examples": {
-                  "dataset_not_initialized": {
-                    "summary": "dataset_not_initialized",
+                  "too_many_files": {
+                    "summary": "too_many_files",
                     "value": {
                       "status": 400,
-                      "code": "dataset_not_initialized",
-                      "message": "The dataset is still being initialized or indexing. Please wait a moment."
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
                     }
                   },
                   "provider_not_initialize": {
@@ -10497,36 +8639,12 @@
                       "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
                     }
                   },
-                  "provider_quota_exceeded": {
-                    "summary": "provider_quota_exceeded",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_quota_exceeded",
-                      "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
-                    }
-                  },
-                  "model_currently_not_support": {
-                    "summary": "model_currently_not_support",
-                    "value": {
-                      "status": 400,
-                      "code": "model_currently_not_support",
-                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
-                    }
-                  },
-                  "completion_request_error": {
-                    "summary": "completion_request_error",
-                    "value": {
-                      "status": 400,
-                      "code": "completion_request_error",
-                      "message": "Completion request failed."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
+                  "invalid_param_not_available": {
+                    "summary": "invalid_param (not available)",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
-                      "message": "Invalid parameter value."
+                      "message": "Document is not available"
                     }
                   }
                 }
@@ -10534,7 +8652,7 @@
             }
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
+            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10547,6 +8665,14 @@
                     }
                   },
                   "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
                     "summary": "forbidden (rate limit)",
                     "value": {
                       "status": 403,
@@ -10559,33 +8685,75 @@
             }
           },
           "404": {
-            "description": "`not_found` : 未找到与 `dataset_id` 匹配的知识库。",
+            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
             "content": {
               "application/json": {
                 "examples": {
-                  "not_found": {
+                  "not_found_1": {
                     "summary": "not_found",
                     "value": {
                       "status": 404,
                       "code": "not_found",
                       "message": "Dataset not found."
                     }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
                   }
                 }
               }
             }
           },
-          "500": {
-            "description": "`internal_server_error` : 检索过程中发生内部错误。",
+          "413": {
+            "description": "`file_too_large` : 上传的文件超出最大大小限制。",
             "content": {
               "application/json": {
                 "examples": {
-                  "internal_server_error": {
-                    "summary": "internal_server_error",
+                  "file_too_large": {
+                    "summary": "file_too_large",
                     "value": {
-                      "status": 500,
-                      "code": "internal_server_error",
-                      "message": "An internal error occurred."
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "`unsupported_file_type` : 上传文件的类型不受支持。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "service_unavailable": {
+                    "summary": "service_unavailable",
+                    "value": {
+                      "status": 503,
+                      "code": "service_unavailable",
+                      "message": "Unable to verify vector space usage right now. Please try again later."
                     }
                   }
                 }
@@ -10593,493 +8761,24 @@
             }
           }
         },
+        "deprecated": true,
         "x-mint": {
-          "href": "/zh/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
+          "href": "/zh/api-reference/documents/update-document-by-file",
           "metadata": {
-            "title": "从知识库检索分段 / 测试检索",
-            "sidebarTitle": "从知识库检索分段 / 测试检索"
+            "title": "用文件更新文档",
+            "sidebarTitle": "用文件更新文档"
           }
         }
       }
     },
-    "/datasets/tags": {
+    "/datasets/{dataset_id}/documents/{document_id}/update-by-text": {
       "post": {
         "tags": [
-          "标签"
+          "文档"
         ],
-        "summary": "创建知识库标签",
-        "description": "创建用于组织知识库的标签。",
-        "operationId": "createKnowledgeTag",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "标签名称。在工作空间内必须唯一。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "标签创建成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "标签标识符。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "标签显示名称。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "标签类型。知识库标签始终为 `knowledge`。"
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "绑定到该标签的知识库数量。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
-                      "type": "knowledge",
-                      "binding_count": "0"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 已存在同名的知识库标签。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Tag name already exists"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/tags/create-knowledge-tag",
-          "metadata": {
-            "title": "创建知识库标签",
-            "sidebarTitle": "创建知识库标签"
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "获取知识库标签列表",
-        "description": "返回工作空间中所有的知识库标签。",
-        "operationId": "getKnowledgeTags",
-        "responses": {
-          "200": {
-            "description": "标签列表。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "description": "标签标识符。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "description": "标签显示名称。"
-                      },
-                      "type": {
-                        "type": "string",
-                        "description": "标签类型。知识库标签始终为 `knowledge`。"
-                      },
-                      "binding_count": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "绑定到该标签的知识库数量。"
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": [
-                      {
-                        "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                        "name": "Product Docs",
-                        "type": "knowledge",
-                        "binding_count": "0"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/tags/list-knowledge-tags",
-          "metadata": {
-            "title": "获取知识库标签列表",
-            "sidebarTitle": "获取知识库标签列表"
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "修改知识库标签",
-        "description": "重命名知识库标签。",
-        "operationId": "updateKnowledgeTag",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id",
-                  "name"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "要重命名的标签 ID。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。"
-                  },
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "标签的新名称。在工作空间内必须唯一。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "标签更新成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "标签标识符。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "标签显示名称。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "标签类型。知识库标签始终为 `knowledge`。"
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "绑定到该标签的知识库数量。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
-                      "type": "knowledge",
-                      "binding_count": "0"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 已存在同名的知识库标签。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Tag name already exists"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 指定的标签不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Tag not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/tags/update-knowledge-tag",
-          "metadata": {
-            "title": "修改知识库标签",
-            "sidebarTitle": "修改知识库标签"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "删除知识库标签",
-        "description": "永久删除知识库标签。不会删除已被标记的知识库。",
-        "operationId": "deleteKnowledgeTag",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "要删除的标签 ID。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : 指定的标签不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Tag not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/tags/delete-knowledge-tag",
-          "metadata": {
-            "title": "删除知识库标签",
-            "sidebarTitle": "删除知识库标签"
-          }
-        }
-      }
-    },
-    "/datasets/tags/binding": {
-      "post": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "绑定标签到知识库",
-        "description": "将一个或多个标签绑定到知识库。一个知识库可以有多个标签。",
-        "operationId": "bindTagsToDataset",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "tag_ids",
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "要绑定的标签 ID。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。 未知的标签 ID 会被忽略，不会报错。"
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "要绑定标签的知识库。参见 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases)。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : 目标知识库不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/tags/create-tag-binding",
-          "metadata": {
-            "title": "绑定标签到知识库",
-            "sidebarTitle": "绑定标签到知识库"
-          }
-        }
-      }
-    },
-    "/datasets/tags/unbinding": {
-      "post": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "解除标签与知识库的绑定",
-        "description": "从知识库中移除一个或多个标签。",
-        "operationId": "unbindTagFromDataset",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "要解绑的标签 ID 列表。未提供旧版 `tag_id` 时必填。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。"
-                  },
-                  "tag_id": {
-                    "type": "string",
-                    "deprecated": true,
-                    "description": "旧版单标签字段。服务端将其归一化为 `tag_ids`。新接入应使用 `tag_ids`。"
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "要解绑标签的知识库。参见 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases)。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : 目标知识库不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/tags/delete-tag-binding",
-          "metadata": {
-            "title": "解除标签与知识库的绑定",
-            "sidebarTitle": "解除标签与知识库的绑定"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/tags": {
-      "get": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "获取知识库绑定的标签",
-        "description": "返回绑定到知识库的标签。",
-        "operationId": "queryDatasetTags",
+        "summary": "用文本更新文档",
+        "description": "更新文档的文本内容、名称或处理配置。文本变更时会重新索引文档。",
+        "operationId": "updateDocumentByText",
         "parameters": [
           {
             "name": "dataset_id",
@@ -11090,36 +8789,134 @@
               "format": "uuid"
             },
             "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          },
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "文档名称。当提供 `text` 时必填。"
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "文档文本内容。"
+                  },
+                  "process_rule": {
+                    "type": "object",
+                    "description": "分块处理规则。",
+                    "required": [
+                      "mode"
+                    ],
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "automatic",
+                          "custom",
+                          "hierarchical"
+                        ],
+                        "description": "`automatic` 使用内置规则，`custom` 允许手动配置，`hierarchical` 启用父子分段结构（配合 `doc_form: hierarchical_model` 使用）。"
+                      },
+                      "rules": {
+                        "type": "object",
+                        "properties": {
+                          "pre_processing_rules": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "enum": [
+                                    "remove_stopwords",
+                                    "remove_extra_spaces",
+                                    "remove_urls_emails"
+                                  ],
+                                  "description": "规则标识符。"
+                                },
+                                "enabled": {
+                                  "type": "boolean",
+                                  "description": "该预处理规则是否启用。"
+                                }
+                              }
+                            }
+                          },
+                          "segmentation": {
+                            "type": "object",
+                            "properties": {
+                              "separator": {
+                                "type": "string",
+                                "default": "\n",
+                                "description": "用于拆分文本的自定义分隔符。"
+                              },
+                              "max_tokens": {
+                                "type": "integer",
+                                "description": "每个分段的最大令牌数。"
+                              },
+                              "chunk_overlap": {
+                                "type": "integer",
+                                "default": 0,
+                                "description": "分段之间的令牌重叠数。"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "doc_form": {
+                    "type": "string",
+                    "enum": [
+                      "text_model",
+                      "hierarchical_model",
+                      "qa_model"
+                    ],
+                    "default": "text_model",
+                    "description": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。"
+                  },
+                  "doc_language": {
+                    "type": "string",
+                    "default": "English",
+                    "description": "用于处理优化的文档语言。"
+                  },
+                  "retrieval_model": {
+                    "$ref": "#/components/schemas/RetrievalModel",
+                    "description": "控制查询此知识库时如何搜索和排序分段。"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "绑定到知识库的标签。",
+            "description": "文档更新成功。",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "标签标识符。"
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "标签显示名称。"
-                          }
-                        }
-                      },
-                      "description": "绑定到此知识库的标签列表。"
+                    "document": {
+                      "$ref": "#/components/schemas/Document"
                     },
-                    "total": {
-                      "type": "integer",
-                      "description": "绑定到该知识库的标签总数。"
+                    "batch": {
+                      "type": "string",
+                      "description": "用于跟踪索引进度的批次 ID。"
                     }
                   }
                 },
@@ -11127,13 +8924,78 @@
                   "success": {
                     "summary": "响应示例",
                     "value": {
-                      "data": [
-                        {
-                          "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                          "name": "Product Docs"
-                        }
-                      ],
-                      "total": 1
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 提供 `text` 时必须提供 `name`，或 `doc_form` 无效。\n- `invalid_param` : 文档不可用，无法更新（仅可更新处于可用状态的文档）。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_name": {
+                    "summary": "invalid_param (name required)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "name is required when text is provided."
+                    }
+                  },
+                  "invalid_param_not_available": {
+                    "summary": "invalid_param (not available)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Document is not available"
                     }
                   }
                 }
@@ -11141,16 +9003,32 @@
             }
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
+            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
-                  "forbidden": {
+                  "forbidden_1": {
                     "summary": "forbidden (api access)",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
                       "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
                     }
                   }
                 }
@@ -11158,16 +9036,41 @@
             }
           },
           "404": {
-            "description": "`not_found` : 未找到知识库。",
+            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
             "content": {
               "application/json": {
                 "examples": {
-                  "not_found": {
+                  "not_found_1": {
                     "summary": "not_found",
                     "value": {
                       "status": 404,
                       "code": "not_found",
                       "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "service_unavailable": {
+                    "summary": "service_unavailable",
+                    "value": {
+                      "status": 503,
+                      "code": "service_unavailable",
+                      "message": "Unable to verify vector space usage right now. Please try again later."
                     }
                   }
                 }
@@ -11176,10 +9079,10 @@
           }
         },
         "x-mint": {
-          "href": "/zh/api-reference/tags/get-knowledge-base-tags",
+          "href": "/zh/api-reference/documents/update-document-by-text",
           "metadata": {
-            "title": "获取知识库绑定的标签",
-            "sidebarTitle": "获取知识库绑定的标签"
+            "title": "用文本更新文档",
+            "sidebarTitle": "用文本更新文档"
           }
         }
       }
@@ -11457,6 +9360,239 @@
         }
       }
     },
+    "/datasets/{dataset_id}/metadata/built-in": {
+      "get": {
+        "tags": [
+          "元数据"
+        ],
+        "summary": "获取内置元数据字段",
+        "description": "返回系统提供的内置元数据字段。",
+        "operationId": "getBuiltInMetadataFieldsZh",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "内置元数据字段。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fields": {
+                      "type": "array",
+                      "description": "系统提供的元数据字段列表。",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "内置字段标识符。`document_name` 表示文档标题，`uploader` 表示创建者，`upload_date` 表示创建时间，`last_update_date` 表示最后修改时间，`source` 表示文档来源。"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "字段数据类型。文本值为 `string`，日期/时间值为 `time`。"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "fields": [
+                        {
+                          "name": "document_name",
+                          "type": "string"
+                        },
+                        {
+                          "name": "uploader",
+                          "type": "string"
+                        },
+                        {
+                          "name": "upload_date",
+                          "type": "time"
+                        },
+                        {
+                          "name": "last_update_date",
+                          "type": "time"
+                        },
+                        {
+                          "name": "source",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : 该知识库未启用 API 访问。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : 未找到知识库。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/metadata/get-built-in-metadata-fields",
+          "metadata": {
+            "title": "获取内置元数据字段",
+            "sidebarTitle": "获取内置元数据字段"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/metadata/built-in/{action}": {
+      "post": {
+        "tags": [
+          "元数据"
+        ],
+        "summary": "更新内置元数据字段",
+        "description": "启用或禁用知识库的内置元数据字段。",
+        "operationId": "toggleBuiltInMetadataFieldZh",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          },
+          {
+            "name": "action",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enable",
+                "disable"
+              ]
+            },
+            "description": "`enable` 启用内置元数据字段，`disable` 停用内置元数据字段。"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "内置元数据字段切换成功。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string",
+                      "description": "操作结果。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "result": "success"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : 未找到知识库。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/metadata/update-built-in-metadata-field",
+          "metadata": {
+            "title": "更新内置元数据字段",
+            "sidebarTitle": "更新内置元数据字段"
+          }
+        }
+      }
+    },
     "/datasets/{dataset_id}/metadata/{metadata_id}": {
       "patch": {
         "tags": [
@@ -11692,815 +9828,6 @@
             "sidebarTitle": "删除元数据字段"
           }
         }
-      }
-    },
-    "/datasets/{dataset_id}/metadata/built-in": {
-      "get": {
-        "tags": [
-          "元数据"
-        ],
-        "summary": "获取内置元数据字段",
-        "description": "返回系统提供的内置元数据字段。",
-        "operationId": "getBuiltInMetadataFieldsZh",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "内置元数据字段。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "fields": {
-                      "type": "array",
-                      "description": "系统提供的元数据字段列表。",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "内置字段标识符。`document_name` 表示文档标题，`uploader` 表示创建者，`upload_date` 表示创建时间，`last_update_date` 表示最后修改时间，`source` 表示文档来源。"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "字段数据类型。文本值为 `string`，日期/时间值为 `time`。"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "fields": [
-                        {
-                          "name": "document_name",
-                          "type": "string"
-                        },
-                        {
-                          "name": "uploader",
-                          "type": "string"
-                        },
-                        {
-                          "name": "upload_date",
-                          "type": "time"
-                        },
-                        {
-                          "name": "last_update_date",
-                          "type": "time"
-                        },
-                        {
-                          "name": "source",
-                          "type": "string"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/metadata/get-built-in-metadata-fields",
-          "metadata": {
-            "title": "获取内置元数据字段",
-            "sidebarTitle": "获取内置元数据字段"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/metadata/built-in/{action}": {
-      "post": {
-        "tags": [
-          "元数据"
-        ],
-        "summary": "更新内置元数据字段",
-        "description": "启用或禁用知识库的内置元数据字段。",
-        "operationId": "toggleBuiltInMetadataFieldZh",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "action",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            },
-            "description": "`enable` 启用内置元数据字段，`disable` 停用内置元数据字段。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "内置元数据字段切换成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作结果。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "result": "success"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/metadata/update-built-in-metadata-field",
-          "metadata": {
-            "title": "更新内置元数据字段",
-            "sidebarTitle": "更新内置元数据字段"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/metadata": {
-      "post": {
-        "tags": [
-          "元数据"
-        ],
-        "summary": "批量更新文档元数据",
-        "description": "在一次请求中批量更新多个文档的元数据值。",
-        "operationId": "batchUpdateDocumentMetadataZh",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "operation_data"
-                ],
-                "properties": {
-                  "operation_data": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "document_id",
-                        "metadata_list"
-                      ],
-                      "properties": {
-                        "document_id": {
-                          "type": "string",
-                          "description": "要更新的文档 ID。参见 [获取知识库的文档列表](/zh/api-reference/documents/list-documents)。"
-                        },
-                        "metadata_list": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "id",
-                              "name"
-                            ],
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "元数据字段 ID。参见 [获取元数据字段列表](/zh/api-reference/metadata/list-metadata-fields)。"
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "元数据字段名称。"
-                              },
-                              "value": {
-                                "description": "元数据值。可以是字符串、数字或 `null`。"
-                              }
-                            }
-                          },
-                          "description": "要设置到文档的元数据字段。"
-                        },
-                        "partial_update": {
-                          "type": "boolean",
-                          "default": false,
-                          "description": "是否部分更新元数据，保留未指定字段的现有值。"
-                        }
-                      }
-                    },
-                    "description": "文档元数据更新操作，每个文档一个条目。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "文档元数据更新成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作结果。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "result": "success"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 本次请求中的文档已有另一个元数据操作正在进行。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Another document metadata operation is running, please wait a moment."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : `operation_data` 中引用的文档在该知识库中不存在。\n- `not_found` : `metadata_list` 中引用的元数据字段在该知识库中不存在。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found (knowledge base)",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found (document)",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found (metadata)",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Metadata not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/metadata/update-document-metadata-in-batch",
-          "metadata": {
-            "title": "批量更新文档元数据",
-            "sidebarTitle": "批量更新文档元数据"
-          }
-        }
-      }
-    },
-    "/workspaces/current/models/model-types/{model_type}": {
-      "get": {
-        "tags": [
-          "模型"
-        ],
-        "summary": "获取可用模型",
-        "description": "返回指定类型的可用模型。用它查找可配置到知识库的 `text-embedding` 和 `rerank` 模型。",
-        "operationId": "getAvailableModelsZh",
-        "parameters": [
-          {
-            "name": "model_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "text-embedding",
-                "rerank",
-                "llm",
-                "tts",
-                "speech2text",
-                "moderation"
-              ]
-            },
-            "description": "要获取的模型类型。对于知识库配置，使用 `text-embedding` 获取嵌入模型，使用 `rerank` 获取重排序模型。"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "指定类型的可用模型。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "模型供应商及其可用模型的列表。",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "provider": {
-                            "type": "string",
-                            "description": "模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。旧版供应商可能返回简写形式（例如 `openai`）。"
-                          },
-                          "label": {
-                            "type": "object",
-                            "description": "供应商的本地化显示名称。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "英文显示名称。"
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "中文显示名称。"
-                              }
-                            }
-                          },
-                          "icon_small": {
-                            "type": "object",
-                            "description": "供应商小图标的 URL。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "小图标 URL。"
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "中文图标 URL。"
-                              }
-                            }
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "供应商状态。凭证已配置且有效时为 `active`。"
-                          },
-                          "models": {
-                            "type": "array",
-                            "description": "该供应商的可用模型列表。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "model": {
-                                  "type": "string",
-                                  "description": "模型标识符。创建或更新知识库时，将此值作为 `embedding_model` 参数使用。"
-                                },
-                                "label": {
-                                  "type": "object",
-                                  "description": "模型的本地化显示名称。",
-                                  "properties": {
-                                    "en_US": {
-                                      "type": "string",
-                                      "description": "英文模型名称。"
-                                    },
-                                    "zh_Hans": {
-                                      "type": "string",
-                                      "description": "中文模型名称。"
-                                    }
-                                  }
-                                },
-                                "model_type": {
-                                  "type": "string",
-                                  "description": "模型类型，与 `model_type` 路径参数匹配。"
-                                },
-                                "features": {
-                                  "type": "array",
-                                  "nullable": true,
-                                  "description": "模型支持的功能，无功能时为 `null`。",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "fetch_from": {
-                                  "type": "string",
-                                  "description": "模型定义的来源。`predefined-model` 表示内置模型，`customizable-model` 表示用户自配置的模型。"
-                                },
-                                "model_properties": {
-                                  "type": "object",
-                                  "description": "模型特定的属性，例如 `context_size`。"
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "description": "模型可用状态。就绪时为 `active`。"
-                                },
-                                "deprecated": {
-                                  "type": "boolean",
-                                  "description": "模型是否已弃用。"
-                                },
-                                "load_balancing_enabled": {
-                                  "type": "boolean",
-                                  "description": "模型是否启用负载均衡。"
-                                },
-                                "has_invalid_load_balancing_configs": {
-                                  "type": "boolean",
-                                  "description": "模型是否存在无效的负载均衡配置。"
-                                }
-                              }
-                            }
-                          },
-                          "tenant_id": {
-                            "type": "string",
-                            "description": "该供应商配置所属的工作空间 ID。"
-                          },
-                          "icon_small_dark": {
-                            "type": "object",
-                            "description": "深色模式图标 URL；供应商没有时为 `null`。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string"
-                              },
-                              "zh_Hans": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "data": [
-                        {
-                          "provider": "langgenius/openai/openai",
-                          "label": {
-                            "en_US": "OpenAI",
-                            "zh_Hans": "OpenAI"
-                          },
-                          "icon_small": {
-                            "en_US": "https://example.com/openai-small.svg",
-                            "zh_Hans": "https://example.com/openai-small.svg"
-                          },
-                          "status": "active",
-                          "models": [
-                            {
-                              "model": "text-embedding-3-small",
-                              "label": {
-                                "en_US": "text-embedding-3-small",
-                                "zh_Hans": "text-embedding-3-small"
-                              },
-                              "model_type": "text-embedding",
-                              "features": null,
-                              "fetch_from": "predefined-model",
-                              "model_properties": {
-                                "context_size": 8191
-                              },
-                              "status": "active",
-                              "deprecated": false,
-                              "load_balancing_enabled": false,
-                              "has_invalid_load_balancing_configs": false
-                            }
-                          ],
-                          "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
-                          "icon_small_dark": null
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/models/get-available-models",
-          "metadata": {
-            "title": "获取可用模型",
-            "sidebarTitle": "获取可用模型"
-          }
-        }
-      }
-    },
-    "/datasets/pipeline/file-upload": {
-      "post": {
-        "tags": [
-          "知识流水线"
-        ],
-        "summary": "上传流水线文件",
-        "description": "上传文件以在知识流水线中使用。将返回的 `id` 用作 [运行流水线](/zh/api-reference/knowledge-pipeline/run-pipeline) 中 `local_file` 项的 `reference`。",
-        "operationId": "uploadPipelineFileZh",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "file"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "要上传的文件，作为 `multipart/form-data` 的一个部分。文档文件默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。\n\nDify Cloud 的 Professional 和 Team 套餐的文档上限为 50 MB。图片、音频、视频文件各有独立上限，默认分别为 10 MB、50 MB、100 MB。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "文件上传成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "已上传文件的唯一标识符。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "原始文件名。"
-                    },
-                    "size": {
-                      "type": "integer",
-                      "description": "文件大小（字节）。"
-                    },
-                    "extension": {
-                      "type": "string",
-                      "description": "文件扩展名。"
-                    },
-                    "mime_type": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "文件的 MIME 类型。若上传未包含 MIME 类型则可能为 `null`。"
-                    },
-                    "created_by": {
-                      "type": "string",
-                      "description": "上传文件的用户 ID。"
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "上传时间戳（ISO 8601 格式）。在记录创建过程中可能为 `null`。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                      "name": "report.pdf",
-                      "size": 524288,
-                      "extension": "pdf",
-                      "mime_type": "application/pdf",
-                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "created_at": "2025-03-06T12:00:00"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `no_file_uploaded` : 请求中未提供文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `too_many_files` : 每次请求仅允许一个文件。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "no_file_uploaded": {
-                    "summary": "no_file_uploaded",
-                    "value": {
-                      "status": 400,
-                      "code": "no_file_uploaded",
-                      "message": "Please upload your file."
-                    }
-                  },
-                  "filename_not_exists_error": {
-                    "summary": "filename_not_exists_error",
-                    "value": {
-                      "status": 400,
-                      "code": "filename_not_exists_error",
-                      "message": "The specified filename does not exist."
-                    }
-                  },
-                  "too_many_files": {
-                    "summary": "too_many_files",
-                    "value": {
-                      "status": 400,
-                      "code": "too_many_files",
-                      "message": "Only one file is allowed."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "`file_too_large` : 文件超出上传大小限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "file_too_large": {
-                    "summary": "file_too_large",
-                    "value": {
-                      "status": 413,
-                      "code": "file_too_large",
-                      "message": "File size exceeded."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "`unsupported_file_type` : 不支持的文件类型。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "unsupported_file_type": {
-                    "summary": "unsupported_file_type",
-                    "value": {
-                      "status": 415,
-                      "code": "unsupported_file_type",
-                      "message": "File type not allowed."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/knowledge-pipeline/upload-pipeline-file",
-          "metadata": {
-            "title": "上传流水线文件",
-            "sidebarTitle": "上传流水线文件"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
-          }
-        ]
       }
     },
     "/datasets/{dataset_id}/pipeline/datasource-plugins": {
@@ -13193,6 +10520,3909 @@
           "metadata": {
             "title": "运行流水线",
             "sidebarTitle": "运行流水线"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/retrieve": {
+      "post": {
+        "tags": [
+          "知识库"
+        ],
+        "summary": "从知识库检索分段 / 测试检索",
+        "description": "搜索知识库，返回与查询最相关的分段，可用于生产环境检索和测试检索。",
+        "operationId": "retrieveSegments",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "maxLength": 250,
+                    "description": "搜索查询文本。"
+                  },
+                  "retrieval_model": {
+                    "$ref": "#/components/schemas/RetrievalModel",
+                    "description": "检索模型配置。控制查询此知识库时如何搜索和排序分段。"
+                  },
+                  "attachment_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "description": "要包含在检索上下文中的附件 ID 列表。"
+                  },
+                  "external_retrieval_model": {
+                    "type": "object",
+                    "description": "外部知识库的检索设置。",
+                    "properties": {
+                      "top_k": {
+                        "type": "integer",
+                        "description": "返回结果的最大数量。"
+                      },
+                      "score_threshold": {
+                        "type": "number",
+                        "description": "用于过滤结果的最小相似度分数阈值。"
+                      },
+                      "score_threshold_enabled": {
+                        "type": "boolean",
+                        "description": "是否启用分数阈值过滤。"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "检索结果。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "query": {
+                      "type": "object",
+                      "description": "原始查询对象。",
+                      "properties": {
+                        "content": {
+                          "type": "string",
+                          "description": "查询文本。"
+                        }
+                      }
+                    },
+                    "records": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "segment": {
+                            "type": "object",
+                            "description": "从知识库中匹配的分段。",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "分段的唯一标识符。"
+                              },
+                              "position": {
+                                "type": "integer",
+                                "description": "分段在文档中的位置。"
+                              },
+                              "document_id": {
+                                "type": "string",
+                                "description": "该分段所属文档的 ID。"
+                              },
+                              "content": {
+                                "type": "string",
+                                "description": "分段的文本内容。"
+                              },
+                              "sign_content": {
+                                "type": "string",
+                                "description": "用于完整性验证的签名内容哈希。"
+                              },
+                              "answer": {
+                                "type": "string",
+                                "description": "回答内容，用于问答模式文档。"
+                              },
+                              "word_count": {
+                                "type": "integer",
+                                "description": "分段内容的字数。"
+                              },
+                              "tokens": {
+                                "type": "integer",
+                                "description": "分段内容的令牌数。"
+                              },
+                              "keywords": {
+                                "type": "array",
+                                "description": "与该分段关联的关键词，用于基于关键词的检索。",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "index_node_id": {
+                                "type": "string",
+                                "description": "向量存储中索引节点的 ID。"
+                              },
+                              "index_node_hash": {
+                                "type": "string",
+                                "description": "索引内容的哈希值，用于检测变更。"
+                              },
+                              "hit_count": {
+                                "type": "integer",
+                                "description": "该分段在检索查询中被匹配的次数。"
+                              },
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "该分段是否启用检索。"
+                              },
+                              "disabled_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "分段被禁用的时间戳。启用时为 `null`。"
+                              },
+                              "disabled_by": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "禁用该分段的用户 ID。启用时为 `null`。"
+                              },
+                              "status": {
+                                "type": "string",
+                                "description": "分段的索引状态。"
+                              },
+                              "created_by": {
+                                "type": "string",
+                                "description": "创建该分段的用户 ID。"
+                              },
+                              "created_at": {
+                                "type": "number",
+                                "description": "创建时间戳（Unix 纪元，单位为秒）。"
+                              },
+                              "indexing_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "索引开始的时间戳。尚未开始时为 `null`。"
+                              },
+                              "completed_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "索引完成的时间戳。尚未完成时为 `null`。"
+                              },
+                              "error": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "索引失败时的错误消息。无错误时为 `null`。"
+                              },
+                              "stopped_at": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "索引停止的时间戳。未停止时为 `null`。"
+                              },
+                              "document": {
+                                "type": "object",
+                                "description": "匹配分段的父文档信息。",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "文档的唯一标识符。"
+                                  },
+                                  "data_source_type": {
+                                    "type": "string",
+                                    "description": "文档的创建方式。"
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "文档名称。"
+                                  },
+                                  "doc_type": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "文档类型分类。未设置时为 `null`。"
+                                  },
+                                  "doc_metadata": {
+                                    "type": "object",
+                                    "nullable": true,
+                                    "description": "文档的元数据值。未配置元数据时为 `null`。"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "child_chunks": {
+                            "type": "array",
+                            "description": "使用分层索引时，分段内匹配的子分段。",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "子分段的唯一标识符。"
+                                },
+                                "content": {
+                                  "type": "string",
+                                  "description": "子分段的文本内容。"
+                                },
+                                "position": {
+                                  "type": "integer",
+                                  "description": "子分段在父分段中的位置。"
+                                },
+                                "score": {
+                                  "type": "number",
+                                  "description": "子分段的相关性得分。"
+                                }
+                              }
+                            }
+                          },
+                          "score": {
+                            "type": "number",
+                            "description": "相关性得分。"
+                          },
+                          "tsne_position": {
+                            "type": "object",
+                            "nullable": true,
+                            "description": "t-SNE 可视化位置。"
+                          },
+                          "files": {
+                            "type": "array",
+                            "description": "附加到该分段的文件。",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "附件文件标识符。"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "原始文件名。"
+                                },
+                                "size": {
+                                  "type": "integer",
+                                  "description": "文件大小（字节）。"
+                                },
+                                "extension": {
+                                  "type": "string",
+                                  "description": "文件扩展名。"
+                                },
+                                "mime_type": {
+                                  "type": "string",
+                                  "description": "文件的 MIME 类型。"
+                                },
+                                "source_url": {
+                                  "type": "string",
+                                  "description": "访问附件的 URL。"
+                                }
+                              }
+                            }
+                          },
+                          "summary": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "通过摘要索引检索到的摘要内容。"
+                          }
+                        }
+                      },
+                      "description": "匹配的检索记录列表。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "query": {
+                        "content": "What is Dify?"
+                      },
+                      "records": [
+                        {
+                          "segment": {
+                            "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                            "position": 1,
+                            "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                            "content": "Dify is an open-source LLM app development platform.",
+                            "sign_content": "",
+                            "answer": "",
+                            "word_count": 9,
+                            "tokens": 12,
+                            "keywords": [
+                              "dify",
+                              "platform",
+                              "llm"
+                            ],
+                            "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                            "index_node_hash": "abc123def456",
+                            "hit_count": 1,
+                            "enabled": true,
+                            "disabled_at": null,
+                            "disabled_by": null,
+                            "status": "completed",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200,
+                            "indexing_at": 1741267200,
+                            "completed_at": 1741267200,
+                            "error": null,
+                            "stopped_at": null,
+                            "document": {
+                              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                              "data_source_type": "upload_file",
+                              "name": "guide.txt",
+                              "doc_type": null,
+                              "doc_metadata": null
+                            }
+                          },
+                          "child_chunks": [],
+                          "score": 0.92,
+                          "tsne_position": null,
+                          "files": [],
+                          "summary": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "- `dataset_not_initialized` : 知识库仍在初始化或索引中。\n- `provider_not_initialize` : 模型供应商未配置有效凭据。\n- `provider_quota_exceeded` : Dify 托管的模型供应商配额已用尽。\n- `model_currently_not_support` : 所选模型当前不受支持。\n- `completion_request_error` : 模型请求失败。\n- `invalid_param` : 请求参数无效。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_not_initialized": {
+                    "summary": "dataset_not_initialized",
+                    "value": {
+                      "status": 400,
+                      "code": "dataset_not_initialized",
+                      "message": "The dataset is still being initialized or indexing. Please wait a moment."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Invalid parameter value."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : 未找到与 `dataset_id` 匹配的知识库。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "`internal_server_error` : 检索过程中发生内部错误。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "An internal error occurred."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
+          "metadata": {
+            "title": "从知识库检索分段 / 测试检索",
+            "sidebarTitle": "从知识库检索分段 / 测试检索"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/tags": {
+      "get": {
+        "tags": [
+          "标签"
+        ],
+        "summary": "获取知识库绑定的标签",
+        "description": "返回绑定到知识库的标签。",
+        "operationId": "queryDatasetTags",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "绑定到知识库的标签。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "标签标识符。"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "标签显示名称。"
+                          }
+                        }
+                      },
+                      "description": "绑定到此知识库的标签列表。"
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "绑定到该知识库的标签总数。"
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                          "name": "Product Docs"
+                        }
+                      ],
+                      "total": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "`forbidden` : 该知识库未启用 API 访问。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "`not_found` : 未找到知识库。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/tags/get-knowledge-base-tags",
+          "metadata": {
+            "title": "获取知识库绑定的标签",
+            "sidebarTitle": "获取知识库绑定的标签"
+          }
+        }
+      }
+    },
+    "/end-users/{end_user_id}": {
+      "get": {
+        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n根据 ID 返回终端用户的详细信息。当需要解析其他接口返回的终端用户 ID（例如 [上传文件](/zh/api-reference/files/upload-file) 响应中的 `created_by`）时很有用。",
+        "operationId": "getEndUserChat",
+        "parameters": [
+          {
+            "description": "要查询的终端用户 ID。",
+            "in": "path",
+            "name": "end_user_id",
+            "required": true,
+            "schema": {
+              "description": "终端用户 ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndUserDetail"
+                },
+                "examples": {
+                  "endUserDetail": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                      "app_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "type": "service-api",
+                      "external_user_id": "abc-123",
+                      "name": null,
+                      "is_anonymous": false,
+                      "session_id": "abc-123",
+                      "created_at": "2024-01-16T12:00:29Z",
+                      "updated_at": "2024-01-16T12:00:29Z"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "成功获取终端用户。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "end_user_not_found": {
+                    "summary": "end_user_not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "end_user_not_found",
+                      "message": "End user not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`end_user_not_found`：未找到终端用户。"
+          }
+        },
+        "summary": "获取终端用户信息",
+        "tags": [
+          "终端用户"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/end-users/get-end-user-info",
+          "metadata": {
+            "title": "获取终端用户信息",
+            "sidebarTitle": "获取终端用户信息"
+          }
+        }
+      }
+    },
+    "/files/upload": {
+      "post": {
+        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n上传文件并返回其 `id`，供后续请求引用。文件归上传它的终端用户所有：只有携带相同 `user` 的请求才能引用该文件。\n\n应用实际能使用哪些文件类型，取决于它的文件上传设置；可通过 [获取应用参数](/zh/api-reference/applications/get-app-parameters) 读取。",
+        "operationId": "uploadChatFile",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "description": "要上传的文件，作为 `multipart/form-data` 的一个部分。文件名不能包含 `/` 或 `\\`。\n\n除部署安全黑名单（`UPLOAD_FILE_EXTENSION_BLACKLIST`，默认为空）中的扩展名外，任何文件类型都可上传。\n\n文件大小按类别限制：图片 10 MB、音频 50 MB、视频 100 MB、其他文件 15 MB（默认值，Dify Cloud 使用默认值）。自部署可通过 `UPLOAD_*_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "user": {
+                    "description": "该上传所属的终端用户标识，由你的应用定义，需在应用内唯一。省略时上传归属于共享的 `DEFAULT-USER`。只有携带相同 `user` 的后续请求才能引用该文件。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true,
+          "description": "文件上传请求。需要 multipart/form-data 格式。"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileResponse"
+                },
+                "examples": {
+                  "uploadSuccess": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                      "reference": null,
+                      "name": "product-photo.png",
+                      "size": 204800,
+                      "extension": "png",
+                      "mime_type": "image/png",
+                      "created_by": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                      "created_at": 1705407629,
+                      "preview_url": null,
+                      "source_url": "https://upload.dify.ai/files/a1b2c3d4-5678-90ab-cdef-1234567890ab/file-preview?timestamp=1705407629&nonce=8b3e26a5&sign=rN5DXW3xkVGwGE5MSvptu_BhQVXpMbXWmVJ0ib0LMzI=",
+                      "original_url": null,
+                      "user_id": null,
+                      "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                      "conversation_id": null,
+                      "file_key": null
+                    }
+                  }
+                }
+              }
+            },
+            "description": "文件上传成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "File extension '.exe' is not allowed for security reasons"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `no_file_uploaded`：请求中未提供文件。\n- `too_many_files`：每次请求仅允许上传一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `invalid_param`：文件名包含 `/` 或 `\\`，或文件扩展名在部署的黑名单中。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": ""
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_too_large`：文件超过其类别的大小限制（见 `file` 字段）。目前运行时返回的 `message` 为空字符串（已知的后端问题），请以 `code` 和状态码为准。"
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`unsupported_file_type`：上传的 `file` 部分未声明 MIME 类型。"
+          }
+        },
+        "summary": "上传文件",
+        "tags": [
+          "文件操作"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/files/upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@product-photo.png' \\\n  --form 'user={user}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/files/upload-file",
+          "metadata": {
+            "title": "上传文件",
+            "sidebarTitle": "上传文件"
+          }
+        }
+      }
+    },
+    "/files/{file_id}/preview": {
+      "get": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent、文本生成应用。\n\n返回此前由 [上传文件](/zh/api-reference/files/upload-file) 返回的文件的原始字节。文件仅可通过引用它的消息所属的应用访问。",
+        "operationId": "previewChatFile",
+        "parameters": [
+          {
+            "description": "要下载的文件 ID，来自上传文件的响应。",
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "description": "要预览的文件唯一标识符，可从[上传文件](/zh/api-reference/files/upload-file) API 响应中获取。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "为 `true` 时，文件以附件形式下载，而不是在浏览器中内联渲染。",
+            "in": "query",
+            "name": "as_attachment",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "若为 `true`，强制将文件作为附件下载，而不是在浏览器中预览。",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "终端用户标识，由你的应用定义，需在应用内唯一。此处对文件访问没有影响，文件访问按应用和消息（而非 `user`）限定。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "用于终端用户上下文的用户标识符。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "返回原始文件内容。`Content-Type` 头设置为文件的 MIME 类型。如果 `as_attachment` 为 `true`，文件将以 `Content-Disposition: attachment` 方式作为下载返回。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_access_denied": {
+                    "summary": "file_access_denied",
+                    "value": {
+                      "status": 403,
+                      "code": "file_access_denied",
+                      "message": "Access to the requested file is denied."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_access_denied`：文件存在，但属于其他应用或工作空间。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_not_found": {
+                    "summary": "file_not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "file_not_found",
+                      "message": "The requested file was not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_not_found`：此 ID 对应的文件无法通过本应用的消息访问。"
+          }
+        },
+        "summary": "下载文件",
+        "tags": [
+          "文件操作"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/files/download-file",
+          "metadata": {
+            "title": "下载文件",
+            "sidebarTitle": "下载文件"
+          }
+        }
+      }
+    },
+    "/form/human_input/{form_token}": {
+      "get": {
+        "description": "**适用于**：Chatflow、Workflow。\n\n返回暂停中的人工介入表单内容。请在人工介入节点中启用 **Web 应用**提交方式；该方式会创建独立 Web 应用接收人，使其 `form_token` 可用于这些 Service API 接口。仅配置邮件或控制台提交方式时不可用。\n\n人工介入调用的完整流程，参见 [人工介入流程](/zh/api-reference/guides/human-input-flow)。",
+        "operationId": "getChatflowHumanInputForm",
+        "parameters": [
+          {
+            "description": "暂停表单的访问令牌，由流式模式下执行工作流或发送对话消息接口返回的 `human_input_required` 事件提供。",
+            "in": "path",
+            "name": "form_token",
+            "required": true,
+            "schema": {
+              "description": "人工输入表单令牌",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumanInputFormDefinitionResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "form_content": "请审阅草稿，设置优先级，然后确认或提出修改。",
+                      "inputs": [
+                        {
+                          "type": "paragraph",
+                          "output_variable_name": "feedback",
+                          "default": {
+                            "type": "constant",
+                            "selector": [],
+                            "value": ""
+                          }
+                        },
+                        {
+                          "type": "select",
+                          "output_variable_name": "priority",
+                          "option_source": {
+                            "type": "constant",
+                            "selector": [],
+                            "value": [
+                              "low",
+                              "medium",
+                              "high"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "file",
+                          "output_variable_name": "attachment",
+                          "allowed_file_types": [
+                            "image",
+                            "document"
+                          ],
+                          "allowed_file_extensions": [],
+                          "allowed_file_upload_methods": [
+                            "local_file",
+                            "remote_url"
+                          ]
+                        },
+                        {
+                          "type": "file-list",
+                          "output_variable_name": "attachments",
+                          "allowed_file_types": [
+                            "image",
+                            "document"
+                          ],
+                          "allowed_file_extensions": [],
+                          "allowed_file_upload_methods": [
+                            "local_file",
+                            "remote_url"
+                          ],
+                          "number_limits": 5
+                        }
+                      ],
+                      "resolved_default_values": {
+                        "feedback": ""
+                      },
+                      "user_actions": [
+                        {
+                          "id": "approve",
+                          "title": "批准",
+                          "button_style": "primary"
+                        },
+                        {
+                          "id": "reject",
+                          "title": "请求修改",
+                          "button_style": "default"
+                        }
+                      ],
+                      "expiration_time": 1745510400
+                    }
+                  }
+                }
+              }
+            },
+            "description": "表单内容获取成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "未找到表单"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到表单。"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "human_input_form_submitted": {
+                    "summary": "human_input_form_submitted",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_submitted",
+                      "message": "该表单已被其他用户提交，form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  },
+                  "human_input_form_expired": {
+                    "summary": "human_input_form_expired",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_expired",
+                      "message": "该表单已过期，form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `human_input_form_submitted`：表单已被提交。表单为一次性使用；无论由哪位用户提交，首个响应即生效。\n- `human_input_form_expired`：在提交到达之前表单已过期。"
+          }
+        },
+        "summary": "获取人工介入表单",
+        "tags": [
+          "人工介入"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/human-input/get-human-input-form",
+          "metadata": {
+            "title": "获取人工介入表单",
+            "sidebarTitle": "获取人工介入表单"
+          }
+        }
+      },
+      "post": {
+        "description": "**适用于**：Chatflow、Workflow。\n\n向暂停中的人工介入表单提交接收人的响应。接受后工作流将恢复；可通过 [流式获取工作流事件](/zh/api-reference/workflow-runs/stream-workflow-events) 跟踪恢复后的运行。请在人工介入节点中启用 **Web 应用**提交方式；仅配置邮件或控制台提交方式时，不会通过这些 Service API 接口公开表单。",
+        "operationId": "submitChatflowHumanInputForm",
+        "parameters": [
+          {
+            "description": "暂停表单的访问令牌，由流式模式下执行工作流或发送对话消息接口返回的 `human_input_required` 事件提供。",
+            "in": "path",
+            "name": "form_token",
+            "required": true,
+            "schema": {
+              "description": "人工输入表单令牌",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HumanInputFormSubmitPayloadWithUser"
+              },
+              "examples": {
+                "approve": {
+                  "summary": "请求示例",
+                  "value": {
+                    "inputs": {
+                      "feedback": "可以发布",
+                      "priority": "high",
+                      "attachment": {
+                        "transfer_method": "local_file",
+                        "upload_file_id": "3c8fa1b2-7d4e-4f9a-b0c1-d2e3f4a5b6c7",
+                        "type": "image"
+                      },
+                      "attachments": [
+                        {
+                          "transfer_method": "local_file",
+                          "upload_file_id": "1a77f0df-c0e6-461c-987c-e72526f341ee",
+                          "type": "document"
+                        },
+                        {
+                          "transfer_method": "remote_url",
+                          "url": "https://example.com/report.pdf",
+                          "type": "document"
+                        }
+                      ]
+                    },
+                    "action": "approve",
+                    "user": "abc-123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumanInputFormSubmitResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {}
+                  }
+                }
+              }
+            },
+            "description": "表单提交成功。响应体为空对象。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "bad_request": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "表单接收人类型无效"
+                    }
+                  },
+                  "invalid_form_data": {
+                    "summary": "invalid_form_data",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_form_data",
+                      "message": "缺少必填输入：feedback"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `bad_request`：表单接收人类型无效。\n- `invalid_form_data`：提交内容未通过表单定义的校验。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "未找到表单"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到表单。"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "human_input_form_submitted": {
+                    "summary": "human_input_form_submitted",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_submitted",
+                      "message": "该表单已被其他用户提交，form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  },
+                  "human_input_form_expired": {
+                    "summary": "human_input_form_expired",
+                    "value": {
+                      "status": 412,
+                      "code": "human_input_form_expired",
+                      "message": "该表单已过期，form_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `human_input_form_submitted`：表单已被提交。表单为一次性使用；无论由哪位用户提交，首个响应即生效。\n- `human_input_form_expired`：在提交到达之前表单已过期。"
+          }
+        },
+        "summary": "提交人工介入表单",
+        "tags": [
+          "人工介入"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/human-input/submit-human-input-form",
+          "metadata": {
+            "title": "提交人工介入表单",
+            "sidebarTitle": "提交人工介入表单"
+          }
+        }
+      }
+    },
+    "/info": {
+      "get": {
+        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n返回应用的基本信息：名称、描述、标签、模式和作者。",
+        "operationId": "getChatAppInfo",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfoResponse"
+                },
+                "examples": {
+                  "appInfo": {
+                    "summary": "响应示例",
+                    "value": {
+                      "name": "我的聊天应用",
+                      "description": "一个有用的客服聊天机器人。",
+                      "tags": [
+                        "customer-service",
+                        "chatbot"
+                      ],
+                      "mode": "chat",
+                      "author_name": "Dify Team"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "应用的基本信息。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "未找到应用"
+          }
+        },
+        "summary": "获取应用基本信息",
+        "tags": [
+          "应用配置"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl -X GET 'https://{api_base_url}/info' \\\n  -H 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/applications/get-app-info",
+          "metadata": {
+            "title": "获取应用基本信息",
+            "sidebarTitle": "获取应用基本信息"
+          }
+        }
+      }
+    },
+    "/messages": {
+      "get": {
+        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n返回会话的消息历史，按时间倒序（最新在前）。传入 `first_id` 可向前翻页获取更早的消息。",
+        "operationId": "getConversationHistory",
+        "parameters": [
+          {
+            "description": "要读取的会话 ID。会话 ID 从 [获取会话列表](/zh/api-reference/conversations/list-conversations) 获取。",
+            "in": "query",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "description": "会话 ID。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "分页游标：当前页第一条消息的 `id`。传入它可获取上一页（更早的消息）；省略则获取最新消息。",
+            "in": "query",
+            "name": "first_id",
+            "required": false,
+            "schema": {
+              "description": "当前页面第一条聊天记录的 ID。省略此值可获取最新消息；获取后续页面时，使用当前列表第一条消息的 ID 来获取更早的消息。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "每次请求返回的聊天历史消息数量。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "每次请求返回的聊天历史消息数量。",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "终端用户标识，由你的应用定义，需在应用内唯一。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "description": "用于终端用户上下文的用户标识符。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageInfiniteScrollPagination"
+                },
+                "examples": {
+                  "conversationHistory": {
+                    "summary": "响应示例",
+                    "value": {
+                      "limit": 20,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "9da23599-e713-473b-982c-4328d4f5c78a",
+                          "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+                          "parent_message_id": null,
+                          "inputs": {
+                            "city": "旧金山"
+                          },
+                          "query": "iPhone 13 Pro Max 的规格是什么？",
+                          "answer": "iPhone 13 Pro Max 的规格如下：……",
+                          "status": "normal",
+                          "error": null,
+                          "message_files": [],
+                          "feedback": {
+                            "rating": "like"
+                          },
+                          "retriever_resources": [],
+                          "agent_thoughts": [],
+                          "created_at": 1705407629,
+                          "extra_contents": [],
+                          "message_tokens": 100,
+                          "answer_tokens": 58,
+                          "total_tokens": 158,
+                          "provider_response_latency": 1.234,
+                          "total_price": "0.0012825",
+                          "currency": "USD"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "成功获取会话历史。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_chat_app`：应用模式与 API 路由不匹配。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "conversation_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Conversation Not Exists."
+                    }
+                  },
+                  "first_message_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "First Message Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：会话不存在。\n- `not_found`：第一条消息不存在（`first_id` 无效）。"
+          }
+        },
+        "summary": "获取会话历史消息",
+        "tags": [
+          "会话管理"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages?conversation_id={conversation_id}&user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/conversations/list-conversation-messages",
+          "metadata": {
+            "title": "获取会话历史消息",
+            "sidebarTitle": "获取会话历史消息"
+          }
+        }
+      }
+    },
+    "/messages/{message_id}/feedbacks": {
+      "post": {
+        "description": "**适用于**：Chatflow、聊天助手、Agent、文本生成应用。\n\n为消息记录 `like` 或 `dislike` 评价，并可附带可选评论。将 `rating` 设为 `null` 可撤销该消息的已有反馈。",
+        "operationId": "postChatMessageFeedback",
+        "parameters": [
+          {
+            "description": "要反馈的消息 ID。消息 ID 从 [获取会话历史消息](/zh/api-reference/conversations/list-conversation-messages) 获取。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "消息 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MessageFeedbackPayloadWithUser"
+              },
+              "examples": {
+                "likeFeedback": {
+                  "summary": "请求示例",
+                  "value": {
+                    "rating": "like",
+                    "user": "abc-123",
+                    "content": "这个回答很有帮助！"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "反馈已成功提交"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：缺少必填的 `user` 字段，或 `rating` 为 `null` 但没有可撤销的已有反馈。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "message_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Message Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：消息不存在。"
+          }
+        },
+        "summary": "提交消息反馈",
+        "tags": [
+          "消息反馈"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/feedback/submit-message-feedback",
+          "metadata": {
+            "title": "提交消息反馈",
+            "sidebarTitle": "提交消息反馈"
+          }
+        }
+      }
+    },
+    "/messages/{message_id}/suggested": {
+      "get": {
+        "description": "**适用于**：Chatflow、新 Agent、聊天助手、Agent。\n\n返回为某条消息推荐的追问问题。",
+        "operationId": "getSuggestedQuestions",
+        "parameters": [
+          {
+            "description": "要获取建议问题的消息 ID。可从对话响应或 [获取会话历史消息](/zh/api-reference/conversations/list-conversation-messages) 获取。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "消息 ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "终端用户标识，由你的应用定义，需在应用内唯一。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "description": "用于终端用户上下文的用户标识符。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultStringListResponse"
+                },
+                "examples": {
+                  "suggestedQuestions": {
+                    "summary": "响应示例",
+                    "value": {
+                      "result": "success",
+                      "data": [
+                        "iPhone 13 Pro Max 有哪些颜色？",
+                        "它的电池与 iPhone 12 相比如何？",
+                        "价格范围是多少？"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "成功获取建议问题。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_chat_app": {
+                    "summary": "not_chat_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_chat_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "bad_request": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "Suggested Questions Is Disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_chat_app`：应用模式与 API 路由不匹配。\n- `bad_request`：建议问题功能已禁用。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "message_not_exists": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Message Not Exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：消息不存在。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：内部服务器错误。"
+          }
+        },
+        "summary": "获取下一轮建议问题列表",
+        "tags": [
+          "对话消息"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages/{message_id}/suggested?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/chat-messages/get-next-suggested-questions",
+          "metadata": {
+            "title": "获取下一轮建议问题列表",
+            "sidebarTitle": "获取下一轮建议问题列表"
+          }
+        }
+      }
+    },
+    "/meta": {
+      "get": {
+        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n返回此应用所用工具的展示图标，以工具名为键。",
+        "operationId": "getChatAppMeta",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppMetaResponse"
+                },
+                "examples": {
+                  "appMeta": {
+                    "summary": "响应示例",
+                    "value": {
+                      "tool_icons": {
+                        "dalle3": "https://example.com/icons/dalle3.png",
+                        "calculator": {
+                          "background": "#4A90D9",
+                          "content": "🧮"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "成功获取应用元数据。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "未找到应用"
+          }
+        },
+        "summary": "获取应用元数据",
+        "tags": [
+          "应用配置"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/applications/get-app-meta",
+          "metadata": {
+            "title": "获取应用元数据",
+            "sidebarTitle": "获取应用元数据"
+          }
+        }
+      }
+    },
+    "/parameters": {
+      "get": {
+        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n返回应用的前端配置：开场白和建议问题、功能开关、用户输入表单，以及文件上传限制。用它来渲染应用的输入项并应用正确的上传限制。",
+        "operationId": "getChatAppParameters",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Parameters"
+                },
+                "examples": {
+                  "appParameters": {
+                    "summary": "响应示例",
+                    "value": {
+                      "opening_statement": "你好！今天有什么可以帮你？",
+                      "suggested_questions": [
+                        "你能做什么？",
+                        "介绍一下你的功能。"
+                      ],
+                      "suggested_questions_after_answer": {
+                        "enabled": true
+                      },
+                      "speech_to_text": {
+                        "enabled": false
+                      },
+                      "text_to_speech": {
+                        "enabled": false,
+                        "voice": "alloy",
+                        "language": "en-US",
+                        "autoPlay": "disabled"
+                      },
+                      "retriever_resource": {
+                        "enabled": true
+                      },
+                      "annotation_reply": {
+                        "enabled": false
+                      },
+                      "more_like_this": {
+                        "enabled": false
+                      },
+                      "sensitive_word_avoidance": {
+                        "enabled": false
+                      },
+                      "user_input_form": [
+                        {
+                          "text-input": {
+                            "label": "城市",
+                            "variable": "city",
+                            "required": true,
+                            "default": ""
+                          }
+                        }
+                      ],
+                      "file_upload": {
+                        "image": {
+                          "enabled": true,
+                          "number_limits": 3,
+                          "detail": "high",
+                          "transfer_methods": [
+                            "remote_url",
+                            "local_file"
+                          ]
+                        }
+                      },
+                      "system_parameters": {
+                        "file_size_limit": 15,
+                        "image_file_size_limit": 10,
+                        "audio_file_size_limit": 50,
+                        "video_file_size_limit": 100,
+                        "workflow_file_upload_limit": 10
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "应用参数信息。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "app_unavailable": {
+                    "summary": "app_unavailable",
+                    "value": {
+                      "status": 400,
+                      "code": "app_unavailable",
+                      "message": "App unavailable, please check your app configurations."
+                    }
+                  },
+                  "agent_not_published": {
+                    "summary": "agent_not_published",
+                    "value": {
+                      "code": "agent_not_published",
+                      "message": "Agent has not been published. Please publish the Agent before using the API.",
+                      "status": 400
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `app_unavailable`：应用不可用或配置错误。\n- `agent_not_published`：应用的 Agent 尚无已发布版本。（新 Agent 应用）"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "未找到应用"
+          }
+        },
+        "summary": "获取应用参数",
+        "tags": [
+          "应用配置"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/applications/get-app-parameters",
+          "metadata": {
+            "title": "获取应用参数",
+            "sidebarTitle": "获取应用参数"
+          }
+        }
+      }
+    },
+    "/site": {
+      "get": {
+        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n返回应用托管 Web 应用的品牌与展示设置，如标题、图标、主题色和默认语言。",
+        "operationId": "getChatWebAppSettings",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Site"
+                },
+                "examples": {
+                  "webAppSettings": {
+                    "summary": "响应示例",
+                    "value": {
+                      "title": "我的聊天应用",
+                      "chat_color_theme": "#4A90D9",
+                      "chat_color_theme_inverted": false,
+                      "icon_type": "emoji",
+                      "icon": "🤖",
+                      "icon_background": "#FFFFFF",
+                      "icon_url": null,
+                      "description": "一个有用的客服聊天机器人。",
+                      "copyright": "2025 Dify",
+                      "privacy_policy": "https://example.com/privacy",
+                      "input_placeholder": "有任何关于我们产品的问题都可以问我……",
+                      "custom_disclaimer": "",
+                      "default_language": "en-US",
+                      "show_workflow_steps": false,
+                      "use_icon_as_answer_icon": true
+                    }
+                  }
+                }
+              }
+            },
+            "description": "应用的 Web 应用设置。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：未找到此应用的站点或工作空间已归档。"
+          }
+        },
+        "summary": "获取应用 Web 应用设置",
+        "tags": [
+          "应用配置"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/applications/get-app-webapp-settings",
+          "metadata": {
+            "title": "获取应用 Web 应用设置",
+            "sidebarTitle": "获取应用 Web 应用设置"
+          }
+        }
+      }
+    },
+    "/text-to-audio": {
+      "post": {
+        "description": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n将文本转换为语音。`text` 和 `message_id` 至少提供一个：使用 `text` 合成任意内容，或使用 `message_id` 为已有消息的答案配音；两者同时提供时优先使用 `message_id`。生成的 schema 尚未表达这一跨字段约束，因此客户端需在发送前自行校验。",
+        "operationId": "textToAudioChat",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TextToAudioPayloadWithUser"
+              },
+              "examples": {
+                "textToAudioExample": {
+                  "summary": "请求示例",
+                  "value": {
+                    "text": "你好，欢迎使用我们的服务。",
+                    "user": "abc-123",
+                    "voice": "alloy",
+                    "streaming": false
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "audio/aac": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/flac": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/mp4": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/mpeg": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/ogg": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/wav": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/webm": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "返回生成的音频。`Content-Type` 响应头反映供应商实际返回的音频容器格式，可识别时会根据响应字节校验。\n\n响应体可能是 AAC、FLAC、MP4、MP3、Ogg、WAV 或 WebM。无法识别的输出按供应商声明的类型标注；未声明时标注为 `audio/mpeg`。\n\n供应商流式返回时按分块传输编码交付；请求中的 `streaming` 字段不控制此行为。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "app_unavailable": {
+                    "summary": "app_unavailable",
+                    "value": {
+                      "status": 400,
+                      "code": "app_unavailable",
+                      "message": "App unavailable, please check your app configurations."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "TTS is not enabled"
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `app_unavailable`：应用不可用或配置错误。\n- `invalid_param`：未启用文字转语音、缺少 `text` 或没有可用音色。\n- `provider_not_initialize`：未配置有效的模型供应商凭据。\n- `provider_quota_exceeded`：模型供应商配额已用尽。\n- `model_currently_not_support`：当前模型不支持此操作。\n- `completion_request_error`：文字转语音请求失败。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：内部服务器错误。"
+          }
+        },
+        "summary": "文字转语音",
+        "tags": [
+          "语音与文字转换"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/audio/convert-text-to-audio",
+          "metadata": {
+            "title": "文字转语音",
+            "sidebarTitle": "文字转语音"
+          }
+        }
+      }
+    },
+    "/workflow/{workflow_run_id}/events": {
+      "get": {
+        "description": "**适用于**：Chatflow、Workflow。\n\n在工作流运行暂停或原始 SSE 连接断开后恢复 Server-Sent Events 流。对于已结束的运行，流仅发送单个 `workflow_finished` 事件后关闭。\n\n如需查看进行中运行的节点级状态与进度，可在调用时附带 `include_state_snapshot=true`：流会先重放各已执行节点的状态，再流式发送新事件。",
+        "operationId": "streamWorkflowEvents",
+        "parameters": [
+          {
+            "description": "要恢复事件流的工作流运行 ID，来自 [执行工作流](/zh/api-reference/workflow-runs/run-workflow) 的响应或流式事件。",
+            "in": "path",
+            "name": "workflow_run_id",
+            "required": true,
+            "schema": {
+              "description": "原始工作流运行请求返回的工作流运行 ID。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "设为 `true` 时，流会在多次 `workflow_paused` 事件之间保持打开（适用于工作流包含多个连续人工介入节点的场景）。默认在首次暂停时关闭流。",
+            "in": "query",
+            "name": "continue_on_pause",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "设置为 `true`，可在多个 `workflow_paused` 事件之间保持流连接，适用于工作流连续包含多个人工输入节点的情况。默认在首次暂停后关闭流。",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "为 `true` 时，从持久化状态快照重放，在流式发送新事件前附带已执行节点的状态摘要。",
+            "in": "query",
+            "name": "include_state_snapshot",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "为 `true` 时，从持久化状态快照重放，在流式发送新事件前附带已执行节点的状态摘要。",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "终端用户标识，由你的应用定义，需在应用内唯一。必须与发起该运行的 `user` 一致。参见 [终端用户身份](/zh/api-reference/guides/end-user-identity)。",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "description": "最初触发运行的终端用户标识符，必须与该运行的创建者一致。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "已恢复工作流运行的事件 SSE 流，格式与 [执行工作流](/zh/api-reference/workflow-runs/run-workflow)（Workflow 应用）或 [发送对话消息](/zh/api-reference/chat-messages/send-chat-message)（Chatflow 应用）相同。当恢复部分运行设置 `reasoning_format: separated` 的 LLM 节点时，本流还会携带 `reasoning_chunk` 事件。"
+                },
+                "examples": {
+                  "resumedRun": {
+                    "summary": "响应示例 - 恢复运行（Workflow）",
+                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"审批\", \"rendered_content\": \"请审阅草稿。\", \"action_id\": \"approve\", \"action_text\": \"批准\", \"submitted_data\": {\"comment\": \"没问题，可以发布。\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_2\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM 节点\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"已批准，现在开始翻译。\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour\"}, \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
+                  },
+                  "resumedRunChatflow": {
+                    "summary": "响应示例 - 恢复运行（Chatflow）",
+                    "value": "event: ping\n\ndata: {\"event\": \"human_input_form_filled\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"node_id\": \"approval_node\", \"node_title\": \"审批\", \"rendered_content\": \"请审阅草稿。\", \"action_id\": \"approve\", \"action_text\": \"批准\", \"submitted_data\": {\"comment\": \"没问题，可以发布。\"}}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"created_at\": 1705407705}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"审阅者已批准草稿。\", \"node_id\": \"node_llm_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407705, \"data\": {\"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"reasoning\": \"\", \"node_id\": \"node_llm_1\", \"is_final\": true}}\n\ndata: {\"event\": \"message\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"answer\": \"已批准\", \"created_at\": 1705407706}\n\ndata: {\"event\": \"node_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"ne_002\", \"node_id\": \"node_llm_1\", \"node_type\": \"llm\", \"title\": \"LLM\", \"index\": 2, \"status\": \"succeeded\", \"elapsed_time\": 1.2, \"created_at\": 1705407705, \"finished_at\": 1705407706}}\n\ndata: {\"event\": \"message_end\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"metadata\": {\"usage\": {\"total_tokens\": 42, \"latency\": 1.3}}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"message_id\": \"2e4f6a8b-1c3d-5e7f-9a0b-2c4d6e8f0a1b\", \"conversation_id\": \"9d3a2f1b-6c7d-4e8f-a0b1-c2d3e4f5a6b7\", \"created_at\": 1705407706, \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"elapsed_time\": 2.1, \"total_tokens\": 42, \"total_steps\": 2, \"created_at\": 1705407629, \"finished_at\": 1705407706}}"
+                  }
+                }
+              }
+            },
+            "description": "Server-Sent Events 流。流以保活用的 `event: ping` 帧（不带 `data:`）开头，之后约每 10 秒到达一次；其余事件以 `data: {JSON}\\n\\n` 形式送达。事件载荷结构与原始流式响应一致。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_workflow_app`：请检查应用模式是否与此 API 路由匹配。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Workflow run not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到工作流运行记录。"
+          }
+        },
+        "summary": "流式获取工作流事件",
+        "tags": [
+          "工作流运行"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "恢复事件流",
+            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
+          },
+          {
+            "lang": "bash",
+            "label": "包含状态快照",
+            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}&include_state_snapshot=true' \\\n  --header 'Authorization: Bearer {api_key}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/workflow-runs/stream-workflow-events",
+          "metadata": {
+            "title": "流式获取工作流事件",
+            "sidebarTitle": "流式获取工作流事件"
+          }
+        }
+      }
+    },
+    "/workflows/logs": {
+      "get": {
+        "description": "**适用于**：Chatflow、Workflow。\n\n列出过往的工作流运行，支持可选筛选。每条记录是运行级摘要（状态、Token 用量、步数和耗时），而非逐节点的执行日志。\n\n如需跟踪某次运行的节点级事件，请改用流式方式：\n\n- **自行发起的运行**：以流式模式调用 [执行工作流](/zh/api-reference/workflow-runs/run-workflow)，运行执行时会发送 `node_started` 和 `node_finished` 事件。\n- **已在进行中的运行**：调用 [流式获取工作流事件](/zh/api-reference/workflow-runs/stream-workflow-events) 并附带 `include_state_snapshot=true`，先重放各已执行节点的状态，再流式发送其余事件。\n\n已结束运行的节点级日志无法通过服务 API 获取。",
+        "operationId": "getWorkflowLogs",
+        "parameters": [
+          {
+            "description": "筛选在此 ISO 8601 时间戳之后创建的日志。",
+            "in": "query",
+            "name": "created_at__after",
+            "required": false,
+            "schema": {
+              "description": "筛选在此 ISO 8601 时间戳之后创建的日志。",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "筛选在此 ISO 8601 时间戳之前创建的日志。",
+            "in": "query",
+            "name": "created_at__before",
+            "required": false,
+            "schema": {
+              "description": "筛选在此 ISO 8601 时间戳之前创建的日志。",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "按账户 ID 筛选。",
+            "in": "query",
+            "name": "created_by_account",
+            "required": false,
+            "schema": {
+              "description": "按账户 ID 筛选。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "按终端用户会话 ID 筛选。",
+            "in": "query",
+            "name": "created_by_end_user_session_id",
+            "required": false,
+            "schema": {
+              "description": "按终端用户会话 ID 筛选。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "在日志中搜索的关键词。",
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "description": "在日志中搜索的关键词。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "每页条目数。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "每页条目数。",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "分页页码。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "分页页码。",
+              "maximum": 99999,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "按执行状态筛选。",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "按执行状态筛选。",
+              "enum": [
+                "failed",
+                "stopped",
+                "succeeded"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowAppLogPaginationResponse"
+                },
+                "examples": {
+                  "workflowLogs": {
+                    "summary": "响应示例",
+                    "value": {
+                      "page": 1,
+                      "limit": 20,
+                      "total": 1,
+                      "has_more": false,
+                      "data": [
+                        {
+                          "id": "b7e2f8a1-3c4d-5e6f-7890-abcdef123456",
+                          "workflow_run": {
+                            "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                            "version": "2025-01-16 12:00:00.000000",
+                            "status": "succeeded",
+                            "error": null,
+                            "elapsed_time": 1.23,
+                            "total_tokens": 150,
+                            "total_steps": 3,
+                            "created_at": 1705407629,
+                            "finished_at": 1705407630,
+                            "exceptions_count": 0,
+                            "triggered_from": "app-run"
+                          },
+                          "created_from": "service-api",
+                          "created_by_role": "end_user",
+                          "created_by_account": null,
+                          "created_by_end_user": {
+                            "id": "f1e2d3c4-b5a6-7890-abcd-ef1234567890",
+                            "type": "service-api",
+                            "is_anonymous": false,
+                            "session_id": "user_workflow_123"
+                          },
+                          "created_at": 1705407629
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "成功获取工作流日志。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Account not found: name@example.com"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：某个查询参数无效，例如 `created_by_account` 未匹配到任何账户、`created_at__before` 或 `created_at__after` 时间戳格式错误，或 `page`、`limit`、`status` 超出有效范围。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          }
+        },
+        "summary": "获取工作流日志",
+        "tags": [
+          "工作流运行"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/workflow-runs/list-workflow-logs",
+          "metadata": {
+            "title": "获取工作流日志",
+            "sidebarTitle": "获取工作流日志"
+          }
+        }
+      }
+    },
+    "/workflows/run": {
+      "post": {
+        "description": "**适用于**：Workflow。\n\n运行应用已发布的工作流并返回其输出，可以是单次 `blocking` 响应，也可以是 `streaming` 的 Server-Sent Events 流。需要已发布的工作流。省略版本 ID 时运行应用当前已发布的工作流。草稿仅存在于编辑器中，不能通过 Service API 调用；发布后，该草稿会成为当前已发布版本。仅在需要运行较早的已发布 `workflow_id` 时使用[按 ID 运行工作流](/zh/api-reference/workflow-runs/run-workflow-by-id)。",
+        "operationId": "executeWorkflow",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowRunPayloadWithUser"
+              },
+              "examples": {
+                "streaming_example": {
+                  "summary": "请求示例 - 流式模式",
+                  "value": {
+                    "inputs": {
+                      "query": "总结这段文本：敏捷的棕色狐狸跳过了懒狗。"
+                    },
+                    "response_mode": "streaming",
+                    "user": "user_workflow_123"
+                  }
+                },
+                "blocking_example": {
+                  "summary": "请求示例 - 阻塞模式",
+                  "value": {
+                    "inputs": {
+                      "query": "将这句话翻译成法语：你好，世界"
+                    },
+                    "response_mode": "blocking",
+                    "user": "user_workflow_456"
+                  }
+                },
+                "with_file_array_variable": {
+                  "summary": "请求示例——文件数组输入",
+                  "value": {
+                    "inputs": {
+                      "my_documents": [
+                        {
+                          "type": "document",
+                          "transfer_method": "local_file",
+                          "upload_file_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+                        },
+                        {
+                          "type": "image",
+                          "transfer_method": "remote_url",
+                          "url": "https://example.com/image.jpg"
+                        }
+                      ]
+                    },
+                    "response_mode": "blocking",
+                    "user": "user_workflow_789"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
+                },
+                "examples": {
+                  "blockingResponse": {
+                    "summary": "响应示例 - 阻塞模式",
+                    "value": {
+                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
+                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "data": {
+                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "status": "succeeded",
+                        "outputs": {
+                          "result": "Bonjour le monde"
+                        },
+                        "error": null,
+                        "elapsed_time": 1.23,
+                        "total_tokens": 150,
+                        "total_steps": 3,
+                        "created_at": 1705407629,
+                        "finished_at": 1705407630
+                      }
+                    }
+                  }
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "Server-Sent Events (SSE) 流。按 [SSE 流式传输指南](/zh/api-reference/guides/streaming) 解析：读取 `data:` 行，根据 `event` 字段分派，忽略 `ping`（保活；流以 `ping` 开头，之后约每 10 秒到达一次）。\n\n**流生命周期**：收到 `workflow_finished`、`workflow_paused` 或 `error` 事件时流关闭。错误以流内 `error` 事件的形式返回，HTTP 状态码始终为 `200`；请检查事件载荷获取详情，不要依赖状态码判断。\n\n**推理事件**：\n- `reasoning_chunk`：来自 `reasoning_format` 为 `separated` 的 LLM 节点的推理内容增量。拼接连续的 `reasoning_chunk` 事件即可还原完整推理内容；`is_final: true` 的事件标志该节点思考结束（且 `reasoning` 可能为空）。载荷位于 `data` 下，与对话应用不同，`message_id` 为 `null`，且不含 `conversation_id`。并行的 `text_chunk` 流不含 `<think>` 标签。\n\n**人工介入事件**：\n- `human_input_required`：工作流到达人工介入节点时与 `workflow_paused` 一同触发。使用载荷中的 `form_token` 通过 [人工介入 API](/zh/api-reference/human-input/get-human-input-form) 处理表单。\n- `human_input_form_filled`：接收者提交了表单，工作流恢复执行。\n- `human_input_form_timeout`：表单超时未响应。如定义了超时回退分支，工作流将沿该分支执行。"
+                },
+                "examples": {
+                  "streamingResponse": {
+                    "summary": "响应示例 - 流式模式",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"翻译这段文本\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM 节点\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"我来翻译。\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
+                  },
+                  "humanInputPause": {
+                    "summary": "响应示例 - 人工介入暂停",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"你好\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"审批\", \"form_content\": \"请审阅草稿。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"批准\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
+                  }
+                }
+              }
+            },
+            "description": "成功响应。`blocking` 模式返回包含 `WorkflowBlockingResponse` 对象的 `application/json`；`streaming` 模式返回包含工作流事件的 `text/event-stream`。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_workflow_app`：应用模式与 API 路由不匹配。\n- `provider_not_initialize`：未找到有效的模型供应商凭据。\n- `provider_quota_exceeded`：模型供应商配额已用尽。\n- `model_currently_not_support`：当前模型不可用。\n- `completion_request_error`：工作流执行请求失败。\n- `invalid_param`：请求参数缺失或无效，例如缺少 `user` 或工作流未发布。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "未找到工作流"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "too_many_requests": {
+                    "summary": "too_many_requests",
+                    "value": {
+                      "status": 429,
+                      "code": "too_many_requests",
+                      "message": "Too many requests. Please try again later."
+                    }
+                  },
+                  "rate_limit_error": {
+                    "summary": "rate_limit_error",
+                    "value": {
+                      "status": 429,
+                      "code": "rate_limit_error",
+                      "message": "Rate Limit Error"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `too_many_requests`：该应用的并发请求过多。\n- `rate_limit_error`：此工作空间在 Dify Cloud 的工作流执行配额已达上限。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "Internal Server Error."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：内部服务器错误。"
+          }
+        },
+        "summary": "执行工作流",
+        "tags": [
+          "工作流运行"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl -N --request POST \\\n  --url 'https://{api_base_url}/workflows/run' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"inputs\": {\"query\": \"总结这段文本：敏捷的棕色狐狸跳过了懒狗。\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
+          }
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/workflow-runs/run-workflow",
+          "metadata": {
+            "title": "执行工作流",
+            "sidebarTitle": "执行工作流"
+          }
+        }
+      }
+    },
+    "/workflows/run/{workflow_run_id}": {
+      "get": {
+        "description": "**适用于**：Chatflow、Workflow。\n\n获取单次工作流运行的状态、输入、输出和执行指标。",
+        "operationId": "getWorkflowRunDetail",
+        "parameters": [
+          {
+            "description": "工作流运行 ID，来自 [执行工作流](/zh/api-reference/workflow-runs/run-workflow) 的响应或流式事件，或 Chatflow 应用的消息元数据。",
+            "in": "path",
+            "name": "workflow_run_id",
+            "required": true,
+            "schema": {
+              "description": "工作流运行 ID，可从工作流执行响应或流式事件中获取。",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowRunResponse"
+                },
+                "examples": {
+                  "workflowRunDetail": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                      "status": "succeeded",
+                      "inputs": "{\"query\": \"将这句话翻译成法语\"}",
+                      "outputs": {
+                        "result": "Traduisez ceci en francais"
+                      },
+                      "error": null,
+                      "total_steps": 3,
+                      "total_tokens": 150,
+                      "created_at": 1705407629,
+                      "finished_at": 1705407630,
+                      "elapsed_time": 1.23
+                    }
+                  }
+                }
+              }
+            },
+            "description": "成功获取工作流运行详情。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_workflow_app`：应用模式与 API 路由不匹配。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "workflow_run_not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Workflow run not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`not_found`：未找到工作流运行记录。"
+          }
+        },
+        "summary": "获取工作流执行情况",
+        "tags": [
+          "工作流运行"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/workflow-runs/get-workflow-run-detail",
+          "metadata": {
+            "title": "获取工作流执行情况",
+            "sidebarTitle": "获取工作流执行情况"
+          }
+        }
+      }
+    },
+    "/workflows/tasks/{task_id}/stop": {
+      "post": {
+        "description": "**适用于**：Workflow。\n\n停止正在运行的工作流任务。仅在 `streaming` 模式下支持。",
+        "operationId": "stopWorkflowTaskGeneration",
+        "parameters": [
+          {
+            "description": "任务 ID，来自 [执行工作流](/zh/api-reference/workflow-runs/run-workflow) 的流式事件。",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "description": "任务 ID，可从运行工作流 API 返回的流式分块中获取。",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RequiredServiceApiUserPayload"
+              },
+              "examples": {
+                "example": {
+                  "summary": "请求示例",
+                  "value": {
+                    "user": "user_workflow_123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResultResponse"
+                },
+                "example": {
+                  "result": "success"
+                }
+              }
+            },
+            "description": "任务已成功停止"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_workflow_app`：应用模式与 API 路由不匹配。\n- `invalid_param`：请求参数缺失或无效，例如缺少 `user`。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The app's API service has been disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：应用 API 已停用、应用状态异常或工作区已归档。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "message": "The requested resource was not found.",
+                  "status": 404
+                }
+              }
+            },
+            "description": "保留的兼容响应。当前运行时在设置停止标记前不会校验任务是否存在；即使任务已不再运行，也会返回正常的 `200` 结果。"
+          }
+        },
+        "summary": "停止工作流任务",
+        "tags": [
+          "工作流运行"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/workflow-runs/stop-workflow-task",
+          "metadata": {
+            "title": "停止工作流任务",
+            "sidebarTitle": "停止工作流任务"
+          }
+        }
+      }
+    },
+    "/workflows/{workflow_id}/run": {
+      "post": {
+        "description": "**适用于**：Workflow。\n\n运行指定的已发布工作流版本，由路径中的 `workflow_id` 指定。请求体、响应和流式行为与 [执行工作流](/zh/api-reference/workflow-runs/run-workflow) 相同，仅执行的版本不同。",
+        "operationId": "runWorkflowById",
+        "parameters": [
+          {
+            "description": "要运行的已发布工作流版本。在 [执行工作流](/zh/api-reference/workflow-runs/run-workflow) 响应和 [获取工作流运行详情](/zh/api-reference/workflow-runs/get-workflow-run-detail) 的 `workflow_id` 字段中返回。必须指向已发布版本；草稿版本 ID 会返回 `bad_request`。",
+            "in": "path",
+            "name": "workflow_id",
+            "required": true,
+            "schema": {
+              "description": "要执行的特定版本的工作流 ID。该值由工作流运行响应中的 `workflow_id` 字段返回。",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowRunPayloadWithUser"
+              },
+              "examples": {
+                "example": {
+                  "summary": "请求示例",
+                  "value": {
+                    "inputs": {
+                      "query": "总结这篇文章"
+                    },
+                    "response_mode": "blocking",
+                    "user": "user_workflow_123"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowBlockingResponse"
+                },
+                "examples": {
+                  "blockingResponse": {
+                    "summary": "响应示例 - 阻塞模式",
+                    "value": {
+                      "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
+                      "workflow_run_id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                      "data": {
+                        "id": "fb47b2e6-5e43-4f90-be01-d5c5a088d156",
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "status": "succeeded",
+                        "outputs": {
+                          "result": "这里是文章摘要"
+                        },
+                        "error": null,
+                        "elapsed_time": 2.45,
+                        "total_tokens": 280,
+                        "total_steps": 4,
+                        "created_at": 1705407629,
+                        "finished_at": 1705407631
+                      }
+                    }
+                  }
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "Server-Sent Events (SSE) 流。按 [SSE 流式传输指南](/zh/api-reference/guides/streaming) 解析：读取 `data:` 行，根据 `event` 字段分派，忽略 `ping`（保活；流以 `ping` 开头，之后约每 10 秒到达一次）。\n\n**流生命周期**：收到 `workflow_finished`、`workflow_paused` 或 `error` 事件时流关闭。错误以流内 `error` 事件的形式返回，HTTP 状态码始终为 `200`；请检查事件载荷获取详情，不要依赖状态码判断。\n\n**推理事件**：\n- `reasoning_chunk`：来自 `reasoning_format` 为 `separated` 的 LLM 节点的推理内容增量。拼接连续的 `reasoning_chunk` 事件即可还原完整推理内容；`is_final: true` 的事件标志该节点思考结束（且 `reasoning` 可能为空）。载荷位于 `data` 下，与对话应用不同，`message_id` 为 `null`，且不含 `conversation_id`。并行的 `text_chunk` 流不含 `<think>` 标签。\n\n**人工介入事件**：\n- `human_input_required`：工作流到达人工介入节点时与 `workflow_paused` 一同触发。使用载荷中的 `form_token` 通过 [人工介入 API](/zh/api-reference/human-input/get-human-input-form) 处理表单。\n- `human_input_form_filled`：接收者提交了表单，工作流恢复执行。\n- `human_input_form_timeout`：表单超时未响应。如定义了超时回退分支，工作流将沿该分支执行。"
+                },
+                "examples": {
+                  "streamingResponse": {
+                    "summary": "响应示例 - 流式模式",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"query\": \"翻译这段文本\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"node_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"node_exec_1\", \"node_id\": \"node_1\", \"node_type\": \"llm\", \"title\": \"LLM 节点\", \"index\": 1, \"created_at\": 1705407629}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"我来翻译。\", \"node_id\": \"node_1\", \"is_final\": false}}\n\ndata: {\"event\": \"reasoning_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"reasoning\": \"\", \"node_id\": \"node_1\", \"is_final\": true}}\n\ndata: {\"event\": \"text_chunk\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"text\": \"Bonjour\", \"from_variable_selector\": [\"node_1\", \"text\"]}}\n\ndata: {\"event\": \"workflow_finished\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"status\": \"succeeded\", \"outputs\": {\"result\": \"Bonjour le monde\"}, \"elapsed_time\": 1.23, \"total_tokens\": 150, \"total_steps\": 3, \"created_at\": 1705407629, \"finished_at\": 1705407630}}"
+                  },
+                  "humanInputPause": {
+                    "summary": "响应示例 - 人工介入暂停",
+                    "value": "event: ping\n\ndata: {\"event\": \"workflow_started\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"workflow_id\": \"7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345\", \"inputs\": {\"draft\": \"你好\"}, \"created_at\": 1705407629, \"reason\": \"initial\"}}\n\ndata: {\"event\": \"human_input_required\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"form_id\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"form_token\": \"tok_abc123\", \"node_id\": \"approval_node\", \"node_title\": \"审批\", \"form_content\": \"请审阅草稿。\", \"inputs\": [{\"type\": \"paragraph\", \"output_variable_name\": \"comment\", \"default\": null}], \"actions\": [{\"id\": \"approve\", \"title\": \"批准\", \"button_style\": \"primary\"}], \"display_in_ui\": false, \"resolved_default_values\": {\"comment\": \"\"}, \"expiration_time\": 1705494029}}\n\ndata: {\"event\": \"workflow_paused\", \"task_id\": \"c3800678-a077-43df-a102-53f23ed20b88\", \"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"data\": {\"workflow_run_id\": \"fb47b2e6-5e43-4f90-be01-d5c5a088d156\", \"status\": \"paused\", \"created_at\": 1705407629, \"elapsed_time\": 0.5}}"
+                  }
+                }
+              }
+            },
+            "description": "成功响应。`blocking` 模式返回包含 `WorkflowBlockingResponse` 对象的 `application/json`；`streaming` 模式返回包含工作流事件的 `text/event-stream`。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_workflow_app": {
+                    "summary": "not_workflow_app",
+                    "value": {
+                      "status": 400,
+                      "code": "not_workflow_app",
+                      "message": "Please check if your app mode matches the right API route."
+                    }
+                  },
+                  "bad_request": {
+                    "summary": "bad_request",
+                    "value": {
+                      "status": 400,
+                      "code": "bad_request",
+                      "message": "Cannot use draft workflow version. Workflow ID: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345. Please use a published workflow version or leave workflow_id empty."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted OpenAI has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Arg user must be provided."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_workflow_app`：应用模式与 API 路由不匹配。\n- `bad_request`：工作流为草稿或 ID 格式无效。\n- `provider_not_initialize`：未找到有效的模型供应商凭据。\n- `provider_quota_exceeded`：模型供应商配额已用尽。\n- `model_currently_not_support`：当前模型不可用。\n- `completion_request_error`：工作流执行请求失败。\n- `invalid_param`：请求参数缺失或无效，例如缺少 `user`。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "workflow_version_execution_not_allowed": {
+                    "summary": "workflow_version_execution_not_allowed",
+                    "value": {
+                      "status": 403,
+                      "code": "workflow_version_execution_not_allowed",
+                      "message": "Workflow version execution is not available on your current plan. Please upgrade to a paid plan."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`workflow_version_execution_not_allowed`：Dify Cloud Sandbox 套餐无法执行指定的工作流版本。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Workflow not found with id: 7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到工作流。"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "too_many_requests": {
+                    "summary": "too_many_requests",
+                    "value": {
+                      "status": 429,
+                      "code": "too_many_requests",
+                      "message": "Too many requests. Please try again later."
+                    }
+                  },
+                  "rate_limit_error": {
+                    "summary": "rate_limit_error",
+                    "value": {
+                      "status": 429,
+                      "code": "rate_limit_error",
+                      "message": "Rate Limit Error"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `too_many_requests`：该应用的并发请求过多。\n- `rate_limit_error`：此工作空间在 Dify Cloud 的工作流执行配额已达上限。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "Internal Server Error."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：内部服务器错误。"
+          }
+        },
+        "summary": "按 ID 执行工作流",
+        "tags": [
+          "工作流运行"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/workflow-runs/run-workflow-by-id",
+          "metadata": {
+            "title": "按 ID 执行工作流",
+            "sidebarTitle": "按 ID 执行工作流"
+          }
+        }
+      }
+    },
+    "/workspaces/current/models/model-types/{model_type}": {
+      "get": {
+        "tags": [
+          "模型"
+        ],
+        "summary": "获取可用模型",
+        "description": "返回指定类型的可用模型。用它查找可配置到知识库的 `text-embedding` 和 `rerank` 模型。",
+        "operationId": "getAvailableModelsZh",
+        "parameters": [
+          {
+            "name": "model_type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "text-embedding",
+                "rerank",
+                "llm",
+                "tts",
+                "speech2text",
+                "moderation"
+              ]
+            },
+            "description": "要获取的模型类型。对于知识库配置，使用 `text-embedding` 获取嵌入模型，使用 `rerank` 获取重排序模型。"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "指定类型的可用模型。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "description": "模型供应商及其可用模型的列表。",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "provider": {
+                            "type": "string",
+                            "description": "模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。旧版供应商可能返回简写形式（例如 `openai`）。"
+                          },
+                          "label": {
+                            "type": "object",
+                            "description": "供应商的本地化显示名称。",
+                            "properties": {
+                              "en_US": {
+                                "type": "string",
+                                "description": "英文显示名称。"
+                              },
+                              "zh_Hans": {
+                                "type": "string",
+                                "description": "中文显示名称。"
+                              }
+                            }
+                          },
+                          "icon_small": {
+                            "type": "object",
+                            "description": "供应商小图标的 URL。",
+                            "properties": {
+                              "en_US": {
+                                "type": "string",
+                                "description": "小图标 URL。"
+                              },
+                              "zh_Hans": {
+                                "type": "string",
+                                "description": "中文图标 URL。"
+                              }
+                            }
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "供应商状态。凭证已配置且有效时为 `active`。"
+                          },
+                          "models": {
+                            "type": "array",
+                            "description": "该供应商的可用模型列表。",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string",
+                                  "description": "模型标识符。创建或更新知识库时，将此值作为 `embedding_model` 参数使用。"
+                                },
+                                "label": {
+                                  "type": "object",
+                                  "description": "模型的本地化显示名称。",
+                                  "properties": {
+                                    "en_US": {
+                                      "type": "string",
+                                      "description": "英文模型名称。"
+                                    },
+                                    "zh_Hans": {
+                                      "type": "string",
+                                      "description": "中文模型名称。"
+                                    }
+                                  }
+                                },
+                                "model_type": {
+                                  "type": "string",
+                                  "description": "模型类型，与 `model_type` 路径参数匹配。"
+                                },
+                                "features": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "description": "模型支持的功能，无功能时为 `null`。",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "fetch_from": {
+                                  "type": "string",
+                                  "description": "模型定义的来源。`predefined-model` 表示内置模型，`customizable-model` 表示用户自配置的模型。"
+                                },
+                                "model_properties": {
+                                  "type": "object",
+                                  "description": "模型特定的属性，例如 `context_size`。"
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "description": "模型可用状态。就绪时为 `active`。"
+                                },
+                                "deprecated": {
+                                  "type": "boolean",
+                                  "description": "模型是否已弃用。"
+                                },
+                                "load_balancing_enabled": {
+                                  "type": "boolean",
+                                  "description": "模型是否启用负载均衡。"
+                                },
+                                "has_invalid_load_balancing_configs": {
+                                  "type": "boolean",
+                                  "description": "模型是否存在无效的负载均衡配置。"
+                                }
+                              }
+                            }
+                          },
+                          "tenant_id": {
+                            "type": "string",
+                            "description": "该供应商配置所属的工作空间 ID。"
+                          },
+                          "icon_small_dark": {
+                            "type": "object",
+                            "description": "深色模式图标 URL；供应商没有时为 `null`。",
+                            "properties": {
+                              "en_US": {
+                                "type": "string"
+                              },
+                              "zh_Hans": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "data": [
+                        {
+                          "provider": "langgenius/openai/openai",
+                          "label": {
+                            "en_US": "OpenAI",
+                            "zh_Hans": "OpenAI"
+                          },
+                          "icon_small": {
+                            "en_US": "https://example.com/openai-small.svg",
+                            "zh_Hans": "https://example.com/openai-small.svg"
+                          },
+                          "status": "active",
+                          "models": [
+                            {
+                              "model": "text-embedding-3-small",
+                              "label": {
+                                "en_US": "text-embedding-3-small",
+                                "zh_Hans": "text-embedding-3-small"
+                              },
+                              "model_type": "text-embedding",
+                              "features": null,
+                              "fetch_from": "predefined-model",
+                              "model_properties": {
+                                "context_size": 8191
+                              },
+                              "status": "active",
+                              "deprecated": false,
+                              "load_balancing_enabled": false,
+                              "has_invalid_load_balancing_configs": false
+                            }
+                          ],
+                          "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                          "icon_small_dark": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-mint": {
+          "href": "/zh/api-reference/models/get-available-models",
+          "metadata": {
+            "title": "获取可用模型",
+            "sidebarTitle": "获取可用模型"
           }
         }
       }


### PR DESCRIPTION
## Summary

- generate the English, Chinese, and Japanese application Service API operations from the Dify contract
- apply the reviewed application overlays from the preceding layer
- keep knowledge operations unchanged for their dedicated layers

## Validation

- three-locale structural parity — 0 issues