### PR TITLE
docs: add knowledge api presentation overlays

### DIFF
--- a/tools/api-pipeline/service_api_overlays/en.json
+++ b/tools/api-pipeline/service_api_overlays/en.json
@@ -14094,6 +14094,8089 @@
     },
     {
       "op": "replace",
+      "path": "/paths/~1datasets/get/description",
+      "source_sha256": "d054bda8cd30bdd4de53ea1626562d5b1b25aa37bb195f0b7ac6dc40f8f35e30",
+      "value": "Returns a paginated list of knowledge bases, optionally filtered by keyword or tags."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/operationId",
+      "source_sha256": "ef2a1d7b12fdb9e1a485e6cd014c7a776d029245455757f45c973f1502ebc6de",
+      "value": "listDatasets"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": [
+              {
+                "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+                "name": "Product Documentation",
+                "description": "Technical documentation for the product API",
+                "provider": "vendor",
+                "permission": "only_me",
+                "data_source_type": null,
+                "indexing_technique": "high_quality",
+                "app_count": 0,
+                "document_count": 0,
+                "word_count": 0,
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "author_name": "admin",
+                "created_at": 1741267200,
+                "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "updated_at": 1741267200,
+                "embedding_model": "text-embedding-3-small",
+                "embedding_model_provider": "langgenius/openai/openai",
+                "embedding_available": true,
+                "retrieval_model_dict": {
+                  "search_method": "semantic_search",
+                  "reranking_enable": false,
+                  "reranking_mode": null,
+                  "reranking_model": {
+                    "reranking_provider_name": "",
+                    "reranking_model_name": ""
+                  },
+                  "weights": null,
+                  "top_k": 3,
+                  "score_threshold_enabled": false,
+                  "score_threshold": null
+                },
+                "tags": [],
+                "doc_form": "text_model",
+                "external_retrieval_model": null,
+                "doc_metadata": [],
+                "built_in_field_enabled": true,
+                "pipeline_id": null,
+                "runtime_mode": null,
+                "chunk_structure": null,
+                "is_published": false,
+                "total_documents": 0,
+                "total_available_documents": 0,
+                "enable_api": true,
+                "is_multimodal": false,
+                "maintainer": "admin"
+              }
+            ],
+            "has_more": false,
+            "limit": 20,
+            "total": 1,
+            "page": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/responses/403/content/application~1json/example",
+      "value": {
+        "code": "forbidden",
+        "message": "Forbidden.",
+        "status": 403
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl -X GET 'https://{api_base_url}/datasets?page=1&limit=20' \\\n  -H 'Authorization: Bearer {api_key}'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/knowledge-bases/list-knowledge-bases",
+        "metadata": {
+          "title": "List Knowledge Bases",
+          "sidebarTitle": "List Knowledge Bases"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/description",
+      "source_sha256": "97dbeecda4c597e86334a41358ddef1281827f2d43084d33d359428edcea6fc5",
+      "value": "Creates an empty knowledge base. Add documents to it with [Create Document by Text](/en/api-reference/documents/create-document-by-text) or [Create Document by File](/en/api-reference/documents/create-document-by-file)."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/operationId",
+      "source_sha256": "d74b5b128e8928e710b6676be97acc183d444263d4e88d0a530a64446f901120",
+      "value": "createDataset"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+            "name": "Product Documentation",
+            "description": "Technical documentation for the product API",
+            "provider": "vendor",
+            "permission": "only_me",
+            "data_source_type": null,
+            "indexing_technique": "high_quality",
+            "app_count": 0,
+            "document_count": 0,
+            "word_count": 0,
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "author_name": "admin",
+            "created_at": 1741267200,
+            "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "updated_at": 1741267200,
+            "embedding_model": "text-embedding-3-small",
+            "embedding_model_provider": "langgenius/openai/openai",
+            "embedding_available": true,
+            "retrieval_model_dict": {
+              "search_method": "semantic_search",
+              "reranking_enable": false,
+              "reranking_mode": null,
+              "reranking_model": {
+                "reranking_provider_name": "",
+                "reranking_model_name": ""
+              },
+              "weights": null,
+              "top_k": 3,
+              "score_threshold_enabled": false,
+              "score_threshold": null
+            },
+            "tags": [],
+            "doc_form": "text_model",
+            "external_retrieval_model": null,
+            "doc_metadata": [],
+            "built_in_field_enabled": true,
+            "pipeline_id": null,
+            "runtime_mode": null,
+            "chunk_structure": null,
+            "is_published": false,
+            "total_documents": 0,
+            "total_available_documents": 0,
+            "enable_api": true,
+            "is_multimodal": false,
+            "maintainer": "admin"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/400/description",
+      "source_sha256": "2bfbcfde3ad246205ccd33f9e5921e27cf4a76186dc1885bf430dc6e0d6cae76",
+      "value": "`invalid_param` : The embedding or reranking model you specified is not configured or available."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Your subscription's knowledge base request rate limit has been reached."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/409/content/application~1json/examples",
+      "value": {
+        "dataset_name_duplicate": {
+          "summary": "dataset_name_duplicate",
+          "value": {
+            "status": 409,
+            "code": "dataset_name_duplicate",
+            "message": "The dataset name already exists. Please modify your dataset name."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/409/description",
+      "source_sha256": "8f9971fca91a6321a9b7ee6cf993565be331319a7ee3f85c340d258fa9bc3f88",
+      "value": "`dataset_name_duplicate` : A knowledge base with the same name already exists."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/knowledge-bases/create-an-empty-knowledge-base",
+        "metadata": {
+          "title": "Create an Empty Knowledge Base",
+          "sidebarTitle": "Create an Empty Knowledge Base"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/description",
+      "source_sha256": "dfa32093fca1413e614dfc90ac9bfdda066d84fa0276cb6124ea320a9c6a0ff8",
+      "value": "Uploads a file for use in a knowledge pipeline. Use the returned `id` as the `reference` of a `local_file` item in [Run Pipeline](/en/api-reference/knowledge-pipeline/run-pipeline)."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/operationId",
+      "source_sha256": "fc84e912240748481af2149f6debf0706ac19ef080fc916ec3d347f2d8636976",
+      "value": "uploadPipelineFile"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "b9c59fbdc0bbf0f019b4e57923038788f12065569bdff78282f5a98efb8c7476",
+      "value": "The file to upload, as one `multipart/form-data` part. Document files are capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments).\n\nOn Dify Cloud, Professional and Team plans raise the document cap to 50 MB. Images, audio, and video follow their own limits: 10 MB, 50 MB, and 100 MB by default."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/201/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "name": "report.pdf",
+            "size": 524288,
+            "extension": "pdf",
+            "mime_type": "application/pdf",
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "created_at": "2025-03-06T12:00:00"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/400/content/application~1json/examples",
+      "value": {
+        "no_file_uploaded": {
+          "summary": "no_file_uploaded",
+          "value": {
+            "status": 400,
+            "code": "no_file_uploaded",
+            "message": "Please upload your file."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/400/description",
+      "source_sha256": "d9117135f720d08a7612ecb5855665e59ad2620a7581f9e95b3011010c998ceb",
+      "value": "- `no_file_uploaded` : No file was provided in the request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `too_many_files` : Only one file is allowed per request."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/403/content/application~1json/example",
+      "value": {
+        "code": "forbidden",
+        "message": "Forbidden.",
+        "status": 403
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large` : The file exceeds the upload size limit."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/415/description",
+      "source_sha256": "cd5a22a978d1f32165a6676fb309f964b87db0818d7176356fe5f433a2803b0c",
+      "value": "`unsupported_file_type` : The file type is not supported."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/knowledge-pipeline/upload-pipeline-file",
+        "metadata": {
+          "title": "Upload Pipeline File",
+          "sidebarTitle": "Upload Pipeline File"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/operationId",
+      "source_sha256": "352ccb4c7592dadaf380d26a1733902600a16f384c657cafcf130765f1e30ae1",
+      "value": "deleteKnowledgeTag"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden` : Your workspace role does not permit editing these resources."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Tag not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/404/description",
+      "source_sha256": "f08401bb2b05b341791960d88321930fa7b110c695c34a98000496fcaf8fd5a3",
+      "value": "- `not_found` : The specified tag does not exist."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/x-mint",
+      "value": {
+        "href": "/en/api-reference/tags/delete-knowledge-tag",
+        "metadata": {
+          "title": "Delete Knowledge Tag",
+          "sidebarTitle": "Delete Knowledge Tag"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/description",
+      "source_sha256": "6f3afca0f7d11924162451927fb4402eb12b16849f2f62c93e0d21af223a1d7f",
+      "value": "Returns all knowledge base tags in the workspace."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/operationId",
+      "source_sha256": "9c6008b0eaf477a25ab5d66a6a34e701963154fbc8cd773d113d6754d6de04b9",
+      "value": "getKnowledgeTags"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": [
+            {
+              "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+              "name": "Product Docs",
+              "type": "knowledge",
+              "binding_count": "0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/responses/403/content/application~1json/example",
+      "value": {
+        "code": "forbidden",
+        "message": "Forbidden.",
+        "status": 403
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/tags/list-knowledge-tags",
+        "metadata": {
+          "title": "List Knowledge Tags",
+          "sidebarTitle": "List Knowledge Tags"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/description",
+      "source_sha256": "c084eab025fd870ff32344afa68d74861fc1261825a21c12b4428827181f240b",
+      "value": "Rename a knowledge base tag."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/operationId",
+      "source_sha256": "201e7ef9d9f3a11a4022a7b1adccc7eab3fb00a6d6b2a152ef8a5f44c6b2cc07",
+      "value": "updateKnowledgeTag"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+            "name": "Product Docs",
+            "type": "knowledge",
+            "binding_count": "0"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Tag name already exists"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/400/description",
+      "source_sha256": "23c822a6680f643f8803faeae345ab3d64ea2c4196383f9d8dd74f2ca4a25aeb",
+      "value": "`invalid_param` : A knowledge tag with the same name already exists."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden` : Your workspace role does not permit editing these resources."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Tag not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/404/description",
+      "source_sha256": "f08401bb2b05b341791960d88321930fa7b110c695c34a98000496fcaf8fd5a3",
+      "value": "- `not_found` : The specified tag does not exist."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/x-mint",
+      "value": {
+        "href": "/en/api-reference/tags/update-knowledge-tag",
+        "metadata": {
+          "title": "Update Knowledge Tag",
+          "sidebarTitle": "Update Knowledge Tag"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/description",
+      "source_sha256": "eac481e2114e573707d7dbc32cc1a97e2a4051a323cc86d99b83ccaff037cecf",
+      "value": "Create a tag for organizing knowledge bases."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/operationId",
+      "source_sha256": "da824e56d5664a07351bf17bebbe0400579a26ba542dfd599cbc6f0fb2aa35e7",
+      "value": "createKnowledgeTag"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+            "name": "Product Docs",
+            "type": "knowledge",
+            "binding_count": "0"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Tag name already exists"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/400/description",
+      "source_sha256": "23c822a6680f643f8803faeae345ab3d64ea2c4196383f9d8dd74f2ca4a25aeb",
+      "value": "`invalid_param` : A knowledge tag with the same name already exists."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden` : Your workspace role does not permit editing these resources."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/tags/create-knowledge-tag",
+        "metadata": {
+          "title": "Create Knowledge Tag",
+          "sidebarTitle": "Create Knowledge Tag"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/operationId",
+      "source_sha256": "9c9e39eda60a4b8997db7b7504de09433135bb41074e42fffff984795c38601c",
+      "value": "bindTagsToDataset"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden` : Your workspace role does not permit editing these resources."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found` : The target knowledge base does not exist."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/tags/create-tag-binding",
+        "metadata": {
+          "title": "Create Tag Binding",
+          "sidebarTitle": "Create Tag Binding"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/operationId",
+      "source_sha256": "fab93b635cdec9e935f12fc280ddbe6bc9e35b454405f6291cecbc7020ba0a72",
+      "value": "unbindTagFromDataset"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden` : Your workspace role does not permit editing these resources."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found` : The target knowledge base does not exist."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/tags/delete-tag-binding",
+        "metadata": {
+          "title": "Delete Tag Binding",
+          "sidebarTitle": "Delete Tag Binding"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/description",
+      "source_sha256": "5a13df0fb2b7bc8d07e48e977ce6fc26b95b5a655a1ee598302de1f5ab10f30c",
+      "value": "Permanently deletes a knowledge base and all of its documents."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/operationId",
+      "source_sha256": "e4554386c315974bcd8ec39a1fbbaa490987c3caa4806f5f14896e006372d0eb",
+      "value": "deleteDataset"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "Knowledge base deleted successfully."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found` : No knowledge base matches `dataset_id`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/409/content/application~1json/examples",
+      "value": {
+        "dataset_in_use": {
+          "summary": "dataset_in_use",
+          "value": {
+            "status": 409,
+            "code": "dataset_in_use",
+            "message": "The dataset is being used by some apps. Please remove the dataset from the apps before deleting it."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/409/description",
+      "source_sha256": "c5d6a5645855d5289b56585a737d39bdcf4f066a9a4f0556d4e30fcbe02e4251",
+      "value": "- `dataset_in_use` : The knowledge base is used by one or more apps and cannot be deleted."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/x-mint",
+      "value": {
+        "href": "/en/api-reference/knowledge-bases/delete-knowledge-base",
+        "metadata": {
+          "title": "Delete Knowledge Base",
+          "sidebarTitle": "Delete Knowledge Base"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/description",
+      "source_sha256": "50f262ee70911d6791abcea1c7ad34cc9663445441e2f01ea7cc7b39893e0e89",
+      "value": "Returns detailed information about a knowledge base, including its embedding model, retrieval configuration, and document statistics."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/operationId",
+      "source_sha256": "c676c10a9666888ddc33dc2417a529160af7ebce95d232081903a693662843b9",
+      "value": "getDatasetDetail"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+            "name": "Product Documentation",
+            "description": "Technical documentation for the product API",
+            "provider": "vendor",
+            "permission": "only_me",
+            "data_source_type": null,
+            "indexing_technique": "high_quality",
+            "app_count": 0,
+            "document_count": 0,
+            "word_count": 0,
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "author_name": "admin",
+            "created_at": 1741267200,
+            "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "updated_at": 1741267200,
+            "embedding_model": "text-embedding-3-small",
+            "embedding_model_provider": "langgenius/openai/openai",
+            "embedding_available": true,
+            "retrieval_model_dict": {
+              "search_method": "semantic_search",
+              "reranking_enable": false,
+              "reranking_mode": null,
+              "reranking_model": {
+                "reranking_provider_name": "",
+                "reranking_model_name": ""
+              },
+              "weights": null,
+              "top_k": 3,
+              "score_threshold_enabled": false,
+              "score_threshold": null
+            },
+            "tags": [],
+            "doc_form": "text_model",
+            "external_retrieval_model": null,
+            "doc_metadata": [],
+            "built_in_field_enabled": true,
+            "pipeline_id": null,
+            "runtime_mode": null,
+            "chunk_structure": null,
+            "is_published": false,
+            "total_documents": 0,
+            "total_available_documents": 0,
+            "enable_api": true,
+            "is_multimodal": false,
+            "maintainer": "admin"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/403/description",
+      "source_sha256": "dd59bb3e339b8c109dc1d8675932155186051892eb6b1ddb12838fc5908128a8",
+      "value": "- `forbidden` : API access is not enabled for this knowledge base."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found` : No knowledge base matches `dataset_id`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/knowledge-bases/get-knowledge-base",
+        "metadata": {
+          "title": "Get Knowledge Base",
+          "sidebarTitle": "Get Knowledge Base"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/description",
+      "source_sha256": "a9fed906d8c13e36df6bc918dd5719446c732c07bf32796e1d12e14353900da3",
+      "value": "Updates a knowledge base. Only the fields included in the request body are changed."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/operationId",
+      "source_sha256": "1e7587c6feb979c59561f9835143a0732d49cb86f2c385b292abf52838e04f6b",
+      "value": "updateDataset"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+            "name": "Product Documentation",
+            "description": "Technical documentation for the product API",
+            "provider": "vendor",
+            "permission": "only_me",
+            "data_source_type": null,
+            "indexing_technique": "high_quality",
+            "app_count": 0,
+            "document_count": 0,
+            "word_count": 0,
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "author_name": "admin",
+            "created_at": 1741267200,
+            "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "updated_at": 1741267200,
+            "embedding_model": "text-embedding-3-small",
+            "embedding_model_provider": "langgenius/openai/openai",
+            "embedding_available": true,
+            "retrieval_model_dict": {
+              "search_method": "semantic_search",
+              "reranking_enable": false,
+              "reranking_mode": null,
+              "reranking_model": {
+                "reranking_provider_name": "",
+                "reranking_model_name": ""
+              },
+              "weights": null,
+              "top_k": 3,
+              "score_threshold_enabled": false,
+              "score_threshold": null
+            },
+            "tags": [],
+            "doc_form": "text_model",
+            "external_retrieval_model": null,
+            "doc_metadata": [],
+            "built_in_field_enabled": true,
+            "pipeline_id": null,
+            "runtime_mode": null,
+            "chunk_structure": null,
+            "is_published": false,
+            "total_documents": 0,
+            "total_available_documents": 0,
+            "enable_api": true,
+            "is_multimodal": false,
+            "maintainer": "admin",
+            "partial_member_list": []
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/400/description",
+      "source_sha256": "b5ad78b6480417ed9255db9e52538769a9ea519771d67eaaba34875e0a6b2dec",
+      "value": "`invalid_param` : The embedding or reranking model you specified is not configured or available."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/403/description",
+      "source_sha256": "dd59bb3e339b8c109dc1d8675932155186051892eb6b1ddb12838fc5908128a8",
+      "value": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found` : No knowledge base matches `dataset_id`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/x-mint",
+      "value": {
+        "href": "/en/api-reference/knowledge-bases/update-knowledge-base",
+        "metadata": {
+          "title": "Update Knowledge Base",
+          "sidebarTitle": "Update Knowledge Base"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/description",
+      "source_sha256": "07400171c02b50f8bc11dd1134a91343b346fa6ab8108b738fcdd4f00355a697",
+      "value": "Creates a document in a knowledge base from an uploaded file. Common formats such as PDF, TXT, and DOCX are supported. Indexing runs asynchronously; track it with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status)."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/operationId",
+      "source_sha256": "7ca535512cd3c0acbaad2d4669cd8c03360708e3e478056b50f137bb21276272",
+      "value": "createDocumentFromFile"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "037f58256da0da34703847fb56cec6fc7b5c0ed8605e4fdb0581d2578dc57168",
+      "value": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`indexing_technique`, `doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "b7e9147e0c9aef30779e9207fad5f007d9b8bb34d74e62a7cb5f864aad6a5080",
+      "value": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "no_file_uploaded": {
+          "summary": "no_file_uploaded",
+          "value": {
+            "status": 400,
+            "code": "no_file_uploaded",
+            "message": "Please upload your file."
+          }
+        },
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_external": {
+          "summary": "invalid_param (external)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "External datasets are not supported."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/400/description",
+      "source_sha256": "05a4c3414cba5c4a7c5698a768e2d0c6fc57cae41ac174d7a52af711b233fa97",
+      "value": "- `no_file_uploaded` : No file was provided in the request.\n- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The knowledge base is external, `indexing_technique` is required, or `process_rule` is missing."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (documents limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large` : The uploaded file exceeds the maximum size."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/create-document-by-file",
+        "metadata": {
+          "title": "Create Document by File",
+          "sidebarTitle": "Create Document by File"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/description",
+      "source_sha256": "ce8837b5254a645c448cde23d6aeda5f09202a4433df372404c836cc8f5985d7",
+      "value": "Creates a document in a knowledge base from raw text. Indexing runs asynchronously; track it with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status)."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/operationId",
+      "source_sha256": "933be53df5a2b7de9eeaff9bd7ff5201e55674341190c6d7a15de140e1cbe209",
+      "value": "createDocumentFromText"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_indexing": {
+          "summary": "invalid_param (indexing_technique)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "indexing_technique is required."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/400/description",
+      "source_sha256": "c265254345546d5954535fe0094526eac879381baad4be9f14512224200d62aa",
+      "value": "- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : `indexing_technique` is required when adding the first document, or `doc_form` is invalid."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (documents limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/create-document-by-text",
+        "metadata": {
+          "title": "Create Document by Text",
+          "sidebarTitle": "Create Document by Text"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/description",
+      "source_sha256": "07400171c02b50f8bc11dd1134a91343b346fa6ab8108b738fcdd4f00355a697",
+      "value": "Deprecated compatibility endpoint. Creates a document in a knowledge base from an uploaded file. Common formats such as PDF, TXT, and DOCX are supported. Indexing runs asynchronously; track it with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status)."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "037f58256da0da34703847fb56cec6fc7b5c0ed8605e4fdb0581d2578dc57168",
+      "value": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`indexing_technique`, `doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "b7e9147e0c9aef30779e9207fad5f007d9b8bb34d74e62a7cb5f864aad6a5080",
+      "value": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "no_file_uploaded": {
+          "summary": "no_file_uploaded",
+          "value": {
+            "status": 400,
+            "code": "no_file_uploaded",
+            "message": "Please upload your file."
+          }
+        },
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_external": {
+          "summary": "invalid_param (external)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "External datasets are not supported."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/400/description",
+      "source_sha256": "05a4c3414cba5c4a7c5698a768e2d0c6fc57cae41ac174d7a52af711b233fa97",
+      "value": "- `no_file_uploaded` : No file was provided in the request.\n- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The knowledge base is external, `indexing_technique` is required, or `process_rule` is missing."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (documents limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large` : The uploaded file exceeds the maximum size."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/description",
+      "source_sha256": "ce8e60129ee9c312cad9bdb211f4230d36e5b3a72242227ccec237363ac50e53",
+      "value": "Deprecated compatibility endpoint. Creates a document in a knowledge base from raw text. Indexing runs asynchronously; track it with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status)."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/200/description",
+      "source_sha256": "b58013cc434c75875e21586fa27549413c986ce036282f332061caf85b6f33aa",
+      "value": "Document created successfully."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_indexing": {
+          "summary": "invalid_param (indexing_technique)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "indexing_technique is required."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/400/description",
+      "source_sha256": "2bfbcfde3ad246205ccd33f9e5921e27cf4a76186dc1885bf430dc6e0d6cae76",
+      "value": "- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : `indexing_technique` is required when adding the first document, or `doc_form` is invalid."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (documents limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/summary",
+      "value": "Create Document by Text"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/tags/0",
+      "source_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186",
+      "value": "Documents",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/tags/0",
+      "context_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/description",
+      "source_sha256": "78789159df482727bc3d6ce2dd0cc370746fa42614834a3a0f9ddace0ffddc2d",
+      "value": "Returns a paginated list of documents in a knowledge base."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/operationId",
+      "source_sha256": "ed04812695198c323f5b2e5e25367529acc7115ce721bb673d5f218c707bf895",
+      "value": "listDocuments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": [
+              {
+                "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "position": 1,
+                "data_source_type": "upload_file",
+                "data_source_info": {
+                  "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                },
+                "data_source_detail_dict": {
+                  "upload_file": {
+                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    "name": "guide.txt",
+                    "size": 2048,
+                    "extension": "txt",
+                    "mime_type": "text/plain",
+                    "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                    "created_at": 1741267200
+                  }
+                },
+                "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                "name": "guide.txt",
+                "created_from": "api",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200,
+                "tokens": 512,
+                "indexing_status": "completed",
+                "error": null,
+                "enabled": true,
+                "disabled_at": null,
+                "disabled_by": null,
+                "archived": false,
+                "display_status": "available",
+                "word_count": 350,
+                "hit_count": 0,
+                "doc_form": "text_model",
+                "doc_metadata": [],
+                "summary_index_status": null,
+                "need_summary": false
+              }
+            ],
+            "has_more": false,
+            "limit": 20,
+            "total": 1,
+            "page": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found` : Knowledge base not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/list-documents",
+        "metadata": {
+          "title": "List Documents",
+          "sidebarTitle": "List Documents"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/description",
+      "source_sha256": "ab554fdd9cdb621d0ad3e866462ee925cf4739ac73dd0ab071948ed84cbde11a",
+      "value": "Downloads one or more documents as a single ZIP archive. Only documents that were uploaded as files can be included."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/operationId",
+      "source_sha256": "0e8cead9550f8599042d95432183326d285ed38219ea533590af75ef0cabfe71",
+      "value": "downloadDocumentsZip"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/200/content/application~1zip/schema/description",
+      "value": "ZIP archive binary stream."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (dataset permission)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You do not have permission to access this dataset."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden (document permission)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "No permission."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : You do not have permission to access this knowledge base.\n- `forbidden` : You do not have permission for one of the requested documents."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found_3",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Only uploaded-file documents can be downloaded as ZIP."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/404/description",
+      "source_sha256": "33d278524dd9904b18696f6543002a01a53e777c37edf5e64cef79379db1dc72",
+      "value": "- `not_found` : Document not found.\n- `not_found` : Knowledge base not found. Also returned as \"Only uploaded-file documents can be downloaded as ZIP.\" when a requested document has no uploaded file."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/download-documents-as-zip",
+        "metadata": {
+          "title": "Download Documents as ZIP",
+          "sidebarTitle": "Download Documents as ZIP"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/description",
+      "source_sha256": "e0e16afd2292fe2d4aed3d4140e8303874f07030c24668ba73768f6284a36e21",
+      "value": "Update metadata values for multiple documents in a single request."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/operationId",
+      "source_sha256": "4f58dac3e79b1e0dbcd9d642c696555d5279086e49a42d6da8107d357027b5a0",
+      "value": "batchUpdateDocumentMetadata"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "result": "success"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Another document metadata operation is running, please wait a moment."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/400/description",
+      "source_sha256": "b1e7a7215ad461820547abdde9f7e0c9515ab9c9e66e8a2a66aa8d395d9c10cf",
+      "value": "`invalid_param` : Another metadata operation is already running for a document in this request."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found (knowledge base)",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found (document)",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found (metadata)",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Metadata not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/404/description",
+      "source_sha256": "cfa8dd782d9a3aff8888ba05f0e0fe6cbfa1ac2acb8475f7c800006b5368e5c3",
+      "value": "- `not_found` : Knowledge base not found.\n- `not_found` : A document referenced in `operation_data` does not exist in this knowledge base.\n- `not_found` : A metadata field referenced in `metadata_list` does not exist in this knowledge base."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/metadata/update-document-metadata-in-batch",
+        "metadata": {
+          "title": "Update Document Metadata in Batch",
+          "sidebarTitle": "Update Document Metadata in Batch"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/description",
+      "source_sha256": "c6b0c2965a3f06693164c1eae0ca6d8e0c2c3fdfd612719ed4db44157330813d",
+      "value": "Enables, disables, archives, or unarchives multiple documents in one request. `document_ids` is optional for compatibility; omitting it or passing an empty array performs no updates and still returns `result: success`."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/operationId",
+      "source_sha256": "e6b2549c3dfaa8f1a245a5c580acb06c1745347d76d8ce63cf8266eb1f58bad8",
+      "value": "batchUpdateDocumentStatus"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/requestBody/content/application~1json/examples",
+      "value": {
+        "update_documents": {
+          "summary": "Request Example",
+          "value": {
+            "document_ids": [
+              "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "c4c4f9aa-2c9b-4f95-9f5a-2c0f7c3a8f21"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "result": "success"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/200/description",
+      "source_sha256": "859ddafafe8ea74b6bb4f0de968b87fd187fdd5313edf2d0435a8df1846be0d2",
+      "value": "Documents updated successfully."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_action": {
+          "summary": "invalid_action",
+          "value": {
+            "status": 400,
+            "code": "invalid_action",
+            "message": "Invalid action."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/400/description",
+      "source_sha256": "6e1b4b62cdc02de4f968d6c5e758ee2bb3ac251971f614da57623f3b8a591c06",
+      "value": "`invalid_action` : Invalid action, or a document is in a state that does not allow the action (e.g. still indexing, or not completed)."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden` : Knowledge base API access is not enabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found` : Knowledge base not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/update-document-status-in-batch",
+        "metadata": {
+          "title": "Update Document Status in Batch",
+          "sidebarTitle": "Update Document Status in Batch"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/description",
+      "source_sha256": "3ee1dc37070aedcadf13c8f1f7f8dd0580c132e9bb092eb2bd8a78fb14bd3497",
+      "value": "Returns indexing progress for every document in a batch: the current stage and chunk completion counts. Poll until each `indexing_status` reaches `completed`, `error`, or `paused`. `completed` and `error` are terminal. The Service API has no resume action for a paused document; resume it in the Dify knowledge-base console, then continue polling this endpoint. The active stages are `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed`. A non-null `stopped_at` records when processing stopped, even though it is not a separate `indexing_status` value."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/operationId",
+      "source_sha256": "39c6932a2f100f1efc39062d5a65c72cebde14cb45097fdf9be0fe276b21e0d1",
+      "value": "getDocumentIndexingStatus"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/0/description",
+      "source_sha256": "05fd9b42d2c8b44ab846e5ea08775bef92e1970160841cf8ac40f184d8abf14e",
+      "value": "Batch ID returned when you create or update a document.",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/0",
+      "context_sha256": "dc296bd6cc966cbe715d70de1858731daf7bc5888473c41133c48cbaa43b801a"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": [
+              {
+                "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "indexing_status": "completed",
+                "processing_started_at": 1741267200,
+                "parsing_completed_at": 1741267200,
+                "cleaning_completed_at": 1741267200,
+                "splitting_completed_at": 1741267200,
+                "completed_at": 1741267200,
+                "paused_at": null,
+                "error": null,
+                "stopped_at": null,
+                "completed_segments": 5,
+                "total_segments": 5
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/404/content/application~1json/examples",
+      "value": {
+        "dataset_not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "documents_not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Documents not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/404/description",
+      "source_sha256": "f925b0dba435508be8b280a637223f4caa0fc1649cf974fd5c22e57b09bc2ec9",
+      "value": "- `not_found` : Knowledge base not found.\n- `not_found` : Documents not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/get-document-indexing-status",
+        "metadata": {
+          "title": "Get Document Indexing Status",
+          "sidebarTitle": "Get Document Indexing Status"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/description",
+      "source_sha256": "8cf27626e083bc4eb4f350d4e92e989cd9a315b858f85debdf083d3e7fdb9161",
+      "value": "Permanently deletes a document and all its chunks from the knowledge base."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/operationId",
+      "source_sha256": "656074aae27c7333625916f7719d19d283e12562cb12ad96314c25bdb5fa5fba",
+      "value": "deleteDocument"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/400/content/application~1json/examples",
+      "value": {
+        "document_indexing": {
+          "summary": "document_indexing",
+          "value": {
+            "status": 400,
+            "code": "document_indexing",
+            "message": "Cannot delete document during indexing."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/400/description",
+      "source_sha256": "51752204a2cb9583364eaf80301be31060091d5a02703d0d6798210d4a8fc0eb",
+      "value": "- `document_indexing` : The document is still being processed and cannot be deleted."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "archived_document_immutable": {
+          "summary": "archived_document_immutable",
+          "value": {
+            "status": 403,
+            "code": "archived_document_immutable",
+            "message": "The archived document is not editable."
+          }
+        },
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/403/description",
+      "source_sha256": "909e8a3e284297c1c7bf931731833a5fb989d3b37ebc181edfbdffe52d1e96ce",
+      "value": "- `archived_document_immutable` : The archived document is not editable.\n- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document Not Exists."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found_2",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/404/description",
+      "source_sha256": "654d9434f735fc4d4ab99327dd4af0be414347c7611fcf1ac55f98c1ce4d551e",
+      "value": "- `not_found` : The document does not exist. Also returned as \"Dataset not found.\" when the knowledge base itself does not exist."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/delete-document",
+        "metadata": {
+          "title": "Delete Document",
+          "sidebarTitle": "Delete Document"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/description",
+      "source_sha256": "223cc48b4a4eb37363dfbbdae2aee5f32ecfdd5f091c7099c9293d0b111a9cf0",
+      "value": "Returns detailed information for a single document."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/operationId",
+      "source_sha256": "75541f97ff3ca7f743159c35501d9eba8b0a71833c97a161c5351f5f1232f519",
+      "value": "getDocumentDetail"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+            "position": 1,
+            "data_source_type": "upload_file",
+            "data_source_info": {
+              "upload_file": {
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "name": "guide.txt",
+                "size": 2048,
+                "extension": "txt",
+                "mime_type": "text/plain",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200
+              }
+            },
+            "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+            "dataset_process_rule": {
+              "id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "mode": "custom"
+            },
+            "document_process_rule": {
+              "mode": "custom",
+              "rules": {
+                "pre_processing_rules": [],
+                "segmentation": {
+                  "separator": "###",
+                  "max_tokens": 500,
+                  "chunk_overlap": 50
+                }
+              }
+            },
+            "name": "guide.txt",
+            "created_from": "api",
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "created_at": 1741267200,
+            "tokens": 512,
+            "indexing_status": "completed",
+            "error": null,
+            "enabled": true,
+            "disabled_at": null,
+            "disabled_by": null,
+            "archived": false,
+            "display_status": "available",
+            "hit_count": 0,
+            "doc_form": "text_model",
+            "doc_language": "English",
+            "doc_type": null,
+            "doc_metadata": [],
+            "completed_at": 1741267260,
+            "updated_at": 1741267260,
+            "indexing_latency": 60.0,
+            "segment_count": 5,
+            "average_segment_length": 70.0,
+            "summary_index_status": null,
+            "need_summary": false
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/200/description",
+      "source_sha256": "9c974d1edde88e6ce065e0fcd27c6902c3b725a8d83bb0956cf1234e5b490f3e",
+      "value": "Document details. The returned fields depend on the `metadata` query parameter."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_metadata": {
+          "summary": "invalid_metadata",
+          "value": {
+            "status": 400,
+            "code": "invalid_metadata",
+            "message": "Invalid metadata value."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/400/description",
+      "source_sha256": "a6f3cd1d294992adca094754d7e0ec4e47ace58dbf60cdf45bb36179378c2dc7",
+      "value": "`invalid_metadata` : The `metadata` query parameter value is invalid (must be `all`, `only`, or `without`)."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (no permission)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "No permission."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/403/description",
+      "source_sha256": "2bef26abe5b5e7f882e37bea609d1c175794388053ba0c3f39d4a5b6be4518a8",
+      "value": "- `forbidden` : You do not have permission to access this document.\n- `forbidden` : Knowledge base API access is not enabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/404/description",
+      "source_sha256": "92c4a92c4d46a82bba2df44f94474fc2bcb7fedc50fe8f19ced9339cab517786",
+      "value": "- `not_found` : Document not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/get-document",
+        "metadata": {
+          "title": "Get Document",
+          "sidebarTitle": "Get Document"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/description",
+      "source_sha256": "76af9a461be7fa6b11b91f204a7691e31b9e256760a10232e79fec948ad06751",
+      "value": "Updates a document and re-indexes it. Send `file` to replace the source file, `data` to change processing settings, or both. If `file` is omitted, Dify reprocesses the existing source with the supplied or current settings; an empty multipart request re-indexes it with the current settings. Track progress with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status)."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/operationId",
+      "source_sha256": "14d98cfdb11f1b9565c90611e28c7d833c4c86c0760067709584aba11278c1fb",
+      "value": "updateDocument"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "9a55a691d8c3e1fa35fa97643ae718f7c770b58e29258bbbedb3ba1b046597a9",
+      "value": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "c3ecc43b937e9c81b6f6591d46eb7fb325ddc2af0207e748bdc83f5f7a30e4ab",
+      "value": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param (not available)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/400/description",
+      "source_sha256": "533998490d38cd2cd57cc910a88ff38c4b5b8ea95add88c0e4404959f3417cb4",
+      "value": "- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The document is not available for update (only available documents can be updated)."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large` : The uploaded file exceeds the maximum size."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/415/description",
+      "source_sha256": "3ce1812190ffa7ff82290341eeee927bbc176af9b1a3673fbe9a48cb95ea127d",
+      "value": "`unsupported_file_type` : The uploaded file's type is not supported."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/summary",
+      "source_sha256": "6f35a637dbb78c62105d71d60424b6d01ea7629747bd579ba157ffd1ce397402",
+      "value": "Update Document"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl --request PATCH \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/documents/{document_id}' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/update-document",
+        "metadata": {
+          "title": "Update Document",
+          "sidebarTitle": "Update Document"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/description",
+      "source_sha256": "842aa9dba53398538fede68859cbcd0f0211cc5e2033ec56ec418a411de7cce0",
+      "value": "Returns a signed URL for downloading a document's original uploaded file."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/operationId",
+      "source_sha256": "fc5cc402ab6a49ac351da3beb9f97321420d3f5e6a22b9f3f58092f30b651c03",
+      "value": "downloadDocument"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "url": "https://storage.example.com/datasets/documents/abc123/original-file.pdf?token=xyz789&expires=1741353600"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (no permission)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "No permission."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/403/description",
+      "source_sha256": "7987c5d119f43227f71c217ac78a4c52e4a02ade6bf43575d26f21fe5b3c0190",
+      "value": "- `forbidden` : You do not have permission to access this document.\n- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found_2",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Uploaded file not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found_3",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document does not have an uploaded file to download."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/404/description",
+      "source_sha256": "92c4a92c4d46a82bba2df44f94474fc2bcb7fedc50fe8f19ced9339cab517786",
+      "value": "- `not_found` : Document not found. Also returned as \"Uploaded file not found.\" when the stored file is missing, and \"Document does not have an uploaded file to download.\" for non-file documents."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/download-document",
+        "metadata": {
+          "title": "Download Document",
+          "sidebarTitle": "Download Document"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/description",
+      "source_sha256": "582c3857384b399f032a82587e616ec2c8660ff2418716154d3e48498c2b78fc",
+      "value": "Returns a paginated list of chunks within a document, optionally filtered by keyword or indexing status."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/operationId",
+      "source_sha256": "9fb703c2ac9028b2c32081b34e5981b98966ee046baedc87d65622e9fcd401e8",
+      "value": "listSegments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": [
+              {
+                "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                "position": 1,
+                "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "content": "Dify is an open-source LLM app development platform.",
+                "sign_content": "",
+                "answer": "",
+                "word_count": 9,
+                "tokens": 12,
+                "keywords": [
+                  "dify",
+                  "platform",
+                  "llm"
+                ],
+                "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                "index_node_hash": "abc123def456",
+                "hit_count": 0,
+                "enabled": true,
+                "disabled_at": null,
+                "disabled_by": null,
+                "status": "completed",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200,
+                "updated_at": 1741267200,
+                "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "indexing_at": 1741267200,
+                "completed_at": 1741267200,
+                "error": null,
+                "stopped_at": null,
+                "child_chunks": [],
+                "attachments": [],
+                "summary": null
+              }
+            ],
+            "doc_form": "text_model",
+            "total": 1,
+            "has_more": false,
+            "limit": 20,
+            "page": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/400/description",
+      "source_sha256": "713478b5ec6389ad152167c1712e6756e62534bda443f37bbb091a896dee5811",
+      "value": "`provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/404/description",
+      "source_sha256": "2679559e87d24a8afee123e19f8953829e093153c3adffc0d5bf8706d8de74ec",
+      "value": "- `not_found` : Dataset not found.\n- `not_found` : Document not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/chunks/list-chunks",
+        "metadata": {
+          "title": "List Chunks",
+          "sidebarTitle": "List Chunks"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/description",
+      "source_sha256": "d856a065db873c19c6368130043ff107ce8a3f13cdc013661f911047e22cca56",
+      "value": "Create one or more chunks within a document."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/operationId",
+      "source_sha256": "c4acb46d3be04bdf1f8ff2bdf9c7c810d64bc11fa737deb10fe797daefebed8c",
+      "value": "createSegments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": [
+              {
+                "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                "position": 1,
+                "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "content": "Dify is an open-source LLM app development platform.",
+                "sign_content": "",
+                "answer": "",
+                "word_count": 9,
+                "tokens": 12,
+                "keywords": [
+                  "dify",
+                  "platform",
+                  "llm"
+                ],
+                "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                "index_node_hash": "abc123def456",
+                "hit_count": 0,
+                "enabled": true,
+                "disabled_at": null,
+                "disabled_by": null,
+                "status": "completed",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200,
+                "updated_at": 1741267200,
+                "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "indexing_at": 1741267200,
+                "completed_at": 1741267200,
+                "error": null,
+                "stopped_at": null,
+                "child_chunks": [],
+                "attachments": [],
+                "summary": null
+              }
+            ],
+            "doc_form": "text_model"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param_limit": {
+          "summary": "invalid_param (segments limit)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Exceeded maximum segments limit of 1000."
+          }
+        },
+        "validation_error": {
+          "summary": "schema validation (non-standard body)",
+          "value": {
+            "error": "1 validation error for SegmentCreatePayload\nsegments.0.content\n  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/400/description",
+      "source_sha256": "a19c866c52f77b90a4b1c2be29a17b1a5f432c936c6058d582c0e9e852ab9d7e",
+      "value": "- `provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : A chunk field is invalid (for example, `answer` is required for Q&A-mode documents) or the number of chunks exceeds the per-request limit.\n- Request-body schema validation (such as empty `content`) returns a non-standard body `{\"error\": \"<validation details>\"}` with no `code` or `status` field."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden (upgrade plan)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document is not completed."
+          }
+        },
+        "not_found_4": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document is disabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/404/description",
+      "source_sha256": "cbc930cc07d2b0d0682f8867bfea9ccd66a0542140764dfd68adadfd208bb8c0",
+      "value": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Document is not completed.\n- `not_found` : Document is disabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/chunks/create-chunks",
+        "metadata": {
+          "title": "Create Chunks",
+          "sidebarTitle": "Create Chunks"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/operationId",
+      "source_sha256": "de021c8ff9fa6a10b79bca7f5899cf1201d5d4c5f473de0af498ba04cf2374ff",
+      "value": "deleteSegment"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "Chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param_model_setting": {
+          "summary": "invalid_param (model setting)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param_deleting": {
+          "summary": "invalid_param (deleting)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Segment is deleting."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/400/description",
+      "source_sha256": "246948fbac3b19c653a5b271f592e54276bf0ebfea59d24f5d4f8bdace089213",
+      "value": "- `invalid_param` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : The chunk is already being deleted by a concurrent request."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/x-mint",
+      "value": {
+        "href": "/en/api-reference/chunks/delete-chunk",
+        "metadata": {
+          "title": "Delete Chunk",
+          "sidebarTitle": "Delete Chunk"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/description",
+      "source_sha256": "592c29e3d9c0271b3940388128173a87db1ef6dd0df56786a3ac67d4cb1b7d1b",
+      "value": "Retrieve the full details of a single chunk."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/operationId",
+      "source_sha256": "0e5d3e0623daa5d8c5ef3c0190a00b1372d1165307d3dd0616392391bbc9225e",
+      "value": "getSegmentDetail"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "Chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": {
+              "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "position": 1,
+              "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "content": "Dify is an open-source LLM app development platform.",
+              "sign_content": "",
+              "answer": "",
+              "word_count": 9,
+              "tokens": 12,
+              "keywords": [
+                "dify",
+                "platform",
+                "llm"
+              ],
+              "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+              "index_node_hash": "abc123def456",
+              "hit_count": 0,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "status": "completed",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "updated_at": 1741267200,
+              "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "indexing_at": 1741267200,
+              "completed_at": 1741267200,
+              "error": null,
+              "stopped_at": null,
+              "child_chunks": [],
+              "attachments": [],
+              "summary": null
+            },
+            "doc_form": "text_model"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/400/description",
+      "source_sha256": "95d6543fbb7b8c8a19b8b710bf3e6fe50b88d187984da48e0671248b0f42a95e",
+      "value": "`invalid_param` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/chunks/get-chunk",
+        "metadata": {
+          "title": "Get Chunk",
+          "sidebarTitle": "Get Chunk"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/description",
+      "source_sha256": "f0fbd0d95fd128b6630d3729b0fa0dddf4439e5f5bab3223bcf8725b94e8cb2a",
+      "value": "Update a chunk's fields. The update re-triggers indexing for that chunk."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/operationId",
+      "source_sha256": "5fc085ac885ebda0a576cf7e298500d88f442446f323908e8e293c73c892e446",
+      "value": "updateSegment"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "Chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": {
+              "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "position": 1,
+              "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "content": "Dify is an open-source LLM app development platform.",
+              "sign_content": "",
+              "answer": "",
+              "word_count": 9,
+              "tokens": 12,
+              "keywords": [
+                "dify",
+                "platform",
+                "llm"
+              ],
+              "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+              "index_node_hash": "abc123def456",
+              "hit_count": 0,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "status": "completed",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "updated_at": 1741267200,
+              "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "indexing_at": 1741267200,
+              "completed_at": 1741267200,
+              "error": null,
+              "stopped_at": null,
+              "child_chunks": [],
+              "attachments": [],
+              "summary": null
+            },
+            "doc_form": "text_model"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param_state": {
+          "summary": "invalid_param (state)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Segment is indexing, please try again later"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/400/description",
+      "source_sha256": "4a4859fd64e6c64e79fa85d33b8af526fd32bce4fb9dd7261f86b041c53f99a9",
+      "value": "- `provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : The chunk is indexing or disabled and cannot be updated, or index configuration is invalid."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/chunks/update-chunk",
+        "metadata": {
+          "title": "Update Chunk",
+          "sidebarTitle": "Update Chunk"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/operationId",
+      "source_sha256": "0f1b8478365258c16c251586d888c7682921f1552e7a7e32b6f78e56a48e4778",
+      "value": "getChildChunks"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": [
+              {
+                "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+                "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                "content": "Dify is an open-source platform.",
+                "position": 1,
+                "word_count": 6,
+                "type": "customized",
+                "created_at": 1741267200,
+                "updated_at": 1741267200
+              }
+            ],
+            "total": 1,
+            "total_pages": 1,
+            "page": 1,
+            "limit": 20
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/chunks/list-child-chunks",
+        "metadata": {
+          "title": "List Child Chunks",
+          "sidebarTitle": "List Child Chunks"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/description",
+      "source_sha256": "009ccce37862657fdf8dfea5f92b2bec5032db663826b5f227e79c765a39dae3",
+      "value": "Create a child chunk under a parent chunk. Intended for documents that use the parent-child (`hierarchical_model`) chunking mode."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/operationId",
+      "source_sha256": "36f2c254b8a3ca28e2c558bac6bd61b8ce652303a00750f331129fd54edbb993",
+      "value": "createChildChunk"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": {
+              "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+              "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "content": "Dify is an open-source platform.",
+              "position": 1,
+              "word_count": 6,
+              "type": "customized",
+              "created_at": 1741267200,
+              "updated_at": 1741267200
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Vector store operation failed: [Errno 111] Connection refused"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/400/description",
+      "source_sha256": "b68da3885cf796bb1cf4e80eda6aa2707c388047e6ac0d05c8085cea34fe9274",
+      "value": "- `provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : Indexing the child chunk in the vector store failed; the message carries the underlying vector-store error."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden (upgrade plan)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/chunks/create-child-chunk",
+        "metadata": {
+          "title": "Create Child Chunk",
+          "sidebarTitle": "Create Child Chunk"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/operationId",
+      "source_sha256": "e9894030ed72eb89e8cb25ed03bec0d9fcf451267cb26406b8cb5155b52a84e5",
+      "value": "deleteChildChunk"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "Child chunk ID returned in `data[].id` by [List Child Chunks](/en/api-reference/chunks/list-child-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0/schema/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "Child chunk ID returned in `data[].id` by [List Child Chunks](/en/api-reference/chunks/list-child-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/2/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/2",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/3/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/3",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Vector store operation failed: [Errno 111] Connection refused"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/400/description",
+      "source_sha256": "b0a4f10acc3ebbda7648f288ebce4c2f99ab7680d85dc75fef58c021f5fc65b3",
+      "value": "`invalid_param` : Removing the child chunk index from the vector store failed; the message carries the underlying vector-store error."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (upgrade plan)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        },
+        "not_found_4": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Child chunk not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/404/description",
+      "source_sha256": "0f8aec0a06e9610ce0eb1948cf91c1ac8dad5fc73e67d2515ab8dd4c5ba1a5fc",
+      "value": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.\n- `not_found` : Child chunk not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/x-mint",
+      "value": {
+        "href": "/en/api-reference/chunks/delete-child-chunk",
+        "metadata": {
+          "title": "Delete Child Chunk",
+          "sidebarTitle": "Delete Child Chunk"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/operationId",
+      "source_sha256": "74580a3eae200d7bf42f4fa7a18a92ceb9ff692b97b97e538a9ddf8f21a48da4",
+      "value": "updateChildChunk"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "Child chunk ID returned in `data[].id` by [List Child Chunks](/en/api-reference/chunks/list-child-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0/schema/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "Child chunk ID returned in `data[].id` by [List Child Chunks](/en/api-reference/chunks/list-child-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/2/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/2",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/3/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/3",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": {
+              "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+              "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "content": "Dify is an open-source platform.",
+              "position": 1,
+              "word_count": 6,
+              "type": "customized",
+              "created_at": 1741267200,
+              "updated_at": 1741267200
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Vector store operation failed: [Errno 111] Connection refused"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/400/description",
+      "source_sha256": "c135ee91eab6b090a8faedc3bc08b6215da3a0a5469a5baede6a71c557e7ce49",
+      "value": "`invalid_param` : Re-indexing the child chunk in the vector store failed; the message carries the underlying vector-store error."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden (upgrade plan)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        },
+        "not_found_4": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Child chunk not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/404/description",
+      "source_sha256": "0f8aec0a06e9610ce0eb1948cf91c1ac8dad5fc73e67d2515ab8dd4c5ba1a5fc",
+      "value": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.\n- `not_found` : Child chunk not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/x-mint",
+      "value": {
+        "href": "/en/api-reference/chunks/update-child-chunk",
+        "metadata": {
+          "title": "Update Child Chunk",
+          "sidebarTitle": "Update Child Chunk"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/description",
+      "source_sha256": "76af9a461be7fa6b11b91f204a7691e31b9e256760a10232e79fec948ad06751",
+      "value": "Deprecated file-update route. Send `file` to replace the source file, `data` to change processing settings, or both. If `file` is omitted, Dify reprocesses the existing source with the supplied or current settings; an empty multipart request re-indexes it with the current settings. Use [Update Document](/en/api-reference/documents/update-document) instead."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/operationId",
+      "source_sha256": "e006eb72f006d16927252ae8ae345867056a538e01ba906f52f14d5ed473fd6d",
+      "value": "updateDocumentByFile"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "9a55a691d8c3e1fa35fa97643ae718f7c770b58e29258bbbedb3ba1b046597a9",
+      "value": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "c3ecc43b937e9c81b6f6591d46eb7fb325ddc2af0207e748bdc83f5f7a30e4ab",
+      "value": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param (not available)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/400/description",
+      "source_sha256": "533998490d38cd2cd57cc910a88ff38c4b5b8ea95add88c0e4404959f3417cb4",
+      "value": "- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The document is not available for update (only available documents can be updated)."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large` : The uploaded file exceeds the maximum size."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/415/description",
+      "source_sha256": "3ce1812190ffa7ff82290341eeee927bbc176af9b1a3673fbe9a48cb95ea127d",
+      "value": "`unsupported_file_type` : The uploaded file's type is not supported."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/update-document-by-file",
+        "metadata": {
+          "title": "Update Document by File",
+          "sidebarTitle": "Update Document by File"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/description",
+      "source_sha256": "a1dbb8871afd5bd406a3a82f7e92f93d767bc19e1109c5a919d3afafceb87e9d",
+      "value": "Updates a document's text content, name, or processing configuration. Re-indexes the document when its text changes."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/operationId",
+      "source_sha256": "917201fe134585d58cc41bb0c91376351cfd3a8df5db20fa35d4144e31c38854",
+      "value": "updateDocumentByText"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_name": {
+          "summary": "invalid_param (name required)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "name is required when text is provided."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param (not available)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/400/description",
+      "source_sha256": "cb5c257c217d8f1f52cca70e8322d37a91a023d0e83cede660742c6b2355e402",
+      "value": "- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : `name` is required when `text` is provided, or `doc_form` is invalid.\n- `invalid_param` : The document is not available for update (only available documents can be updated)."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/documents/update-document-by-text",
+        "metadata": {
+          "title": "Update Document by Text",
+          "sidebarTitle": "Update Document by Text"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/description",
+      "source_sha256": "76af9a461be7fa6b11b91f204a7691e31b9e256760a10232e79fec948ad06751",
+      "value": "Deprecated file-update route. Send `file` to replace the source file, `data` to change processing settings, or both. If `file` is omitted, Dify reprocesses the existing source with the supplied or current settings; an empty multipart request re-indexes it with the current settings. Use [Update Document](/en/api-reference/documents/update-document) instead."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "9a55a691d8c3e1fa35fa97643ae718f7c770b58e29258bbbedb3ba1b046597a9",
+      "value": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "c3ecc43b937e9c81b6f6591d46eb7fb325ddc2af0207e748bdc83f5f7a30e4ab",
+      "value": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param (not available)",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/400/description",
+      "source_sha256": "533998490d38cd2cd57cc910a88ff38c4b5b8ea95add88c0e4404959f3417cb4",
+      "value": "- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The document is not available for update (only available documents can be updated)."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large` : The uploaded file exceeds the maximum size."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/415/description",
+      "source_sha256": "3ce1812190ffa7ff82290341eeee927bbc176af9b1a3673fbe9a48cb95ea127d",
+      "value": "`unsupported_file_type` : The uploaded file's type is not supported."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/description",
+      "source_sha256": "805859b25c965fd06914de3e232504d9bbfbaf416fdd82ed99dbc2709d16ce50",
+      "value": "Deprecated compatibility endpoint. Updates a document's text content, name, or processing configuration. Re-indexes the document when its text changes."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/200/description",
+      "source_sha256": "60c97252fe7fe0895d4b925c08232e452fddc660a602c5f262a33da8a24fea73",
+      "value": "Document updated successfully."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (vector space)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/summary",
+      "value": "Update Document by Text"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/tags/0",
+      "source_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186",
+      "value": "Documents",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/tags/0",
+      "context_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/description",
+      "source_sha256": "1b6a273471cefc413566b4ead87134a3c84acb495bb3ede249151f78d4f0a928",
+      "value": "Deprecated compatibility endpoint. Searches a knowledge base and returns the chunks most relevant to the query, for both production retrieval and test retrieval."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "query": {
+              "content": "What is Dify?"
+            },
+            "records": [
+              {
+                "segment": {
+                  "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                  "position": 1,
+                  "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                  "content": "Dify is an open-source LLM app development platform.",
+                  "sign_content": "",
+                  "answer": "",
+                  "word_count": 9,
+                  "tokens": 12,
+                  "keywords": [
+                    "dify",
+                    "platform",
+                    "llm"
+                  ],
+                  "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                  "index_node_hash": "abc123def456",
+                  "hit_count": 1,
+                  "enabled": true,
+                  "disabled_at": null,
+                  "disabled_by": null,
+                  "status": "completed",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200,
+                  "indexing_at": 1741267200,
+                  "completed_at": 1741267200,
+                  "error": null,
+                  "stopped_at": null,
+                  "document": {
+                    "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                    "data_source_type": "upload_file",
+                    "name": "guide.txt",
+                    "doc_type": null,
+                    "doc_metadata": null
+                  }
+                },
+                "child_chunks": [],
+                "score": 0.92,
+                "tsne_position": null,
+                "files": [],
+                "summary": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/400/content/application~1json/examples",
+      "value": {
+        "dataset_not_initialized": {
+          "summary": "dataset_not_initialized",
+          "value": {
+            "status": 400,
+            "code": "dataset_not_initialized",
+            "message": "The dataset is still being initialized or indexing. Please wait a moment."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "provider_quota_exceeded": {
+          "summary": "provider_quota_exceeded",
+          "value": {
+            "status": 400,
+            "code": "provider_quota_exceeded",
+            "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+          }
+        },
+        "model_currently_not_support": {
+          "summary": "model_currently_not_support",
+          "value": {
+            "status": 400,
+            "code": "model_currently_not_support",
+            "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+          }
+        },
+        "completion_request_error": {
+          "summary": "completion_request_error",
+          "value": {
+            "status": 400,
+            "code": "completion_request_error",
+            "message": "Completion request failed."
+          }
+        },
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Invalid parameter value."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/400/description",
+      "source_sha256": "ce76176880f616918d6c7b20b977018e5f26e8c2adc19c1802021b9d67eb68cc",
+      "value": "- `dataset_not_initialized` : The knowledge base is still initializing or indexing.\n- `provider_not_initialize` : The model provider has no valid credentials configured.\n- `provider_quota_exceeded` : The Dify-hosted model provider quota is exhausted.\n- `model_currently_not_support` : The selected model is not currently supported.\n- `completion_request_error` : The model request failed.\n- `invalid_param` : A request parameter is invalid."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found` : No knowledge base matches `dataset_id`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/500/content/application~1json/examples",
+      "value": {
+        "internal_server_error": {
+          "summary": "internal_server_error",
+          "value": {
+            "status": 500,
+            "code": "internal_server_error",
+            "message": "An internal error occurred."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/description",
+      "source_sha256": "33788921af25e665982d40a0341ca680d594f974489419ca3c7d556ca426ed6e",
+      "value": "Returns all metadata fields for the knowledge base, both custom and built-in, with the count of documents using each field."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/operationId",
+      "source_sha256": "5e365a51b777f5a50df02e5a679f81677cbe2708c2badd0385befcb32ee24b4d",
+      "value": "listMetadataFields"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "doc_metadata": [
+              {
+                "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+                "name": "author",
+                "type": "string",
+                "count": 3
+              }
+            ],
+            "built_in_field_enabled": true
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found` : Dataset not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/metadata/list-metadata-fields",
+        "metadata": {
+          "title": "List Metadata Fields",
+          "sidebarTitle": "List Metadata Fields"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/description",
+      "source_sha256": "0dd0ea8732c98ed5d3a3badd1f2f9bd8f2cb57f863c4c9b45c8a4b76ac5a03b9",
+      "value": "Create a custom metadata field for annotating documents in the knowledge base with structured information."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/operationId",
+      "source_sha256": "1b81f8a0bb0dd05a33889880caa3e41661cb38ca78688207f398c0de2babad6a",
+      "value": "createMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/201/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+            "name": "author",
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Metadata name already exists."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/400/description",
+      "source_sha256": "6618a59cf2b130264f25a3c6d5352c17f1fdc63d689f9df5cf1c1313d4d4364e",
+      "value": "`invalid_param` : The metadata name already exists, exceeds 255 characters, or conflicts with a built-in field."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found` : Dataset not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/metadata/create-metadata-field",
+        "metadata": {
+          "title": "Create Metadata Field",
+          "sidebarTitle": "Create Metadata Field"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/description",
+      "source_sha256": "79876621503885ff3ce16d66a89bfd775932a7417299c054f71da517745d1790",
+      "value": "Returns the built-in metadata fields provided by the system."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/operationId",
+      "source_sha256": "0ebc461f5dc80515e5865bde6627ce671ce93022a96fdd3354891a986deac0ba",
+      "value": "getBuiltInMetadataFields"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "fields": [
+              {
+                "name": "document_name",
+                "type": "string"
+              },
+              {
+                "name": "uploader",
+                "type": "string"
+              },
+              {
+                "name": "upload_date",
+                "type": "time"
+              },
+              {
+                "name": "last_update_date",
+                "type": "time"
+              },
+              {
+                "name": "source",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/metadata/get-built-in-metadata-fields",
+        "metadata": {
+          "title": "Get Built-in Metadata Fields",
+          "sidebarTitle": "Get Built-in Metadata Fields"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/operationId",
+      "source_sha256": "10ed165dc04c5ed77fe191c8449d1bbe798ae7bfccc6078c1f5fc38471b87f70",
+      "value": "toggleBuiltInMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "result": "success"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found` : Dataset not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/metadata/update-built-in-metadata-field",
+        "metadata": {
+          "title": "Update Built-in Metadata Field",
+          "sidebarTitle": "Update Built-in Metadata Field"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/description",
+      "source_sha256": "889cb7e9f96e1d067ed27f09a1f58215da9fda5058e7c0506e6a7b454da03b22",
+      "value": "Permanently delete a custom metadata field. Documents that used the field lose their values for it."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/operationId",
+      "source_sha256": "587d3c959a22832a86facf279c9fe7aa5258d9050a18bb85c4385b09bb36f46f",
+      "value": "deleteMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/1/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "ID of the metadata field to delete. See [List Metadata Fields](/en/api-reference/metadata/list-metadata-fields).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/1",
+      "context_sha256": "56828aa53cb580a85fc937f42ff1b232eda74b7c159588e499001cb1afb90e97"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/404/description",
+      "source_sha256": "f9344bbe04212d738ce1ad681c593cd2fec6aca518dba6acefb60439467ddef9",
+      "value": "- `not_found` : Dataset not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/x-mint",
+      "value": {
+        "href": "/en/api-reference/metadata/delete-metadata-field",
+        "metadata": {
+          "title": "Delete Metadata Field",
+          "sidebarTitle": "Delete Metadata Field"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/operationId",
+      "source_sha256": "13589e3a8b1e25e4b2b4131bf3e289e13fe78a6e74e14a7cf2ade74a8bf3e26c",
+      "value": "updateMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/1/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "ID of the metadata field to rename. See [List Metadata Fields](/en/api-reference/metadata/list-metadata-fields).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/1",
+      "context_sha256": "56828aa53cb580a85fc937f42ff1b232eda74b7c159588e499001cb1afb90e97"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+            "name": "author",
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Metadata name already exists."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/400/description",
+      "source_sha256": "6618a59cf2b130264f25a3c6d5352c17f1fdc63d689f9df5cf1c1313d4d4364e",
+      "value": "`invalid_param` : The metadata name already exists, exceeds 255 characters, or conflicts with a built-in field."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/404/description",
+      "source_sha256": "f9344bbe04212d738ce1ad681c593cd2fec6aca518dba6acefb60439467ddef9",
+      "value": "- `not_found` : Dataset not found."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/x-mint",
+      "value": {
+        "href": "/en/api-reference/metadata/update-metadata-field",
+        "metadata": {
+          "title": "Update Metadata Field",
+          "sidebarTitle": "Update Metadata Field"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/description",
+      "source_sha256": "feb4ac9b0ae2f85182d1ee6a54ca594baed433b611429620dfd78fa6365953e3",
+      "value": "Returns the datasource nodes configured in the knowledge pipeline, each with the plugin it uses and the metadata needed to run it."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/operationId",
+      "source_sha256": "f990d17656951c7129d79f0d5d2e4080ff2591e79d94e24bc373ae5a4402cc6d",
+      "value": "listDatasourcePlugins"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": [
+            {
+              "node_id": "1719288585006",
+              "plugin_id": "langgenius/notion_datasource",
+              "provider_name": "notion",
+              "datasource_type": "online_document",
+              "title": "Notion Documents",
+              "user_input_variables": [],
+              "credentials": [
+                {
+                  "id": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
+                  "name": "Production Notion",
+                  "type": "api-key",
+                  "is_default": true
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Pipeline not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/400/description",
+      "source_sha256": "db2230c4a1d91554b104c3ffdff8b7f3c502d3cf1a33ea3af97f922ed40b4bf9",
+      "value": "`invalid_param` : The knowledge base has no processing pipeline configured."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : API access is not enabled for this knowledge base."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found` : No knowledge base matches `dataset_id`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/knowledge-pipeline/list-datasource-plugins",
+        "metadata": {
+          "title": "List Datasource Plugins",
+          "sidebarTitle": "List Datasource Plugins"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/description",
+      "source_sha256": "13d3e5d7adcd75ac7332e0d629682a2ca35b4b67e912b0960ee2c303d5805e8b",
+      "value": "Runs a single datasource node in the knowledge pipeline and streams its execution events."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/operationId",
+      "source_sha256": "7f25eec20a543dee68717bb411edb791dd707832a104c288918fd1589af2dd80",
+      "value": "runDatasourceNode"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/1/description",
+      "source_sha256": "a23fb9cd48d79a47e5d934fd913a0bdd0bc370ff0e607a088b913b10245fd367",
+      "value": "ID of the datasource node to run, from [List Datasource Plugins](/en/api-reference/knowledge-pipeline/list-datasource-plugins).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/1",
+      "context_sha256": "917ec31080f646f2c485bf333dcf0ed42526aacdc1ffb11e011998b1c255c715"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/200/content/text~1event-stream/examples",
+      "value": {
+        "successfulStream": {
+          "summary": "Response example - successful stream",
+          "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"Datasource\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/200/content/text~1event-stream/schema/description",
+      "value": "A Server-Sent Events stream of the draft pipeline run. Parse `data:` records using the [SSE Streaming guide](/en/api-reference/guides/streaming). Common events include `workflow_started`, `node_started`, `node_finished`, `workflow_finished`, and `error`; event payloads use the same workflow envelope documented for workflow streams."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Pipeline not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/400/description",
+      "source_sha256": "d57c0d2e88fbc9431697aba76dcae3474a713f9f957f134bfabd3855e4b65d32",
+      "value": "`invalid_param` : The knowledge base has no processing pipeline configured, or the request body failed validation."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : API access is not enabled for this knowledge base."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found` : No knowledge base matches `dataset_id`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/knowledge-pipeline/run-datasource-node",
+        "metadata": {
+          "title": "Run Datasource Node",
+          "sidebarTitle": "Run Datasource Node"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/description",
+      "source_sha256": "faa3758b412a8ad31d89a4d1c1191f1770864268db1140c3eb54c8e87248d5fe",
+      "value": "Runs the full knowledge pipeline over one or more datasources. Published runs are queued and always return batch metadata as JSON. Draft runs support blocking JSON and streaming Server-Sent Events. For a published run, pass the returned `batch` to [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status) and poll until every document reaches `completed`, `error`, or `paused`."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/operationId",
+      "source_sha256": "db44679c628f777475bd972f7b36223d20c28e3cd93e58eb10d5ec69d2058d40",
+      "value": "runPipeline"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/requestBody/content/application~1json/examples",
+      "value": {
+        "local_file": {
+          "summary": "Request Example - Local file",
+          "value": {
+            "inputs": {},
+            "datasource_type": "local_file",
+            "datasource_info_list": [
+              {
+                "reference": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "name": "quarterly-report.pdf"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": false,
+            "response_mode": "blocking"
+          }
+        },
+        "online_document": {
+          "summary": "Request Example - Online document",
+          "value": {
+            "inputs": {},
+            "datasource_type": "online_document",
+            "datasource_info_list": [
+              {
+                "workspace_id": "ws-abc123",
+                "page": {
+                  "page_id": "pg-def456",
+                  "type": "page",
+                  "page_name": "Product Roadmap"
+                },
+                "credential_id": "cred-789xyz"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": false,
+            "response_mode": "streaming"
+          }
+        },
+        "website_crawl": {
+          "summary": "Request Example - Website crawl",
+          "value": {
+            "inputs": {},
+            "datasource_type": "website_crawl",
+            "datasource_info_list": [
+              {
+                "url": "https://example.com/docs/getting-started",
+                "title": "Getting Started Guide"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": true,
+            "response_mode": "blocking"
+          }
+        },
+        "online_drive": {
+          "summary": "Request Example - Online drive",
+          "value": {
+            "inputs": {},
+            "datasource_type": "online_drive",
+            "datasource_info_list": [
+              {
+                "id": "file-abc123",
+                "type": "file",
+                "bucket": "my-bucket",
+                "name": "meeting-notes.docx"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": true,
+            "response_mode": "blocking"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/application~1json/examples",
+      "value": {
+        "published": {
+          "summary": "Published Pipeline Response",
+          "value": {
+            "batch": "20260825143015948271",
+            "dataset": {
+              "id": "c9f5e6f0-d10a-4f57-a1d8-a4b63f8459f4",
+              "name": "Product docs",
+              "description": "Product documentation",
+              "chunk_structure": "text_model"
+            },
+            "documents": [
+              {
+                "id": "9af03c49-30c4-4d64-a605-17f3171fbf9a",
+                "position": 1,
+                "data_source_type": "local_file",
+                "data_source_info": {
+                  "reference": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "quarterly-report.pdf"
+                },
+                "name": "quarterly-report.pdf",
+                "indexing_status": "waiting",
+                "error": null,
+                "enabled": true
+              }
+            ]
+          }
+        },
+        "draft_blocking": {
+          "summary": "Draft Blocking Response",
+          "value": {
+            "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "workflow_run_id": "f1e2d3c4-b5a6-7890-abcd-ef0987654321",
+            "data": {
+              "id": "f1e2d3c4-b5a6-7890-abcd-ef0987654321",
+              "status": "succeeded",
+              "outputs": {},
+              "created_at": 1741267200,
+              "finished_at": 1741267210,
+              "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+              "error": null,
+              "elapsed_time": 10.0,
+              "total_tokens": 0,
+              "total_steps": 1
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/application~1json/schema/description",
+      "value": "JSON result for a published run, or for a draft run in `blocking` mode."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/text~1event-stream/examples",
+      "value": {
+        "successfulStream": {
+          "summary": "Response example - successful stream",
+          "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"Datasource\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/text~1event-stream/schema/description",
+      "value": "A Server-Sent Events stream of the draft pipeline run. Parse `data:` records using the [SSE Streaming guide](/en/api-reference/guides/streaming). Common events include `workflow_started`, `node_started`, `node_finished`, `workflow_finished`, and `error`; event payloads use the same workflow envelope documented for workflow streams."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/description",
+      "source_sha256": "45761354a7ce3733550c7edbcc2dbe40b681b7a44ba567081d5dd69228cdb15f",
+      "value": "Pipeline execution result. Published runs return queued batch metadata as JSON. Draft runs return Server-Sent Events in `streaming` mode or a workflow result as JSON in `blocking` mode."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Pipeline not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/400/description",
+      "source_sha256": "d57c0d2e88fbc9431697aba76dcae3474a713f9f957f134bfabd3855e4b65d32",
+      "value": "`invalid_param` : The knowledge base has no processing pipeline configured, or the request body failed validation."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/403/description",
+      "source_sha256": "ab52983735f79a161ccb282f9eed5a5f20c2d5d1615e465886b14a9ebf6b8c16",
+      "value": "- `forbidden` : API access is not enabled for this knowledge base."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found` : No knowledge base matches `dataset_id`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/500/content/application~1json/examples",
+      "value": {
+        "pipeline_run_error": {
+          "summary": "pipeline_run_error",
+          "value": {
+            "status": 500,
+            "code": "pipeline_run_error",
+            "message": "Pipeline execution failed: connection timeout"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/knowledge-pipeline/run-pipeline",
+        "metadata": {
+          "title": "Run Pipeline",
+          "sidebarTitle": "Run Pipeline"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/description",
+      "source_sha256": "1b6a273471cefc413566b4ead87134a3c84acb495bb3ede249151f78d4f0a928",
+      "value": "Searches a knowledge base and returns the chunks most relevant to the query, for both production retrieval and test retrieval."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/operationId",
+      "source_sha256": "19ff09ba426482984392455ff84146de3c6422362f175e8969078ad93da31581",
+      "value": "retrieveSegments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "query": {
+              "content": "What is Dify?"
+            },
+            "records": [
+              {
+                "segment": {
+                  "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                  "position": 1,
+                  "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                  "content": "Dify is an open-source LLM app development platform.",
+                  "sign_content": "",
+                  "answer": "",
+                  "word_count": 9,
+                  "tokens": 12,
+                  "keywords": [
+                    "dify",
+                    "platform",
+                    "llm"
+                  ],
+                  "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                  "index_node_hash": "abc123def456",
+                  "hit_count": 1,
+                  "enabled": true,
+                  "disabled_at": null,
+                  "disabled_by": null,
+                  "status": "completed",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200,
+                  "indexing_at": 1741267200,
+                  "completed_at": 1741267200,
+                  "error": null,
+                  "stopped_at": null,
+                  "document": {
+                    "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                    "data_source_type": "upload_file",
+                    "name": "guide.txt",
+                    "doc_type": null,
+                    "doc_metadata": null
+                  }
+                },
+                "child_chunks": [],
+                "score": 0.92,
+                "tsne_position": null,
+                "files": [],
+                "summary": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/400/content/application~1json/examples",
+      "value": {
+        "dataset_not_initialized": {
+          "summary": "dataset_not_initialized",
+          "value": {
+            "status": 400,
+            "code": "dataset_not_initialized",
+            "message": "The dataset is still being initialized or indexing. Please wait a moment."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "provider_quota_exceeded": {
+          "summary": "provider_quota_exceeded",
+          "value": {
+            "status": 400,
+            "code": "provider_quota_exceeded",
+            "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+          }
+        },
+        "model_currently_not_support": {
+          "summary": "model_currently_not_support",
+          "value": {
+            "status": 400,
+            "code": "model_currently_not_support",
+            "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+          }
+        },
+        "completion_request_error": {
+          "summary": "completion_request_error",
+          "value": {
+            "status": 400,
+            "code": "completion_request_error",
+            "message": "Completion request failed."
+          }
+        },
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Invalid parameter value."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/400/description",
+      "source_sha256": "ce76176880f616918d6c7b20b977018e5f26e8c2adc19c1802021b9d67eb68cc",
+      "value": "- `dataset_not_initialized` : The knowledge base is still initializing or indexing.\n- `provider_not_initialize` : The model provider has no valid credentials configured.\n- `provider_quota_exceeded` : The Dify-hosted model provider quota is exhausted.\n- `model_currently_not_support` : The selected model is not currently supported.\n- `completion_request_error` : The model request failed.\n- `invalid_param` : A request parameter is invalid."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden (rate limit)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found` : No knowledge base matches `dataset_id`."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/500/content/application~1json/examples",
+      "value": {
+        "internal_server_error": {
+          "summary": "internal_server_error",
+          "value": {
+            "status": 500,
+            "code": "internal_server_error",
+            "message": "An internal error occurred."
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/x-mint",
+      "value": {
+        "href": "/en/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
+        "metadata": {
+          "title": "Retrieve Chunks from a Knowledge Base / Test Retrieval",
+          "sidebarTitle": "Retrieve Chunks from a Knowledge Base / Test Retrieval"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/description",
+      "source_sha256": "fb2e79f72fece5c6adcee227ed40bb9e2680575510ea87ac2e07ab2173e98d07",
+      "value": "Returns the tags bound to a knowledge base."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/operationId",
+      "source_sha256": "37573482ef29c34a30d4d9b7ebc5ccc95aad0e566b3e5b7639f7bfdfee3cac6a",
+      "value": "queryDatasetTags"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1tags/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": [
+              {
+                "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                "name": "Product Docs"
+              }
+            ],
+            "total": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden (api access)",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden` : Dataset api access is not enabled."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/tags/get-knowledge-base-tags",
+        "metadata": {
+          "title": "Get Knowledge Base Tags",
+          "sidebarTitle": "Get Knowledge Base Tags"
+        }
+      }
+    },
+    {
+      "op": "replace",
       "path": "/paths/~1end-users~1{end_user_id}/get/description",
       "source_sha256": "c71a3cc9a229bafc345728f45437806a24c9b2ef69e6b244b57384fd7c02beb9",
       "value": "**Available for**: Chatflow, Workflow, New Agent, Chatbot, Agent, Text Generator apps.\n\nReturns an end user's details by ID. Useful for resolving an end-user ID returned by another endpoint, such as `created_by` in the [Upload File](/en/api-reference/files/upload-file) response."
@@ -17126,6 +25209,95 @@
         "metadata": {
           "title": "Run Workflow by ID",
           "sidebarTitle": "Run Workflow by ID"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/description",
+      "source_sha256": "9fbc97df50241cb2eaa3aefc3016b04ef8e3d7b07ae64b47cbd14d759fd5ebaf",
+      "value": "Returns the available models of a given type. Use it to find the `text-embedding` and `rerank` models to configure on a knowledge base."
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/operationId",
+      "source_sha256": "f4ee87fe7d3529fa0dbe0937acc9f5092742b98d9ba99fe22e2bb41dd150d776",
+      "value": "getAvailableModels"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "Response Example",
+          "value": {
+            "data": [
+              {
+                "provider": "langgenius/openai/openai",
+                "label": {
+                  "en_US": "OpenAI",
+                  "zh_Hans": "OpenAI"
+                },
+                "icon_small": {
+                  "en_US": "https://example.com/openai-small.svg",
+                  "zh_Hans": "https://example.com/openai-small.svg"
+                },
+                "status": "active",
+                "models": [
+                  {
+                    "model": "text-embedding-3-small",
+                    "label": {
+                      "en_US": "text-embedding-3-small",
+                      "zh_Hans": "text-embedding-3-small"
+                    },
+                    "model_type": "text-embedding",
+                    "features": null,
+                    "fetch_from": "predefined-model",
+                    "model_properties": {
+                      "context_size": 8191
+                    },
+                    "status": "active",
+                    "deprecated": false,
+                    "load_balancing_enabled": false,
+                    "has_invalid_load_balancing_configs": false
+                  }
+                ],
+                "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                "icon_small_dark": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/x-mint",
+      "value": {
+        "href": "/en/api-reference/models/get-available-models",
+        "metadata": {
+          "title": "Get Available Models",
+          "sidebarTitle": "Get Available Models"
         }
       }
     },

--- a/tools/api-pipeline/service_api_overlays/ja.json
+++ b/tools/api-pipeline/service_api_overlays/ja.json
@@ -17074,6 +17074,9981 @@
     },
     {
       "op": "replace",
+      "path": "/paths/~1datasets/get/description",
+      "source_sha256": "d054bda8cd30bdd4de53ea1626562d5b1b25aa37bb195f0b7ac6dc40f8f35e30",
+      "value": "ナレッジベースのページネーションリストを返します。任意でキーワードまたはタグでフィルタリングできます。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/operationId",
+      "source_sha256": "ef2a1d7b12fdb9e1a485e6cd014c7a776d029245455757f45c973f1502ebc6de",
+      "value": "listDatasets"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/0/description",
+      "source_sha256": "42ec0cfe0d70ab1439e6efd97eab8ed04b3723cf7eaa967a9ea50082c82f8ecc",
+      "value": "権限に関係なくすべてのナレッジベースを含めるかどうかです。",
+      "context_path": "/paths/~1datasets/get/parameters/0",
+      "context_sha256": "43b4e055bc75ab202a9351452644b28f30a9df43acf9aa4c861570c664718ab5"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/0/schema/description",
+      "source_sha256": "42ec0cfe0d70ab1439e6efd97eab8ed04b3723cf7eaa967a9ea50082c82f8ecc",
+      "value": "権限に関係なくすべてのナレッジベースを含めるかどうかです。",
+      "context_path": "/paths/~1datasets/get/parameters/0",
+      "context_sha256": "43b4e055bc75ab202a9351452644b28f30a9df43acf9aa4c861570c664718ab5"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/1/description",
+      "source_sha256": "969b4fbf074465fa6786b80e50aa7c231966efcf3ffd4fb9907eac1eb2470a92",
+      "value": "名前でフィルタリングする検索キーワードです。",
+      "context_path": "/paths/~1datasets/get/parameters/1",
+      "context_sha256": "9acaa12b486581d63cba590823ada40cd9fd885d8e2a62a9983d6354588ea25d"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/1/schema/description",
+      "source_sha256": "969b4fbf074465fa6786b80e50aa7c231966efcf3ffd4fb9907eac1eb2470a92",
+      "value": "名前でフィルタリングする検索キーワードです。",
+      "context_path": "/paths/~1datasets/get/parameters/1",
+      "context_sha256": "9acaa12b486581d63cba590823ada40cd9fd885d8e2a62a9983d6354588ea25d"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/2/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+      "context_path": "/paths/~1datasets/get/parameters/2",
+      "context_sha256": "3be071ee50409713ac99937bf5587118e5758fe840cbdf90b10c5ba5b26b2736"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/2/schema/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+      "context_path": "/paths/~1datasets/get/parameters/2",
+      "context_sha256": "3be071ee50409713ac99937bf5587118e5758fe840cbdf90b10c5ba5b26b2736"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/3/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。",
+      "context_path": "/paths/~1datasets/get/parameters/3",
+      "context_sha256": "41b7d5c5e4ba2a4e4a83c7b574b112e3f35aa91988101a0aa03cd0459fb3ddbb"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/3/schema/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。",
+      "context_path": "/paths/~1datasets/get/parameters/3",
+      "context_sha256": "41b7d5c5e4ba2a4e4a83c7b574b112e3f35aa91988101a0aa03cd0459fb3ddbb"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/4/description",
+      "source_sha256": "ada725b7472603774b1855ed05b52c49914a723fea230dd88496f4f9e27efff4",
+      "value": "絞り込みに使用するタグ ID。",
+      "context_path": "/paths/~1datasets/get/parameters/4",
+      "context_sha256": "b27b76effe7ce7480fc65aee6a14b223e116a424558569a4aa16e487c58a4da2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/4/schema/description",
+      "source_sha256": "ada725b7472603774b1855ed05b52c49914a723fea230dd88496f4f9e27efff4",
+      "value": "絞り込みに使用するタグ ID。",
+      "context_path": "/paths/~1datasets/get/parameters/4",
+      "context_sha256": "b27b76effe7ce7480fc65aee6a14b223e116a424558569a4aa16e487c58a4da2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": [
+              {
+                "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+                "name": "製品ドキュメント",
+                "description": "プロダクト API 技術ドキュメント",
+                "provider": "vendor",
+                "permission": "only_me",
+                "data_source_type": null,
+                "indexing_technique": "high_quality",
+                "app_count": 0,
+                "document_count": 0,
+                "word_count": 0,
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "author_name": "admin",
+                "created_at": 1741267200,
+                "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "updated_at": 1741267200,
+                "embedding_model": "text-embedding-3-small",
+                "embedding_model_provider": "langgenius/openai/openai",
+                "embedding_available": true,
+                "retrieval_model_dict": {
+                  "search_method": "semantic_search",
+                  "reranking_enable": false,
+                  "reranking_mode": null,
+                  "reranking_model": {
+                    "reranking_provider_name": "",
+                    "reranking_model_name": ""
+                  },
+                  "weights": null,
+                  "top_k": 3,
+                  "score_threshold_enabled": false,
+                  "score_threshold": null
+                },
+                "tags": [],
+                "doc_form": "text_model",
+                "external_retrieval_model": null,
+                "doc_metadata": [],
+                "built_in_field_enabled": true,
+                "pipeline_id": null,
+                "runtime_mode": null,
+                "chunk_structure": null,
+                "is_published": false,
+                "total_documents": 0,
+                "total_available_documents": 0,
+                "enable_api": true,
+                "is_multimodal": false,
+                "maintainer": "admin"
+              }
+            ],
+            "has_more": false,
+            "limit": 20,
+            "total": 1,
+            "page": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/responses/200/description",
+      "source_sha256": "7ed6360275a2b2800d796d418ba9c3e4569db2878f4409169da3d70ce1e68aa4",
+      "value": "ナレッジベースのリストです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/responses/403/content/application~1json/example",
+      "value": {
+        "code": "forbidden",
+        "message": "Forbidden.",
+        "status": 403
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "アクセス禁止 — ナレッジベース API またはワークスペースへのアクセス権がありません"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/summary",
+      "source_sha256": "056b42bc39595df68d6d796734d9df097a8b8ee33750de526f000968a33bb864",
+      "value": "ナレッジベースリストを取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "ナレッジベース",
+      "context_path": "/paths/~1datasets/get/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl -X GET 'https://{api_base_url}/datasets?page=1&limit=20' \\\n  -H 'Authorization: Bearer {api_key}'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/knowledge-bases/list-knowledge-bases",
+        "metadata": {
+          "title": "ナレッジベースリストを取得",
+          "sidebarTitle": "ナレッジベースリストを取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/description",
+      "source_sha256": "97dbeecda4c597e86334a41358ddef1281827f2d43084d33d359428edcea6fc5",
+      "value": "空のナレッジベースを作成します。ドキュメントを追加するには [テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) または [ファイルからドキュメントを作成](/ja/api-reference/documents/create-document-by-file) を使用します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/operationId",
+      "source_sha256": "d74b5b128e8928e710b6676be97acc183d444263d4e88d0a530a64446f901120",
+      "value": "createDataset"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+            "name": "製品ドキュメント",
+            "description": "プロダクト API 技術ドキュメント",
+            "provider": "vendor",
+            "permission": "only_me",
+            "data_source_type": null,
+            "indexing_technique": "high_quality",
+            "app_count": 0,
+            "document_count": 0,
+            "word_count": 0,
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "author_name": "admin",
+            "created_at": 1741267200,
+            "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "updated_at": 1741267200,
+            "embedding_model": "text-embedding-3-small",
+            "embedding_model_provider": "langgenius/openai/openai",
+            "embedding_available": true,
+            "retrieval_model_dict": {
+              "search_method": "semantic_search",
+              "reranking_enable": false,
+              "reranking_mode": null,
+              "reranking_model": {
+                "reranking_provider_name": "",
+                "reranking_model_name": ""
+              },
+              "weights": null,
+              "top_k": 3,
+              "score_threshold_enabled": false,
+              "score_threshold": null
+            },
+            "tags": [],
+            "doc_form": "text_model",
+            "external_retrieval_model": null,
+            "doc_metadata": [],
+            "built_in_field_enabled": true,
+            "pipeline_id": null,
+            "runtime_mode": null,
+            "chunk_structure": null,
+            "is_published": false,
+            "total_documents": 0,
+            "total_available_documents": 0,
+            "enable_api": true,
+            "is_multimodal": false,
+            "maintainer": "admin"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/200/description",
+      "source_sha256": "72d87a0ca72260ccc324a9dc4e83aa4532e7fe64f857bdd233b92ab6d944a2d6",
+      "value": "ナレッジベースが正常に作成されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/400/description",
+      "source_sha256": "2bfbcfde3ad246205ccd33f9e5921e27cf4a76186dc1885bf430dc6e0d6cae76",
+      "value": "`invalid_param`：指定した埋め込みモデルまたはリランクモデルが設定されていないか、利用できません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/409/content/application~1json/examples",
+      "value": {
+        "dataset_name_duplicate": {
+          "summary": "dataset_name_duplicate",
+          "value": {
+            "status": 409,
+            "code": "dataset_name_duplicate",
+            "message": "The dataset name already exists. Please modify your dataset name."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/409/description",
+      "source_sha256": "8f9971fca91a6321a9b7ee6cf993565be331319a7ee3f85c340d258fa9bc3f88",
+      "value": "`dataset_name_duplicate`：同じ名前のナレッジベースが既に存在します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/summary",
+      "source_sha256": "a659b50aca6ef20599bfdb4287f3c8202c846f8dbb8d7b3b4cdcaca7235ed818",
+      "value": "空のナレッジベースを作成"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "ナレッジベース",
+      "context_path": "/paths/~1datasets/post/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/knowledge-bases/create-an-empty-knowledge-base",
+        "metadata": {
+          "title": "空のナレッジベースを作成",
+          "sidebarTitle": "空のナレッジベースを作成"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/description",
+      "source_sha256": "dfa32093fca1413e614dfc90ac9bfdda066d84fa0276cb6124ea320a9c6a0ff8",
+      "value": "ナレッジパイプラインで使用するファイルをアップロードします。返された `id` を [パイプラインを実行](/ja/api-reference/knowledge-pipeline/run-pipeline) の `local_file` アイテムの `reference` として使用します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/operationId",
+      "source_sha256": "fc84e912240748481af2149f6debf0706ac19ef080fc916ec3d347f2d8636976",
+      "value": "uploadPipelineFile"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "b9c59fbdc0bbf0f019b4e57923038788f12065569bdff78282f5a98efb8c7476",
+      "value": "アップロードするファイル。`multipart/form-data` の 1 パートとして送信します。ドキュメントファイルのデフォルト上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。\n\nDify Cloud の Professional と Team プランではドキュメントの上限が 50 MB になります。画像・音声・動画ファイルには別の上限があり、デフォルトはそれぞれ 10 MB、50 MB、100 MB です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/201/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "name": "report.pdf",
+            "size": 524288,
+            "extension": "pdf",
+            "mime_type": "application/pdf",
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "created_at": "2025-03-06T12:00:00"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/201/description",
+      "source_sha256": "5f7d99edda2065312155bdc80d2fe8a2052b630156986e31d219cabe8a33bda4",
+      "value": "ファイルが正常にアップロードされました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/400/content/application~1json/examples",
+      "value": {
+        "no_file_uploaded": {
+          "summary": "no_file_uploaded",
+          "value": {
+            "status": 400,
+            "code": "no_file_uploaded",
+            "message": "Please upload your file."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/400/description",
+      "source_sha256": "d9117135f720d08a7612ecb5855665e59ad2620a7581f9e95b3011010c998ceb",
+      "value": "- `no_file_uploaded`：リクエストにファイルが提供されていません。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/403/content/application~1json/example",
+      "value": {
+        "code": "forbidden",
+        "message": "Forbidden.",
+        "status": 403
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "アクセス禁止 — ナレッジベース API またはワークスペースへのアクセス権がありません"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：ファイルサイズの上限を超えています。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/415/description",
+      "source_sha256": "cd5a22a978d1f32165a6676fb309f964b87db0818d7176356fe5f433a2803b0c",
+      "value": "`unsupported_file_type`：許可されていないファイルタイプです。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/summary",
+      "source_sha256": "85fe36dd346c9f07cafde5cbe1f09f41a6315ff17209de92f7c39055c6f2c752",
+      "value": "パイプラインファイルをアップロード"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/tags/0",
+      "source_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a",
+      "value": "ナレッジパイプライン",
+      "context_path": "/paths/~1datasets~1pipeline~1file-upload/post/tags/0",
+      "context_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/knowledge-pipeline/upload-pipeline-file",
+        "metadata": {
+          "title": "パイプラインファイルをアップロード",
+          "sidebarTitle": "パイプラインファイルをアップロード"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/description",
+      "source_sha256": "36c1d6aedaea66bf7a722ae1a4dabc11c6422e9fd4835dd1c2eb01f2d32bd160",
+      "value": "ナレッジベースタグを完全に削除します。タグ付けされたナレッジベース自体は削除されません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/operationId",
+      "source_sha256": "352ccb4c7592dadaf380d26a1733902600a16f384c657cafcf130765f1e30ae1",
+      "value": "deleteKnowledgeTag"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden`：ワークスペースでこれらのリソースを編集する権限がありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Tag not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/404/description",
+      "source_sha256": "f08401bb2b05b341791960d88321930fa7b110c695c34a98000496fcaf8fd5a3",
+      "value": "- `not_found`：指定されたタグが存在しません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/summary",
+      "source_sha256": "9407024f59f90342b2f4ed6d576d9da10cc7c1adcafad8ee0fccb090ce5e45ee",
+      "value": "ナレッジベースタグを削除"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "タグ管理",
+      "context_path": "/paths/~1datasets~1tags/delete/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/x-mint",
+      "value": {
+        "href": "/ja/api-reference/tags/delete-knowledge-tag",
+        "metadata": {
+          "title": "ナレッジベースタグを削除",
+          "sidebarTitle": "ナレッジベースタグを削除"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/description",
+      "source_sha256": "6f3afca0f7d11924162451927fb4402eb12b16849f2f62c93e0d21af223a1d7f",
+      "value": "ワークスペース内のすべてのナレッジベースタグを返します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/operationId",
+      "source_sha256": "9c6008b0eaf477a25ab5d66a6a34e701963154fbc8cd773d113d6754d6de04b9",
+      "value": "getKnowledgeTags"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": [
+            {
+              "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+              "name": "製品ドキュメント",
+              "type": "knowledge",
+              "binding_count": "0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/responses/200/description",
+      "source_sha256": "c7926134070bc6b36183f18a4ecf0a0c323d3a8b87a1fa89e2c316ae1226caf9",
+      "value": "タグのリストです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/responses/403/content/application~1json/example",
+      "value": {
+        "code": "forbidden",
+        "message": "Forbidden.",
+        "status": 403
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "アクセス禁止 — ナレッジベース API またはワークスペースへのアクセス権がありません"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/summary",
+      "source_sha256": "d569cac2620b7b7ae22408d842df736153bdfc06f7a18b721e35ebd34a9fcd90",
+      "value": "ナレッジベースタグリストを取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "タグ管理",
+      "context_path": "/paths/~1datasets~1tags/get/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/tags/list-knowledge-tags",
+        "metadata": {
+          "title": "ナレッジベースタグリストを取得",
+          "sidebarTitle": "ナレッジベースタグリストを取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/description",
+      "source_sha256": "c084eab025fd870ff32344afa68d74861fc1261825a21c12b4428827181f240b",
+      "value": "ナレッジベースタグの名前を変更します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/operationId",
+      "source_sha256": "201e7ef9d9f3a11a4022a7b1adccc7eab3fb00a6d6b2a152ef8a5f44c6b2cc07",
+      "value": "updateKnowledgeTag"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+            "name": "製品ドキュメント",
+            "type": "knowledge",
+            "binding_count": "0"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/200/description",
+      "source_sha256": "b41321c22a6905333c28a46e5cee36e03ebd5f7860e9186b979480e38cd356b7",
+      "value": "タグが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Tag name already exists"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/400/description",
+      "source_sha256": "23c822a6680f643f8803faeae345ab3d64ea2c4196383f9d8dd74f2ca4a25aeb",
+      "value": "`invalid_param`：同じ名前のナレッジタグが既に存在します。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden`：ワークスペースでこれらのリソースを編集する権限がありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Tag not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/404/description",
+      "source_sha256": "f08401bb2b05b341791960d88321930fa7b110c695c34a98000496fcaf8fd5a3",
+      "value": "- `not_found`：指定されたタグが存在しません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/summary",
+      "source_sha256": "53f111a0f14b3266f88d1619cdbdfb0168a2589f93a753ccfd097c2f4fe1a018",
+      "value": "ナレッジベースタグを変更"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "タグ管理",
+      "context_path": "/paths/~1datasets~1tags/patch/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/x-mint",
+      "value": {
+        "href": "/ja/api-reference/tags/update-knowledge-tag",
+        "metadata": {
+          "title": "ナレッジベースタグを変更",
+          "sidebarTitle": "ナレッジベースタグを変更"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/description",
+      "source_sha256": "eac481e2114e573707d7dbc32cc1a97e2a4051a323cc86d99b83ccaff037cecf",
+      "value": "ナレッジベースを整理するためのタグを作成します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/operationId",
+      "source_sha256": "da824e56d5664a07351bf17bebbe0400579a26ba542dfd599cbc6f0fb2aa35e7",
+      "value": "createKnowledgeTag"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+            "name": "製品ドキュメント",
+            "type": "knowledge",
+            "binding_count": "0"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/200/description",
+      "source_sha256": "03d63ab330fb9b0fd0a4d6a30ed917e307d982ef3d58b328b75d58098cb912e7",
+      "value": "タグが正常に作成されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Tag name already exists"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/400/description",
+      "source_sha256": "23c822a6680f643f8803faeae345ab3d64ea2c4196383f9d8dd74f2ca4a25aeb",
+      "value": "`invalid_param`：同じ名前のナレッジタグが既に存在します。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden`：ワークスペースでこれらのリソースを編集する権限がありません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/summary",
+      "source_sha256": "2dcfbe6e4f7b1d04b099e20c30cd81b75be4064237b02bb8b1d26fd05d6ea6b1",
+      "value": "ナレッジベースタグを作成"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "タグ管理",
+      "context_path": "/paths/~1datasets~1tags/post/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/tags/create-knowledge-tag",
+        "metadata": {
+          "title": "ナレッジベースタグを作成",
+          "sidebarTitle": "ナレッジベースタグを作成"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/description",
+      "source_sha256": "3546aa56c7a696416e22a16897ed3b6329a7f026e4f5740c5c89f67aeac67150",
+      "value": "ナレッジベースに 1 つ以上のタグをバインドします。ナレッジベースには複数のタグを設定できます。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/operationId",
+      "source_sha256": "9c9e39eda60a4b8997db7b7504de09433135bb41074e42fffff984795c38601c",
+      "value": "bindTagsToDataset"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden`：ワークスペースでこれらのリソースを編集する権限がありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found`：対象のナレッジベースが存在しません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/summary",
+      "source_sha256": "66f069631a4d711736fa8a6651ab9b99eced7a2048139efbf0d4604dd9f91bac",
+      "value": "タグをナレッジベースにバインド"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "タグ管理",
+      "context_path": "/paths/~1datasets~1tags~1binding/post/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/tags/create-tag-binding",
+        "metadata": {
+          "title": "タグをナレッジベースにバインド",
+          "sidebarTitle": "タグをナレッジベースにバインド"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/description",
+      "source_sha256": "02adc40133ec012bb247bbce2d09a95610d99e3ff10d1f39e40b7df72a9c5ed9",
+      "value": "ナレッジベースから 1 つまたは複数のタグを削除します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/operationId",
+      "source_sha256": "fab93b635cdec9e935f12fc280ddbe6bc9e35b454405f6291cecbc7020ba0a72",
+      "value": "unbindTagFromDataset"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden`：ワークスペースでこれらのリソースを編集する権限がありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found`：対象のナレッジベースが存在しません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/summary",
+      "source_sha256": "4ddbd1719c554d2d8812e87dd6db22f75cad665eed77788cea69e24eab033824",
+      "value": "タグとナレッジベースのバインドを解除"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "タグ管理",
+      "context_path": "/paths/~1datasets~1tags~1unbinding/post/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/tags/delete-tag-binding",
+        "metadata": {
+          "title": "タグとナレッジベースのバインドを解除",
+          "sidebarTitle": "タグとナレッジベースのバインドを解除"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/description",
+      "source_sha256": "5a13df0fb2b7bc8d07e48e977ce6fc26b95b5a655a1ee598302de1f5ab10f30c",
+      "value": "ナレッジベースとそのすべてのドキュメントを完全に削除します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/operationId",
+      "source_sha256": "e4554386c315974bcd8ec39a1fbbaa490987c3caa4806f5f14896e006372d0eb",
+      "value": "deleteDataset"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "ナレッジベースが正常に削除されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/409/content/application~1json/examples",
+      "value": {
+        "dataset_in_use": {
+          "summary": "dataset_in_use",
+          "value": {
+            "status": 409,
+            "code": "dataset_in_use",
+            "message": "The dataset is being used by some apps. Please remove the dataset from the apps before deleting it."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/409/description",
+      "source_sha256": "c5d6a5645855d5289b56585a737d39bdcf4f066a9a4f0556d4e30fcbe02e4251",
+      "value": "- `dataset_in_use`：ナレッジベースは 1 つ以上のアプリで使用されているため削除できません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/summary",
+      "source_sha256": "9952b29da673dff0df9c55c928162eb0179fefc4d0abfb762cc321b0b87798c2",
+      "value": "ナレッジベースを削除"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "ナレッジベース",
+      "context_path": "/paths/~1datasets~1{dataset_id}/delete/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/x-mint",
+      "value": {
+        "href": "/ja/api-reference/knowledge-bases/delete-knowledge-base",
+        "metadata": {
+          "title": "ナレッジベースを削除",
+          "sidebarTitle": "ナレッジベースを削除"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/description",
+      "source_sha256": "50f262ee70911d6791abcea1c7ad34cc9663445441e2f01ea7cc7b39893e0e89",
+      "value": "ナレッジベースの詳細情報（埋め込みモデル、検索設定、ドキュメント統計を含む）を返します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/operationId",
+      "source_sha256": "c676c10a9666888ddc33dc2417a529160af7ebce95d232081903a693662843b9",
+      "value": "getDatasetDetail"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+            "name": "製品ドキュメント",
+            "description": "プロダクト API 技術ドキュメント",
+            "provider": "vendor",
+            "permission": "only_me",
+            "data_source_type": null,
+            "indexing_technique": "high_quality",
+            "app_count": 0,
+            "document_count": 0,
+            "word_count": 0,
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "author_name": "admin",
+            "created_at": 1741267200,
+            "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "updated_at": 1741267200,
+            "embedding_model": "text-embedding-3-small",
+            "embedding_model_provider": "langgenius/openai/openai",
+            "embedding_available": true,
+            "retrieval_model_dict": {
+              "search_method": "semantic_search",
+              "reranking_enable": false,
+              "reranking_mode": null,
+              "reranking_model": {
+                "reranking_provider_name": "",
+                "reranking_model_name": ""
+              },
+              "weights": null,
+              "top_k": 3,
+              "score_threshold_enabled": false,
+              "score_threshold": null
+            },
+            "tags": [],
+            "doc_form": "text_model",
+            "external_retrieval_model": null,
+            "doc_metadata": [],
+            "built_in_field_enabled": true,
+            "pipeline_id": null,
+            "runtime_mode": null,
+            "chunk_structure": null,
+            "is_published": false,
+            "total_documents": 0,
+            "total_available_documents": 0,
+            "enable_api": true,
+            "is_multimodal": false,
+            "maintainer": "admin"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/200/description",
+      "source_sha256": "63deae9214b5c944cb03da99f53e51b354153799f7efdd84bb4a0d03f5785e9c",
+      "value": "ナレッジベースの詳細です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/403/description",
+      "source_sha256": "dd59bb3e339b8c109dc1d8675932155186051892eb6b1ddb12838fc5908128a8",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/summary",
+      "source_sha256": "bebfeab87756ca112ac66648f6210813c25f8c04b42bfff29d54c8f539e78fd5",
+      "value": "ナレッジベース詳細を取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "ナレッジベース",
+      "context_path": "/paths/~1datasets~1{dataset_id}/get/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/knowledge-bases/get-knowledge-base",
+        "metadata": {
+          "title": "ナレッジベース詳細を取得",
+          "sidebarTitle": "ナレッジベース詳細を取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/description",
+      "source_sha256": "a9fed906d8c13e36df6bc918dd5719446c732c07bf32796e1d12e14353900da3",
+      "value": "ナレッジベースを更新します。リクエストボディに含まれるフィールドのみが変更されます。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/operationId",
+      "source_sha256": "1e7587c6feb979c59561f9835143a0732d49cb86f2c385b292abf52838e04f6b",
+      "value": "updateDataset"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+            "name": "製品ドキュメント",
+            "description": "プロダクト API 技術ドキュメント",
+            "provider": "vendor",
+            "permission": "only_me",
+            "data_source_type": null,
+            "indexing_technique": "high_quality",
+            "app_count": 0,
+            "document_count": 0,
+            "word_count": 0,
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "author_name": "admin",
+            "created_at": 1741267200,
+            "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "updated_at": 1741267200,
+            "embedding_model": "text-embedding-3-small",
+            "embedding_model_provider": "langgenius/openai/openai",
+            "embedding_available": true,
+            "retrieval_model_dict": {
+              "search_method": "semantic_search",
+              "reranking_enable": false,
+              "reranking_mode": null,
+              "reranking_model": {
+                "reranking_provider_name": "",
+                "reranking_model_name": ""
+              },
+              "weights": null,
+              "top_k": 3,
+              "score_threshold_enabled": false,
+              "score_threshold": null
+            },
+            "tags": [],
+            "doc_form": "text_model",
+            "external_retrieval_model": null,
+            "doc_metadata": [],
+            "built_in_field_enabled": true,
+            "pipeline_id": null,
+            "runtime_mode": null,
+            "chunk_structure": null,
+            "is_published": false,
+            "total_documents": 0,
+            "total_available_documents": 0,
+            "enable_api": true,
+            "is_multimodal": false,
+            "maintainer": "admin",
+            "partial_member_list": []
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/200/description",
+      "source_sha256": "b4e80193207a4603fcb5015dfbf22dc8e672908fa53567cf6fbca915db559cf4",
+      "value": "ナレッジベースが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/400/description",
+      "source_sha256": "b5ad78b6480417ed9255db9e52538769a9ea519771d67eaaba34875e0a6b2dec",
+      "value": "`invalid_param`：指定した埋め込みモデルまたはリランクモデルが設定されていないか、利用できません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/403/description",
+      "source_sha256": "dd59bb3e339b8c109dc1d8675932155186051892eb6b1ddb12838fc5908128a8",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/summary",
+      "source_sha256": "07c7134789c05b311571b1579725a5f34825f5d8bb75f199cad5786c4e61772f",
+      "value": "ナレッジベースを更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "ナレッジベース",
+      "context_path": "/paths/~1datasets~1{dataset_id}/patch/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/x-mint",
+      "value": {
+        "href": "/ja/api-reference/knowledge-bases/update-knowledge-base",
+        "metadata": {
+          "title": "ナレッジベースを更新",
+          "sidebarTitle": "ナレッジベースを更新"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/description",
+      "source_sha256": "07400171c02b50f8bc11dd1134a91343b346fa6ab8108b738fcdd4f00355a697",
+      "value": "アップロードしたファイルからナレッジベースにドキュメントを作成します。PDF、TXT、DOCX などの一般的な形式をサポートします。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/operationId",
+      "source_sha256": "7ca535512cd3c0acbaad2d4669cd8c03360708e3e478056b50f137bb21276272",
+      "value": "createDocumentFromFile"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "037f58256da0da34703847fb56cec6fc7b5c0ed8605e4fdb0581d2578dc57168",
+      "value": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "b7e9147e0c9aef30779e9207fad5f007d9b8bb34d74e62a7cb5f864aad6a5080",
+      "value": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/200/description",
+      "source_sha256": "851e93c47a78428a82d029229950578ac29d60fd32590568a8535a7b24f1139f",
+      "value": "ドキュメントが正常に作成されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "no_file_uploaded": {
+          "summary": "no_file_uploaded",
+          "value": {
+            "status": 400,
+            "code": "no_file_uploaded",
+            "message": "Please upload your file."
+          }
+        },
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_external": {
+          "summary": "invalid_param（外部ナレッジベース）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "External datasets are not supported."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/400/description",
+      "source_sha256": "05a4c3414cba5c4a7c5698a768e2d0c6fc57cae41ac174d7a52af711b233fa97",
+      "value": "- `no_file_uploaded`：リクエストにファイルが提供されていません。\n- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：ナレッジベースが外部です。`indexing_technique` が必須、または `process_rule` がありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（ドキュメント数制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：ファイルサイズが上限を超えています。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/summary",
+      "source_sha256": "6ee6fc9abf303a6b02433c4484c32d04e180a0ccea977de7455426b45bb67658",
+      "value": "ファイルからドキュメントを作成"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/create-document-by-file",
+        "metadata": {
+          "title": "ファイルからドキュメントを作成",
+          "sidebarTitle": "ファイルからドキュメントを作成"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/description",
+      "source_sha256": "ce8837b5254a645c448cde23d6aeda5f09202a4433df372404c836cc8f5985d7",
+      "value": "生のテキストからナレッジベースにドキュメントを作成します。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/operationId",
+      "source_sha256": "933be53df5a2b7de9eeaff9bd7ff5201e55674341190c6d7a15de140e1cbe209",
+      "value": "createDocumentFromText"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/200/description",
+      "source_sha256": "851e93c47a78428a82d029229950578ac29d60fd32590568a8535a7b24f1139f",
+      "value": "ドキュメントが正常に作成されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_indexing": {
+          "summary": "invalid_param（インデックス方式）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "indexing_technique is required."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/400/description",
+      "source_sha256": "c265254345546d5954535fe0094526eac879381baad4be9f14512224200d62aa",
+      "value": "- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：最初のドキュメント追加時には `indexing_technique` が必須です。または `doc_form` が無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（ドキュメント数制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/summary",
+      "source_sha256": "1e6b990b6de94b6910045168cef2ec1a188d87dceb46d788be7574c2bfdcdab9",
+      "value": "テキストからドキュメントを作成"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/create-document-by-text",
+        "metadata": {
+          "title": "テキストからドキュメントを作成",
+          "sidebarTitle": "テキストからドキュメントを作成"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/description",
+      "source_sha256": "07400171c02b50f8bc11dd1134a91343b346fa6ab8108b738fcdd4f00355a697",
+      "value": "非推奨の互換エンドポイントです。アップロードしたファイルからナレッジベースにドキュメントを作成します。PDF、TXT、DOCX などの一般的な形式をサポートします。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "037f58256da0da34703847fb56cec6fc7b5c0ed8605e4fdb0581d2578dc57168",
+      "value": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "b7e9147e0c9aef30779e9207fad5f007d9b8bb34d74e62a7cb5f864aad6a5080",
+      "value": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/200/description",
+      "source_sha256": "851e93c47a78428a82d029229950578ac29d60fd32590568a8535a7b24f1139f",
+      "value": "ドキュメントが正常に作成されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "no_file_uploaded": {
+          "summary": "no_file_uploaded",
+          "value": {
+            "status": 400,
+            "code": "no_file_uploaded",
+            "message": "Please upload your file."
+          }
+        },
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_external": {
+          "summary": "invalid_param（外部ナレッジベース）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "External datasets are not supported."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/400/description",
+      "source_sha256": "05a4c3414cba5c4a7c5698a768e2d0c6fc57cae41ac174d7a52af711b233fa97",
+      "value": "- `no_file_uploaded`：リクエストにファイルが提供されていません。\n- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：ナレッジベースが外部です。`indexing_technique` が必須、または `process_rule` がありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（ドキュメント数制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：ファイルサイズが上限を超えています。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/summary",
+      "source_sha256": "6ee6fc9abf303a6b02433c4484c32d04e180a0ccea977de7455426b45bb67658",
+      "value": "ファイルからドキュメントを作成"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/description",
+      "source_sha256": "ce8e60129ee9c312cad9bdb211f4230d36e5b3a72242227ccec237363ac50e53",
+      "value": "非推奨の互換エンドポイントです。生のテキストからナレッジベースにドキュメントを作成します。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/200/description",
+      "source_sha256": "b58013cc434c75875e21586fa27549413c986ce036282f332061caf85b6f33aa",
+      "value": "ドキュメントが正常に作成されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_indexing": {
+          "summary": "invalid_param（インデックス方式）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "indexing_technique is required."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/400/description",
+      "source_sha256": "2bfbcfde3ad246205ccd33f9e5921e27cf4a76186dc1885bf430dc6e0d6cae76",
+      "value": "- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：最初のドキュメント追加時には `indexing_technique` が必須です。または `doc_form` が無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（ドキュメント数制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/summary",
+      "value": "テキストからドキュメントを作成"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/tags/0",
+      "source_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/tags/0",
+      "context_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/description",
+      "source_sha256": "78789159df482727bc3d6ce2dd0cc370746fa42614834a3a0f9ddace0ffddc2d",
+      "value": "ナレッジベース内のドキュメントのページネーションされた一覧を返します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/operationId",
+      "source_sha256": "ed04812695198c323f5b2e5e25367529acc7115ce721bb673d5f218c707bf895",
+      "value": "listDocuments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/1/description",
+      "source_sha256": "aba31e6369655c584b35d021ac80b7a64ff80eaba5de41afdeb1914b4493bf42",
+      "value": "ドキュメント名でフィルタリングするための検索キーワードです。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/1",
+      "context_sha256": "89b7ea40266f4a9525fc01d8dab03987f7e1f536346fffbee3d7151c7a14a603"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/1/schema/description",
+      "source_sha256": "aba31e6369655c584b35d021ac80b7a64ff80eaba5de41afdeb1914b4493bf42",
+      "value": "ドキュメント名でフィルタリングするための検索キーワードです。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/1",
+      "context_sha256": "89b7ea40266f4a9525fc01d8dab03987f7e1f536346fffbee3d7151c7a14a603"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/2/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/2",
+      "context_sha256": "3be071ee50409713ac99937bf5587118e5758fe840cbdf90b10c5ba5b26b2736"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/2/schema/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/2",
+      "context_sha256": "3be071ee50409713ac99937bf5587118e5758fe840cbdf90b10c5ba5b26b2736"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/3/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/3",
+      "context_sha256": "41b7d5c5e4ba2a4e4a83c7b574b112e3f35aa91988101a0aa03cd0459fb3ddbb"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/3/schema/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/3",
+      "context_sha256": "41b7d5c5e4ba2a4e4a83c7b574b112e3f35aa91988101a0aa03cd0459fb3ddbb"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/4/description",
+      "source_sha256": "50bce7bd6ac91e8f61540bc9cdbdb5ae9e6867325a9912e84bbabe8f4f09202f",
+      "value": "表示ステータスでフィルタリングします。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/4",
+      "context_sha256": "bf6598591c593ad0884619b7e5dfab5dbe0ef43e85b57e6632e871de05948e1e"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/4/schema/description",
+      "source_sha256": "50bce7bd6ac91e8f61540bc9cdbdb5ae9e6867325a9912e84bbabe8f4f09202f",
+      "value": "表示ステータスでフィルタリングします。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/4",
+      "context_sha256": "bf6598591c593ad0884619b7e5dfab5dbe0ef43e85b57e6632e871de05948e1e"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": [
+              {
+                "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "position": 1,
+                "data_source_type": "upload_file",
+                "data_source_info": {
+                  "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                },
+                "data_source_detail_dict": {
+                  "upload_file": {
+                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    "name": "guide.txt",
+                    "size": 2048,
+                    "extension": "txt",
+                    "mime_type": "text/plain",
+                    "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                    "created_at": 1741267200
+                  }
+                },
+                "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                "name": "guide.txt",
+                "created_from": "api",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200,
+                "tokens": 512,
+                "indexing_status": "completed",
+                "error": null,
+                "enabled": true,
+                "disabled_at": null,
+                "disabled_by": null,
+                "archived": false,
+                "display_status": "available",
+                "word_count": 350,
+                "hit_count": 0,
+                "doc_form": "text_model",
+                "doc_metadata": [],
+                "summary_index_status": null,
+                "need_summary": false
+              }
+            ],
+            "has_more": false,
+            "limit": 20,
+            "total": 1,
+            "page": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/200/description",
+      "source_sha256": "deb062667cf2e19735b642761ff5c8ddb9ad956b616de5b458b8f13f0a11c51e",
+      "value": "ドキュメントのリストです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found`：ナレッジベースが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/summary",
+      "source_sha256": "efb442829ce970e1abdf81dda8229db976a8e524ede03b124c418c7382962f28",
+      "value": "ナレッジベースのドキュメントリストを取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/list-documents",
+        "metadata": {
+          "title": "ナレッジベースのドキュメントリストを取得",
+          "sidebarTitle": "ナレッジベースのドキュメントリストを取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/description",
+      "source_sha256": "ab554fdd9cdb621d0ad3e866462ee925cf4739ac73dd0ab071948ed84cbde11a",
+      "value": "1 つ以上のドキュメントを単一の ZIP アーカイブとしてダウンロードします。ファイルとしてアップロードされたドキュメントのみ含められます。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/operationId",
+      "source_sha256": "0e8cead9550f8599042d95432183326d285ed38219ea533590af75ef0cabfe71",
+      "value": "downloadDocumentsZip"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/200/content/application~1zip/schema/description",
+      "value": "ZIP アーカイブのバイナリストリームです。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/200/description",
+      "source_sha256": "dfa45cbc91f27b04a692458bc086dfc4b91265540a7ce1fb334de04829692a38",
+      "value": "リクエストされたドキュメントを含む ZIP アーカイブです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（ナレッジベース権限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You do not have permission to access this dataset."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（ドキュメント権限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "No permission."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden`：このナレッジベースにアクセスする権限がありません。\n- `forbidden`：リクエストされたドキュメントのいずれかにアクセスする権限がありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found_3",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Only uploaded-file documents can be downloaded as ZIP."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/404/description",
+      "source_sha256": "33d278524dd9904b18696f6543002a01a53e777c37edf5e64cef79379db1dc72",
+      "value": "- `not_found`：ドキュメントが見つかりません。\n- `not_found`：ナレッジベースが見つかりません。 リクエストしたドキュメントがアップロードファイル由来でない場合も、アップロードファイルのドキュメントだけが ZIP ダウンロード対象であることを示すエラーが返ります。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/summary",
+      "source_sha256": "d040c430ec818031d4a6071ac7b44a612ad0d770c44fa30b2271a8d550101185",
+      "value": "ドキュメントを一括ダウンロード（ZIP）"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/download-documents-as-zip",
+        "metadata": {
+          "title": "ドキュメントを一括ダウンロード（ZIP）",
+          "sidebarTitle": "ドキュメントを一括ダウンロード（ZIP）"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/description",
+      "source_sha256": "e0e16afd2292fe2d4aed3d4140e8303874f07030c24668ba73768f6284a36e21",
+      "value": "複数のドキュメントのメタデータ値を 1 回のリクエストで更新します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/operationId",
+      "source_sha256": "4f58dac3e79b1e0dbcd9d642c696555d5279086e49a42d6da8107d357027b5a0",
+      "value": "batchUpdateDocumentMetadata"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "result": "success"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/200/description",
+      "source_sha256": "09f6bc9638276cdb0877be7f1339c6ef911bd14e5c81f0d02bf526597fc5fe30",
+      "value": "ドキュメントメタデータが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Another document metadata operation is running, please wait a moment."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/400/description",
+      "source_sha256": "b1e7a7215ad461820547abdde9f7e0c9515ab9c9e66e8a2a66aa8d395d9c10cf",
+      "value": "`invalid_param`：このリクエスト内のドキュメントで別のメタデータ操作が実行中です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found（ナレッジベース）",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found (document)",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found (metadata)",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Metadata not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/404/description",
+      "source_sha256": "cfa8dd782d9a3aff8888ba05f0e0fe6cbfa1ac2acb8475f7c800006b5368e5c3",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：`operation_data` で参照されたドキュメントがこのナレッジベースに存在しません。\n- `not_found`：`metadata_list` で参照されたメタデータフィールドがこのナレッジベースに存在しません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/summary",
+      "source_sha256": "542f84a66a20a8da766f4de90c208ca710e162cead8630535acfcfe4b093ca3c",
+      "value": "ドキュメントメタデータを一括更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "メタデータ",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/metadata/update-document-metadata-in-batch",
+        "metadata": {
+          "title": "ドキュメントメタデータを一括更新",
+          "sidebarTitle": "ドキュメントメタデータを一括更新"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/description",
+      "source_sha256": "c6b0c2965a3f06693164c1eae0ca6d8e0c2c3fdfd612719ed4db44157330813d",
+      "value": "複数のドキュメントを 1 回のリクエストで有効化、無効化、アーカイブ、またはアーカイブ解除します。互換性のため `document_ids` は任意です。省略するか空配列を渡すと更新は行われませんが、`result: success` が返ります。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/operationId",
+      "source_sha256": "e6b2549c3dfaa8f1a245a5c580acb06c1745347d76d8ce63cf8266eb1f58bad8",
+      "value": "batchUpdateDocumentStatus"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/0/description",
+      "source_sha256": "a51dc76c03c027de687cf177900f2d13b30845b250daa806a286c633ad75505c",
+      "value": "実行する操作：`enable`、`disable`、`archive`、`un_archive`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/0",
+      "context_sha256": "65537a06d370a21500cd609c296ade3fc7153ab0908b8cb96ffa4672ed7168b4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/0/schema/description",
+      "source_sha256": "a51dc76c03c027de687cf177900f2d13b30845b250daa806a286c633ad75505c",
+      "value": "実行する操作：`enable`、`disable`、`archive`、`un_archive`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/0",
+      "context_sha256": "65537a06d370a21500cd609c296ade3fc7153ab0908b8cb96ffa4672ed7168b4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/1/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/requestBody/content/application~1json/examples",
+      "value": {
+        "update_documents": {
+          "summary": "リクエスト例",
+          "value": {
+            "document_ids": [
+              "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "c4c4f9aa-2c9b-4f95-9f5a-2c0f7c3a8f21"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "result": "success"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/200/description",
+      "source_sha256": "859ddafafe8ea74b6bb4f0de968b87fd187fdd5313edf2d0435a8df1846be0d2",
+      "value": "ドキュメントが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_action": {
+          "summary": "invalid_action",
+          "value": {
+            "status": 400,
+            "code": "invalid_action",
+            "message": "Invalid action."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/400/description",
+      "source_sha256": "6e1b4b62cdc02de4f968d6c5e758ee2bb3ac251971f614da57623f3b8a591c06",
+      "value": "`invalid_action`：アクションが無効です。またはドキュメントがアクションを許可しない状態です（インデックス中、または未完了など）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found`：ナレッジベースが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/summary",
+      "source_sha256": "d7427b4c34451ae3e333e70baaa0a653cdd7eca86f9b1ae5d793afbdc449fd47",
+      "value": "ドキュメントステータスを一括更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/update-document-status-in-batch",
+        "metadata": {
+          "title": "ドキュメントステータスを一括更新",
+          "sidebarTitle": "ドキュメントステータスを一括更新"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/description",
+      "source_sha256": "3ee1dc37070aedcadf13c8f1f7f8dd0580c132e9bb092eb2bd8a78fb14bd3497",
+      "value": "バッチ内の各ドキュメントについて、現在の段階とチャンク完了数を返します。各 `indexing_status` が `completed`、`error`、または `paused` になるまでポーリングしてください。`completed` と `error` は終端状態です。Service API には一時停止したドキュメントを再開する操作がありません。Dify のナレッジベース画面で再開してから、このエンドポイントのポーリングを続けてください。実行中の段階は `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed` と進みます。`stopped_at` が null でない場合は処理の停止時刻を示しますが、`stopped` は独立した `indexing_status` 値ではありません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/operationId",
+      "source_sha256": "39c6932a2f100f1efc39062d5a65c72cebde14cb45097fdf9be0fe276b21e0d1",
+      "value": "getDocumentIndexingStatus"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/0/description",
+      "source_sha256": "05fd9b42d2c8b44ab846e5ea08775bef92e1970160841cf8ac40f184d8abf14e",
+      "value": "ドキュメントの作成時または更新時に返されるバッチ ID です。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/0",
+      "context_sha256": "dc296bd6cc966cbe715d70de1858731daf7bc5888473c41133c48cbaa43b801a"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/0/schema/description",
+      "source_sha256": "05fd9b42d2c8b44ab846e5ea08775bef92e1970160841cf8ac40f184d8abf14e",
+      "value": "バッチ ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/0",
+      "context_sha256": "dc296bd6cc966cbe715d70de1858731daf7bc5888473c41133c48cbaa43b801a"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/1/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": [
+              {
+                "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "indexing_status": "completed",
+                "processing_started_at": 1741267200,
+                "parsing_completed_at": 1741267200,
+                "cleaning_completed_at": 1741267200,
+                "splitting_completed_at": 1741267200,
+                "completed_at": 1741267200,
+                "paused_at": null,
+                "error": null,
+                "stopped_at": null,
+                "completed_segments": 5,
+                "total_segments": 5
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/200/description",
+      "source_sha256": "0c8b1f8fc9842dc81a753321a521f66d7cca0fa3afd296ba2dfa0f33fa0f5bb6",
+      "value": "バッチ内のドキュメントのインデックス状態です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/404/content/application~1json/examples",
+      "value": {
+        "dataset_not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "documents_not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Documents not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/404/description",
+      "source_sha256": "f925b0dba435508be8b280a637223f4caa0fc1649cf974fd5c22e57b09bc2ec9",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/summary",
+      "source_sha256": "0a2e15b45d5050c4e0a3fdf0531cdb83c7228b7ef02f6ba49845a6b135ed4ccd",
+      "value": "ドキュメントのインデックス状態（進捗）を取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/get-document-indexing-status",
+        "metadata": {
+          "title": "ドキュメントのインデックス状態（進捗）を取得",
+          "sidebarTitle": "ドキュメントのインデックス状態（進捗）を取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/description",
+      "source_sha256": "8cf27626e083bc4eb4f350d4e92e989cd9a315b858f85debdf083d3e7fdb9161",
+      "value": "ナレッジベースからドキュメントとそのすべてのチャンクを完全に削除します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/operationId",
+      "source_sha256": "656074aae27c7333625916f7719d19d283e12562cb12ad96314c25bdb5fa5fba",
+      "value": "deleteDocument"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/400/content/application~1json/examples",
+      "value": {
+        "document_indexing": {
+          "summary": "document_indexing",
+          "value": {
+            "status": 400,
+            "code": "document_indexing",
+            "message": "Cannot delete document during indexing."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/400/description",
+      "source_sha256": "51752204a2cb9583364eaf80301be31060091d5a02703d0d6798210d4a8fc0eb",
+      "value": "- `document_indexing`：ドキュメントは処理中のため削除できません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "archived_document_immutable": {
+          "summary": "archived_document_immutable",
+          "value": {
+            "status": 403,
+            "code": "archived_document_immutable",
+            "message": "The archived document is not editable."
+          }
+        },
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/403/description",
+      "source_sha256": "909e8a3e284297c1c7bf931731833a5fb989d3b37ebc181edfbdffe52d1e96ce",
+      "value": "- `archived_document_immutable`：アーカイブされたドキュメントは編集できません。\n- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document Not Exists."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found_2",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/404/description",
+      "source_sha256": "654d9434f735fc4d4ab99327dd4af0be414347c7611fcf1ac55f98c1ce4d551e",
+      "value": "- `not_found`：ドキュメントが存在しません。 ナレッジベース自体が存在しない場合も、ナレッジベースが見つからないことを示すエラーが返ります。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/summary",
+      "source_sha256": "70f5004e3f3a2f2d95035c906999bd25f419317eb83bf1b2bb33c2a67606aa68",
+      "value": "ドキュメントを削除"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/delete-document",
+        "metadata": {
+          "title": "ドキュメントを削除",
+          "sidebarTitle": "ドキュメントを削除"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/description",
+      "source_sha256": "223cc48b4a4eb37363dfbbdae2aee5f32ecfdd5f091c7099c9293d0b111a9cf0",
+      "value": "1 つのドキュメントの詳細情報を返します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/operationId",
+      "source_sha256": "75541f97ff3ca7f743159c35501d9eba8b0a71833c97a161c5351f5f1232f519",
+      "value": "getDocumentDetail"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/2/description",
+      "source_sha256": "4872f96fedffd9e413abf58ce36a21d9eda0ba203c4c38f9c553593c4a30d5ec",
+      "value": "`all` はメタデータを含むすべてのフィールドを返します。`only` は `id`、`doc_type`、`doc_metadata` のみを返します。`without` は `doc_metadata` を除くすべてのフィールドを返します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/2",
+      "context_sha256": "4929e9b2a6d9c9242510d14164e6d830c4ddbb6c558853d66fb3d8b6f3adb215"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/2/schema/description",
+      "source_sha256": "4872f96fedffd9e413abf58ce36a21d9eda0ba203c4c38f9c553593c4a30d5ec",
+      "value": "`all` はメタデータを含むすべてのフィールドを返します。`only` は `id`、`doc_type`、`doc_metadata` のみを返します。`without` は `doc_metadata` を除くすべてのフィールドを返します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/2",
+      "context_sha256": "4929e9b2a6d9c9242510d14164e6d830c4ddbb6c558853d66fb3d8b6f3adb215"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+            "position": 1,
+            "data_source_type": "upload_file",
+            "data_source_info": {
+              "upload_file": {
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "name": "guide.txt",
+                "size": 2048,
+                "extension": "txt",
+                "mime_type": "text/plain",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200
+              }
+            },
+            "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+            "dataset_process_rule": {
+              "id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "mode": "custom"
+            },
+            "document_process_rule": {
+              "mode": "custom",
+              "rules": {
+                "pre_processing_rules": [],
+                "segmentation": {
+                  "separator": "###",
+                  "max_tokens": 500,
+                  "chunk_overlap": 50
+                }
+              }
+            },
+            "name": "guide.txt",
+            "created_from": "api",
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "created_at": 1741267200,
+            "tokens": 512,
+            "indexing_status": "completed",
+            "error": null,
+            "enabled": true,
+            "disabled_at": null,
+            "disabled_by": null,
+            "archived": false,
+            "display_status": "available",
+            "hit_count": 0,
+            "doc_form": "text_model",
+            "doc_language": "English",
+            "doc_type": null,
+            "doc_metadata": [],
+            "completed_at": 1741267260,
+            "updated_at": 1741267260,
+            "indexing_latency": 60.0,
+            "segment_count": 5,
+            "average_segment_length": 70.0,
+            "summary_index_status": null,
+            "need_summary": false
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/200/description",
+      "source_sha256": "9c974d1edde88e6ce065e0fcd27c6902c3b725a8d83bb0956cf1234e5b490f3e",
+      "value": "ドキュメントの詳細です。返されるフィールドは `metadata` クエリパラメータによって異なります。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_metadata": {
+          "summary": "invalid_metadata",
+          "value": {
+            "status": 400,
+            "code": "invalid_metadata",
+            "message": "Invalid metadata value."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/400/description",
+      "source_sha256": "a6f3cd1d294992adca094754d7e0ec4e47ace58dbf60cdf45bb36179378c2dc7",
+      "value": "`invalid_metadata`：`metadata` クエリパラメータの値が無効です（`all`、`only`、`without` のいずれかである必要があります）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（権限なし）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "No permission."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/403/description",
+      "source_sha256": "2bef26abe5b5e7f882e37bea609d1c175794388053ba0c3f39d4a5b6be4518a8",
+      "value": "- `forbidden`：このドキュメントにアクセスする権限がありません。\n- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/404/description",
+      "source_sha256": "92c4a92c4d46a82bba2df44f94474fc2bcb7fedc50fe8f19ced9339cab517786",
+      "value": "- `not_found`：ドキュメントが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/summary",
+      "source_sha256": "48b0cb3171b8524948244d59f615aa88e9ff7ef73ce66a5a1a7c146c2a1886a3",
+      "value": "ドキュメント詳細を取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/get-document",
+        "metadata": {
+          "title": "ドキュメント詳細を取得",
+          "sidebarTitle": "ドキュメント詳細を取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/description",
+      "source_sha256": "76af9a461be7fa6b11b91f204a7691e31b9e256760a10232e79fec948ad06751",
+      "value": "ドキュメントを更新して再インデックスします。`file` で元ファイルを置き換え、`data` で処理設定を変更できます。両方の指定も可能です。`file` を省略すると、指定した設定または現在の設定で既存の元ファイルを再処理します。空の multipart リクエストでは現在の設定で再インデックスします。返された `batch` ID を使って[ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status)で進捗を追跡してください。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/operationId",
+      "source_sha256": "14d98cfdb11f1b9565c90611e28c7d833c4c86c0760067709584aba11278c1fb",
+      "value": "updateDocument"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "9a55a691d8c3e1fa35fa97643ae718f7c770b58e29258bbbedb3ba1b046597a9",
+      "value": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "c3ecc43b937e9c81b6f6591d46eb7fb325ddc2af0207e748bdc83f5f7a30e4ab",
+      "value": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/200/description",
+      "source_sha256": "16662764860b1e0ddf01c5e676e787076fb8b5dbd4d0fea1be7dc44670a4bff0",
+      "value": "ドキュメントが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param（利用不可）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/400/description",
+      "source_sha256": "533998490d38cd2cd57cc910a88ff38c4b5b8ea95add88c0e4404959f3417cb4",
+      "value": "- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：ファイルサイズが上限を超えています。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/415/description",
+      "source_sha256": "3ce1812190ffa7ff82290341eeee927bbc176af9b1a3673fbe9a48cb95ea127d",
+      "value": "`unsupported_file_type`：許可されていないファイルタイプです。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/summary",
+      "source_sha256": "6f35a637dbb78c62105d71d60424b6d01ea7629747bd579ba157ffd1ce397402",
+      "value": "ドキュメントを更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl --request PATCH \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/documents/{document_id}' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/update-document",
+        "metadata": {
+          "title": "ドキュメントを更新",
+          "sidebarTitle": "ドキュメントを更新"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/description",
+      "source_sha256": "842aa9dba53398538fede68859cbcd0f0211cc5e2033ec56ec418a411de7cce0",
+      "value": "ドキュメントの元のアップロードファイルをダウンロードするための署名付き URL を返します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/operationId",
+      "source_sha256": "fc5cc402ab6a49ac351da3beb9f97321420d3f5e6a22b9f3f58092f30b651c03",
+      "value": "downloadDocument"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "url": "https://storage.example.com/datasets/documents/abc123/original-file.pdf?token=xyz789&expires=1741353600"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/200/description",
+      "source_sha256": "4b9bf98151426ef51d6ea3eee52990acd500fed35ba0870f24f003926add1991",
+      "value": "ダウンロード URL が正常に生成されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（権限なし）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "No permission."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/403/description",
+      "source_sha256": "7987c5d119f43227f71c217ac78a4c52e4a02ade6bf43575d26f21fe5b3c0190",
+      "value": "- `forbidden`：このドキュメントにアクセスする権限がありません。\n- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found_2",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Uploaded file not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found_3",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document does not have an uploaded file to download."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/404/description",
+      "source_sha256": "92c4a92c4d46a82bba2df44f94474fc2bcb7fedc50fe8f19ced9339cab517786",
+      "value": "- `not_found`：ドキュメントが見つかりません。 保存ファイルがない場合はアップロード済みファイルが見つからないことを示すエラー、ファイル以外のドキュメントではダウンロード可能なアップロードファイルがないことを示すエラーが返ります。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/summary",
+      "source_sha256": "90b21a62faa89b9775907d1ddf1992490283ece74d46bf7cdae5653a194530ba",
+      "value": "ドキュメントをダウンロード"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/download-document",
+        "metadata": {
+          "title": "ドキュメントをダウンロード",
+          "sidebarTitle": "ドキュメントをダウンロード"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/description",
+      "source_sha256": "582c3857384b399f032a82587e616ec2c8660ff2418716154d3e48498c2b78fc",
+      "value": "ドキュメント内のチャンクのページネーションリストを返します。任意でキーワードまたはインデックスステータスでフィルタリングできます。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/operationId",
+      "source_sha256": "9fb703c2ac9028b2c32081b34e5981b98966ee046baedc87d65622e9fcd401e8",
+      "value": "listSegments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/2/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "検索キーワードです。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/2",
+      "context_sha256": "4c19ed6189abc1d3b555cee9488bc12c1308ff8769f72729805198c8d1451923"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/2/schema/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "検索キーワードです。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/2",
+      "context_sha256": "4c19ed6189abc1d3b555cee9488bc12c1308ff8769f72729805198c8d1451923"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/3/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/3",
+      "context_sha256": "d91843f5442902d84910396ce711ce7f4852175631599c1c4d2b72262307bcb6"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/3/schema/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/3",
+      "context_sha256": "d91843f5442902d84910396ce711ce7f4852175631599c1c4d2b72262307bcb6"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/4/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/4",
+      "context_sha256": "940c6bab5bcb50752c3da3dec2188cc938793db83499f905113f2da64a771d24"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/4/schema/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/4",
+      "context_sha256": "940c6bab5bcb50752c3da3dec2188cc938793db83499f905113f2da64a771d24"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/5/description",
+      "source_sha256": "8553c4a96f020a09cde5ec784da5824c9b02c954d7cae9faa4d0300b9835a2d8",
+      "value": "`completed`、`indexing`、`error` などのインデックス状態でチャンクを絞り込みます。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/5",
+      "context_sha256": "a558ae5b54cbd62806a948f6c8905bb95bdd5a02e4210f2b0dbb2d709dfe813b"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/5/schema/description",
+      "source_sha256": "8553c4a96f020a09cde5ec784da5824c9b02c954d7cae9faa4d0300b9835a2d8",
+      "value": "`completed`、`indexing`、`error` などのインデックス状態でチャンクを絞り込みます。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/5",
+      "context_sha256": "a558ae5b54cbd62806a948f6c8905bb95bdd5a02e4210f2b0dbb2d709dfe813b"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": [
+              {
+                "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                "position": 1,
+                "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
+                "sign_content": "",
+                "answer": "",
+                "word_count": 9,
+                "tokens": 12,
+                "keywords": [
+                  "dify",
+                  "platform",
+                  "llm"
+                ],
+                "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                "index_node_hash": "abc123def456",
+                "hit_count": 0,
+                "enabled": true,
+                "disabled_at": null,
+                "disabled_by": null,
+                "status": "completed",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200,
+                "updated_at": 1741267200,
+                "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "indexing_at": 1741267200,
+                "completed_at": 1741267200,
+                "error": null,
+                "stopped_at": null,
+                "child_chunks": [],
+                "attachments": [],
+                "summary": null
+              }
+            ],
+            "doc_form": "text_model",
+            "total": 1,
+            "has_more": false,
+            "limit": 20,
+            "page": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/200/description",
+      "source_sha256": "85ca1913e26ecf63bcf33b2ebadd93ef201662db791e160742a37d251a65b39b",
+      "value": "チャンクのリストです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/400/description",
+      "source_sha256": "713478b5ec6389ad152167c1712e6756e62534bda443f37bbb091a896dee5811",
+      "value": "`provider_not_initialize`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/404/description",
+      "source_sha256": "2679559e87d24a8afee123e19f8953829e093153c3adffc0d5bf8706d8de74ec",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/summary",
+      "source_sha256": "2cfa078070ef8223b29e847980047cd348d84e5fa11629531e4c515ca9b69a4b",
+      "value": "チャンク一覧を取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "チャンク",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/chunks/list-chunks",
+        "metadata": {
+          "title": "チャンク一覧を取得",
+          "sidebarTitle": "チャンク一覧を取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/description",
+      "source_sha256": "d856a065db873c19c6368130043ff107ce8a3f13cdc013661f911047e22cca56",
+      "value": "ドキュメント内に 1 つ以上のチャンクを作成します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/operationId",
+      "source_sha256": "c4acb46d3be04bdf1f8ff2bdf9c7c810d64bc11fa737deb10fe797daefebed8c",
+      "value": "createSegments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": [
+              {
+                "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                "position": 1,
+                "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
+                "sign_content": "",
+                "answer": "",
+                "word_count": 9,
+                "tokens": 12,
+                "keywords": [
+                  "dify",
+                  "platform",
+                  "llm"
+                ],
+                "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                "index_node_hash": "abc123def456",
+                "hit_count": 0,
+                "enabled": true,
+                "disabled_at": null,
+                "disabled_by": null,
+                "status": "completed",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200,
+                "updated_at": 1741267200,
+                "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "indexing_at": 1741267200,
+                "completed_at": 1741267200,
+                "error": null,
+                "stopped_at": null,
+                "child_chunks": [],
+                "attachments": [],
+                "summary": null
+              }
+            ],
+            "doc_form": "text_model"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/200/description",
+      "source_sha256": "9e01e8e9d0aafd621b73fcc3a4df08af015b6129c94acac7fa0cb7e73bdedf01",
+      "value": "チャンクが正常に作成されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param_limit": {
+          "summary": "invalid_param（チャンク数制限）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Exceeded maximum segments limit of 1000."
+          }
+        },
+        "validation_error": {
+          "summary": "schema 検証（非標準リクエストボディ）",
+          "value": {
+            "error": "1 validation error for SegmentCreatePayload\nsegments.0.content\n  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/400/description",
+      "source_sha256": "a19c866c52f77b90a4b1c2be29a17b1a5f432c936c6058d582c0e9e852ab9d7e",
+      "value": "- `provider_not_initialize`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param`：チャンクのフィールドが無効です（例：Q&A モードのドキュメントでは `answer` が必須）。またはチャンク数がリクエストごとの上限を超えています。\n- リクエストボディのスキーマ検証（`content` が空など）では、`code` や `status` を持たない非標準のボディ `{\"error\": \"<検証の詳細>\"}` が返されます。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（プランのアップグレードが必要）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "この機能を利用するには、有料プランへアップグレードしてください。"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden`：この機能を利用するには、有料プランへアップグレードしてください。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document is not completed."
+          }
+        },
+        "not_found_4": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document is disabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/404/description",
+      "source_sha256": "cbc930cc07d2b0d0682f8867bfea9ccd66a0542140764dfd68adadfd208bb8c0",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：ドキュメントの処理が完了していません。\n- `not_found`：ドキュメントが無効化されています。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/summary",
+      "source_sha256": "f2b41b75a56de04fb5ab76b8e82b2cbb842d02c92ec9a588488704d90a5fdbaa",
+      "value": "ドキュメントにチャンクを追加"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "チャンク",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/chunks/create-chunks",
+        "metadata": {
+          "title": "ドキュメントにチャンクを追加",
+          "sidebarTitle": "ドキュメントにチャンクを追加"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/description",
+      "source_sha256": "45c2f6d6d25bfdc5723d6942d4a0eff1c7f82cfc19a0c1cdf4c45dffcd598812",
+      "value": "ドキュメントからチャンクを完全に削除します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/operationId",
+      "source_sha256": "de021c8ff9fa6a10b79bca7f5899cf1201d5d4c5f473de0af498ba04cf2374ff",
+      "value": "deleteSegment"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/2/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param_model_setting": {
+          "summary": "invalid_param（モデル設定）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param_deleting": {
+          "summary": "invalid_param（削除中）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Segment is deleting."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/400/description",
+      "source_sha256": "246948fbac3b19c653a5b271f592e54276bf0ebfea59d24f5d4f8bdace089213",
+      "value": "- `invalid_param`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param`：チャンクは別の同時リクエストによってすでに削除中です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/summary",
+      "source_sha256": "42229b8dfdb424a1f60e302563bd47ec5eccf5bd79b45950b73fb30db2722635",
+      "value": "ドキュメント内のチャンクを削除"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "チャンク",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/x-mint",
+      "value": {
+        "href": "/ja/api-reference/chunks/delete-chunk",
+        "metadata": {
+          "title": "ドキュメント内のチャンクを削除",
+          "sidebarTitle": "ドキュメント内のチャンクを削除"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/description",
+      "source_sha256": "592c29e3d9c0271b3940388128173a87db1ef6dd0df56786a3ac67d4cb1b7d1b",
+      "value": "1 つのチャンクの詳細をすべて取得します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/operationId",
+      "source_sha256": "0e5d3e0623daa5d8c5ef3c0190a00b1372d1165307d3dd0616392391bbc9225e",
+      "value": "getSegmentDetail"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/2/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": {
+              "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "position": 1,
+              "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
+              "sign_content": "",
+              "answer": "",
+              "word_count": 9,
+              "tokens": 12,
+              "keywords": [
+                "dify",
+                "platform",
+                "llm"
+              ],
+              "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+              "index_node_hash": "abc123def456",
+              "hit_count": 0,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "status": "completed",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "updated_at": 1741267200,
+              "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "indexing_at": 1741267200,
+              "completed_at": 1741267200,
+              "error": null,
+              "stopped_at": null,
+              "child_chunks": [],
+              "attachments": [],
+              "summary": null
+            },
+            "doc_form": "text_model"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/200/description",
+      "source_sha256": "53f8b5ad904784dc956dc2ec4a871cdff0423c6b61126434b7c8b00139b22315",
+      "value": "チャンクの詳細です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/400/description",
+      "source_sha256": "95d6543fbb7b8c8a19b8b710bf3e6fe50b88d187984da48e0671248b0f42a95e",
+      "value": "`invalid_param`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/summary",
+      "source_sha256": "78707a415eb06083072132d062c09e2e096c3c6a8636d42e5f931bab68062d60",
+      "value": "ドキュメント内のチャンク詳細を取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "チャンク",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/chunks/get-chunk",
+        "metadata": {
+          "title": "ドキュメント内のチャンク詳細を取得",
+          "sidebarTitle": "ドキュメント内のチャンク詳細を取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/description",
+      "source_sha256": "f0fbd0d95fd128b6630d3729b0fa0dddf4439e5f5bab3223bcf8725b94e8cb2a",
+      "value": "チャンクのフィールドを更新します。この更新により、そのチャンクのインデックス作成が再トリガーされます。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/operationId",
+      "source_sha256": "5fc085ac885ebda0a576cf7e298500d88f442446f323908e8e293c73c892e446",
+      "value": "updateSegment"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/2/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": {
+              "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "position": 1,
+              "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
+              "sign_content": "",
+              "answer": "",
+              "word_count": 9,
+              "tokens": 12,
+              "keywords": [
+                "dify",
+                "platform",
+                "llm"
+              ],
+              "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+              "index_node_hash": "abc123def456",
+              "hit_count": 0,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "status": "completed",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "updated_at": 1741267200,
+              "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "indexing_at": 1741267200,
+              "completed_at": 1741267200,
+              "error": null,
+              "stopped_at": null,
+              "child_chunks": [],
+              "attachments": [],
+              "summary": null
+            },
+            "doc_form": "text_model"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/200/description",
+      "source_sha256": "63e3259066c2b26c706cb662fbc775bba3667820b9634cbdeac3097cb4ef3017",
+      "value": "チャンクが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param_state": {
+          "summary": "invalid_param（状態）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Segment is indexing, please try again later"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/400/description",
+      "source_sha256": "4a4859fd64e6c64e79fa85d33b8af526fd32bce4fb9dd7261f86b041c53f99a9",
+      "value": "- `provider_not_initialize`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param`：チャンクがインデックス中または無効化されているため更新できません。またはインデックス設定が無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/summary",
+      "source_sha256": "c15be4cec0361c2ad81b2dd5a2b01b42d73e34372163453132741156880aeb9e",
+      "value": "ドキュメント内のチャンクを更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "チャンク",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/chunks/update-chunk",
+        "metadata": {
+          "title": "ドキュメント内のチャンクを更新",
+          "sidebarTitle": "ドキュメント内のチャンクを更新"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/description",
+      "source_sha256": "a2a17a68564cdf9ee4a9fb46e0b53445d6c03c014a11d22618ba37c308a07061",
+      "value": "特定の親チャンク配下の子チャンクのページネーションリストを返します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/operationId",
+      "source_sha256": "0f1b8478365258c16c251586d888c7682921f1552e7a7e32b6f78e56a48e4778",
+      "value": "getChildChunks"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/2/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/3/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "検索キーワードです。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/3",
+      "context_sha256": "4c19ed6189abc1d3b555cee9488bc12c1308ff8769f72729805198c8d1451923"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/3/schema/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "検索キーワードです。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/3",
+      "context_sha256": "4c19ed6189abc1d3b555cee9488bc12c1308ff8769f72729805198c8d1451923"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/4/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/4",
+      "context_sha256": "d91843f5442902d84910396ce711ce7f4852175631599c1c4d2b72262307bcb6"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/4/schema/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/4",
+      "context_sha256": "d91843f5442902d84910396ce711ce7f4852175631599c1c4d2b72262307bcb6"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/5/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/5",
+      "context_sha256": "940c6bab5bcb50752c3da3dec2188cc938793db83499f905113f2da64a771d24"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/5/schema/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "取得するページ番号。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/5",
+      "context_sha256": "940c6bab5bcb50752c3da3dec2188cc938793db83499f905113f2da64a771d24"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": [
+              {
+                "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+                "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                "content": "Dify はオープンソースのプラットフォームです。",
+                "position": 1,
+                "word_count": 6,
+                "type": "customized",
+                "created_at": 1741267200,
+                "updated_at": 1741267200
+              }
+            ],
+            "total": 1,
+            "total_pages": 1,
+            "page": 1,
+            "limit": 20
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/200/description",
+      "source_sha256": "f2fe105ad2b2ef0a8d94b010ab055e9c360fb070adb87189128297de8878ecf1",
+      "value": "子チャンクのリストです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/summary",
+      "source_sha256": "312ced1f585fb66af96701b281920eb208e92a3aec1bc39bd9ba57ca0532c022",
+      "value": "子チャンク一覧を取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "チャンク",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/chunks/list-child-chunks",
+        "metadata": {
+          "title": "子チャンク一覧を取得",
+          "sidebarTitle": "子チャンク一覧を取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/description",
+      "source_sha256": "009ccce37862657fdf8dfea5f92b2bec5032db663826b5f227e79c765a39dae3",
+      "value": "親チャンクの下に子チャンクを作成します。親子（`hierarchical_model`）チャンキングモードを使用するドキュメント向けです。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/operationId",
+      "source_sha256": "36f2c254b8a3ca28e2c558bac6bd61b8ce652303a00750f331129fd54edbb993",
+      "value": "createChildChunk"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/2/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": {
+              "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+              "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "content": "Dify はオープンソースのプラットフォームです。",
+              "position": 1,
+              "word_count": 6,
+              "type": "customized",
+              "created_at": 1741267200,
+              "updated_at": 1741267200
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/200/description",
+      "source_sha256": "3693c1c8711d3a6b6594dbaf4d38650eb27740293f86f35d71b4b63f2c0a4c22",
+      "value": "子チャンクが正常に作成されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Vector store operation failed: [Errno 111] Connection refused"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/400/description",
+      "source_sha256": "b68da3885cf796bb1cf4e80eda6aa2707c388047e6ac0d05c8085cea34fe9274",
+      "value": "- `provider_not_initialize`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param`：ベクトルストアでの子チャンクのインデックス作成に失敗しました。メッセージにはベクトルストアの元のエラーが含まれます。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（プランのアップグレードが必要）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "この機能を利用するには、有料プランへアップグレードしてください。"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden`：この機能を利用するには、有料プランへアップグレードしてください。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/summary",
+      "source_sha256": "e4a80146ef8dea86044b31e8477ee145c6756e6bfad9af0f63c49e989d0970f9",
+      "value": "子チャンクを作成"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "チャンク",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/chunks/create-child-chunk",
+        "metadata": {
+          "title": "子チャンクを作成",
+          "sidebarTitle": "子チャンクを作成"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/description",
+      "source_sha256": "b3d6fa9fcf8a189ca4191f14f39c5f3230ea83de280ee33fdd1e907d7dd881b6",
+      "value": "親チャンクから子チャンクを完全に削除します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/operationId",
+      "source_sha256": "e9894030ed72eb89e8cb25ed03bec0d9fcf451267cb26406b8cb5155b52a84e5",
+      "value": "deleteChildChunk"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "[子チャンクを一覧表示](/ja/api-reference/chunks/list-child-chunks) が返す `data[].id` の子チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0/schema/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "[子チャンクを一覧表示](/ja/api-reference/chunks/list-child-chunks) が返す `data[].id` の子チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/1/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/2/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/2",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/2/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/2",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/3/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/3",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/3/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/3",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Vector store operation failed: [Errno 111] Connection refused"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/400/description",
+      "source_sha256": "b0a4f10acc3ebbda7648f288ebce4c2f99ab7680d85dc75fef58c021f5fc65b3",
+      "value": "`invalid_param`：ベクトルストアからの子チャンクインデックスの削除に失敗しました。メッセージにはベクトルストアの元のエラーが含まれます。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（プランのアップグレードが必要）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "この機能を利用するには、有料プランへアップグレードしてください。"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden`：この機能を利用するには、有料プランへアップグレードしてください。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        },
+        "not_found_4": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Child chunk not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/404/description",
+      "source_sha256": "0f8aec0a06e9610ce0eb1948cf91c1ac8dad5fc73e67d2515ab8dd4c5ba1a5fc",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。\n- `not_found`：子チャンクが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/summary",
+      "source_sha256": "0687ba8cb41058bd64687e7d0b1327892ab89a3e2ee193bcffad8a305f58ae7c",
+      "value": "子チャンクを削除"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "チャンク",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/x-mint",
+      "value": {
+        "href": "/ja/api-reference/chunks/delete-child-chunk",
+        "metadata": {
+          "title": "子チャンクを削除",
+          "sidebarTitle": "子チャンクを削除"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/description",
+      "source_sha256": "c3bf735834bdd01308334fcff18a7afc3e13f0d00c3f54c65e5b86978e96805c",
+      "value": "既存の子チャンクのコンテンツを更新します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/operationId",
+      "source_sha256": "74580a3eae200d7bf42f4fa7a18a92ceb9ff692b97b97e538a9ddf8f21a48da4",
+      "value": "updateChildChunk"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "[子チャンクを一覧表示](/ja/api-reference/chunks/list-child-chunks) が返す `data[].id` の子チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0/schema/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "[子チャンクを一覧表示](/ja/api-reference/chunks/list-child-chunks) が返す `data[].id` の子チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/1/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/2/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/2",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/2/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/2",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/3/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/3",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/3/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "チャンク ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/3",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": {
+              "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+              "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "content": "Dify はオープンソースのプラットフォームです。",
+              "position": 1,
+              "word_count": 6,
+              "type": "customized",
+              "created_at": 1741267200,
+              "updated_at": 1741267200
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/200/description",
+      "source_sha256": "b8afe5664382d136acff908ea897cb057e39aa58a53484a0c746d481aa65466e",
+      "value": "子チャンクが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Vector store operation failed: [Errno 111] Connection refused"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/400/description",
+      "source_sha256": "c135ee91eab6b090a8faedc3bc08b6215da3a0a5469a5baede6a71c557e7ce49",
+      "value": "`invalid_param`：ベクトルストアでの子チャンクの再インデックスに失敗しました。メッセージにはベクトルストアの元のエラーが含まれます。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（プランのアップグレードが必要）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "この機能を利用するには、有料プランへアップグレードしてください。"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden`：この機能を利用するには、有料プランへアップグレードしてください。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        },
+        "not_found_4": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Child chunk not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/404/description",
+      "source_sha256": "0f8aec0a06e9610ce0eb1948cf91c1ac8dad5fc73e67d2515ab8dd4c5ba1a5fc",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。\n- `not_found`：子チャンクが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/summary",
+      "source_sha256": "2ed9ea253e3d439a216edecbe07624280c97fe2a4df2a74d8b7e1c17a980d9b6",
+      "value": "子チャンクを更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "チャンク",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/x-mint",
+      "value": {
+        "href": "/ja/api-reference/chunks/update-child-chunk",
+        "metadata": {
+          "title": "子チャンクを更新",
+          "sidebarTitle": "子チャンクを更新"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/description",
+      "source_sha256": "76af9a461be7fa6b11b91f204a7691e31b9e256760a10232e79fec948ad06751",
+      "value": "非推奨のファイル更新ルートです。`file` で元ファイルを置き換え、`data` で処理設定を変更できます。両方の指定も可能です。`file` を省略すると、指定した設定または現在の設定で既存の元ファイルを再処理します。空の multipart リクエストでは現在の設定で再インデックスします。[ドキュメントを更新](/ja/api-reference/documents/update-document)を使用してください。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/operationId",
+      "source_sha256": "e006eb72f006d16927252ae8ae345867056a538e01ba906f52f14d5ed473fd6d",
+      "value": "updateDocumentByFile"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "9a55a691d8c3e1fa35fa97643ae718f7c770b58e29258bbbedb3ba1b046597a9",
+      "value": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "c3ecc43b937e9c81b6f6591d46eb7fb325ddc2af0207e748bdc83f5f7a30e4ab",
+      "value": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/200/description",
+      "source_sha256": "16662764860b1e0ddf01c5e676e787076fb8b5dbd4d0fea1be7dc44670a4bff0",
+      "value": "ドキュメントが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param（利用不可）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/400/description",
+      "source_sha256": "533998490d38cd2cd57cc910a88ff38c4b5b8ea95add88c0e4404959f3417cb4",
+      "value": "- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：ファイルサイズが上限を超えています。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/415/description",
+      "source_sha256": "3ce1812190ffa7ff82290341eeee927bbc176af9b1a3673fbe9a48cb95ea127d",
+      "value": "`unsupported_file_type`：許可されていないファイルタイプです。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/summary",
+      "source_sha256": "6f35a637dbb78c62105d71d60424b6d01ea7629747bd579ba157ffd1ce397402",
+      "value": "ファイルでドキュメントを更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/update-document-by-file",
+        "metadata": {
+          "title": "ファイルでドキュメントを更新",
+          "sidebarTitle": "ファイルでドキュメントを更新"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/description",
+      "source_sha256": "a1dbb8871afd5bd406a3a82f7e92f93d767bc19e1109c5a919d3afafceb87e9d",
+      "value": "ドキュメントのテキスト内容、名前、または処理設定を更新します。テキストが変更されると、ドキュメントを再インデックスします。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/operationId",
+      "source_sha256": "917201fe134585d58cc41bb0c91376351cfd3a8df5db20fa35d4144e31c38854",
+      "value": "updateDocumentByText"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/200/description",
+      "source_sha256": "16662764860b1e0ddf01c5e676e787076fb8b5dbd4d0fea1be7dc44670a4bff0",
+      "value": "ドキュメントが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_name": {
+          "summary": "invalid_param（名前が必要）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "name is required when text is provided."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param（利用不可）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/400/description",
+      "source_sha256": "cb5c257c217d8f1f52cca70e8322d37a91a023d0e83cede660742c6b2355e402",
+      "value": "- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：`text` を指定する場合は `name` が必須です。または `doc_form` が無効です。\n- `invalid_param`：ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/summary",
+      "source_sha256": "b9c5f2ecf1e7fb0d882c104b61e6f2bdf1b5e9dfbe2fe765ce0fe9b41dca55b6",
+      "value": "テキストでドキュメントを更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/documents/update-document-by-text",
+        "metadata": {
+          "title": "テキストでドキュメントを更新",
+          "sidebarTitle": "テキストでドキュメントを更新"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/description",
+      "source_sha256": "76af9a461be7fa6b11b91f204a7691e31b9e256760a10232e79fec948ad06751",
+      "value": "非推奨のファイル更新ルートです。`file` で元ファイルを置き換え、`data` で処理設定を変更できます。両方の指定も可能です。`file` を省略すると、指定した設定または現在の設定で既存の元ファイルを再処理します。空の multipart リクエストでは現在の設定で再インデックスします。[ドキュメントを更新](/ja/api-reference/documents/update-document)を使用してください。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "9a55a691d8c3e1fa35fa97643ae718f7c770b58e29258bbbedb3ba1b046597a9",
+      "value": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "c3ecc43b937e9c81b6f6591d46eb7fb325ddc2af0207e748bdc83f5f7a30e4ab",
+      "value": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/200/description",
+      "source_sha256": "16662764860b1e0ddf01c5e676e787076fb8b5dbd4d0fea1be7dc44670a4bff0",
+      "value": "ドキュメントが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param（利用不可）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/400/description",
+      "source_sha256": "533998490d38cd2cd57cc910a88ff38c4b5b8ea95add88c0e4404959f3417cb4",
+      "value": "- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：ファイルサイズが上限を超えています。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/415/description",
+      "source_sha256": "3ce1812190ffa7ff82290341eeee927bbc176af9b1a3673fbe9a48cb95ea127d",
+      "value": "`unsupported_file_type`：許可されていないファイルタイプです。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/summary",
+      "source_sha256": "6f35a637dbb78c62105d71d60424b6d01ea7629747bd579ba157ffd1ce397402",
+      "value": "ファイルでドキュメントを更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/description",
+      "source_sha256": "805859b25c965fd06914de3e232504d9bbfbaf416fdd82ed99dbc2709d16ce50",
+      "value": "非推奨の互換エンドポイントです。ドキュメントのテキスト内容、名前、または処理設定を更新します。テキストが変更されると、ドキュメントを再インデックスします。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "ドキュメント ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/200/description",
+      "source_sha256": "60c97252fe7fe0895d4b925c08232e452fddc660a602c5f262a33da8a24fea73",
+      "value": "ドキュメントが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（ベクトル容量制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/summary",
+      "value": "テキストでドキュメントを更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/tags/0",
+      "source_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186",
+      "value": "ドキュメント",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/tags/0",
+      "context_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/description",
+      "source_sha256": "1b6a273471cefc413566b4ead87134a3c84acb495bb3ede249151f78d4f0a928",
+      "value": "非推奨の互換エンドポイントです。ナレッジベースを検索し、クエリに最も関連性の高いチャンクを返します。本番環境の検索とテスト検索の両方に使用できます。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "query": {
+              "content": "Dify とは何ですか？"
+            },
+            "records": [
+              {
+                "segment": {
+                  "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                  "position": 1,
+                  "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                  "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
+                  "sign_content": "",
+                  "answer": "",
+                  "word_count": 9,
+                  "tokens": 12,
+                  "keywords": [
+                    "dify",
+                    "platform",
+                    "llm"
+                  ],
+                  "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                  "index_node_hash": "abc123def456",
+                  "hit_count": 1,
+                  "enabled": true,
+                  "disabled_at": null,
+                  "disabled_by": null,
+                  "status": "completed",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200,
+                  "indexing_at": 1741267200,
+                  "completed_at": 1741267200,
+                  "error": null,
+                  "stopped_at": null,
+                  "document": {
+                    "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                    "data_source_type": "upload_file",
+                    "name": "guide.txt",
+                    "doc_type": null,
+                    "doc_metadata": null
+                  }
+                },
+                "child_chunks": [],
+                "score": 0.92,
+                "tsne_position": null,
+                "files": [],
+                "summary": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/200/description",
+      "source_sha256": "72cfd432d9024789aaaf04552ae7d8f665081ee8b8203b24a46f5c3f476e12c4",
+      "value": "検索結果です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/400/content/application~1json/examples",
+      "value": {
+        "dataset_not_initialized": {
+          "summary": "dataset_not_initialized",
+          "value": {
+            "status": 400,
+            "code": "dataset_not_initialized",
+            "message": "The dataset is still being initialized or indexing. Please wait a moment."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "provider_quota_exceeded": {
+          "summary": "provider_quota_exceeded",
+          "value": {
+            "status": 400,
+            "code": "provider_quota_exceeded",
+            "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+          }
+        },
+        "model_currently_not_support": {
+          "summary": "model_currently_not_support",
+          "value": {
+            "status": 400,
+            "code": "model_currently_not_support",
+            "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+          }
+        },
+        "completion_request_error": {
+          "summary": "completion_request_error",
+          "value": {
+            "status": 400,
+            "code": "completion_request_error",
+            "message": "Completion request failed."
+          }
+        },
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Invalid parameter value."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/400/description",
+      "source_sha256": "ce76176880f616918d6c7b20b977018e5f26e8c2adc19c1802021b9d67eb68cc",
+      "value": "- `dataset_not_initialized`：ナレッジベースはまだ初期化中またはインデキシング中です。\n- `provider_not_initialize`：モデルプロバイダーに有効な認証情報が設定されていません。\n- `provider_quota_exceeded`：Dify がホストするモデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support`：選択したモデルは現在サポートされていません。\n- `completion_request_error`：モデルへのリクエストに失敗しました。\n- `invalid_param`：リクエストパラメータが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/500/content/application~1json/examples",
+      "value": {
+        "internal_server_error": {
+          "summary": "internal_server_error",
+          "value": {
+            "status": 500,
+            "code": "internal_server_error",
+            "message": "An internal error occurred."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/500/description",
+      "source_sha256": "7ff0985ae16b809bfe60dcabf89c0a9c1cb26eb5094b1a42c7ca1383a98415f7",
+      "value": "`internal_server_error`：検索中に内部エラーが発生しました。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/summary",
+      "source_sha256": "87e8c189e7515f3b05e873bccc1b31e6ec5fe835993b2ee9a505844da544adbe",
+      "value": "ナレッジベースからチャンクを取得 / テスト検索"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "ナレッジベース",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/description",
+      "source_sha256": "33788921af25e665982d40a0341ca680d594f974489419ca3c7d556ca426ed6e",
+      "value": "ナレッジベースのすべてのメタデータフィールド（カスタムと組み込みの両方）を、各フィールドを使用しているドキュメント数とともに返します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/operationId",
+      "source_sha256": "5e365a51b777f5a50df02e5a679f81677cbe2708c2badd0385befcb32ee24b4d",
+      "value": "listMetadataFields"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "doc_metadata": [
+              {
+                "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+                "name": "author",
+                "type": "string",
+                "count": 3
+              }
+            ],
+            "built_in_field_enabled": true
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/200/description",
+      "source_sha256": "ba7c1f3f8ce269fb27b00ca968e87878daaf1c89f5699d8aa4debc5b040e4e60",
+      "value": "ナレッジベースのメタデータフィールドです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found`：ナレッジベースが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/summary",
+      "source_sha256": "e2a58827df2435c7defdf6d4ef3f7960ce05a5aff67ca731a203893287d22799",
+      "value": "メタデータフィールドリストを取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "メタデータ",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/get/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/metadata/list-metadata-fields",
+        "metadata": {
+          "title": "メタデータフィールドリストを取得",
+          "sidebarTitle": "メタデータフィールドリストを取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/description",
+      "source_sha256": "0dd0ea8732c98ed5d3a3badd1f2f9bd8f2cb57f863c4c9b45c8a4b76ac5a03b9",
+      "value": "ナレッジベース内のドキュメントを構造化情報でアノテーションするための、カスタムメタデータフィールドを作成します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/operationId",
+      "source_sha256": "1b81f8a0bb0dd05a33889880caa3e41661cb38ca78688207f398c0de2babad6a",
+      "value": "createMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/201/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+            "name": "author",
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/201/description",
+      "source_sha256": "52ea81184bc40f3e35601bbb17532d400e4d4ac8f71be00d3ea9293a6eab5a40",
+      "value": "メタデータフィールドが正常に作成されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Metadata name already exists."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/400/description",
+      "source_sha256": "6618a59cf2b130264f25a3c6d5352c17f1fdc63d689f9df5cf1c1313d4d4364e",
+      "value": "`invalid_param`：メタデータ名が既に存在する、255 文字を超えている、または組み込みフィールドと競合しています。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found`：ナレッジベースが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/summary",
+      "source_sha256": "da5154d1fca1b54fc4a9fa8928c2c56e66b54db0d2593735f8336c0c6af9811d",
+      "value": "メタデータフィールドを作成"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "メタデータ",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/post/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/metadata/create-metadata-field",
+        "metadata": {
+          "title": "メタデータフィールドを作成",
+          "sidebarTitle": "メタデータフィールドを作成"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/description",
+      "source_sha256": "79876621503885ff3ce16d66a89bfd775932a7417299c054f71da517745d1790",
+      "value": "システムが提供する組み込みメタデータフィールドを返します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/operationId",
+      "source_sha256": "0ebc461f5dc80515e5865bde6627ce671ce93022a96fdd3354891a986deac0ba",
+      "value": "getBuiltInMetadataFields"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "fields": [
+              {
+                "name": "document_name",
+                "type": "string"
+              },
+              {
+                "name": "uploader",
+                "type": "string"
+              },
+              {
+                "name": "upload_date",
+                "type": "time"
+              },
+              {
+                "name": "last_update_date",
+                "type": "time"
+              },
+              {
+                "name": "source",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/200/description",
+      "source_sha256": "66ca26a2c3f8597dee10b0bf3226c1b865b3ffd646cf13f5405b5f140fd8a5cf",
+      "value": "組み込みメタデータフィールドです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/summary",
+      "source_sha256": "8d069313bb79848c6914f29163ea56afdd6667982ecb6720c054f9a4480e3971",
+      "value": "組み込みメタデータフィールドを取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "メタデータ",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/metadata/get-built-in-metadata-fields",
+        "metadata": {
+          "title": "組み込みメタデータフィールドを取得",
+          "sidebarTitle": "組み込みメタデータフィールドを取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/description",
+      "source_sha256": "5b47d6c5a23f9bb9e342aaedd716fce8cb872538976e688a323d15841eccffd3",
+      "value": "ナレッジベースの組み込みメタデータフィールドを有効または無効にします。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/operationId",
+      "source_sha256": "10ed165dc04c5ed77fe191c8449d1bbe798ae7bfccc6078c1f5fc38471b87f70",
+      "value": "toggleBuiltInMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/0/description",
+      "source_sha256": "1dd3f3055e8d762d30ec9aab34e699bcf05414f6a58aad415b2815f38ea62b1d",
+      "value": "`enable` で内蔵メタデータフィールドを有効化、`disable` で無効化します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/0",
+      "context_sha256": "ad4b96dc1585b0b6e78eb02ace0b893e9eff37da8362f8dd347e147652246557"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/0/schema/description",
+      "source_sha256": "1dd3f3055e8d762d30ec9aab34e699bcf05414f6a58aad415b2815f38ea62b1d",
+      "value": "`enable` で内蔵メタデータフィールドを有効化、`disable` で無効化します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/0",
+      "context_sha256": "ad4b96dc1585b0b6e78eb02ace0b893e9eff37da8362f8dd347e147652246557"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/1/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "result": "success"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/200/description",
+      "source_sha256": "cd5d4d9feacf7cf84e4ecf4cdd7226bde00e0accbbc8476462084e1db7bfc726",
+      "value": "組み込みメタデータフィールドの切り替えに成功しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found`：ナレッジベースが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/summary",
+      "source_sha256": "91d7cbb4a9b63f9418c32b9744442662d546f4619b8380d12b9707728cce64d2",
+      "value": "組み込みメタデータフィールドを更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "メタデータ",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/metadata/update-built-in-metadata-field",
+        "metadata": {
+          "title": "組み込みメタデータフィールドを更新",
+          "sidebarTitle": "組み込みメタデータフィールドを更新"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/description",
+      "source_sha256": "889cb7e9f96e1d067ed27f09a1f58215da9fda5058e7c0506e6a7b454da03b22",
+      "value": "カスタムメタデータフィールドを完全に削除します。このフィールドを使用していたドキュメントは、それに対応する値を失います。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/operationId",
+      "source_sha256": "587d3c959a22832a86facf279c9fe7aa5258d9050a18bb85c4385b09bb36f46f",
+      "value": "deleteMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/1/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "削除するメタデータフィールドの ID です。[メタデータフィールドリストを取得](/ja/api-reference/metadata/list-metadata-fields) を参照してください。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/1",
+      "context_sha256": "56828aa53cb580a85fc937f42ff1b232eda74b7c159588e499001cb1afb90e97"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/1/schema/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "メタデータフィールド ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/1",
+      "context_sha256": "56828aa53cb580a85fc937f42ff1b232eda74b7c159588e499001cb1afb90e97"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/404/description",
+      "source_sha256": "f9344bbe04212d738ce1ad681c593cd2fec6aca518dba6acefb60439467ddef9",
+      "value": "- `not_found`：ナレッジベースが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/summary",
+      "source_sha256": "7572a80455fc5f4bc21e259970f515c0fc637edab79302fd28f7688749370eef",
+      "value": "メタデータフィールドを削除"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "メタデータ",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/x-mint",
+      "value": {
+        "href": "/ja/api-reference/metadata/delete-metadata-field",
+        "metadata": {
+          "title": "メタデータフィールドを削除",
+          "sidebarTitle": "メタデータフィールドを削除"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/description",
+      "source_sha256": "5100d9c6a30b663ee91ff3b754d9424d8b1987b20828443ed73d104fef95f98d",
+      "value": "カスタムメタデータフィールドの名前を変更します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/operationId",
+      "source_sha256": "13589e3a8b1e25e4b2b4131bf3e289e13fe78a6e74e14a7cf2ade74a8bf3e26c",
+      "value": "updateMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/1/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "名前を変更するメタデータフィールドの ID です。[メタデータフィールドリストを取得](/ja/api-reference/metadata/list-metadata-fields) を参照してください。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/1",
+      "context_sha256": "56828aa53cb580a85fc937f42ff1b232eda74b7c159588e499001cb1afb90e97"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/1/schema/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "メタデータフィールド ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/1",
+      "context_sha256": "56828aa53cb580a85fc937f42ff1b232eda74b7c159588e499001cb1afb90e97"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+            "name": "author",
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/200/description",
+      "source_sha256": "da787a9ca2f96fb3d99c39ea5671cb4f8687bf3a0a2b54273e117daf91e53a9a",
+      "value": "メタデータフィールドが正常に更新されました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Metadata name already exists."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/400/description",
+      "source_sha256": "6618a59cf2b130264f25a3c6d5352c17f1fdc63d689f9df5cf1c1313d4d4364e",
+      "value": "`invalid_param`：メタデータ名が既に存在する、255 文字を超えている、または組み込みフィールドと競合しています。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/404/description",
+      "source_sha256": "f9344bbe04212d738ce1ad681c593cd2fec6aca518dba6acefb60439467ddef9",
+      "value": "- `not_found`：ナレッジベースが見つかりません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/summary",
+      "source_sha256": "2dde97c499bf61a191a64cad37045c22b551a034fcc9214599fd5c850037d1bd",
+      "value": "メタデータフィールドを更新"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "メタデータ",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/x-mint",
+      "value": {
+        "href": "/ja/api-reference/metadata/update-metadata-field",
+        "metadata": {
+          "title": "メタデータフィールドを更新",
+          "sidebarTitle": "メタデータフィールドを更新"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/description",
+      "source_sha256": "feb4ac9b0ae2f85182d1ee6a54ca594baed433b611429620dfd78fa6365953e3",
+      "value": "ナレッジパイプラインに設定されたデータソースノードを、それぞれが使用するプラグインとノードの実行に必要なメタデータとともに返します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/operationId",
+      "source_sha256": "f990d17656951c7129d79f0d5d2e4080ff2591e79d94e24bc373ae5a4402cc6d",
+      "value": "listDatasourcePlugins"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/1/description",
+      "source_sha256": "5c48d3437a279f6bd9bde8071f0c9482a5fc24366e0d244247f80f4d668dc02d",
+      "value": "公開済みまたはドラフトのナレッジパイプラインからノードを取得するかどうか。`true` は公開済みバージョン、`false` はドラフトのノードを返します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/1",
+      "context_sha256": "4c3aff055f9619794ea483a8b387e4fda4079e664eb04368f67b9493ea8be1bd"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/1/schema/description",
+      "source_sha256": "5c48d3437a279f6bd9bde8071f0c9482a5fc24366e0d244247f80f4d668dc02d",
+      "value": "公開済みまたはドラフトのナレッジパイプラインからノードを取得するかどうか。`true` は公開済みバージョン、`false` はドラフトのノードを返します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/1",
+      "context_sha256": "4c3aff055f9619794ea483a8b387e4fda4079e664eb04368f67b9493ea8be1bd"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": [
+            {
+              "node_id": "1719288585006",
+              "plugin_id": "langgenius/notion_datasource",
+              "provider_name": "notion",
+              "datasource_type": "online_document",
+              "title": "Notion ドキュメント",
+              "user_input_variables": [],
+              "credentials": [
+                {
+                  "id": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
+                  "name": "本番環境の Notion",
+                  "type": "api-key",
+                  "is_default": true
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/200/description",
+      "source_sha256": "7c3bea87e57a887b4b18fb38f1d03521a3d01fb391bfacecff3395ad14ead7bd",
+      "value": "パイプラインに設定されているデータソースノードのリストです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Pipeline not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/400/description",
+      "source_sha256": "db2230c4a1d91554b104c3ffdff8b7f3c502d3cf1a33ea3af97f922ed40b4bf9",
+      "value": "`invalid_param`：このナレッジベースには処理パイプラインが設定されていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/summary",
+      "source_sha256": "4d0e7142c4d6897e49dc27247872d389f612ad12b565369307ce4943b646eba7",
+      "value": "データソースプラグインリストを取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/tags/0",
+      "source_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a",
+      "value": "ナレッジパイプライン",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/tags/0",
+      "context_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/knowledge-pipeline/list-datasource-plugins",
+        "metadata": {
+          "title": "データソースプラグインリストを取得",
+          "sidebarTitle": "データソースプラグインリストを取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/description",
+      "source_sha256": "13d3e5d7adcd75ac7332e0d629682a2ca35b4b67e912b0960ee2c303d5805e8b",
+      "value": "ナレッジパイプライン内の単一のデータソースノードを実行し、その実行イベントをストリーミングします。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/operationId",
+      "source_sha256": "7f25eec20a543dee68717bb411edb791dd707832a104c288918fd1589af2dd80",
+      "value": "runDatasourceNode"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/1/description",
+      "source_sha256": "a23fb9cd48d79a47e5d934fd913a0bdd0bc370ff0e607a088b913b10245fd367",
+      "value": "実行するデータソースノードの ID です。[データソースプラグインリストを取得](/ja/api-reference/knowledge-pipeline/list-datasource-plugins) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/1",
+      "context_sha256": "917ec31080f646f2c485bf333dcf0ed42526aacdc1ffb11e011998b1c255c715"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/1/schema/description",
+      "source_sha256": "a23fb9cd48d79a47e5d934fd913a0bdd0bc370ff0e607a088b913b10245fd367",
+      "value": "実行するデータソースノード ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/1",
+      "context_sha256": "917ec31080f646f2c485bf333dcf0ed42526aacdc1ffb11e011998b1c255c715"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/200/content/text~1event-stream/examples",
+      "value": {
+        "successfulStream": {
+          "summary": "レスポンス例 - 成功したストリーム",
+          "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"データソース\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/200/content/text~1event-stream/schema/description",
+      "value": "ドラフトのナレッジパイプライン実行を配信する Server-Sent Events ストリームです。[SSE ストリーミングガイド](/ja/api-reference/guides/streaming)に従って `data:` レコードを解析してください。主なイベントは `workflow_started`、`node_started`、`node_finished`、`workflow_finished`、`error` で、ワークフローイベントストリームと同じエンベロープ形式を使用します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/200/description",
+      "source_sha256": "59ab3bf79aefdaacb4128bf3c6b006b7f5321f448fff4a39833fb3815fd70ca4",
+      "value": "ノード実行イベントを含むストリーミングレスポンスです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Pipeline not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/400/description",
+      "source_sha256": "d57c0d2e88fbc9431697aba76dcae3474a713f9f957f134bfabd3855e4b65d32",
+      "value": "`invalid_param`：このナレッジベースには処理パイプラインが設定されていない、またはリクエストボディの検証に失敗しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/summary",
+      "source_sha256": "507b3c6b167e264c8e02ab5ea68899e0a8d6c29a9d876403bc877a2f68e48c79",
+      "value": "データソースノードを実行"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/tags/0",
+      "source_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a",
+      "value": "ナレッジパイプライン",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/tags/0",
+      "context_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/knowledge-pipeline/run-datasource-node",
+        "metadata": {
+          "title": "データソースノードを実行",
+          "sidebarTitle": "データソースノードを実行"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/description",
+      "source_sha256": "faa3758b412a8ad31d89a4d1c1191f1770864268db1140c3eb54c8e87248d5fe",
+      "value": "1 つ以上のデータソースに対してナレッジパイプライン全体を実行します。公開済みの実行はキューに追加され、常にバッチメタデータを JSON で返します。ドラフトの実行では、ブロッキング JSON とストリーミング Server-Sent Events を利用できます。 公開済み実行では、返された `batch` を[ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status)に渡し、すべてのドキュメントが `completed`、`error`、または `paused` になるまでポーリングしてください。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/operationId",
+      "source_sha256": "db44679c628f777475bd972f7b36223d20c28e3cd93e58eb10d5ec69d2058d40",
+      "value": "runPipeline"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/requestBody/content/application~1json/examples",
+      "value": {
+        "local_file": {
+          "summary": "リクエスト例 - ローカルファイル",
+          "value": {
+            "inputs": {},
+            "datasource_type": "local_file",
+            "datasource_info_list": [
+              {
+                "reference": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "name": "quarterly-report.pdf"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": false,
+            "response_mode": "blocking"
+          }
+        },
+        "online_document": {
+          "summary": "リクエスト例 - オンラインドキュメント",
+          "value": {
+            "inputs": {},
+            "datasource_type": "online_document",
+            "datasource_info_list": [
+              {
+                "workspace_id": "ws-abc123",
+                "page": {
+                  "page_id": "pg-def456",
+                  "type": "page",
+                  "page_name": "製品ロードマップ"
+                },
+                "credential_id": "cred-789xyz"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": false,
+            "response_mode": "streaming"
+          }
+        },
+        "website_crawl": {
+          "summary": "リクエスト例 - ウェブサイトクロール",
+          "value": {
+            "inputs": {},
+            "datasource_type": "website_crawl",
+            "datasource_info_list": [
+              {
+                "url": "https://example.com/docs/getting-started",
+                "title": "はじめにガイド"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": true,
+            "response_mode": "blocking"
+          }
+        },
+        "online_drive": {
+          "summary": "リクエスト例 - オンラインドライブ",
+          "value": {
+            "inputs": {},
+            "datasource_type": "online_drive",
+            "datasource_info_list": [
+              {
+                "id": "file-abc123",
+                "type": "file",
+                "bucket": "my-bucket",
+                "name": "meeting-notes.docx"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": true,
+            "response_mode": "blocking"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/application~1json/examples",
+      "value": {
+        "published": {
+          "summary": "公開済みパイプラインのレスポンス",
+          "value": {
+            "batch": "20260825143015948271",
+            "dataset": {
+              "id": "c9f5e6f0-d10a-4f57-a1d8-a4b63f8459f4",
+              "name": "製品ドキュメント",
+              "description": "製品の説明資料",
+              "chunk_structure": "text_model"
+            },
+            "documents": [
+              {
+                "id": "9af03c49-30c4-4d64-a605-17f3171fbf9a",
+                "position": 1,
+                "data_source_type": "local_file",
+                "data_source_info": {
+                  "reference": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "quarterly-report.pdf"
+                },
+                "name": "quarterly-report.pdf",
+                "indexing_status": "waiting",
+                "error": null,
+                "enabled": true
+              }
+            ]
+          }
+        },
+        "draft_blocking": {
+          "summary": "ドラフトのブロッキングレスポンス",
+          "value": {
+            "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "workflow_run_id": "f1e2d3c4-b5a6-7890-abcd-ef0987654321",
+            "data": {
+              "id": "f1e2d3c4-b5a6-7890-abcd-ef0987654321",
+              "status": "succeeded",
+              "outputs": {},
+              "created_at": 1741267200,
+              "finished_at": 1741267210,
+              "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+              "error": null,
+              "elapsed_time": 10.0,
+              "total_tokens": 0,
+              "total_steps": 1
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/application~1json/schema/description",
+      "value": "公開済み実行の JSON 結果、またはドラフト実行を `blocking` モードで実行した場合の JSON 結果です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/text~1event-stream/examples",
+      "value": {
+        "successfulStream": {
+          "summary": "レスポンス例 - 成功したストリーム",
+          "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"データソース\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/text~1event-stream/schema/description",
+      "value": "ドラフトのナレッジパイプライン実行を配信する Server-Sent Events ストリームです。[SSE ストリーミングガイド](/ja/api-reference/guides/streaming)に従って `data:` レコードを解析してください。主なイベントは `workflow_started`、`node_started`、`node_finished`、`workflow_finished`、`error` で、ワークフローイベントストリームと同じエンベロープ形式を使用します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/description",
+      "source_sha256": "45761354a7ce3733550c7edbcc2dbe40b681b7a44ba567081d5dd69228cdb15f",
+      "value": "パイプラインの実行結果。公開済みの実行はキューに追加されたバッチメタデータを JSON で返します。ドラフトの実行は、`streaming` モードでは Server-Sent Events、`blocking` モードではワークフロー結果を JSON で返します。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Pipeline not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/400/description",
+      "source_sha256": "d57c0d2e88fbc9431697aba76dcae3474a713f9f957f134bfabd3855e4b65d32",
+      "value": "`invalid_param`：このナレッジベースには処理パイプラインが設定されていない、またはリクエストボディの検証に失敗しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/403/description",
+      "source_sha256": "ab52983735f79a161ccb282f9eed5a5f20c2d5d1615e465886b14a9ebf6b8c16",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/500/content/application~1json/examples",
+      "value": {
+        "pipeline_run_error": {
+          "summary": "pipeline_run_error",
+          "value": {
+            "status": 500,
+            "code": "pipeline_run_error",
+            "message": "Pipeline execution failed: connection timeout"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/500/description",
+      "source_sha256": "16f4ac1f65da72ed06b3ecd39d2313d5fbc81febec85e4d94e3877a21b8b3692",
+      "value": "`pipeline_run_error`：パイプライン実行に失敗しました。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/summary",
+      "source_sha256": "6194c9c4272379e2430ee7f679d5c73d203011bb9333a078c7b0b294a7a501df",
+      "value": "パイプラインを実行"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/tags/0",
+      "source_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a",
+      "value": "ナレッジパイプライン",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/tags/0",
+      "context_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/knowledge-pipeline/run-pipeline",
+        "metadata": {
+          "title": "パイプラインを実行",
+          "sidebarTitle": "パイプラインを実行"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/description",
+      "source_sha256": "1b6a273471cefc413566b4ead87134a3c84acb495bb3ede249151f78d4f0a928",
+      "value": "ナレッジベースを検索し、クエリに最も関連性の高いチャンクを返します。本番環境の検索とテスト検索の両方に使用できます。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/operationId",
+      "source_sha256": "19ff09ba426482984392455ff84146de3c6422362f175e8969078ad93da31581",
+      "value": "retrieveSegments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "query": {
+              "content": "Dify とは何ですか？"
+            },
+            "records": [
+              {
+                "segment": {
+                  "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                  "position": 1,
+                  "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                  "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
+                  "sign_content": "",
+                  "answer": "",
+                  "word_count": 9,
+                  "tokens": 12,
+                  "keywords": [
+                    "dify",
+                    "platform",
+                    "llm"
+                  ],
+                  "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                  "index_node_hash": "abc123def456",
+                  "hit_count": 1,
+                  "enabled": true,
+                  "disabled_at": null,
+                  "disabled_by": null,
+                  "status": "completed",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200,
+                  "indexing_at": 1741267200,
+                  "completed_at": 1741267200,
+                  "error": null,
+                  "stopped_at": null,
+                  "document": {
+                    "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                    "data_source_type": "upload_file",
+                    "name": "guide.txt",
+                    "doc_type": null,
+                    "doc_metadata": null
+                  }
+                },
+                "child_chunks": [],
+                "score": 0.92,
+                "tsne_position": null,
+                "files": [],
+                "summary": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/200/description",
+      "source_sha256": "72cfd432d9024789aaaf04552ae7d8f665081ee8b8203b24a46f5c3f476e12c4",
+      "value": "検索結果です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/400/content/application~1json/examples",
+      "value": {
+        "dataset_not_initialized": {
+          "summary": "dataset_not_initialized",
+          "value": {
+            "status": 400,
+            "code": "dataset_not_initialized",
+            "message": "The dataset is still being initialized or indexing. Please wait a moment."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "provider_quota_exceeded": {
+          "summary": "provider_quota_exceeded",
+          "value": {
+            "status": 400,
+            "code": "provider_quota_exceeded",
+            "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+          }
+        },
+        "model_currently_not_support": {
+          "summary": "model_currently_not_support",
+          "value": {
+            "status": 400,
+            "code": "model_currently_not_support",
+            "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+          }
+        },
+        "completion_request_error": {
+          "summary": "completion_request_error",
+          "value": {
+            "status": 400,
+            "code": "completion_request_error",
+            "message": "Completion request failed."
+          }
+        },
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Invalid parameter value."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/400/description",
+      "source_sha256": "ce76176880f616918d6c7b20b977018e5f26e8c2adc19c1802021b9d67eb68cc",
+      "value": "- `dataset_not_initialized`：ナレッジベースはまだ初期化中またはインデキシング中です。\n- `provider_not_initialize`：モデルプロバイダーに有効な認証情報が設定されていません。\n- `provider_quota_exceeded`：Dify がホストするモデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support`：選択したモデルは現在サポートされていません。\n- `completion_request_error`：モデルへのリクエストに失敗しました。\n- `invalid_param`：リクエストパラメータが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（レート制限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/500/content/application~1json/examples",
+      "value": {
+        "internal_server_error": {
+          "summary": "internal_server_error",
+          "value": {
+            "status": 500,
+            "code": "internal_server_error",
+            "message": "An internal error occurred."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/500/description",
+      "source_sha256": "7ff0985ae16b809bfe60dcabf89c0a9c1cb26eb5094b1a42c7ca1383a98415f7",
+      "value": "`internal_server_error`：検索中に内部エラーが発生しました。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/summary",
+      "source_sha256": "87e8c189e7515f3b05e873bccc1b31e6ec5fe835993b2ee9a505844da544adbe",
+      "value": "ナレッジベースからチャンクを取得 / テスト検索"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "ナレッジベース",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/x-mint",
+      "value": {
+        "href": "/ja/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
+        "metadata": {
+          "title": "ナレッジベースからチャンクを取得 / テスト検索",
+          "sidebarTitle": "ナレッジベースからチャンクを取得 / テスト検索"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/description",
+      "source_sha256": "fb2e79f72fece5c6adcee227ed40bb9e2680575510ea87ac2e07ab2173e98d07",
+      "value": "ナレッジベースにバインドされたタグを返します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/operationId",
+      "source_sha256": "37573482ef29c34a30d4d9b7ebc5ccc95aad0e566b3e5b7639f7bfdfee3cac6a",
+      "value": "queryDatasetTags"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1tags/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "ナレッジベース ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1tags/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": [
+              {
+                "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                "name": "製品ドキュメント"
+              }
+            ],
+            "total": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/200/description",
+      "source_sha256": "4eeb56724fdbffc386777edbce05a72ec0dab7cc3c68c1de428df3add001b027",
+      "value": "ナレッジベースにバインドされたタグです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API アクセス）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/summary",
+      "source_sha256": "2e65c66e51b7ebe86135ba85681ea809228785490b52390d5bd9880ec0dd1172",
+      "value": "ナレッジベースにバインドされたタグを取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "タグ管理",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1tags/get/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/tags/get-knowledge-base-tags",
+        "metadata": {
+          "title": "ナレッジベースにバインドされたタグを取得",
+          "sidebarTitle": "ナレッジベースにバインドされたタグを取得"
+        }
+      }
+    },
+    {
+      "op": "replace",
       "path": "/paths/~1end-users~1{end_user_id}/get/description",
       "source_sha256": "c71a3cc9a229bafc345728f45437806a24c9b2ef69e6b244b57384fd7c02beb9",
       "value": "**対象アプリ**：Chatflow、Workflow、新しい Agent、チャットボット、Agent、テキストジェネレーター。\n\nID を指定してエンドユーザーの詳細を返します。別のエンドポイントが返したエンドユーザー ID（例：[ファイルをアップロード](/ja/api-reference/files/upload-file) レスポンスの `created_by`）を解決するのに便利です。"
@@ -20796,6 +30771,131 @@
         "metadata": {
           "title": "ID でワークフローを実行",
           "sidebarTitle": "ID でワークフローを実行"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/description",
+      "source_sha256": "9fbc97df50241cb2eaa3aefc3016b04ef8e3d7b07ae64b47cbd14d759fd5ebaf",
+      "value": "指定したタイプの利用可能なモデルを返します。ナレッジベースに設定する `text-embedding` モデルと `rerank` モデルを見つけるために使用します。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/operationId",
+      "source_sha256": "f4ee87fe7d3529fa0dbe0937acc9f5092742b98d9ba99fe22e2bb41dd150d776",
+      "value": "getAvailableModels"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/parameters/0/description",
+      "source_sha256": "779c9a4c0c0e5098f998e71ed1fb5e41c3e47ec1e5b7f5e4e32fc226ad47454c",
+      "value": "取得するモデルの種類。",
+      "context_path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/parameters/0",
+      "context_sha256": "158387c2f9e0dd11d63064542fcf97121ba859a8904f5f82c7ee992b121fe3df"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/parameters/0/schema/description",
+      "source_sha256": "779c9a4c0c0e5098f998e71ed1fb5e41c3e47ec1e5b7f5e4e32fc226ad47454c",
+      "value": "取得するモデルの種類。",
+      "context_path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/parameters/0",
+      "context_sha256": "158387c2f9e0dd11d63064542fcf97121ba859a8904f5f82c7ee992b121fe3df"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "レスポンス例",
+          "value": {
+            "data": [
+              {
+                "provider": "langgenius/openai/openai",
+                "label": {
+                  "en_US": "OpenAI",
+                  "zh_Hans": "OpenAI"
+                },
+                "icon_small": {
+                  "en_US": "https://example.com/openai-small.svg",
+                  "zh_Hans": "https://example.com/openai-small.svg"
+                },
+                "status": "active",
+                "models": [
+                  {
+                    "model": "text-embedding-3-small",
+                    "label": {
+                      "en_US": "text-embedding-3-small",
+                      "zh_Hans": "text-embedding-3-small"
+                    },
+                    "model_type": "text-embedding",
+                    "features": null,
+                    "fetch_from": "predefined-model",
+                    "model_properties": {
+                      "context_size": 8191
+                    },
+                    "status": "active",
+                    "deprecated": false,
+                    "load_balancing_enabled": false,
+                    "has_invalid_load_balancing_configs": false
+                  }
+                ],
+                "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                "icon_small_dark": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/200/description",
+      "source_sha256": "bc82619e3afc16385018acef86e9503f2c9ec0ad504530f9e60e4583a0da51ff",
+      "value": "指定された種類で利用可能なモデルです。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/summary",
+      "source_sha256": "7046ae9d6a5c6a5c6ee968031ad256254f162665fae67ba0ca88262f6019e1c8",
+      "value": "利用可能なモデルを取得"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/tags/0",
+      "source_sha256": "527919df30e60438b9999d570aca82ff0214c59755ad69ea14a15900b5b06c26",
+      "value": "モデル",
+      "context_path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/tags/0",
+      "context_sha256": "527919df30e60438b9999d570aca82ff0214c59755ad69ea14a15900b5b06c26"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/x-mint",
+      "value": {
+        "href": "/ja/api-reference/models/get-available-models",
+        "metadata": {
+          "title": "利用可能なモデルを取得",
+          "sidebarTitle": "利用可能なモデルを取得"
         }
       }
     },

--- a/tools/api-pipeline/service_api_overlays/zh.json
+++ b/tools/api-pipeline/service_api_overlays/zh.json
@@ -17074,6 +17074,9981 @@
     },
     {
       "op": "replace",
+      "path": "/paths/~1datasets/get/description",
+      "source_sha256": "d054bda8cd30bdd4de53ea1626562d5b1b25aa37bb195f0b7ac6dc40f8f35e30",
+      "value": "返回知识库的分页列表，可按关键词或标签筛选。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/operationId",
+      "source_sha256": "ef2a1d7b12fdb9e1a485e6cd014c7a776d029245455757f45c973f1502ebc6de",
+      "value": "listDatasets"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/0/description",
+      "source_sha256": "42ec0cfe0d70ab1439e6efd97eab8ed04b3723cf7eaa967a9ea50082c82f8ecc",
+      "value": "是否包含所有知识库，无论权限如何。",
+      "context_path": "/paths/~1datasets/get/parameters/0",
+      "context_sha256": "43b4e055bc75ab202a9351452644b28f30a9df43acf9aa4c861570c664718ab5"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/0/schema/description",
+      "source_sha256": "42ec0cfe0d70ab1439e6efd97eab8ed04b3723cf7eaa967a9ea50082c82f8ecc",
+      "value": "是否包含所有知识库，无论权限如何。",
+      "context_path": "/paths/~1datasets/get/parameters/0",
+      "context_sha256": "43b4e055bc75ab202a9351452644b28f30a9df43acf9aa4c861570c664718ab5"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/1/description",
+      "source_sha256": "969b4fbf074465fa6786b80e50aa7c231966efcf3ffd4fb9907eac1eb2470a92",
+      "value": "按名称筛选的搜索关键词。",
+      "context_path": "/paths/~1datasets/get/parameters/1",
+      "context_sha256": "9acaa12b486581d63cba590823ada40cd9fd885d8e2a62a9983d6354588ea25d"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/1/schema/description",
+      "source_sha256": "969b4fbf074465fa6786b80e50aa7c231966efcf3ffd4fb9907eac1eb2470a92",
+      "value": "按名称筛选的搜索关键词。",
+      "context_path": "/paths/~1datasets/get/parameters/1",
+      "context_sha256": "9acaa12b486581d63cba590823ada40cd9fd885d8e2a62a9983d6354588ea25d"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/2/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。",
+      "context_path": "/paths/~1datasets/get/parameters/2",
+      "context_sha256": "3be071ee50409713ac99937bf5587118e5758fe840cbdf90b10c5ba5b26b2736"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/2/schema/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。",
+      "context_path": "/paths/~1datasets/get/parameters/2",
+      "context_sha256": "3be071ee50409713ac99937bf5587118e5758fe840cbdf90b10c5ba5b26b2736"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/3/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。",
+      "context_path": "/paths/~1datasets/get/parameters/3",
+      "context_sha256": "41b7d5c5e4ba2a4e4a83c7b574b112e3f35aa91988101a0aa03cd0459fb3ddbb"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/3/schema/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。",
+      "context_path": "/paths/~1datasets/get/parameters/3",
+      "context_sha256": "41b7d5c5e4ba2a4e4a83c7b574b112e3f35aa91988101a0aa03cd0459fb3ddbb"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/4/description",
+      "source_sha256": "ada725b7472603774b1855ed05b52c49914a723fea230dd88496f4f9e27efff4",
+      "value": "用于筛选的标签 ID。",
+      "context_path": "/paths/~1datasets/get/parameters/4",
+      "context_sha256": "b27b76effe7ce7480fc65aee6a14b223e116a424558569a4aa16e487c58a4da2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/parameters/4/schema/description",
+      "source_sha256": "ada725b7472603774b1855ed05b52c49914a723fea230dd88496f4f9e27efff4",
+      "value": "用于筛选的标签 ID。",
+      "context_path": "/paths/~1datasets/get/parameters/4",
+      "context_sha256": "b27b76effe7ce7480fc65aee6a14b223e116a424558569a4aa16e487c58a4da2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": [
+              {
+                "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+                "name": "产品文档",
+                "description": "产品 API 技术文档",
+                "provider": "vendor",
+                "permission": "only_me",
+                "data_source_type": null,
+                "indexing_technique": "high_quality",
+                "app_count": 0,
+                "document_count": 0,
+                "word_count": 0,
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "author_name": "admin",
+                "created_at": 1741267200,
+                "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "updated_at": 1741267200,
+                "embedding_model": "text-embedding-3-small",
+                "embedding_model_provider": "langgenius/openai/openai",
+                "embedding_available": true,
+                "retrieval_model_dict": {
+                  "search_method": "semantic_search",
+                  "reranking_enable": false,
+                  "reranking_mode": null,
+                  "reranking_model": {
+                    "reranking_provider_name": "",
+                    "reranking_model_name": ""
+                  },
+                  "weights": null,
+                  "top_k": 3,
+                  "score_threshold_enabled": false,
+                  "score_threshold": null
+                },
+                "tags": [],
+                "doc_form": "text_model",
+                "external_retrieval_model": null,
+                "doc_metadata": [],
+                "built_in_field_enabled": true,
+                "pipeline_id": null,
+                "runtime_mode": null,
+                "chunk_structure": null,
+                "is_published": false,
+                "total_documents": 0,
+                "total_available_documents": 0,
+                "enable_api": true,
+                "is_multimodal": false,
+                "maintainer": "admin"
+              }
+            ],
+            "has_more": false,
+            "limit": 20,
+            "total": 1,
+            "page": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/responses/200/description",
+      "source_sha256": "7ed6360275a2b2800d796d418ba9c3e4569db2878f4409169da3d70ce1e68aa4",
+      "value": "知识库列表。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/responses/403/content/application~1json/example",
+      "value": {
+        "code": "forbidden",
+        "message": "Forbidden.",
+        "status": 403
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "禁止访问——未启用知识库 API 或无工作区访问权限"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/summary",
+      "source_sha256": "056b42bc39595df68d6d796734d9df097a8b8ee33750de526f000968a33bb864",
+      "value": "获取知识库列表"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/get/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "知识库",
+      "context_path": "/paths/~1datasets/get/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl -X GET 'https://{api_base_url}/datasets?page=1&limit=20' \\\n  -H 'Authorization: Bearer {api_key}'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/knowledge-bases/list-knowledge-bases",
+        "metadata": {
+          "title": "获取知识库列表",
+          "sidebarTitle": "获取知识库列表"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/description",
+      "source_sha256": "97dbeecda4c597e86334a41358ddef1281827f2d43084d33d359428edcea6fc5",
+      "value": "创建一个空知识库。之后用 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 或 [从文件创建文档](/zh/api-reference/documents/create-document-by-file) 向其中添加文档。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/operationId",
+      "source_sha256": "d74b5b128e8928e710b6676be97acc183d444263d4e88d0a530a64446f901120",
+      "value": "createDataset"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+            "name": "产品文档",
+            "description": "产品 API 技术文档",
+            "provider": "vendor",
+            "permission": "only_me",
+            "data_source_type": null,
+            "indexing_technique": "high_quality",
+            "app_count": 0,
+            "document_count": 0,
+            "word_count": 0,
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "author_name": "admin",
+            "created_at": 1741267200,
+            "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "updated_at": 1741267200,
+            "embedding_model": "text-embedding-3-small",
+            "embedding_model_provider": "langgenius/openai/openai",
+            "embedding_available": true,
+            "retrieval_model_dict": {
+              "search_method": "semantic_search",
+              "reranking_enable": false,
+              "reranking_mode": null,
+              "reranking_model": {
+                "reranking_provider_name": "",
+                "reranking_model_name": ""
+              },
+              "weights": null,
+              "top_k": 3,
+              "score_threshold_enabled": false,
+              "score_threshold": null
+            },
+            "tags": [],
+            "doc_form": "text_model",
+            "external_retrieval_model": null,
+            "doc_metadata": [],
+            "built_in_field_enabled": true,
+            "pipeline_id": null,
+            "runtime_mode": null,
+            "chunk_structure": null,
+            "is_published": false,
+            "total_documents": 0,
+            "total_available_documents": 0,
+            "enable_api": true,
+            "is_multimodal": false,
+            "maintainer": "admin"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/200/description",
+      "source_sha256": "72d87a0ca72260ccc324a9dc4e83aa4532e7fe64f857bdd233b92ab6d944a2d6",
+      "value": "知识库创建成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/400/description",
+      "source_sha256": "2bfbcfde3ad246205ccd33f9e5921e27cf4a76186dc1885bf430dc6e0d6cae76",
+      "value": "`invalid_param`：指定的嵌入模型或重排序模型未配置或不可用。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/responses/409/content/application~1json/examples",
+      "value": {
+        "dataset_name_duplicate": {
+          "summary": "dataset_name_duplicate",
+          "value": {
+            "status": 409,
+            "code": "dataset_name_duplicate",
+            "message": "The dataset name already exists. Please modify your dataset name."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/responses/409/description",
+      "source_sha256": "8f9971fca91a6321a9b7ee6cf993565be331319a7ee3f85c340d258fa9bc3f88",
+      "value": "`dataset_name_duplicate`：已存在同名知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/summary",
+      "source_sha256": "a659b50aca6ef20599bfdb4287f3c8202c846f8dbb8d7b3b4cdcaca7235ed818",
+      "value": "创建空知识库"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets/post/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "知识库",
+      "context_path": "/paths/~1datasets/post/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/knowledge-bases/create-an-empty-knowledge-base",
+        "metadata": {
+          "title": "创建空知识库",
+          "sidebarTitle": "创建空知识库"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/description",
+      "source_sha256": "dfa32093fca1413e614dfc90ac9bfdda066d84fa0276cb6124ea320a9c6a0ff8",
+      "value": "上传文件以在知识流水线中使用。将返回的 `id` 用作 [运行流水线](/zh/api-reference/knowledge-pipeline/run-pipeline) 中 `local_file` 项的 `reference`。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/operationId",
+      "source_sha256": "fc84e912240748481af2149f6debf0706ac19ef080fc916ec3d347f2d8636976",
+      "value": "uploadPipelineFile"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "b9c59fbdc0bbf0f019b4e57923038788f12065569bdff78282f5a98efb8c7476",
+      "value": "要上传的文件，作为 `multipart/form-data` 的一个部分。文档文件默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。\n\nDify Cloud 的 Professional 和 Team 套餐的文档上限为 50 MB。图片、音频、视频文件各有独立上限，默认分别为 10 MB、50 MB、100 MB。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/201/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "name": "report.pdf",
+            "size": 524288,
+            "extension": "pdf",
+            "mime_type": "application/pdf",
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "created_at": "2025-03-06T12:00:00"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/201/description",
+      "source_sha256": "5f7d99edda2065312155bdc80d2fe8a2052b630156986e31d219cabe8a33bda4",
+      "value": "文件上传成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/400/content/application~1json/examples",
+      "value": {
+        "no_file_uploaded": {
+          "summary": "no_file_uploaded",
+          "value": {
+            "status": 400,
+            "code": "no_file_uploaded",
+            "message": "Please upload your file."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/400/description",
+      "source_sha256": "d9117135f720d08a7612ecb5855665e59ad2620a7581f9e95b3011010c998ceb",
+      "value": "- `no_file_uploaded`：请求中未提供文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `too_many_files`：每次请求仅允许一个文件。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/403/content/application~1json/example",
+      "value": {
+        "code": "forbidden",
+        "message": "Forbidden.",
+        "status": 403
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "禁止访问——未启用知识库 API 或无工作区访问权限"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：文件超出上传大小限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/responses/415/description",
+      "source_sha256": "cd5a22a978d1f32165a6676fb309f964b87db0818d7176356fe5f433a2803b0c",
+      "value": "`unsupported_file_type`：不支持的文件类型。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/summary",
+      "source_sha256": "85fe36dd346c9f07cafde5cbe1f09f41a6315ff17209de92f7c39055c6f2c752",
+      "value": "上传流水线文件"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/tags/0",
+      "source_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a",
+      "value": "知识流水线",
+      "context_path": "/paths/~1datasets~1pipeline~1file-upload/post/tags/0",
+      "context_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1pipeline~1file-upload/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/knowledge-pipeline/upload-pipeline-file",
+        "metadata": {
+          "title": "上传流水线文件",
+          "sidebarTitle": "上传流水线文件"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/description",
+      "source_sha256": "36c1d6aedaea66bf7a722ae1a4dabc11c6422e9fd4835dd1c2eb01f2d32bd160",
+      "value": "永久删除知识库标签。不会删除已被标记的知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/operationId",
+      "source_sha256": "352ccb4c7592dadaf380d26a1733902600a16f384c657cafcf130765f1e30ae1",
+      "value": "deleteKnowledgeTag"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden`：您的工作区角色没有编辑这些资源的权限。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Tag not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/responses/404/description",
+      "source_sha256": "f08401bb2b05b341791960d88321930fa7b110c695c34a98000496fcaf8fd5a3",
+      "value": "- `not_found`：指定的标签不存在。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/summary",
+      "source_sha256": "9407024f59f90342b2f4ed6d576d9da10cc7c1adcafad8ee0fccb090ce5e45ee",
+      "value": "删除知识库标签"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/delete/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "标签",
+      "context_path": "/paths/~1datasets~1tags/delete/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/delete/x-mint",
+      "value": {
+        "href": "/zh/api-reference/tags/delete-knowledge-tag",
+        "metadata": {
+          "title": "删除知识库标签",
+          "sidebarTitle": "删除知识库标签"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/description",
+      "source_sha256": "6f3afca0f7d11924162451927fb4402eb12b16849f2f62c93e0d21af223a1d7f",
+      "value": "返回工作空间中所有的知识库标签。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/operationId",
+      "source_sha256": "9c6008b0eaf477a25ab5d66a6a34e701963154fbc8cd773d113d6754d6de04b9",
+      "value": "getKnowledgeTags"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": [
+            {
+              "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+              "name": "产品文档",
+              "type": "knowledge",
+              "binding_count": "0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/responses/200/description",
+      "source_sha256": "c7926134070bc6b36183f18a4ecf0a0c323d3a8b87a1fa89e2c316ae1226caf9",
+      "value": "标签列表。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/responses/403/content/application~1json/example",
+      "value": {
+        "code": "forbidden",
+        "message": "Forbidden.",
+        "status": 403
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "禁止访问——未启用知识库 API 或无工作区访问权限"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/summary",
+      "source_sha256": "d569cac2620b7b7ae22408d842df736153bdfc06f7a18b721e35ebd34a9fcd90",
+      "value": "获取知识库标签列表"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/get/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "标签",
+      "context_path": "/paths/~1datasets~1tags/get/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/tags/list-knowledge-tags",
+        "metadata": {
+          "title": "获取知识库标签列表",
+          "sidebarTitle": "获取知识库标签列表"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/description",
+      "source_sha256": "c084eab025fd870ff32344afa68d74861fc1261825a21c12b4428827181f240b",
+      "value": "重命名知识库标签。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/operationId",
+      "source_sha256": "201e7ef9d9f3a11a4022a7b1adccc7eab3fb00a6d6b2a152ef8a5f44c6b2cc07",
+      "value": "updateKnowledgeTag"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+            "name": "产品文档",
+            "type": "knowledge",
+            "binding_count": "0"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/200/description",
+      "source_sha256": "b41321c22a6905333c28a46e5cee36e03ebd5f7860e9186b979480e38cd356b7",
+      "value": "标签更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Tag name already exists"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/400/description",
+      "source_sha256": "23c822a6680f643f8803faeae345ab3d64ea2c4196383f9d8dd74f2ca4a25aeb",
+      "value": "`invalid_param`：已存在同名的知识库标签。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden`：您的工作区角色没有编辑这些资源的权限。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Tag not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/responses/404/description",
+      "source_sha256": "f08401bb2b05b341791960d88321930fa7b110c695c34a98000496fcaf8fd5a3",
+      "value": "- `not_found`：指定的标签不存在。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/summary",
+      "source_sha256": "53f111a0f14b3266f88d1619cdbdfb0168a2589f93a753ccfd097c2f4fe1a018",
+      "value": "修改知识库标签"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/patch/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "标签",
+      "context_path": "/paths/~1datasets~1tags/patch/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/patch/x-mint",
+      "value": {
+        "href": "/zh/api-reference/tags/update-knowledge-tag",
+        "metadata": {
+          "title": "修改知识库标签",
+          "sidebarTitle": "修改知识库标签"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/description",
+      "source_sha256": "eac481e2114e573707d7dbc32cc1a97e2a4051a323cc86d99b83ccaff037cecf",
+      "value": "创建用于组织知识库的标签。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/operationId",
+      "source_sha256": "da824e56d5664a07351bf17bebbe0400579a26ba542dfd599cbc6f0fb2aa35e7",
+      "value": "createKnowledgeTag"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+            "name": "产品文档",
+            "type": "knowledge",
+            "binding_count": "0"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/200/description",
+      "source_sha256": "03d63ab330fb9b0fd0a4d6a30ed917e307d982ef3d58b328b75d58098cb912e7",
+      "value": "标签创建成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Tag name already exists"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/400/description",
+      "source_sha256": "23c822a6680f643f8803faeae345ab3d64ea2c4196383f9d8dd74f2ca4a25aeb",
+      "value": "`invalid_param`：已存在同名的知识库标签。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden`：您的工作区角色没有编辑这些资源的权限。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/summary",
+      "source_sha256": "2dcfbe6e4f7b1d04b099e20c30cd81b75be4064237b02bb8b1d26fd05d6ea6b1",
+      "value": "创建知识库标签"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags/post/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "标签",
+      "context_path": "/paths/~1datasets~1tags/post/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/tags/create-knowledge-tag",
+        "metadata": {
+          "title": "创建知识库标签",
+          "sidebarTitle": "创建知识库标签"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/description",
+      "source_sha256": "3546aa56c7a696416e22a16897ed3b6329a7f026e4f5740c5c89f67aeac67150",
+      "value": "将一个或多个标签绑定到知识库。一个知识库可以有多个标签。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/operationId",
+      "source_sha256": "9c9e39eda60a4b8997db7b7504de09433135bb41074e42fffff984795c38601c",
+      "value": "bindTagsToDataset"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden`：您的工作区角色没有编辑这些资源的权限。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found`：目标知识库不存在。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/summary",
+      "source_sha256": "66f069631a4d711736fa8a6651ab9b99eced7a2048139efbf0d4604dd9f91bac",
+      "value": "绑定标签到知识库"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1binding/post/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "标签",
+      "context_path": "/paths/~1datasets~1tags~1binding/post/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1binding/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/tags/create-tag-binding",
+        "metadata": {
+          "title": "绑定标签到知识库",
+          "sidebarTitle": "绑定标签到知识库"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/description",
+      "source_sha256": "02adc40133ec012bb247bbce2d09a95610d99e3ff10d1f39e40b7df72a9c5ed9",
+      "value": "从知识库中移除一个或多个标签。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/operationId",
+      "source_sha256": "fab93b635cdec9e935f12fc280ddbe6bc9e35b454405f6291cecbc7020ba0a72",
+      "value": "unbindTagFromDataset"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/403/description",
+      "source_sha256": "78eb8d4f243ae3b80b84d3828b3d0e7acf70bd14e3d10111eb6c090011433f0f",
+      "value": "`forbidden`：您的工作区角色没有编辑这些资源的权限。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found`：目标知识库不存在。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/summary",
+      "source_sha256": "4ddbd1719c554d2d8812e87dd6db22f75cad665eed77788cea69e24eab033824",
+      "value": "解除标签与知识库的绑定"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "标签",
+      "context_path": "/paths/~1datasets~1tags~1unbinding/post/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1tags~1unbinding/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/tags/delete-tag-binding",
+        "metadata": {
+          "title": "解除标签与知识库的绑定",
+          "sidebarTitle": "解除标签与知识库的绑定"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/description",
+      "source_sha256": "5a13df0fb2b7bc8d07e48e977ce6fc26b95b5a655a1ee598302de1f5ab10f30c",
+      "value": "永久删除知识库及其所有文档。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/operationId",
+      "source_sha256": "e4554386c315974bcd8ec39a1fbbaa490987c3caa4806f5f14896e006372d0eb",
+      "value": "deleteDataset"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "知识库删除成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/409/content/application~1json/examples",
+      "value": {
+        "dataset_in_use": {
+          "summary": "dataset_in_use",
+          "value": {
+            "status": 409,
+            "code": "dataset_in_use",
+            "message": "The dataset is being used by some apps. Please remove the dataset from the apps before deleting it."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/responses/409/description",
+      "source_sha256": "c5d6a5645855d5289b56585a737d39bdcf4f066a9a4f0556d4e30fcbe02e4251",
+      "value": "- `dataset_in_use`：知识库正被一个或多个应用使用，无法删除。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/summary",
+      "source_sha256": "9952b29da673dff0df9c55c928162eb0179fefc4d0abfb762cc321b0b87798c2",
+      "value": "删除知识库"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "知识库",
+      "context_path": "/paths/~1datasets~1{dataset_id}/delete/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/delete/x-mint",
+      "value": {
+        "href": "/zh/api-reference/knowledge-bases/delete-knowledge-base",
+        "metadata": {
+          "title": "删除知识库",
+          "sidebarTitle": "删除知识库"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/description",
+      "source_sha256": "50f262ee70911d6791abcea1c7ad34cc9663445441e2f01ea7cc7b39893e0e89",
+      "value": "返回知识库的详细信息，包括嵌入模型、检索配置和文档统计信息。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/operationId",
+      "source_sha256": "c676c10a9666888ddc33dc2417a529160af7ebce95d232081903a693662843b9",
+      "value": "getDatasetDetail"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+            "name": "产品文档",
+            "description": "产品 API 技术文档",
+            "provider": "vendor",
+            "permission": "only_me",
+            "data_source_type": null,
+            "indexing_technique": "high_quality",
+            "app_count": 0,
+            "document_count": 0,
+            "word_count": 0,
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "author_name": "admin",
+            "created_at": 1741267200,
+            "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "updated_at": 1741267200,
+            "embedding_model": "text-embedding-3-small",
+            "embedding_model_provider": "langgenius/openai/openai",
+            "embedding_available": true,
+            "retrieval_model_dict": {
+              "search_method": "semantic_search",
+              "reranking_enable": false,
+              "reranking_mode": null,
+              "reranking_model": {
+                "reranking_provider_name": "",
+                "reranking_model_name": ""
+              },
+              "weights": null,
+              "top_k": 3,
+              "score_threshold_enabled": false,
+              "score_threshold": null
+            },
+            "tags": [],
+            "doc_form": "text_model",
+            "external_retrieval_model": null,
+            "doc_metadata": [],
+            "built_in_field_enabled": true,
+            "pipeline_id": null,
+            "runtime_mode": null,
+            "chunk_structure": null,
+            "is_published": false,
+            "total_documents": 0,
+            "total_available_documents": 0,
+            "enable_api": true,
+            "is_multimodal": false,
+            "maintainer": "admin"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/200/description",
+      "source_sha256": "63deae9214b5c944cb03da99f53e51b354153799f7efdd84bb4a0d03f5785e9c",
+      "value": "知识库详情。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/403/description",
+      "source_sha256": "dd59bb3e339b8c109dc1d8675932155186051892eb6b1ddb12838fc5908128a8",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/summary",
+      "source_sha256": "bebfeab87756ca112ac66648f6210813c25f8c04b42bfff29d54c8f539e78fd5",
+      "value": "获取知识库详情"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/get/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "知识库",
+      "context_path": "/paths/~1datasets~1{dataset_id}/get/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/knowledge-bases/get-knowledge-base",
+        "metadata": {
+          "title": "获取知识库详情",
+          "sidebarTitle": "获取知识库详情"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/description",
+      "source_sha256": "a9fed906d8c13e36df6bc918dd5719446c732c07bf32796e1d12e14353900da3",
+      "value": "更新知识库。仅更改请求体中包含的字段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/operationId",
+      "source_sha256": "1e7587c6feb979c59561f9835143a0732d49cb86f2c385b292abf52838e04f6b",
+      "value": "updateDataset"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+            "name": "产品文档",
+            "description": "产品 API 技术文档",
+            "provider": "vendor",
+            "permission": "only_me",
+            "data_source_type": null,
+            "indexing_technique": "high_quality",
+            "app_count": 0,
+            "document_count": 0,
+            "word_count": 0,
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "author_name": "admin",
+            "created_at": 1741267200,
+            "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "updated_at": 1741267200,
+            "embedding_model": "text-embedding-3-small",
+            "embedding_model_provider": "langgenius/openai/openai",
+            "embedding_available": true,
+            "retrieval_model_dict": {
+              "search_method": "semantic_search",
+              "reranking_enable": false,
+              "reranking_mode": null,
+              "reranking_model": {
+                "reranking_provider_name": "",
+                "reranking_model_name": ""
+              },
+              "weights": null,
+              "top_k": 3,
+              "score_threshold_enabled": false,
+              "score_threshold": null
+            },
+            "tags": [],
+            "doc_form": "text_model",
+            "external_retrieval_model": null,
+            "doc_metadata": [],
+            "built_in_field_enabled": true,
+            "pipeline_id": null,
+            "runtime_mode": null,
+            "chunk_structure": null,
+            "is_published": false,
+            "total_documents": 0,
+            "total_available_documents": 0,
+            "enable_api": true,
+            "is_multimodal": false,
+            "maintainer": "admin",
+            "partial_member_list": []
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/200/description",
+      "source_sha256": "b4e80193207a4603fcb5015dfbf22dc8e672908fa53567cf6fbca915db559cf4",
+      "value": "知识库更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/400/description",
+      "source_sha256": "b5ad78b6480417ed9255db9e52538769a9ea519771d67eaaba34875e0a6b2dec",
+      "value": "`invalid_param`：指定的嵌入模型或重排序模型未配置或不可用。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/403/description",
+      "source_sha256": "dd59bb3e339b8c109dc1d8675932155186051892eb6b1ddb12838fc5908128a8",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/summary",
+      "source_sha256": "07c7134789c05b311571b1579725a5f34825f5d8bb75f199cad5786c4e61772f",
+      "value": "更新知识库"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "知识库",
+      "context_path": "/paths/~1datasets~1{dataset_id}/patch/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}/patch/x-mint",
+      "value": {
+        "href": "/zh/api-reference/knowledge-bases/update-knowledge-base",
+        "metadata": {
+          "title": "更新知识库",
+          "sidebarTitle": "更新知识库"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/description",
+      "source_sha256": "07400171c02b50f8bc11dd1134a91343b346fa6ab8108b738fcdd4f00355a697",
+      "value": "在知识库中通过上传文件创建文档。支持 PDF、TXT、DOCX 等常见格式。索引异步进行；使用返回的 `batch` ID 通过 [获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/operationId",
+      "source_sha256": "7ca535512cd3c0acbaad2d4669cd8c03360708e3e478056b50f137bb21276272",
+      "value": "createDocumentFromFile"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "037f58256da0da34703847fb56cec6fc7b5c0ed8605e4fdb0581d2578dc57168",
+      "value": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "b7e9147e0c9aef30779e9207fad5f007d9b8bb34d74e62a7cb5f864aad6a5080",
+      "value": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/200/description",
+      "source_sha256": "851e93c47a78428a82d029229950578ac29d60fd32590568a8535a7b24f1139f",
+      "value": "文档创建成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "no_file_uploaded": {
+          "summary": "no_file_uploaded",
+          "value": {
+            "status": 400,
+            "code": "no_file_uploaded",
+            "message": "Please upload your file."
+          }
+        },
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_external": {
+          "summary": "invalid_param（外部知识库）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "External datasets are not supported."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/400/description",
+      "source_sha256": "05a4c3414cba5c4a7c5698a768e2d0c6fc57cae41ac174d7a52af711b233fa97",
+      "value": "- `no_file_uploaded`：请求中未提供文件。\n- `too_many_files`：每次请求仅允许一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：该知识库为外部知识库、缺少 `indexing_technique`，或缺少 `process_rule`。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（文档数量限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：文档数量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：上传的文件超出最大大小限制。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/summary",
+      "source_sha256": "6ee6fc9abf303a6b02433c4484c32d04e180a0ccea977de7455426b45bb67658",
+      "value": "从文件创建文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-file/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/create-document-by-file",
+        "metadata": {
+          "title": "从文件创建文档",
+          "sidebarTitle": "从文件创建文档"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/description",
+      "source_sha256": "ce8837b5254a645c448cde23d6aeda5f09202a4433df372404c836cc8f5985d7",
+      "value": "在知识库中通过纯文本创建文档。索引异步进行；使用返回的 `batch` ID 通过 [获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/operationId",
+      "source_sha256": "933be53df5a2b7de9eeaff9bd7ff5201e55674341190c6d7a15de140e1cbe209",
+      "value": "createDocumentFromText"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/200/description",
+      "source_sha256": "851e93c47a78428a82d029229950578ac29d60fd32590568a8535a7b24f1139f",
+      "value": "文档创建成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_indexing": {
+          "summary": "invalid_param（索引方式）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "indexing_technique is required."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/400/description",
+      "source_sha256": "c265254345546d5954535fe0094526eac879381baad4be9f14512224200d62aa",
+      "value": "- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：添加首个文档时必须提供 `indexing_technique`，或 `doc_form` 无效。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（文档数量限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：文档数量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/summary",
+      "source_sha256": "1e6b990b6de94b6910045168cef2ec1a188d87dceb46d788be7574c2bfdcdab9",
+      "value": "从文本创建文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create-by-text/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/create-document-by-text",
+        "metadata": {
+          "title": "从文本创建文档",
+          "sidebarTitle": "从文本创建文档"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/description",
+      "source_sha256": "07400171c02b50f8bc11dd1134a91343b346fa6ab8108b738fcdd4f00355a697",
+      "value": "已弃用的兼容接口。在知识库中通过上传文件创建文档。支持 PDF、TXT、DOCX 等常见格式。索引异步进行；使用返回的 `batch` ID 通过 [获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "037f58256da0da34703847fb56cec6fc7b5c0ed8605e4fdb0581d2578dc57168",
+      "value": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "b7e9147e0c9aef30779e9207fad5f007d9b8bb34d74e62a7cb5f864aad6a5080",
+      "value": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/200/description",
+      "source_sha256": "851e93c47a78428a82d029229950578ac29d60fd32590568a8535a7b24f1139f",
+      "value": "文档创建成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "no_file_uploaded": {
+          "summary": "no_file_uploaded",
+          "value": {
+            "status": 400,
+            "code": "no_file_uploaded",
+            "message": "Please upload your file."
+          }
+        },
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_external": {
+          "summary": "invalid_param（外部知识库）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "External datasets are not supported."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/400/description",
+      "source_sha256": "05a4c3414cba5c4a7c5698a768e2d0c6fc57cae41ac174d7a52af711b233fa97",
+      "value": "- `no_file_uploaded`：请求中未提供文件。\n- `too_many_files`：每次请求仅允许一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：该知识库为外部知识库、缺少 `indexing_technique`，或缺少 `process_rule`。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（文档数量限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：文档数量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：上传的文件超出最大大小限制。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/summary",
+      "source_sha256": "6ee6fc9abf303a6b02433c4484c32d04e180a0ccea977de7455426b45bb67658",
+      "value": "从文件创建文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_file/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/description",
+      "source_sha256": "ce8e60129ee9c312cad9bdb211f4230d36e5b3a72242227ccec237363ac50e53",
+      "value": "已弃用的兼容接口。在知识库中通过纯文本创建文档。索引异步进行；使用返回的 `batch` ID 通过 [获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 0,
+              "indexing_status": "indexing",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "indexing",
+              "word_count": 0,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/200/description",
+      "source_sha256": "b58013cc434c75875e21586fa27549413c986ce036282f332061caf85b6f33aa",
+      "value": "文档创建成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_indexing": {
+          "summary": "invalid_param（索引方式）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "indexing_technique is required."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/400/description",
+      "source_sha256": "2bfbcfde3ad246205ccd33f9e5921e27cf4a76186dc1885bf430dc6e0d6cae76",
+      "value": "- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：添加首个文档时必须提供 `indexing_technique`，或 `doc_form` 无效。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（文档数量限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The number of documents has reached the limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：文档数量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/summary",
+      "value": "从文本创建文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/tags/0",
+      "source_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1document~1create_by_text/post/tags/0",
+      "context_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/description",
+      "source_sha256": "78789159df482727bc3d6ce2dd0cc370746fa42614834a3a0f9ddace0ffddc2d",
+      "value": "返回知识库中文档的分页列表。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/operationId",
+      "source_sha256": "ed04812695198c323f5b2e5e25367529acc7115ce721bb673d5f218c707bf895",
+      "value": "listDocuments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/1/description",
+      "source_sha256": "aba31e6369655c584b35d021ac80b7a64ff80eaba5de41afdeb1914b4493bf42",
+      "value": "按文档名称筛选的搜索关键词。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/1",
+      "context_sha256": "89b7ea40266f4a9525fc01d8dab03987f7e1f536346fffbee3d7151c7a14a603"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/1/schema/description",
+      "source_sha256": "aba31e6369655c584b35d021ac80b7a64ff80eaba5de41afdeb1914b4493bf42",
+      "value": "按文档名称筛选的搜索关键词。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/1",
+      "context_sha256": "89b7ea40266f4a9525fc01d8dab03987f7e1f536346fffbee3d7151c7a14a603"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/2/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/2",
+      "context_sha256": "3be071ee50409713ac99937bf5587118e5758fe840cbdf90b10c5ba5b26b2736"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/2/schema/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/2",
+      "context_sha256": "3be071ee50409713ac99937bf5587118e5758fe840cbdf90b10c5ba5b26b2736"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/3/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/3",
+      "context_sha256": "41b7d5c5e4ba2a4e4a83c7b574b112e3f35aa91988101a0aa03cd0459fb3ddbb"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/3/schema/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/3",
+      "context_sha256": "41b7d5c5e4ba2a4e4a83c7b574b112e3f35aa91988101a0aa03cd0459fb3ddbb"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/4/description",
+      "source_sha256": "50bce7bd6ac91e8f61540bc9cdbdb5ae9e6867325a9912e84bbabe8f4f09202f",
+      "value": "按显示状态筛选。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/4",
+      "context_sha256": "bf6598591c593ad0884619b7e5dfab5dbe0ef43e85b57e6632e871de05948e1e"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/4/schema/description",
+      "source_sha256": "50bce7bd6ac91e8f61540bc9cdbdb5ae9e6867325a9912e84bbabe8f4f09202f",
+      "value": "按显示状态筛选。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/parameters/4",
+      "context_sha256": "bf6598591c593ad0884619b7e5dfab5dbe0ef43e85b57e6632e871de05948e1e"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": [
+              {
+                "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "position": 1,
+                "data_source_type": "upload_file",
+                "data_source_info": {
+                  "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                },
+                "data_source_detail_dict": {
+                  "upload_file": {
+                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    "name": "guide.txt",
+                    "size": 2048,
+                    "extension": "txt",
+                    "mime_type": "text/plain",
+                    "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                    "created_at": 1741267200
+                  }
+                },
+                "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                "name": "guide.txt",
+                "created_from": "api",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200,
+                "tokens": 512,
+                "indexing_status": "completed",
+                "error": null,
+                "enabled": true,
+                "disabled_at": null,
+                "disabled_by": null,
+                "archived": false,
+                "display_status": "available",
+                "word_count": 350,
+                "hit_count": 0,
+                "doc_form": "text_model",
+                "doc_metadata": [],
+                "summary_index_status": null,
+                "need_summary": false
+              }
+            ],
+            "has_more": false,
+            "limit": 20,
+            "total": 1,
+            "page": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/200/description",
+      "source_sha256": "deb062667cf2e19735b642761ff5c8ddb9ad956b616de5b458b8f13f0a11c51e",
+      "value": "文档列表。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found`：知识库未找到。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/summary",
+      "source_sha256": "efb442829ce970e1abdf81dda8229db976a8e524ede03b124c418c7382962f28",
+      "value": "获取知识库的文档列表"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents/get/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/list-documents",
+        "metadata": {
+          "title": "获取知识库的文档列表",
+          "sidebarTitle": "获取知识库的文档列表"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/description",
+      "source_sha256": "ab554fdd9cdb621d0ad3e866462ee925cf4739ac73dd0ab071948ed84cbde11a",
+      "value": "将一个或多个文档下载为单个 ZIP 压缩包。仅可包含以文件形式上传的文档。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/operationId",
+      "source_sha256": "0e8cead9550f8599042d95432183326d285ed38219ea533590af75ef0cabfe71",
+      "value": "downloadDocumentsZip"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/200/content/application~1zip/schema/description",
+      "value": "ZIP 压缩包二进制流。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/200/description",
+      "source_sha256": "dfa45cbc91f27b04a692458bc086dfc4b91265540a7ce1fb334de04829692a38",
+      "value": "包含所请求文档的 ZIP 压缩包。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（知识库权限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "You do not have permission to access this dataset."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（文档权限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "No permission."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。\n- `forbidden`：你没有访问此知识库的权限。\n- `forbidden`：你对请求的某个文档没有访问权限。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found_3",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Only uploaded-file documents can be downloaded as ZIP."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/responses/404/description",
+      "source_sha256": "33d278524dd9904b18696f6543002a01a53e777c37edf5e64cef79379db1dc72",
+      "value": "- `not_found`：未找到文档。\n- `not_found`：未找到知识库。 请求的文档不是通过上传文件创建时，也会返回仅上传文件类文档可打包下载的错误。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/summary",
+      "source_sha256": "d040c430ec818031d4a6071ac7b44a612ad0d770c44fa30b2271a8d550101185",
+      "value": "批量下载文档（ZIP）"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1download-zip/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/download-documents-as-zip",
+        "metadata": {
+          "title": "批量下载文档（ZIP）",
+          "sidebarTitle": "批量下载文档（ZIP）"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/description",
+      "source_sha256": "e0e16afd2292fe2d4aed3d4140e8303874f07030c24668ba73768f6284a36e21",
+      "value": "在一次请求中批量更新多个文档的元数据值。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/operationId",
+      "source_sha256": "4f58dac3e79b1e0dbcd9d642c696555d5279086e49a42d6da8107d357027b5a0",
+      "value": "batchUpdateDocumentMetadata"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "result": "success"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/200/description",
+      "source_sha256": "09f6bc9638276cdb0877be7f1339c6ef911bd14e5c81f0d02bf526597fc5fe30",
+      "value": "文档元数据更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Another document metadata operation is running, please wait a moment."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/400/description",
+      "source_sha256": "b1e7a7215ad461820547abdde9f7e0c9515ab9c9e66e8a2a66aa8d395d9c10cf",
+      "value": "`invalid_param`：本次请求中的文档已有另一个元数据操作正在进行。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found（知识库）",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found (document)",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found (metadata)",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Metadata not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/responses/404/description",
+      "source_sha256": "cfa8dd782d9a3aff8888ba05f0e0fe6cbfa1ac2acb8475f7c800006b5368e5c3",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：`operation_data` 中引用的文档在该知识库中不存在。\n- `not_found`：`metadata_list` 中引用的元数据字段在该知识库中不存在。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/summary",
+      "source_sha256": "542f84a66a20a8da766f4de90c208ca710e162cead8630535acfcfe4b093ca3c",
+      "value": "批量更新文档元数据"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "元数据",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1metadata/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/metadata/update-document-metadata-in-batch",
+        "metadata": {
+          "title": "批量更新文档元数据",
+          "sidebarTitle": "批量更新文档元数据"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/description",
+      "source_sha256": "c6b0c2965a3f06693164c1eae0ca6d8e0c2c3fdfd612719ed4db44157330813d",
+      "value": "在一次请求中批量启用、禁用、归档或取消归档多个文档。为保持兼容，`document_ids` 为可选字段；省略该字段或传入空数组时不会更新任何文档，但仍返回 `result: success`。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/operationId",
+      "source_sha256": "e6b2549c3dfaa8f1a245a5c580acb06c1745347d76d8ce63cf8266eb1f58bad8",
+      "value": "batchUpdateDocumentStatus"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/0/description",
+      "source_sha256": "a51dc76c03c027de687cf177900f2d13b30845b250daa806a286c633ad75505c",
+      "value": "要执行的操作：`enable`、`disable`、`archive` 或 `un_archive`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/0",
+      "context_sha256": "65537a06d370a21500cd609c296ade3fc7153ab0908b8cb96ffa4672ed7168b4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/0/schema/description",
+      "source_sha256": "a51dc76c03c027de687cf177900f2d13b30845b250daa806a286c633ad75505c",
+      "value": "要执行的操作：`enable`、`disable`、`archive` 或 `un_archive`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/0",
+      "context_sha256": "65537a06d370a21500cd609c296ade3fc7153ab0908b8cb96ffa4672ed7168b4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/1/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/requestBody/content/application~1json/examples",
+      "value": {
+        "update_documents": {
+          "summary": "请求示例",
+          "value": {
+            "document_ids": [
+              "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "c4c4f9aa-2c9b-4f95-9f5a-2c0f7c3a8f21"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "result": "success"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/200/description",
+      "source_sha256": "859ddafafe8ea74b6bb4f0de968b87fd187fdd5313edf2d0435a8df1846be0d2",
+      "value": "文档更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_action": {
+          "summary": "invalid_action",
+          "value": {
+            "status": 400,
+            "code": "invalid_action",
+            "message": "Invalid action."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/400/description",
+      "source_sha256": "6e1b4b62cdc02de4f968d6c5e758ee2bb3ac251971f614da57623f3b8a591c06",
+      "value": "`invalid_action`：操作无效，或某个文档处于不允许该操作的状态（例如仍在索引中或尚未处理完成）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found`：知识库未找到。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/summary",
+      "source_sha256": "d7427b4c34451ae3e333e70baaa0a653cdd7eca86f9b1ae5d793afbdc449fd47",
+      "value": "批量更新文档状态"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1status~1{action}/patch/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/update-document-status-in-batch",
+        "metadata": {
+          "title": "批量更新文档状态",
+          "sidebarTitle": "批量更新文档状态"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/description",
+      "source_sha256": "3ee1dc37070aedcadf13c8f1f7f8dd0580c132e9bb092eb2bd8a78fb14bd3497",
+      "value": "返回批次中每个文档的索引进度，包括当前阶段和分段完成计数。轮询直到每个 `indexing_status` 变为 `completed`、`error` 或 `paused`。`completed` 和 `error` 为终态。Service API 没有恢复暂停文档的操作；请在 Dify 知识库控制台恢复文档，再继续轮询此端点。活动阶段按 `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed` 推进。`stopped_at` 非空时记录处理停止时间，但 `stopped` 并不是独立的 `indexing_status` 值。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/operationId",
+      "source_sha256": "39c6932a2f100f1efc39062d5a65c72cebde14cb45097fdf9be0fe276b21e0d1",
+      "value": "getDocumentIndexingStatus"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/0/description",
+      "source_sha256": "05fd9b42d2c8b44ab846e5ea08775bef92e1970160841cf8ac40f184d8abf14e",
+      "value": "创建或更新文档时返回的批次 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/0",
+      "context_sha256": "dc296bd6cc966cbe715d70de1858731daf7bc5888473c41133c48cbaa43b801a"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/0/schema/description",
+      "source_sha256": "05fd9b42d2c8b44ab846e5ea08775bef92e1970160841cf8ac40f184d8abf14e",
+      "value": "批次 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/0",
+      "context_sha256": "dc296bd6cc966cbe715d70de1858731daf7bc5888473c41133c48cbaa43b801a"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/1/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": [
+              {
+                "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "indexing_status": "completed",
+                "processing_started_at": 1741267200,
+                "parsing_completed_at": 1741267200,
+                "cleaning_completed_at": 1741267200,
+                "splitting_completed_at": 1741267200,
+                "completed_at": 1741267200,
+                "paused_at": null,
+                "error": null,
+                "stopped_at": null,
+                "completed_segments": 5,
+                "total_segments": 5
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/200/description",
+      "source_sha256": "0c8b1f8fc9842dc81a753321a521f66d7cca0fa3afd296ba2dfa0f33fa0f5bb6",
+      "value": "批次中文档的索引状态。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/404/content/application~1json/examples",
+      "value": {
+        "dataset_not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "documents_not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Documents not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/responses/404/description",
+      "source_sha256": "f925b0dba435508be8b280a637223f4caa0fc1649cf974fd5c22e57b09bc2ec9",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/summary",
+      "source_sha256": "0a2e15b45d5050c4e0a3fdf0531cdb83c7228b7ef02f6ba49845a6b135ed4ccd",
+      "value": "获取文档索引状态（进度）"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{batch}~1indexing-status/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/get-document-indexing-status",
+        "metadata": {
+          "title": "获取文档索引状态（进度）",
+          "sidebarTitle": "获取文档索引状态（进度）"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/description",
+      "source_sha256": "8cf27626e083bc4eb4f350d4e92e989cd9a315b858f85debdf083d3e7fdb9161",
+      "value": "从知识库中永久删除文档及其所有分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/operationId",
+      "source_sha256": "656074aae27c7333625916f7719d19d283e12562cb12ad96314c25bdb5fa5fba",
+      "value": "deleteDocument"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/400/content/application~1json/examples",
+      "value": {
+        "document_indexing": {
+          "summary": "document_indexing",
+          "value": {
+            "status": 400,
+            "code": "document_indexing",
+            "message": "Cannot delete document during indexing."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/400/description",
+      "source_sha256": "51752204a2cb9583364eaf80301be31060091d5a02703d0d6798210d4a8fc0eb",
+      "value": "- `document_indexing`：文档仍在处理中，无法删除。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "archived_document_immutable": {
+          "summary": "archived_document_immutable",
+          "value": {
+            "status": 403,
+            "code": "archived_document_immutable",
+            "message": "The archived document is not editable."
+          }
+        },
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/403/description",
+      "source_sha256": "909e8a3e284297c1c7bf931731833a5fb989d3b37ebc181edfbdffe52d1e96ce",
+      "value": "- `archived_document_immutable`：已归档的文档不可编辑。\n- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document Not Exists."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found_2",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/responses/404/description",
+      "source_sha256": "654d9434f735fc4d4ab99327dd4af0be414347c7611fcf1ac55f98c1ce4d551e",
+      "value": "- `not_found`：文档不存在。 知识库本身不存在时，也会返回未找到知识库的错误。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/summary",
+      "source_sha256": "70f5004e3f3a2f2d95035c906999bd25f419317eb83bf1b2bb33c2a67606aa68",
+      "value": "删除文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/delete/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/delete-document",
+        "metadata": {
+          "title": "删除文档",
+          "sidebarTitle": "删除文档"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/description",
+      "source_sha256": "223cc48b4a4eb37363dfbbdae2aee5f32ecfdd5f091c7099c9293d0b111a9cf0",
+      "value": "返回单个文档的详细信息。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/operationId",
+      "source_sha256": "75541f97ff3ca7f743159c35501d9eba8b0a71833c97a161c5351f5f1232f519",
+      "value": "getDocumentDetail"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/2/description",
+      "source_sha256": "4872f96fedffd9e413abf58ce36a21d9eda0ba203c4c38f9c553593c4a30d5ec",
+      "value": "`all` 返回所有字段（包括元数据）。`only` 仅返回 `id`、`doc_type` 和 `doc_metadata`。`without` 返回除 `doc_metadata` 外的所有字段。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/2",
+      "context_sha256": "4929e9b2a6d9c9242510d14164e6d830c4ddbb6c558853d66fb3d8b6f3adb215"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/2/schema/description",
+      "source_sha256": "4872f96fedffd9e413abf58ce36a21d9eda0ba203c4c38f9c553593c4a30d5ec",
+      "value": "`all` 返回所有字段（包括元数据）。`only` 仅返回 `id`、`doc_type` 和 `doc_metadata`。`without` 返回除 `doc_metadata` 外的所有字段。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/parameters/2",
+      "context_sha256": "4929e9b2a6d9c9242510d14164e6d830c4ddbb6c558853d66fb3d8b6f3adb215"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+            "position": 1,
+            "data_source_type": "upload_file",
+            "data_source_info": {
+              "upload_file": {
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "name": "guide.txt",
+                "size": 2048,
+                "extension": "txt",
+                "mime_type": "text/plain",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200
+              }
+            },
+            "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+            "dataset_process_rule": {
+              "id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "mode": "custom"
+            },
+            "document_process_rule": {
+              "mode": "custom",
+              "rules": {
+                "pre_processing_rules": [],
+                "segmentation": {
+                  "separator": "###",
+                  "max_tokens": 500,
+                  "chunk_overlap": 50
+                }
+              }
+            },
+            "name": "guide.txt",
+            "created_from": "api",
+            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+            "created_at": 1741267200,
+            "tokens": 512,
+            "indexing_status": "completed",
+            "error": null,
+            "enabled": true,
+            "disabled_at": null,
+            "disabled_by": null,
+            "archived": false,
+            "display_status": "available",
+            "hit_count": 0,
+            "doc_form": "text_model",
+            "doc_language": "English",
+            "doc_type": null,
+            "doc_metadata": [],
+            "completed_at": 1741267260,
+            "updated_at": 1741267260,
+            "indexing_latency": 60.0,
+            "segment_count": 5,
+            "average_segment_length": 70.0,
+            "summary_index_status": null,
+            "need_summary": false
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/200/description",
+      "source_sha256": "9c974d1edde88e6ce065e0fcd27c6902c3b725a8d83bb0956cf1234e5b490f3e",
+      "value": "文档详情。返回的字段取决于 `metadata` 查询参数。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_metadata": {
+          "summary": "invalid_metadata",
+          "value": {
+            "status": 400,
+            "code": "invalid_metadata",
+            "message": "Invalid metadata value."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/400/description",
+      "source_sha256": "a6f3cd1d294992adca094754d7e0ec4e47ace58dbf60cdf45bb36179378c2dc7",
+      "value": "`invalid_metadata`：`metadata` 查询参数的值无效（必须为 `all`、`only` 或 `without`）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（无权限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "No permission."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/403/description",
+      "source_sha256": "2bef26abe5b5e7f882e37bea609d1c175794388053ba0c3f39d4a5b6be4518a8",
+      "value": "- `forbidden`：你没有访问此文档的权限。\n- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/responses/404/description",
+      "source_sha256": "92c4a92c4d46a82bba2df44f94474fc2bcb7fedc50fe8f19ced9339cab517786",
+      "value": "- `not_found`：未找到文档。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/summary",
+      "source_sha256": "48b0cb3171b8524948244d59f615aa88e9ff7ef73ce66a5a1a7c146c2a1886a3",
+      "value": "获取文档详情"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/get-document",
+        "metadata": {
+          "title": "获取文档详情",
+          "sidebarTitle": "获取文档详情"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/description",
+      "source_sha256": "76af9a461be7fa6b11b91f204a7691e31b9e256760a10232e79fec948ad06751",
+      "value": "更新文档并重新索引。传入 `file` 可替换源文件，传入 `data` 可修改处理设置，也可同时传入两者。省略 `file` 时，Dify 使用提供的设置或当前设置重新处理现有源文件；空的 multipart 请求会使用当前设置重新索引。使用返回的 `batch` ID 通过 [获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪进度。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/operationId",
+      "source_sha256": "14d98cfdb11f1b9565c90611e28c7d833c4c86c0760067709584aba11278c1fb",
+      "value": "updateDocument"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "9a55a691d8c3e1fa35fa97643ae718f7c770b58e29258bbbedb3ba1b046597a9",
+      "value": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "c3ecc43b937e9c81b6f6591d46eb7fb325ddc2af0207e748bdc83f5f7a30e4ab",
+      "value": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/200/description",
+      "source_sha256": "16662764860b1e0ddf01c5e676e787076fb8b5dbd4d0fea1be7dc44670a4bff0",
+      "value": "文档更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param（不可用）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/400/description",
+      "source_sha256": "533998490d38cd2cd57cc910a88ff38c4b5b8ea95add88c0e4404959f3417cb4",
+      "value": "- `too_many_files`：每次请求仅允许一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：文档不可用，无法更新（仅可更新处于可用状态的文档）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：上传的文件超出最大大小限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/responses/415/description",
+      "source_sha256": "3ce1812190ffa7ff82290341eeee927bbc176af9b1a3673fbe9a48cb95ea127d",
+      "value": "`unsupported_file_type`：上传文件的类型不受支持。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/summary",
+      "source_sha256": "6f35a637dbb78c62105d71d60424b6d01ea7629747bd579ba157ffd1ce397402",
+      "value": "更新文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/x-codeSamples",
+      "value": [
+        {
+          "lang": "bash",
+          "label": "cURL",
+          "source": "curl --request PATCH \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/documents/{document_id}' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}/patch/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/update-document",
+        "metadata": {
+          "title": "更新文档",
+          "sidebarTitle": "更新文档"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/description",
+      "source_sha256": "842aa9dba53398538fede68859cbcd0f0211cc5e2033ec56ec418a411de7cce0",
+      "value": "返回用于下载文档原始上传文件的签名 URL。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/operationId",
+      "source_sha256": "fc5cc402ab6a49ac351da3beb9f97321420d3f5e6a22b9f3f58092f30b651c03",
+      "value": "downloadDocument"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "url": "https://storage.example.com/datasets/documents/abc123/original-file.pdf?token=xyz789&expires=1741353600"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/200/description",
+      "source_sha256": "4b9bf98151426ef51d6ea3eee52990acd500fed35ba0870f24f003926add1991",
+      "value": "下载 URL 生成成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（无权限）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "No permission."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/403/description",
+      "source_sha256": "7987c5d119f43227f71c217ac78a4c52e4a02ade6bf43575d26f21fe5b3c0190",
+      "value": "- `forbidden`：你没有访问此文档的权限。\n- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found_2",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Uploaded file not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found_3",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document does not have an uploaded file to download."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/responses/404/description",
+      "source_sha256": "92c4a92c4d46a82bba2df44f94474fc2bcb7fedc50fe8f19ced9339cab517786",
+      "value": "- `not_found`：未找到文档。 存储文件缺失时也会返回未找到上传文件的错误；非文件类文档则返回该文档没有可下载上传文件的错误。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/summary",
+      "source_sha256": "90b21a62faa89b9775907d1ddf1992490283ece74d46bf7cdae5653a194530ba",
+      "value": "下载文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1download/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/download-document",
+        "metadata": {
+          "title": "下载文档",
+          "sidebarTitle": "下载文档"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/description",
+      "source_sha256": "582c3857384b399f032a82587e616ec2c8660ff2418716154d3e48498c2b78fc",
+      "value": "返回文档内分段的分页列表，可按关键词或索引状态筛选。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/operationId",
+      "source_sha256": "9fb703c2ac9028b2c32081b34e5981b98966ee046baedc87d65622e9fcd401e8",
+      "value": "listSegments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/2/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "搜索关键词。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/2",
+      "context_sha256": "4c19ed6189abc1d3b555cee9488bc12c1308ff8769f72729805198c8d1451923"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/2/schema/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "搜索关键词。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/2",
+      "context_sha256": "4c19ed6189abc1d3b555cee9488bc12c1308ff8769f72729805198c8d1451923"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/3/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/3",
+      "context_sha256": "d91843f5442902d84910396ce711ce7f4852175631599c1c4d2b72262307bcb6"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/3/schema/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/3",
+      "context_sha256": "d91843f5442902d84910396ce711ce7f4852175631599c1c4d2b72262307bcb6"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/4/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/4",
+      "context_sha256": "940c6bab5bcb50752c3da3dec2188cc938793db83499f905113f2da64a771d24"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/4/schema/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/4",
+      "context_sha256": "940c6bab5bcb50752c3da3dec2188cc938793db83499f905113f2da64a771d24"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/5/description",
+      "source_sha256": "8553c4a96f020a09cde5ec784da5824c9b02c954d7cae9faa4d0300b9835a2d8",
+      "value": "按索引状态筛选分段，例如 `completed`、`indexing` 或 `error`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/5",
+      "context_sha256": "a558ae5b54cbd62806a948f6c8905bb95bdd5a02e4210f2b0dbb2d709dfe813b"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/5/schema/description",
+      "source_sha256": "8553c4a96f020a09cde5ec784da5824c9b02c954d7cae9faa4d0300b9835a2d8",
+      "value": "按索引状态筛选分段，例如 `completed`、`indexing` 或 `error`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/parameters/5",
+      "context_sha256": "a558ae5b54cbd62806a948f6c8905bb95bdd5a02e4210f2b0dbb2d709dfe813b"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": [
+              {
+                "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                "position": 1,
+                "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "content": "Dify 是一个开源的 LLM 应用开发平台。",
+                "sign_content": "",
+                "answer": "",
+                "word_count": 9,
+                "tokens": 12,
+                "keywords": [
+                  "dify",
+                  "platform",
+                  "llm"
+                ],
+                "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                "index_node_hash": "abc123def456",
+                "hit_count": 0,
+                "enabled": true,
+                "disabled_at": null,
+                "disabled_by": null,
+                "status": "completed",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200,
+                "updated_at": 1741267200,
+                "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "indexing_at": 1741267200,
+                "completed_at": 1741267200,
+                "error": null,
+                "stopped_at": null,
+                "child_chunks": [],
+                "attachments": [],
+                "summary": null
+              }
+            ],
+            "doc_form": "text_model",
+            "total": 1,
+            "has_more": false,
+            "limit": 20,
+            "page": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/200/description",
+      "source_sha256": "85ca1913e26ecf63bcf33b2ebadd93ef201662db791e160742a37d251a65b39b",
+      "value": "分段列表。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/400/description",
+      "source_sha256": "713478b5ec6389ad152167c1712e6756e62534bda443f37bbb091a896dee5811",
+      "value": "`provider_not_initialize`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/responses/404/description",
+      "source_sha256": "2679559e87d24a8afee123e19f8953829e093153c3adffc0d5bf8706d8de74ec",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/summary",
+      "source_sha256": "2cfa078070ef8223b29e847980047cd348d84e5fa11629531e4c515ca9b69a4b",
+      "value": "从文档获取分段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "分段",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/chunks/list-chunks",
+        "metadata": {
+          "title": "从文档获取分段",
+          "sidebarTitle": "从文档获取分段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/description",
+      "source_sha256": "d856a065db873c19c6368130043ff107ce8a3f13cdc013661f911047e22cca56",
+      "value": "在文档中创建一个或多个分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/operationId",
+      "source_sha256": "c4acb46d3be04bdf1f8ff2bdf9c7c810d64bc11fa737deb10fe797daefebed8c",
+      "value": "createSegments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": [
+              {
+                "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                "position": 1,
+                "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                "content": "Dify 是一个开源的 LLM 应用开发平台。",
+                "sign_content": "",
+                "answer": "",
+                "word_count": 9,
+                "tokens": 12,
+                "keywords": [
+                  "dify",
+                  "platform",
+                  "llm"
+                ],
+                "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                "index_node_hash": "abc123def456",
+                "hit_count": 0,
+                "enabled": true,
+                "disabled_at": null,
+                "disabled_by": null,
+                "status": "completed",
+                "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "created_at": 1741267200,
+                "updated_at": 1741267200,
+                "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                "indexing_at": 1741267200,
+                "completed_at": 1741267200,
+                "error": null,
+                "stopped_at": null,
+                "child_chunks": [],
+                "attachments": [],
+                "summary": null
+              }
+            ],
+            "doc_form": "text_model"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/200/description",
+      "source_sha256": "9e01e8e9d0aafd621b73fcc3a4df08af015b6129c94acac7fa0cb7e73bdedf01",
+      "value": "分段创建成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param_limit": {
+          "summary": "invalid_param（分段数量限制）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Exceeded maximum segments limit of 1000."
+          }
+        },
+        "validation_error": {
+          "summary": "schema 校验（非标准请求体）",
+          "value": {
+            "error": "1 validation error for SegmentCreatePayload\nsegments.0.content\n  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/400/description",
+      "source_sha256": "a19c866c52f77b90a4b1c2be29a17b1a5f432c936c6058d582c0e9e852ab9d7e",
+      "value": "- `provider_not_initialize`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param`：某个分段字段无效（例如 Q&A 模式的文档要求提供 `answer`），或分段数量超出单次请求上限。\n- 请求体 schema 校验失败（例如 `content` 为空）时返回非标准响应体 `{\"error\": \"<校验详情>\"}`，不含 `code` 或 `status` 字段。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（需要升级套餐）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。\n- `forbidden`：请升级到付费套餐以使用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document is not completed."
+          }
+        },
+        "not_found_4": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document is disabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/responses/404/description",
+      "source_sha256": "cbc930cc07d2b0d0682f8867bfea9ccd66a0542140764dfd68adadfd208bb8c0",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：文档尚未处理完成。\n- `not_found`：文档已被禁用。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/summary",
+      "source_sha256": "f2b41b75a56de04fb5ab76b8e82b2cbb842d02c92ec9a588488704d90a5fdbaa",
+      "value": "向文档添加分段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "分段",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/chunks/create-chunks",
+        "metadata": {
+          "title": "向文档添加分段",
+          "sidebarTitle": "向文档添加分段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/description",
+      "source_sha256": "45c2f6d6d25bfdc5723d6942d4a0eff1c7f82cfc19a0c1cdf4c45dffcd598812",
+      "value": "从文档中永久删除一个分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/operationId",
+      "source_sha256": "de021c8ff9fa6a10b79bca7f5899cf1201d5d4c5f473de0af498ba04cf2374ff",
+      "value": "deleteSegment"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/2/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "分段 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param_model_setting": {
+          "summary": "invalid_param（模型设置）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param_deleting": {
+          "summary": "invalid_param（正在删除）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Segment is deleting."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/400/description",
+      "source_sha256": "246948fbac3b19c653a5b271f592e54276bf0ebfea59d24f5d4f8bdace089213",
+      "value": "- `invalid_param`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param`：该分段正在被另一并发请求删除。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/summary",
+      "source_sha256": "42229b8dfdb424a1f60e302563bd47ec5eccf5bd79b45950b73fb30db2722635",
+      "value": "删除文档中的分段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "分段",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/delete/x-mint",
+      "value": {
+        "href": "/zh/api-reference/chunks/delete-chunk",
+        "metadata": {
+          "title": "删除文档中的分段",
+          "sidebarTitle": "删除文档中的分段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/description",
+      "source_sha256": "592c29e3d9c0271b3940388128173a87db1ef6dd0df56786a3ac67d4cb1b7d1b",
+      "value": "获取单个分段的完整详情。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/operationId",
+      "source_sha256": "0e5d3e0623daa5d8c5ef3c0190a00b1372d1165307d3dd0616392391bbc9225e",
+      "value": "getSegmentDetail"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/2/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "分段 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": {
+              "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "position": 1,
+              "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "content": "Dify 是一个开源的 LLM 应用开发平台。",
+              "sign_content": "",
+              "answer": "",
+              "word_count": 9,
+              "tokens": 12,
+              "keywords": [
+                "dify",
+                "platform",
+                "llm"
+              ],
+              "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+              "index_node_hash": "abc123def456",
+              "hit_count": 0,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "status": "completed",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "updated_at": 1741267200,
+              "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "indexing_at": 1741267200,
+              "completed_at": 1741267200,
+              "error": null,
+              "stopped_at": null,
+              "child_chunks": [],
+              "attachments": [],
+              "summary": null
+            },
+            "doc_form": "text_model"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/200/description",
+      "source_sha256": "53f8b5ad904784dc956dc2ec4a871cdff0423c6b61126434b7c8b00139b22315",
+      "value": "分段详情。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/400/description",
+      "source_sha256": "95d6543fbb7b8c8a19b8b710bf3e6fe50b88d187984da48e0671248b0f42a95e",
+      "value": "`invalid_param`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/summary",
+      "source_sha256": "78707a415eb06083072132d062c09e2e096c3c6a8636d42e5f931bab68062d60",
+      "value": "获取文档中的分段详情"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "分段",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/chunks/get-chunk",
+        "metadata": {
+          "title": "获取文档中的分段详情",
+          "sidebarTitle": "获取文档中的分段详情"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/description",
+      "source_sha256": "f0fbd0d95fd128b6630d3729b0fa0dddf4439e5f5bab3223bcf8725b94e8cb2a",
+      "value": "更新分段的字段。更新会为该分段重新触发索引。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/operationId",
+      "source_sha256": "5fc085ac885ebda0a576cf7e298500d88f442446f323908e8e293c73c892e446",
+      "value": "updateSegment"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/2/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "分段 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": {
+              "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "position": 1,
+              "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "content": "Dify 是一个开源的 LLM 应用开发平台。",
+              "sign_content": "",
+              "answer": "",
+              "word_count": 9,
+              "tokens": 12,
+              "keywords": [
+                "dify",
+                "platform",
+                "llm"
+              ],
+              "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+              "index_node_hash": "abc123def456",
+              "hit_count": 0,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "status": "completed",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "updated_at": 1741267200,
+              "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "indexing_at": 1741267200,
+              "completed_at": 1741267200,
+              "error": null,
+              "stopped_at": null,
+              "child_chunks": [],
+              "attachments": [],
+              "summary": null
+            },
+            "doc_form": "text_model"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/200/description",
+      "source_sha256": "63e3259066c2b26c706cb662fbc775bba3667820b9634cbdeac3097cb4ef3017",
+      "value": "分段更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param_state": {
+          "summary": "invalid_param（状态）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Segment is indexing, please try again later"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/400/description",
+      "source_sha256": "4a4859fd64e6c64e79fa85d33b8af526fd32bce4fb9dd7261f86b041c53f99a9",
+      "value": "- `provider_not_initialize`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param`：分段正在索引中或已被禁用，无法更新，或索引配置无效。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/summary",
+      "source_sha256": "c15be4cec0361c2ad81b2dd5a2b01b42d73e34372163453132741156880aeb9e",
+      "value": "更新文档中的分段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "分段",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/chunks/update-chunk",
+        "metadata": {
+          "title": "更新文档中的分段",
+          "sidebarTitle": "更新文档中的分段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/description",
+      "source_sha256": "a2a17a68564cdf9ee4a9fb46e0b53445d6c03c014a11d22618ba37c308a07061",
+      "value": "返回特定父分段下子分段的分页列表。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/operationId",
+      "source_sha256": "0f1b8478365258c16c251586d888c7682921f1552e7a7e32b6f78e56a48e4778",
+      "value": "getChildChunks"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/2/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "分段 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/3/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "搜索关键词。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/3",
+      "context_sha256": "4c19ed6189abc1d3b555cee9488bc12c1308ff8769f72729805198c8d1451923"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/3/schema/description",
+      "source_sha256": "6df3eefeb87c839bfaff2ca1531b5446ba6895c2a3740878eb72f30d4cd0101c",
+      "value": "搜索关键词。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/3",
+      "context_sha256": "4c19ed6189abc1d3b555cee9488bc12c1308ff8769f72729805198c8d1451923"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/4/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/4",
+      "context_sha256": "d91843f5442902d84910396ce711ce7f4852175631599c1c4d2b72262307bcb6"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/4/schema/description",
+      "source_sha256": "6fd440ae9f06dff33bd70e8f8366cb431a7da8c9a01df328df9291759ced89c5",
+      "value": "每页的项目数量。服务器上限为 `100`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/4",
+      "context_sha256": "d91843f5442902d84910396ce711ce7f4852175631599c1c4d2b72262307bcb6"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/5/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/5",
+      "context_sha256": "940c6bab5bcb50752c3da3dec2188cc938793db83499f905113f2da64a771d24"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/5/schema/description",
+      "source_sha256": "3fc2cebcfb2707e10d5d54385914fe1fa043a6eb60063fb6666f8cf8de33cabf",
+      "value": "要获取的页码。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/parameters/5",
+      "context_sha256": "940c6bab5bcb50752c3da3dec2188cc938793db83499f905113f2da64a771d24"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": [
+              {
+                "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+                "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                "content": "Dify 是一个开源平台。",
+                "position": 1,
+                "word_count": 6,
+                "type": "customized",
+                "created_at": 1741267200,
+                "updated_at": 1741267200
+              }
+            ],
+            "total": 1,
+            "total_pages": 1,
+            "page": 1,
+            "limit": 20
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/200/description",
+      "source_sha256": "f2fe105ad2b2ef0a8d94b010ab055e9c360fb070adb87189128297de8878ecf1",
+      "value": "子分段列表。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/summary",
+      "source_sha256": "312ced1f585fb66af96701b281920eb208e92a3aec1bc39bd9ba57ca0532c022",
+      "value": "获取子分段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "分段",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/chunks/list-child-chunks",
+        "metadata": {
+          "title": "获取子分段",
+          "sidebarTitle": "获取子分段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/description",
+      "source_sha256": "009ccce37862657fdf8dfea5f92b2bec5032db663826b5f227e79c765a39dae3",
+      "value": "在父分段下创建子分段。适用于使用父子（`hierarchical_model`）分块模式的文档。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/operationId",
+      "source_sha256": "36f2c254b8a3ca28e2c558bac6bd61b8ce652303a00750f331129fd54edbb993",
+      "value": "createChildChunk"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/2/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/2/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "分段 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/parameters/2",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": {
+              "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+              "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "content": "Dify 是一个开源平台。",
+              "position": 1,
+              "word_count": 6,
+              "type": "customized",
+              "created_at": 1741267200,
+              "updated_at": 1741267200
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/200/description",
+      "source_sha256": "3693c1c8711d3a6b6594dbaf4d38650eb27740293f86f35d71b4b63f2c0a4c22",
+      "value": "子分段创建成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+          }
+        },
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Vector store operation failed: [Errno 111] Connection refused"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/400/description",
+      "source_sha256": "b68da3885cf796bb1cf4e80eda6aa2707c388047e6ac0d05c8085cea34fe9274",
+      "value": "- `provider_not_initialize`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param`：在向量库中为子分段建立索引失败；错误信息中会携带底层向量库的报错。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（需要升级套餐）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。\n- `forbidden`：请升级到付费套餐以使用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/responses/404/description",
+      "source_sha256": "ff48c505c00eefe3fa084521575f9194c431da1fc7759c806328dbac4f0e2e56",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/summary",
+      "source_sha256": "e4a80146ef8dea86044b31e8477ee145c6756e6bfad9af0f63c49e989d0970f9",
+      "value": "创建子分段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "分段",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/chunks/create-child-chunk",
+        "metadata": {
+          "title": "创建子分段",
+          "sidebarTitle": "创建子分段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/description",
+      "source_sha256": "b3d6fa9fcf8a189ca4191f14f39c5f3230ea83de280ee33fdd1e907d7dd881b6",
+      "value": "从父分段中永久删除一个子分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/operationId",
+      "source_sha256": "e9894030ed72eb89e8cb25ed03bec0d9fcf451267cb26406b8cb5155b52a84e5",
+      "value": "deleteChildChunk"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "子分段 ID，来自[获取子分段](/zh/api-reference/chunks/list-child-chunks) 返回的 `data[].id`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0/schema/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "子分段 ID，来自[获取子分段](/zh/api-reference/chunks/list-child-chunks) 返回的 `data[].id`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/1/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/2/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/2",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/2/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/2",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/3/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/3",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/3/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "分段 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/parameters/3",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Vector store operation failed: [Errno 111] Connection refused"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/400/description",
+      "source_sha256": "b0a4f10acc3ebbda7648f288ebce4c2f99ab7680d85dc75fef58c021f5fc65b3",
+      "value": "`invalid_param`：从向量库中移除子分段索引失败；错误信息中会携带底层向量库的报错。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（需要升级套餐）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。\n- `forbidden`：请升级到付费套餐以使用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        },
+        "not_found_4": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Child chunk not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/responses/404/description",
+      "source_sha256": "0f8aec0a06e9610ce0eb1948cf91c1ac8dad5fc73e67d2515ab8dd4c5ba1a5fc",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。\n- `not_found`：未找到子分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/summary",
+      "source_sha256": "0687ba8cb41058bd64687e7d0b1327892ab89a3e2ee193bcffad8a305f58ae7c",
+      "value": "删除子分段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "分段",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/delete/x-mint",
+      "value": {
+        "href": "/zh/api-reference/chunks/delete-child-chunk",
+        "metadata": {
+          "title": "删除子分段",
+          "sidebarTitle": "删除子分段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/description",
+      "source_sha256": "c3bf735834bdd01308334fcff18a7afc3e13f0d00c3f54c65e5b86978e96805c",
+      "value": "更新现有子分段的内容。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/operationId",
+      "source_sha256": "74580a3eae200d7bf42f4fa7a18a92ceb9ff692b97b97e538a9ddf8f21a48da4",
+      "value": "updateChildChunk"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "子分段 ID，来自[获取子分段](/zh/api-reference/chunks/list-child-chunks) 返回的 `data[].id`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0/schema/description",
+      "source_sha256": "e6caf044518241ebc32b373c8fb97cd9f0db7f9cb1a4113ab3f9346d9d59db87",
+      "value": "子分段 ID，来自[获取子分段](/zh/api-reference/chunks/list-child-chunks) 返回的 `data[].id`。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/0",
+      "context_sha256": "5a73a28a9836f0676903a1bafffe995c35d9062acfbd65759ef2002937b74da0"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/1/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/2/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/2",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/2/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/2",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/3/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/3",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/3/schema/description",
+      "source_sha256": "2ddb8aea85e23f9c6ed1f8fe8cb0e27abfd7c708f4806e6669052dba232c1e3d",
+      "value": "分段 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/parameters/3",
+      "context_sha256": "be56eb272831adf89fcae6adb26bb0e0eb9a676402d08037a10e61ae356547a2"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": {
+              "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+              "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+              "content": "Dify 是一个开源平台。",
+              "position": 1,
+              "word_count": 6,
+              "type": "customized",
+              "created_at": 1741267200,
+              "updated_at": 1741267200
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/200/description",
+      "source_sha256": "b8afe5664382d136acff908ea897cb057e39aa58a53484a0c746d481aa65466e",
+      "value": "子分段更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Vector store operation failed: [Errno 111] Connection refused"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/400/description",
+      "source_sha256": "c135ee91eab6b090a8faedc3bc08b6215da3a0a5469a5baede6a71c557e7ce49",
+      "value": "`invalid_param`：在向量库中重新索引子分段失败；错误信息中会携带底层向量库的报错。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
+        "forbidden_4": {
+          "summary": "forbidden（需要升级套餐）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。\n- `forbidden`：请升级到付费套餐以使用此功能。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        },
+        "not_found_3": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Segment not found."
+          }
+        },
+        "not_found_4": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Child chunk not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/responses/404/description",
+      "source_sha256": "0f8aec0a06e9610ce0eb1948cf91c1ac8dad5fc73e67d2515ab8dd4c5ba1a5fc",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。\n- `not_found`：未找到子分段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/summary",
+      "source_sha256": "2ed9ea253e3d439a216edecbe07624280c97fe2a4df2a74d8b7e1c17a980d9b6",
+      "value": "更新子分段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/tags/0",
+      "source_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443",
+      "value": "分段",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/tags/0",
+      "context_sha256": "60c0a362218d4f91f794900b54a611c166af183fca22b41b3618d68312269443"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1segments~1{segment_id}~1child_chunks~1{child_chunk_id}/patch/x-mint",
+      "value": {
+        "href": "/zh/api-reference/chunks/update-child-chunk",
+        "metadata": {
+          "title": "更新子分段",
+          "sidebarTitle": "更新子分段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/description",
+      "source_sha256": "76af9a461be7fa6b11b91f204a7691e31b9e256760a10232e79fec948ad06751",
+      "value": "已废弃的文件更新路由。传入 `file` 可替换源文件，传入 `data` 可修改处理设置，也可同时传入两者。省略 `file` 时，Dify 使用提供的设置或当前设置重新处理现有源文件；空的 multipart 请求会使用当前设置重新索引。请改用[更新文档](/zh/api-reference/documents/update-document)。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/operationId",
+      "source_sha256": "e006eb72f006d16927252ae8ae345867056a538e01ba906f52f14d5ed473fd6d",
+      "value": "updateDocumentByFile"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "9a55a691d8c3e1fa35fa97643ae718f7c770b58e29258bbbedb3ba1b046597a9",
+      "value": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "c3ecc43b937e9c81b6f6591d46eb7fb325ddc2af0207e748bdc83f5f7a30e4ab",
+      "value": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/200/description",
+      "source_sha256": "16662764860b1e0ddf01c5e676e787076fb8b5dbd4d0fea1be7dc44670a4bff0",
+      "value": "文档更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param（不可用）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/400/description",
+      "source_sha256": "533998490d38cd2cd57cc910a88ff38c4b5b8ea95add88c0e4404959f3417cb4",
+      "value": "- `too_many_files`：每次请求仅允许一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：文档不可用，无法更新（仅可更新处于可用状态的文档）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：上传的文件超出最大大小限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/responses/415/description",
+      "source_sha256": "3ce1812190ffa7ff82290341eeee927bbc176af9b1a3673fbe9a48cb95ea127d",
+      "value": "`unsupported_file_type`：上传文件的类型不受支持。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/summary",
+      "source_sha256": "6f35a637dbb78c62105d71d60424b6d01ea7629747bd579ba157ffd1ce397402",
+      "value": "用文件更新文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-file/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/update-document-by-file",
+        "metadata": {
+          "title": "用文件更新文档",
+          "sidebarTitle": "用文件更新文档"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/description",
+      "source_sha256": "a1dbb8871afd5bd406a3a82f7e92f93d767bc19e1109c5a919d3afafceb87e9d",
+      "value": "更新文档的文本内容、名称或处理配置。文本变更时会重新索引文档。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/operationId",
+      "source_sha256": "917201fe134585d58cc41bb0c91376351cfd3a8df5db20fa35d4144e31c38854",
+      "value": "updateDocumentByText"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/200/description",
+      "source_sha256": "16662764860b1e0ddf01c5e676e787076fb8b5dbd4d0fea1be7dc44670a4bff0",
+      "value": "文档更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/400/content/application~1json/examples",
+      "value": {
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_name": {
+          "summary": "invalid_param（名称必填）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "name is required when text is provided."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param（不可用）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/400/description",
+      "source_sha256": "cb5c257c217d8f1f52cca70e8322d37a91a023d0e83cede660742c6b2355e402",
+      "value": "- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：提供 `text` 时必须提供 `name`，或 `doc_form` 无效。\n- `invalid_param`：文档不可用，无法更新（仅可更新处于可用状态的文档）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/summary",
+      "source_sha256": "b9c5f2ecf1e7fb0d882c104b61e6f2bdf1b5e9dfbe2fe765ce0fe9b41dca55b6",
+      "value": "用文本更新文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update-by-text/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/documents/update-document-by-text",
+        "metadata": {
+          "title": "用文本更新文档",
+          "sidebarTitle": "用文本更新文档"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/description",
+      "source_sha256": "76af9a461be7fa6b11b91f204a7691e31b9e256760a10232e79fec948ad06751",
+      "value": "已废弃的文件更新路由。传入 `file` 可替换源文件，传入 `data` 可修改处理设置，也可同时传入两者。省略 `file` 时，Dify 使用提供的设置或当前设置重新处理现有源文件；空的 multipart 请求会使用当前设置重新索引。请改用[更新文档](/zh/api-reference/documents/update-document)。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/description",
+      "source_sha256": "9a55a691d8c3e1fa35fa97643ae718f7c770b58e29258bbbedb3ba1b046597a9",
+      "value": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/requestBody/content/multipart~1form-data/schema/properties/data/example",
+      "value": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/requestBody/content/multipart~1form-data/schema/properties/file/description",
+      "source_sha256": "c3ecc43b937e9c81b6f6591d46eb7fb325ddc2af0207e748bdc83f5f7a30e4ab",
+      "value": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/200/description",
+      "source_sha256": "16662764860b1e0ddf01c5e676e787076fb8b5dbd4d0fea1be7dc44670a4bff0",
+      "value": "文档更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/400/content/application~1json/examples",
+      "value": {
+        "too_many_files": {
+          "summary": "too_many_files",
+          "value": {
+            "status": 400,
+            "code": "too_many_files",
+            "message": "Only one file is allowed."
+          }
+        },
+        "filename_not_exists_error": {
+          "summary": "filename_not_exists_error",
+          "value": {
+            "status": 400,
+            "code": "filename_not_exists_error",
+            "message": "The specified filename does not exist."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "invalid_param_not_available": {
+          "summary": "invalid_param（不可用）",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Document is not available"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/400/description",
+      "source_sha256": "533998490d38cd2cd57cc910a88ff38c4b5b8ea95add88c0e4404959f3417cb4",
+      "value": "- `too_many_files`：每次请求仅允许一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：文档不可用，无法更新（仅可更新处于可用状态的文档）。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/413/content/application~1json/examples",
+      "value": {
+        "file_too_large": {
+          "summary": "file_too_large",
+          "value": {
+            "status": 413,
+            "code": "file_too_large",
+            "message": "File size exceeded."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/413/description",
+      "source_sha256": "f8a5e82f4abd4342a13a837347b6e39d22eb6ceef54d3c263d375ae9fba7e165",
+      "value": "`file_too_large`：上传的文件超出最大大小限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/415/content/application~1json/examples",
+      "value": {
+        "unsupported_file_type": {
+          "summary": "unsupported_file_type",
+          "value": {
+            "status": 415,
+            "code": "unsupported_file_type",
+            "message": "File type not allowed."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/responses/415/description",
+      "source_sha256": "3ce1812190ffa7ff82290341eeee927bbc176af9b1a3673fbe9a48cb95ea127d",
+      "value": "`unsupported_file_type`：上传文件的类型不受支持。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/summary",
+      "source_sha256": "6f35a637dbb78c62105d71d60424b6d01ea7629747bd579ba157ffd1ce397402",
+      "value": "用文件更新文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/tags/0",
+      "source_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_file/post/tags/0",
+      "context_sha256": "796e958604092b5bc1df25ebde59c77e0c38518bf4fe4b0a344295a0ca7625af"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/description",
+      "source_sha256": "805859b25c965fd06914de3e232504d9bbfbaf416fdd82ed99dbc2709d16ce50",
+      "value": "已弃用的兼容接口。更新文档的文本内容、名称或处理配置。文本变更时会重新索引文档。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/1/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/1/schema/description",
+      "source_sha256": "23fbd4aea41b4407818f3214f2c63f326cea9de5de7ab5e54b21a9192a16025c",
+      "value": "文档 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/parameters/1",
+      "context_sha256": "47793d748ef6f8423c263ad20c9add2f7f285108e32c0e866fa2b7cf46600fa4"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "document": {
+              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+              "position": 1,
+              "data_source_type": "upload_file",
+              "data_source_info": {
+                "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              },
+              "data_source_detail_dict": {
+                "upload_file": {
+                  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "guide.txt",
+                  "size": 2048,
+                  "extension": "txt",
+                  "mime_type": "text/plain",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200
+                }
+              },
+              "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+              "name": "guide.txt",
+              "created_from": "api",
+              "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+              "created_at": 1741267200,
+              "tokens": 512,
+              "indexing_status": "completed",
+              "error": null,
+              "enabled": true,
+              "disabled_at": null,
+              "disabled_by": null,
+              "archived": false,
+              "display_status": "available",
+              "word_count": 350,
+              "hit_count": 0,
+              "doc_form": "text_model",
+              "doc_metadata": [],
+              "summary_index_status": null,
+              "need_summary": false
+            },
+            "batch": "20250306150245647595"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/200/description",
+      "source_sha256": "60c97252fe7fe0895d4b925c08232e452fddc660a602c5f262a33da8a24fea73",
+      "value": "文档更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（向量空间限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "The capacity of the vector space has reached the limit of your subscription."
+          }
+        },
+        "forbidden_3": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found_1": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        },
+        "not_found_2": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Document not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/responses/404/description",
+      "source_sha256": "132ba4637d397eb9195e9a3d597d78aab23590d86dd1becf15f56cd022d995c4",
+      "value": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/summary",
+      "value": "用文本更新文档"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/tags/0",
+      "source_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186",
+      "value": "文档",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1documents~1{document_id}~1update_by_text/post/tags/0",
+      "context_sha256": "49c20569f26996720e2b5f85ab44a5f6d32039f8f85716d269e09cd745a5e186"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/description",
+      "source_sha256": "1b6a273471cefc413566b4ead87134a3c84acb495bb3ede249151f78d4f0a928",
+      "value": "已弃用的兼容接口。搜索知识库，返回与查询最相关的分段，可用于生产环境检索和测试检索。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "query": {
+              "content": "什么是 Dify？"
+            },
+            "records": [
+              {
+                "segment": {
+                  "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                  "position": 1,
+                  "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                  "content": "Dify 是一个开源的 LLM 应用开发平台。",
+                  "sign_content": "",
+                  "answer": "",
+                  "word_count": 9,
+                  "tokens": 12,
+                  "keywords": [
+                    "dify",
+                    "platform",
+                    "llm"
+                  ],
+                  "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                  "index_node_hash": "abc123def456",
+                  "hit_count": 1,
+                  "enabled": true,
+                  "disabled_at": null,
+                  "disabled_by": null,
+                  "status": "completed",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200,
+                  "indexing_at": 1741267200,
+                  "completed_at": 1741267200,
+                  "error": null,
+                  "stopped_at": null,
+                  "document": {
+                    "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                    "data_source_type": "upload_file",
+                    "name": "guide.txt",
+                    "doc_type": null,
+                    "doc_metadata": null
+                  }
+                },
+                "child_chunks": [],
+                "score": 0.92,
+                "tsne_position": null,
+                "files": [],
+                "summary": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/200/description",
+      "source_sha256": "72cfd432d9024789aaaf04552ae7d8f665081ee8b8203b24a46f5c3f476e12c4",
+      "value": "检索结果。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/400/content/application~1json/examples",
+      "value": {
+        "dataset_not_initialized": {
+          "summary": "dataset_not_initialized",
+          "value": {
+            "status": 400,
+            "code": "dataset_not_initialized",
+            "message": "The dataset is still being initialized or indexing. Please wait a moment."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "provider_quota_exceeded": {
+          "summary": "provider_quota_exceeded",
+          "value": {
+            "status": 400,
+            "code": "provider_quota_exceeded",
+            "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+          }
+        },
+        "model_currently_not_support": {
+          "summary": "model_currently_not_support",
+          "value": {
+            "status": 400,
+            "code": "model_currently_not_support",
+            "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+          }
+        },
+        "completion_request_error": {
+          "summary": "completion_request_error",
+          "value": {
+            "status": 400,
+            "code": "completion_request_error",
+            "message": "Completion request failed."
+          }
+        },
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Invalid parameter value."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/400/description",
+      "source_sha256": "ce76176880f616918d6c7b20b977018e5f26e8c2adc19c1802021b9d67eb68cc",
+      "value": "- `dataset_not_initialized`：知识库仍在初始化或索引中。\n- `provider_not_initialize`：模型供应商未配置有效凭据。\n- `provider_quota_exceeded`：Dify 托管的模型供应商配额已用尽。\n- `model_currently_not_support`：所选模型当前不受支持。\n- `completion_request_error`：模型请求失败。\n- `invalid_param`：请求参数无效。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/500/content/application~1json/examples",
+      "value": {
+        "internal_server_error": {
+          "summary": "internal_server_error",
+          "value": {
+            "status": 500,
+            "code": "internal_server_error",
+            "message": "An internal error occurred."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/responses/500/description",
+      "source_sha256": "7ff0985ae16b809bfe60dcabf89c0a9c1cb26eb5094b1a42c7ca1383a98415f7",
+      "value": "`internal_server_error`：检索过程中发生内部错误。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/summary",
+      "source_sha256": "87e8c189e7515f3b05e873bccc1b31e6ec5fe835993b2ee9a505844da544adbe",
+      "value": "从知识库检索分段 / 测试检索"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "知识库",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1hit-testing/post/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/description",
+      "source_sha256": "33788921af25e665982d40a0341ca680d594f974489419ca3c7d556ca426ed6e",
+      "value": "返回知识库的所有元数据字段（包括自定义和内置字段），以及使用每个字段的文档数量。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/operationId",
+      "source_sha256": "5e365a51b777f5a50df02e5a679f81677cbe2708c2badd0385befcb32ee24b4d",
+      "value": "listMetadataFields"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "doc_metadata": [
+              {
+                "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+                "name": "author",
+                "type": "string",
+                "count": 3
+              }
+            ],
+            "built_in_field_enabled": true
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/200/description",
+      "source_sha256": "ba7c1f3f8ce269fb27b00ca968e87878daaf1c89f5699d8aa4debc5b040e4e60",
+      "value": "知识库的元数据字段。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found`：未找到知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/summary",
+      "source_sha256": "e2a58827df2435c7defdf6d4ef3f7960ce05a5aff67ca731a203893287d22799",
+      "value": "获取元数据字段列表"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "元数据",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/get/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/metadata/list-metadata-fields",
+        "metadata": {
+          "title": "获取元数据字段列表",
+          "sidebarTitle": "获取元数据字段列表"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/description",
+      "source_sha256": "0dd0ea8732c98ed5d3a3badd1f2f9bd8f2cb57f863c4c9b45c8a4b76ac5a03b9",
+      "value": "为知识库创建自定义元数据字段，用于给文档标注结构化信息。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/operationId",
+      "source_sha256": "1b81f8a0bb0dd05a33889880caa3e41661cb38ca78688207f398c0de2babad6a",
+      "value": "createMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/201/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+            "name": "author",
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/201/description",
+      "source_sha256": "52ea81184bc40f3e35601bbb17532d400e4d4ac8f71be00d3ea9293a6eab5a40",
+      "value": "元数据字段创建成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Metadata name already exists."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/400/description",
+      "source_sha256": "6618a59cf2b130264f25a3c6d5352c17f1fdc63d689f9df5cf1c1313d4d4364e",
+      "value": "`invalid_param`：元数据名称已存在、超过 255 个字符，或与内置字段冲突。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found`：未找到知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/summary",
+      "source_sha256": "da5154d1fca1b54fc4a9fa8928c2c56e66b54db0d2593735f8336c0c6af9811d",
+      "value": "创建元数据字段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "元数据",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata/post/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/metadata/create-metadata-field",
+        "metadata": {
+          "title": "创建元数据字段",
+          "sidebarTitle": "创建元数据字段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/description",
+      "source_sha256": "79876621503885ff3ce16d66a89bfd775932a7417299c054f71da517745d1790",
+      "value": "返回系统提供的内置元数据字段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/operationId",
+      "source_sha256": "0ebc461f5dc80515e5865bde6627ce671ce93022a96fdd3354891a986deac0ba",
+      "value": "getBuiltInMetadataFields"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "fields": [
+              {
+                "name": "document_name",
+                "type": "string"
+              },
+              {
+                "name": "uploader",
+                "type": "string"
+              },
+              {
+                "name": "upload_date",
+                "type": "time"
+              },
+              {
+                "name": "last_update_date",
+                "type": "time"
+              },
+              {
+                "name": "source",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/200/description",
+      "source_sha256": "66ca26a2c3f8597dee10b0bf3226c1b865b3ffd646cf13f5405b5f140fd8a5cf",
+      "value": "内置元数据字段。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/summary",
+      "source_sha256": "8d069313bb79848c6914f29163ea56afdd6667982ecb6720c054f9a4480e3971",
+      "value": "获取内置元数据字段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "元数据",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/metadata/get-built-in-metadata-fields",
+        "metadata": {
+          "title": "获取内置元数据字段",
+          "sidebarTitle": "获取内置元数据字段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/description",
+      "source_sha256": "5b47d6c5a23f9bb9e342aaedd716fce8cb872538976e688a323d15841eccffd3",
+      "value": "启用或禁用知识库的内置元数据字段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/operationId",
+      "source_sha256": "10ed165dc04c5ed77fe191c8449d1bbe798ae7bfccc6078c1f5fc38471b87f70",
+      "value": "toggleBuiltInMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/0/description",
+      "source_sha256": "1dd3f3055e8d762d30ec9aab34e699bcf05414f6a58aad415b2815f38ea62b1d",
+      "value": "`enable` 启用内置元数据字段，`disable` 停用内置元数据字段。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/0",
+      "context_sha256": "ad4b96dc1585b0b6e78eb02ace0b893e9eff37da8362f8dd347e147652246557"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/0/schema/description",
+      "source_sha256": "1dd3f3055e8d762d30ec9aab34e699bcf05414f6a58aad415b2815f38ea62b1d",
+      "value": "`enable` 启用内置元数据字段，`disable` 停用内置元数据字段。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/0",
+      "context_sha256": "ad4b96dc1585b0b6e78eb02ace0b893e9eff37da8362f8dd347e147652246557"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/1/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/1/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/parameters/1",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "result": "success"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/200/description",
+      "source_sha256": "cd5d4d9feacf7cf84e4ecf4cdd7226bde00e0accbbc8476462084e1db7bfc726",
+      "value": "内置元数据字段切换成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/responses/404/description",
+      "source_sha256": "033340bf2fdf623931edc7594307dfe500a175b00a43055a5013b00207fbaec8",
+      "value": "- `not_found`：未找到知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/summary",
+      "source_sha256": "91d7cbb4a9b63f9418c32b9744442662d546f4619b8380d12b9707728cce64d2",
+      "value": "更新内置元数据字段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "元数据",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1built-in~1{action}/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/metadata/update-built-in-metadata-field",
+        "metadata": {
+          "title": "更新内置元数据字段",
+          "sidebarTitle": "更新内置元数据字段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/description",
+      "source_sha256": "889cb7e9f96e1d067ed27f09a1f58215da9fda5058e7c0506e6a7b454da03b22",
+      "value": "永久删除自定义元数据字段。使用过该字段的文档将丢失其对应的值。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/operationId",
+      "source_sha256": "587d3c959a22832a86facf279c9fe7aa5258d9050a18bb85c4385b09bb36f46f",
+      "value": "deleteMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/1/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "要删除的元数据字段 ID。参见 [获取元数据字段列表](/zh/api-reference/metadata/list-metadata-fields)。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/1",
+      "context_sha256": "56828aa53cb580a85fc937f42ff1b232eda74b7c159588e499001cb1afb90e97"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/1/schema/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "元数据字段 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/parameters/1",
+      "context_sha256": "56828aa53cb580a85fc937f42ff1b232eda74b7c159588e499001cb1afb90e97"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/204/description",
+      "source_sha256": "ffc9d8bfbce73cbe20559721dcac43f32c618da841d0f037db0100ba311d67aa",
+      "value": "成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/responses/404/description",
+      "source_sha256": "f9344bbe04212d738ce1ad681c593cd2fec6aca518dba6acefb60439467ddef9",
+      "value": "- `not_found`：未找到知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/summary",
+      "source_sha256": "7572a80455fc5f4bc21e259970f515c0fc637edab79302fd28f7688749370eef",
+      "value": "删除元数据字段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "元数据",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/delete/x-mint",
+      "value": {
+        "href": "/zh/api-reference/metadata/delete-metadata-field",
+        "metadata": {
+          "title": "删除元数据字段",
+          "sidebarTitle": "删除元数据字段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/description",
+      "source_sha256": "5100d9c6a30b663ee91ff3b754d9424d8b1987b20828443ed73d104fef95f98d",
+      "value": "重命名自定义元数据字段。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/operationId",
+      "source_sha256": "13589e3a8b1e25e4b2b4131bf3e289e13fe78a6e74e14a7cf2ade74a8bf3e26c",
+      "value": "updateMetadataField"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/1/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "要重命名的元数据字段 ID。参见 [获取元数据字段列表](/zh/api-reference/metadata/list-metadata-fields)。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/1",
+      "context_sha256": "56828aa53cb580a85fc937f42ff1b232eda74b7c159588e499001cb1afb90e97"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/1/schema/description",
+      "source_sha256": "cad9e211b2f84fb9cda5a548c7ee2e20743cb6b4e1429af40937dc91fad7219c",
+      "value": "元数据字段 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/parameters/1",
+      "context_sha256": "56828aa53cb580a85fc937f42ff1b232eda74b7c159588e499001cb1afb90e97"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+            "name": "author",
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/200/description",
+      "source_sha256": "da787a9ca2f96fb3d99c39ea5671cb4f8687bf3a0a2b54273e117daf91e53a9a",
+      "value": "元数据字段更新成功。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Metadata name already exists."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/400/description",
+      "source_sha256": "6618a59cf2b130264f25a3c6d5352c17f1fdc63d689f9df5cf1c1313d4d4364e",
+      "value": "`invalid_param`：元数据名称已存在、超过 255 个字符，或与内置字段冲突。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/responses/404/description",
+      "source_sha256": "f9344bbe04212d738ce1ad681c593cd2fec6aca518dba6acefb60439467ddef9",
+      "value": "- `not_found`：未找到知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/summary",
+      "source_sha256": "2dde97c499bf61a191a64cad37045c22b551a034fcc9214599fd5c850037d1bd",
+      "value": "更新元数据字段"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/tags/0",
+      "source_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a",
+      "value": "元数据",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/tags/0",
+      "context_sha256": "45ee3fee772be9005b60187434822c5ea44d8f9e067f995426b48a1d510a746a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1metadata~1{metadata_id}/patch/x-mint",
+      "value": {
+        "href": "/zh/api-reference/metadata/update-metadata-field",
+        "metadata": {
+          "title": "更新元数据字段",
+          "sidebarTitle": "更新元数据字段"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/description",
+      "source_sha256": "feb4ac9b0ae2f85182d1ee6a54ca594baed433b611429620dfd78fa6365953e3",
+      "value": "返回知识流水线中已配置的数据源节点，每个节点包含其使用的插件，以及运行该节点所需的元数据。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/operationId",
+      "source_sha256": "f990d17656951c7129d79f0d5d2e4080ff2591e79d94e24bc373ae5a4402cc6d",
+      "value": "listDatasourcePlugins"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/1/description",
+      "source_sha256": "5c48d3437a279f6bd9bde8071f0c9482a5fc24366e0d244247f80f4d668dc02d",
+      "value": "是否从已发布或草稿知识流水线中获取节点。`true` 返回已发布版本的节点，`false` 返回草稿版本的节点。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/1",
+      "context_sha256": "4c3aff055f9619794ea483a8b387e4fda4079e664eb04368f67b9493ea8be1bd"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/1/schema/description",
+      "source_sha256": "5c48d3437a279f6bd9bde8071f0c9482a5fc24366e0d244247f80f4d668dc02d",
+      "value": "是否从已发布或草稿知识流水线中获取节点。`true` 返回已发布版本的节点，`false` 返回草稿版本的节点。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/parameters/1",
+      "context_sha256": "4c3aff055f9619794ea483a8b387e4fda4079e664eb04368f67b9493ea8be1bd"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": [
+            {
+              "node_id": "1719288585006",
+              "plugin_id": "langgenius/notion_datasource",
+              "provider_name": "notion",
+              "datasource_type": "online_document",
+              "title": "Notion 文档",
+              "user_input_variables": [],
+              "credentials": [
+                {
+                  "id": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
+                  "name": "生产环境 Notion",
+                  "type": "api-key",
+                  "is_default": true
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/200/description",
+      "source_sha256": "7c3bea87e57a887b4b18fb38f1d03521a3d01fb391bfacecff3395ad14ead7bd",
+      "value": "流水线中已配置的数据源节点列表。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Pipeline not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/400/description",
+      "source_sha256": "db2230c4a1d91554b104c3ffdff8b7f3c502d3cf1a33ea3af97f922ed40b4bf9",
+      "value": "`invalid_param`：该知识库未配置处理流水线。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/summary",
+      "source_sha256": "4d0e7142c4d6897e49dc27247872d389f612ad12b565369307ce4943b646eba7",
+      "value": "获取数据源插件列表"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/tags/0",
+      "source_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a",
+      "value": "知识流水线",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/tags/0",
+      "context_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource-plugins/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/knowledge-pipeline/list-datasource-plugins",
+        "metadata": {
+          "title": "获取数据源插件列表",
+          "sidebarTitle": "获取数据源插件列表"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/description",
+      "source_sha256": "13d3e5d7adcd75ac7332e0d629682a2ca35b4b67e912b0960ee2c303d5805e8b",
+      "value": "运行知识流水线中的单个数据源节点，并流式返回其执行事件。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/operationId",
+      "source_sha256": "7f25eec20a543dee68717bb411edb791dd707832a104c288918fd1589af2dd80",
+      "value": "runDatasourceNode"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/1/description",
+      "source_sha256": "a23fb9cd48d79a47e5d934fd913a0bdd0bc370ff0e607a088b913b10245fd367",
+      "value": "要运行的数据源节点 ID，来自 [获取数据源插件列表](/zh/api-reference/knowledge-pipeline/list-datasource-plugins)。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/1",
+      "context_sha256": "917ec31080f646f2c485bf333dcf0ed42526aacdc1ffb11e011998b1c255c715"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/1/schema/description",
+      "source_sha256": "a23fb9cd48d79a47e5d934fd913a0bdd0bc370ff0e607a088b913b10245fd367",
+      "value": "要执行的数据源节点 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/parameters/1",
+      "context_sha256": "917ec31080f646f2c485bf333dcf0ed42526aacdc1ffb11e011998b1c255c715"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/200/content/text~1event-stream/examples",
+      "value": {
+        "successfulStream": {
+          "summary": "响应示例 - 成功事件流",
+          "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"数据源\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/200/content/text~1event-stream/schema/description",
+      "value": "草稿知识流水线运行的 Server-Sent Events 流。按 [SSE 流式传输指南](/zh/api-reference/guides/streaming) 解析 `data:` 记录。常见事件包括 `workflow_started`、`node_started`、`node_finished`、`workflow_finished` 和 `error`；事件载荷使用与工作流事件流相同的封装格式。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/200/description",
+      "source_sha256": "59ab3bf79aefdaacb4128bf3c6b006b7f5321f448fff4a39833fb3815fd70ca4",
+      "value": "包含节点执行事件的流式响应。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Pipeline not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/400/description",
+      "source_sha256": "d57c0d2e88fbc9431697aba76dcae3474a713f9f957f134bfabd3855e4b65d32",
+      "value": "`invalid_param`：该知识库未配置处理流水线，或请求体校验失败。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/summary",
+      "source_sha256": "507b3c6b167e264c8e02ab5ea68899e0a8d6c29a9d876403bc877a2f68e48c79",
+      "value": "执行数据源节点"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/tags/0",
+      "source_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a",
+      "value": "知识流水线",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/tags/0",
+      "context_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1datasource~1nodes~1{node_id}~1run/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/knowledge-pipeline/run-datasource-node",
+        "metadata": {
+          "title": "执行数据源节点",
+          "sidebarTitle": "执行数据源节点"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/description",
+      "source_sha256": "faa3758b412a8ad31d89a4d1c1191f1770864268db1140c3eb54c8e87248d5fe",
+      "value": "对一个或多个数据源运行完整的知识流水线。已发布运行会进入队列，并始终以 JSON 返回批次元数据；草稿运行支持阻塞 JSON 和流式 Server-Sent Events。 对已发布运行，将返回的 `batch` 传给[获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status)，轮询直到所有文档达到 `completed`、`error` 或 `paused`。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/operationId",
+      "source_sha256": "db44679c628f777475bd972f7b36223d20c28e3cd93e58eb10d5ec69d2058d40",
+      "value": "runPipeline"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/requestBody/content/application~1json/examples",
+      "value": {
+        "local_file": {
+          "summary": "请求示例 - 本地文件",
+          "value": {
+            "inputs": {},
+            "datasource_type": "local_file",
+            "datasource_info_list": [
+              {
+                "reference": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "name": "quarterly-report.pdf"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": false,
+            "response_mode": "blocking"
+          }
+        },
+        "online_document": {
+          "summary": "请求示例 - 在线文档",
+          "value": {
+            "inputs": {},
+            "datasource_type": "online_document",
+            "datasource_info_list": [
+              {
+                "workspace_id": "ws-abc123",
+                "page": {
+                  "page_id": "pg-def456",
+                  "type": "page",
+                  "page_name": "产品路线图"
+                },
+                "credential_id": "cred-789xyz"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": false,
+            "response_mode": "streaming"
+          }
+        },
+        "website_crawl": {
+          "summary": "请求示例 - 网站爬取",
+          "value": {
+            "inputs": {},
+            "datasource_type": "website_crawl",
+            "datasource_info_list": [
+              {
+                "url": "https://example.com/docs/getting-started",
+                "title": "入门指南"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": true,
+            "response_mode": "blocking"
+          }
+        },
+        "online_drive": {
+          "summary": "请求示例 - 在线存储",
+          "value": {
+            "inputs": {},
+            "datasource_type": "online_drive",
+            "datasource_info_list": [
+              {
+                "id": "file-abc123",
+                "type": "file",
+                "bucket": "my-bucket",
+                "name": "meeting-notes.docx"
+              }
+            ],
+            "start_node_id": "1719288585006",
+            "is_published": true,
+            "response_mode": "blocking"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/application~1json/examples",
+      "value": {
+        "published": {
+          "summary": "已发布流水线响应",
+          "value": {
+            "batch": "20260825143015948271",
+            "dataset": {
+              "id": "c9f5e6f0-d10a-4f57-a1d8-a4b63f8459f4",
+              "name": "产品文档",
+              "description": "产品说明文档",
+              "chunk_structure": "text_model"
+            },
+            "documents": [
+              {
+                "id": "9af03c49-30c4-4d64-a605-17f3171fbf9a",
+                "position": 1,
+                "data_source_type": "local_file",
+                "data_source_info": {
+                  "reference": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "name": "quarterly-report.pdf"
+                },
+                "name": "quarterly-report.pdf",
+                "indexing_status": "waiting",
+                "error": null,
+                "enabled": true
+              }
+            ]
+          }
+        },
+        "draft_blocking": {
+          "summary": "草稿阻塞响应",
+          "value": {
+            "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "workflow_run_id": "f1e2d3c4-b5a6-7890-abcd-ef0987654321",
+            "data": {
+              "id": "f1e2d3c4-b5a6-7890-abcd-ef0987654321",
+              "status": "succeeded",
+              "outputs": {},
+              "created_at": 1741267200,
+              "finished_at": 1741267210,
+              "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+              "error": null,
+              "elapsed_time": 10.0,
+              "total_tokens": 0,
+              "total_steps": 1
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/application~1json/schema/description",
+      "value": "已发布运行的 JSON 结果，或草稿运行在 `blocking` 模式下的 JSON 结果。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/text~1event-stream/examples",
+      "value": {
+        "successfulStream": {
+          "summary": "响应示例 - 成功事件流",
+          "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"数据源\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/content/text~1event-stream/schema/description",
+      "value": "草稿知识流水线运行的 Server-Sent Events 流。按 [SSE 流式传输指南](/zh/api-reference/guides/streaming) 解析 `data:` 记录。常见事件包括 `workflow_started`、`node_started`、`node_finished`、`workflow_finished` 和 `error`；事件载荷使用与工作流事件流相同的封装格式。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/200/description",
+      "source_sha256": "45761354a7ce3733550c7edbcc2dbe40b681b7a44ba567081d5dd69228cdb15f",
+      "value": "流水线执行结果。已发布运行以 JSON 返回排队批次元数据；草稿运行在 `streaming` 模式下返回 Server-Sent Events，在 `blocking` 模式下以 JSON 返回工作流结果。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/400/content/application~1json/examples",
+      "value": {
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Pipeline not found"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/400/description",
+      "source_sha256": "d57c0d2e88fbc9431697aba76dcae3474a713f9f957f134bfabd3855e4b65d32",
+      "value": "`invalid_param`：该知识库未配置处理流水线，或请求体校验失败。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/403/description",
+      "source_sha256": "ab52983735f79a161ccb282f9eed5a5f20c2d5d1615e465886b14a9ebf6b8c16",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/404/description",
+      "source_sha256": "d94d30ae1ab4711511ac883fef5ef97bd85681fea6a8f647b5066387dcacbc10",
+      "value": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/500/content/application~1json/examples",
+      "value": {
+        "pipeline_run_error": {
+          "summary": "pipeline_run_error",
+          "value": {
+            "status": 500,
+            "code": "pipeline_run_error",
+            "message": "Pipeline execution failed: connection timeout"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/responses/500/description",
+      "source_sha256": "16f4ac1f65da72ed06b3ecd39d2313d5fbc81febec85e4d94e3877a21b8b3692",
+      "value": "`pipeline_run_error`：流水线执行失败。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/summary",
+      "source_sha256": "6194c9c4272379e2430ee7f679d5c73d203011bb9333a078c7b0b294a7a501df",
+      "value": "运行流水线"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/tags/0",
+      "source_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a",
+      "value": "知识流水线",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/tags/0",
+      "context_sha256": "91f0d5a255f3f26e42288dc2d1ea0797c1c7e9d3b2c971974c62552c44e1005a"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1pipeline~1run/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/knowledge-pipeline/run-pipeline",
+        "metadata": {
+          "title": "运行流水线",
+          "sidebarTitle": "运行流水线"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/description",
+      "source_sha256": "1b6a273471cefc413566b4ead87134a3c84acb495bb3ede249151f78d4f0a928",
+      "value": "搜索知识库，返回与查询最相关的分段，可用于生产环境检索和测试检索。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/operationId",
+      "source_sha256": "19ff09ba426482984392455ff84146de3c6422362f175e8969078ad93da31581",
+      "value": "retrieveSegments"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "query": {
+              "content": "什么是 Dify？"
+            },
+            "records": [
+              {
+                "segment": {
+                  "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                  "position": 1,
+                  "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                  "content": "Dify 是一个开源的 LLM 应用开发平台。",
+                  "sign_content": "",
+                  "answer": "",
+                  "word_count": 9,
+                  "tokens": 12,
+                  "keywords": [
+                    "dify",
+                    "platform",
+                    "llm"
+                  ],
+                  "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                  "index_node_hash": "abc123def456",
+                  "hit_count": 1,
+                  "enabled": true,
+                  "disabled_at": null,
+                  "disabled_by": null,
+                  "status": "completed",
+                  "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                  "created_at": 1741267200,
+                  "indexing_at": 1741267200,
+                  "completed_at": 1741267200,
+                  "error": null,
+                  "stopped_at": null,
+                  "document": {
+                    "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                    "data_source_type": "upload_file",
+                    "name": "guide.txt",
+                    "doc_type": null,
+                    "doc_metadata": null
+                  }
+                },
+                "child_chunks": [],
+                "score": 0.92,
+                "tsne_position": null,
+                "files": [],
+                "summary": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/200/description",
+      "source_sha256": "72cfd432d9024789aaaf04552ae7d8f665081ee8b8203b24a46f5c3f476e12c4",
+      "value": "检索结果。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/400/content/application~1json/examples",
+      "value": {
+        "dataset_not_initialized": {
+          "summary": "dataset_not_initialized",
+          "value": {
+            "status": 400,
+            "code": "dataset_not_initialized",
+            "message": "The dataset is still being initialized or indexing. Please wait a moment."
+          }
+        },
+        "provider_not_initialize": {
+          "summary": "provider_not_initialize",
+          "value": {
+            "status": 400,
+            "code": "provider_not_initialize",
+            "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+          }
+        },
+        "provider_quota_exceeded": {
+          "summary": "provider_quota_exceeded",
+          "value": {
+            "status": 400,
+            "code": "provider_quota_exceeded",
+            "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+          }
+        },
+        "model_currently_not_support": {
+          "summary": "model_currently_not_support",
+          "value": {
+            "status": 400,
+            "code": "model_currently_not_support",
+            "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+          }
+        },
+        "completion_request_error": {
+          "summary": "completion_request_error",
+          "value": {
+            "status": 400,
+            "code": "completion_request_error",
+            "message": "Completion request failed."
+          }
+        },
+        "invalid_param": {
+          "summary": "invalid_param",
+          "value": {
+            "status": 400,
+            "code": "invalid_param",
+            "message": "Invalid parameter value."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/400/description",
+      "source_sha256": "ce76176880f616918d6c7b20b977018e5f26e8c2adc19c1802021b9d67eb68cc",
+      "value": "- `dataset_not_initialized`：知识库仍在初始化或索引中。\n- `provider_not_initialize`：模型供应商未配置有效凭据。\n- `provider_quota_exceeded`：Dify 托管的模型供应商配额已用尽。\n- `model_currently_not_support`：所选模型当前不受支持。\n- `completion_request_error`：模型请求失败。\n- `invalid_param`：请求参数无效。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden_1": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        },
+        "forbidden_2": {
+          "summary": "forbidden（速率限制）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/403/description",
+      "source_sha256": "969d1feaf15731c5161adf5cb4e9ab9a0b9fefe3659c74d18bb4e1b7bc8a1894",
+      "value": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/404/content/application~1json/examples",
+      "value": {
+        "not_found": {
+          "summary": "not_found",
+          "value": {
+            "status": 404,
+            "code": "not_found",
+            "message": "Dataset not found."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/404/description",
+      "source_sha256": "8ea8bdbf24ae5bfe53b44afa270d5b37ef1fda3273b3fe46293d28ce841e85cd",
+      "value": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/500/content/application~1json/examples",
+      "value": {
+        "internal_server_error": {
+          "summary": "internal_server_error",
+          "value": {
+            "status": 500,
+            "code": "internal_server_error",
+            "message": "An internal error occurred."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/responses/500/description",
+      "source_sha256": "7ff0985ae16b809bfe60dcabf89c0a9c1cb26eb5094b1a42c7ca1383a98415f7",
+      "value": "`internal_server_error`：检索过程中发生内部错误。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/summary",
+      "source_sha256": "87e8c189e7515f3b05e873bccc1b31e6ec5fe835993b2ee9a505844da544adbe",
+      "value": "从知识库检索分段 / 测试检索"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/tags/0",
+      "source_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44",
+      "value": "知识库",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/tags/0",
+      "context_sha256": "c7f0e2748af5bd34eab7581d8ae875d981822e136f5e42a0bb61d188ac327f44"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1retrieve/post/x-mint",
+      "value": {
+        "href": "/zh/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
+        "metadata": {
+          "title": "从知识库检索分段 / 测试检索",
+          "sidebarTitle": "从知识库检索分段 / 测试检索"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/description",
+      "source_sha256": "fb2e79f72fece5c6adcee227ed40bb9e2680575510ea87ac2e07ab2173e98d07",
+      "value": "返回绑定到知识库的标签。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/operationId",
+      "source_sha256": "37573482ef29c34a30d4d9b7ebc5ccc95aad0e566b3e5b7639f7bfdfee3cac6a",
+      "value": "queryDatasetTags"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/parameters/0/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1tags/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/parameters/0/schema/description",
+      "source_sha256": "9e697dfc04117120ce35b4341b4290fc4c77eabb9f30cd9efca8ff0c71be91f9",
+      "value": "知识库 ID。",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1tags/get/parameters/0",
+      "context_sha256": "dbd2dc224f62802cd07fc0e260c3f662a687eb5c54ec1765e990e81082814841"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": [
+              {
+                "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                "name": "产品文档"
+              }
+            ],
+            "total": 1
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/200/description",
+      "source_sha256": "4eeb56724fdbffc386777edbce05a72ec0dab7cc3c68c1de428df3add001b027",
+      "value": "绑定到知识库的标签。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/403/content/application~1json/examples",
+      "value": {
+        "forbidden": {
+          "summary": "forbidden（API 访问）",
+          "value": {
+            "status": 403,
+            "code": "forbidden",
+            "message": "Dataset api access is not enabled."
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/responses/403/description",
+      "source_sha256": "78cfc42f89cdec297ccb600311195b5a6e49e4672944d2f51488ef161dca359f",
+      "value": "- `forbidden`：该知识库未启用 API 访问。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/summary",
+      "source_sha256": "2e65c66e51b7ebe86135ba85681ea809228785490b52390d5bd9880ec0dd1172",
+      "value": "获取知识库绑定的标签"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/tags/0",
+      "source_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7",
+      "value": "标签",
+      "context_path": "/paths/~1datasets~1{dataset_id}~1tags/get/tags/0",
+      "context_sha256": "3f913eb2574a9ff5f196388b13af09668001697924377581420f3f9a344150f7"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1datasets~1{dataset_id}~1tags/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/tags/get-knowledge-base-tags",
+        "metadata": {
+          "title": "获取知识库绑定的标签",
+          "sidebarTitle": "获取知识库绑定的标签"
+        }
+      }
+    },
+    {
+      "op": "replace",
       "path": "/paths/~1end-users~1{end_user_id}/get/description",
       "source_sha256": "c71a3cc9a229bafc345728f45437806a24c9b2ef69e6b244b57384fd7c02beb9",
       "value": "**适用于**：Chatflow、Workflow、新 Agent、聊天助手、Agent、文本生成应用。\n\n根据 ID 返回终端用户的详细信息。当需要解析其他接口返回的终端用户 ID（例如 [上传文件](/zh/api-reference/files/upload-file) 响应中的 `created_by`）时很有用。"
@@ -20796,6 +30771,131 @@
         "metadata": {
           "title": "按 ID 执行工作流",
           "sidebarTitle": "按 ID 执行工作流"
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/description",
+      "source_sha256": "9fbc97df50241cb2eaa3aefc3016b04ef8e3d7b07ae64b47cbd14d759fd5ebaf",
+      "value": "返回指定类型的可用模型。用它查找可配置到知识库的 `text-embedding` 和 `rerank` 模型。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/operationId",
+      "source_sha256": "f4ee87fe7d3529fa0dbe0937acc9f5092742b98d9ba99fe22e2bb41dd150d776",
+      "value": "getAvailableModels"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/parameters/0/description",
+      "source_sha256": "779c9a4c0c0e5098f998e71ed1fb5e41c3e47ec1e5b7f5e4e32fc226ad47454c",
+      "value": "要获取的模型类型。",
+      "context_path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/parameters/0",
+      "context_sha256": "158387c2f9e0dd11d63064542fcf97121ba859a8904f5f82c7ee992b121fe3df"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/parameters/0/schema/description",
+      "source_sha256": "779c9a4c0c0e5098f998e71ed1fb5e41c3e47ec1e5b7f5e4e32fc226ad47454c",
+      "value": "要获取的模型类型。",
+      "context_path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/parameters/0",
+      "context_sha256": "158387c2f9e0dd11d63064542fcf97121ba859a8904f5f82c7ee992b121fe3df"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/200/content/application~1json/examples",
+      "value": {
+        "success": {
+          "summary": "响应示例",
+          "value": {
+            "data": [
+              {
+                "provider": "langgenius/openai/openai",
+                "label": {
+                  "en_US": "OpenAI",
+                  "zh_Hans": "OpenAI"
+                },
+                "icon_small": {
+                  "en_US": "https://example.com/openai-small.svg",
+                  "zh_Hans": "https://example.com/openai-small.svg"
+                },
+                "status": "active",
+                "models": [
+                  {
+                    "model": "text-embedding-3-small",
+                    "label": {
+                      "en_US": "text-embedding-3-small",
+                      "zh_Hans": "text-embedding-3-small"
+                    },
+                    "model_type": "text-embedding",
+                    "features": null,
+                    "fetch_from": "predefined-model",
+                    "model_properties": {
+                      "context_size": 8191
+                    },
+                    "status": "active",
+                    "deprecated": false,
+                    "load_balancing_enabled": false,
+                    "has_invalid_load_balancing_configs": false
+                  }
+                ],
+                "tenant_id": "11223344-5566-7788-99aa-bbccddeeff00",
+                "icon_small_dark": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/200/description",
+      "source_sha256": "bc82619e3afc16385018acef86e9503f2c9ec0ad504530f9e60e4583a0da51ff",
+      "value": "指定类型的可用模型。"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/401/content/application~1json/examples",
+      "value": {
+        "unauthorized": {
+          "summary": "unauthorized",
+          "value": {
+            "status": 401,
+            "code": "unauthorized",
+            "message": "Authorization header must be provided and start with 'Bearer'"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/responses/401/description",
+      "source_sha256": "0f4e3fb16feb8cd466cc842450ef4c21d4bd3052e5db51733392c3304cf68710",
+      "value": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/summary",
+      "source_sha256": "7046ae9d6a5c6a5c6ee968031ad256254f162665fae67ba0ca88262f6019e1c8",
+      "value": "获取可用模型"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/tags/0",
+      "source_sha256": "527919df30e60438b9999d570aca82ff0214c59755ad69ea14a15900b5b06c26",
+      "value": "模型",
+      "context_path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/tags/0",
+      "context_sha256": "527919df30e60438b9999d570aca82ff0214c59755ad69ea14a15900b5b06c26"
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1workspaces~1current~1models~1model-types~1{model_type}/get/x-mint",
+      "value": {
+        "href": "/zh/api-reference/models/get-available-models",
+        "metadata": {
+          "title": "获取可用模型",
+          "sidebarTitle": "获取可用模型"
         }
       }
     },


### PR DESCRIPTION
## Summary

- add reviewed presentation overlays for knowledge Service API operations
- preserve localized summaries, descriptions, examples, Mintlify metadata, and published operation IDs
- change only the three overlay files; rendered references follow in the subsequent layers

## Validation

- overlay JSON parsed successfully in all three locales