### PR TITLE
docs: generate knowledge base references

### DIFF
--- a/en/api-reference/openapi_service.json
+++ b/en/api-reference/openapi_service.json
@@ -2789,326 +2789,73 @@
       }
     },
     "/datasets": {
-      "post": {
-        "tags": [
-          "Knowledge Bases"
-        ],
-        "summary": "Create an Empty Knowledge Base",
-        "description": "Creates an empty knowledge base. Add documents to it with [Create Document by Text](/en/api-reference/documents/create-document-by-text) or [Create Document by File](/en/api-reference/documents/create-document-by-file).",
-        "operationId": "createDataset",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 40,
-                    "description": "Name of the knowledge base."
-                  },
-                  "description": {
-                    "type": "string",
-                    "maxLength": 400,
-                    "default": "",
-                    "description": "Description of the knowledge base."
-                  },
-                  "indexing_technique": {
-                    "type": "string",
-                    "enum": [
-                      "high_quality",
-                      "economy"
-                    ],
-                    "nullable": true,
-                    "description": "`high_quality` uses embedding models for precise search; `economy` uses keyword-based indexing."
-                  },
-                  "permission": {
-                    "type": "string",
-                    "enum": [
-                      "only_me",
-                      "all_team_members",
-                      "partial_members"
-                    ],
-                    "default": "only_me",
-                    "description": "Controls who can access this knowledge base. `only_me` restricts to the creator, `all_team_members` grants access to the entire workspace, `partial_members` grants access to specified members."
-                  },
-                  "provider": {
-                    "type": "string",
-                    "enum": [
-                      "vendor",
-                      "external"
-                    ],
-                    "default": "vendor",
-                    "description": "`vendor` for internal knowledge base, `external` for external knowledge base."
-                  },
-                  "embedding_model": {
-                    "type": "string",
-                    "description": "Embedding model name. Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
-                  },
-                  "embedding_model_provider": {
-                    "type": "string",
-                    "description": "Embedding model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). A bare name like `openai` expands to `langgenius/<name>/<name>` and works only for langgenius-published plugins.\n\nGet valid values from the `provider` field of [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "Retrieval model configuration. Controls how chunks are searched and ranked when querying this knowledge base."
-                  },
-                  "external_knowledge_api_id": {
-                    "type": "string",
-                    "description": "ID of the external knowledge API connection."
-                  },
-                  "external_knowledge_id": {
-                    "type": "string",
-                    "description": "ID of the external knowledge base."
-                  },
-                  "summary_index_setting": {
-                    "type": "object",
-                    "nullable": true,
-                    "description": "Summary index configuration.",
-                    "properties": {
-                      "enable": {
-                        "type": "boolean",
-                        "description": "Whether to enable summary indexing."
-                      },
-                      "model_name": {
-                        "type": "string",
-                        "description": "Name of the model used for generating summaries."
-                      },
-                      "model_provider_name": {
-                        "type": "string",
-                        "description": "Provider of the summary generation model."
-                      },
-                      "summary_prompt": {
-                        "type": "string",
-                        "description": "Custom prompt template for summary generation."
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Knowledge base created successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Dataset"
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
-                      "name": "Product Documentation",
-                      "description": "Technical documentation for the product API",
-                      "provider": "vendor",
-                      "permission": "only_me",
-                      "data_source_type": null,
-                      "indexing_technique": "high_quality",
-                      "app_count": 0,
-                      "document_count": 0,
-                      "word_count": 0,
-                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "author_name": "admin",
-                      "created_at": 1741267200,
-                      "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "updated_at": 1741267200,
-                      "embedding_model": "text-embedding-3-small",
-                      "embedding_model_provider": "langgenius/openai/openai",
-                      "embedding_available": true,
-                      "retrieval_model_dict": {
-                        "search_method": "semantic_search",
-                        "reranking_enable": false,
-                        "reranking_mode": null,
-                        "reranking_model": {
-                          "reranking_provider_name": "",
-                          "reranking_model_name": ""
-                        },
-                        "weights": null,
-                        "top_k": 3,
-                        "score_threshold_enabled": false,
-                        "score_threshold": null
-                      },
-                      "tags": [],
-                      "doc_form": "text_model",
-                      "external_knowledge_info": null,
-                      "external_retrieval_model": null,
-                      "doc_metadata": [],
-                      "built_in_field_enabled": true,
-                      "pipeline_id": null,
-                      "runtime_mode": null,
-                      "chunk_structure": null,
-                      "icon_info": null,
-                      "summary_index_setting": null,
-                      "is_published": false,
-                      "total_documents": 0,
-                      "total_available_documents": 0,
-                      "enable_api": true,
-                      "is_multimodal": false,
-                      "maintainer": "admin"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : The embedding or reranking model you specified is not configured or available.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : Your subscription's knowledge base request rate limit has been reached.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "`dataset_name_duplicate` : A knowledge base with the same name already exists.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "dataset_name_duplicate": {
-                    "summary": "dataset_name_duplicate",
-                    "value": {
-                      "status": 409,
-                      "code": "dataset_name_duplicate",
-                      "message": "The dataset name already exists. Please modify your dataset name."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/knowledge-bases/create-an-empty-knowledge-base",
-          "metadata": {
-            "title": "Create an Empty Knowledge Base",
-            "sidebarTitle": "Create an Empty Knowledge Base"
-          }
-        }
-      },
       "get": {
-        "tags": [
-          "Knowledge Bases"
-        ],
-        "summary": "List Knowledge Bases",
         "description": "Returns a paginated list of knowledge bases, optionally filtered by keyword or tags.",
         "operationId": "listDatasets",
         "parameters": [
           {
-            "name": "page",
+            "description": "Whether to include all knowledge bases regardless of permissions.",
             "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 1
-            },
-            "description": "Page number."
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 20
-            },
-            "description": "Number of items per page."
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            },
-            "description": "Search keyword to filter by name."
-          },
-          {
             "name": "include_all",
-            "in": "query",
+            "required": false,
             "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "Whether to include all knowledge bases regardless of permissions."
+              "default": false,
+              "description": "Whether to include all knowledge bases regardless of permissions.",
+              "type": "boolean"
+            }
           },
           {
-            "name": "tag_ids",
+            "description": "Search keyword to filter by name.",
             "in": "query",
+            "name": "keyword",
+            "required": false,
             "schema": {
-              "type": "array",
+              "description": "Search keyword to filter by name.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of items per page. Server caps at `100`.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of items per page. Server caps at `100`.",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number to retrieve.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "Page number to retrieve.",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Tag IDs to filter by.",
+            "in": "query",
+            "name": "tag_ids",
+            "required": false,
+            "schema": {
+              "description": "Tag IDs to filter by.",
               "items": {
                 "type": "string"
-              }
-            },
-            "style": "form",
-            "explode": true,
-            "description": "Tag IDs to filter by. Get tag IDs from [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags)."
+              },
+              "type": "array"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "List of knowledge bases.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "Array of knowledge base objects.",
-                      "items": {
-                        "$ref": "#/components/schemas/Dataset"
-                      }
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "Whether more items exist on the next page."
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "Number of items per page."
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "Total number of matching items."
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "Current page number."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetListResponse"
                 },
                 "examples": {
                   "success": {
@@ -3149,15 +2896,12 @@
                           },
                           "tags": [],
                           "doc_form": "text_model",
-                          "external_knowledge_info": null,
                           "external_retrieval_model": null,
                           "doc_metadata": [],
                           "built_in_field_enabled": true,
                           "pipeline_id": null,
                           "runtime_mode": null,
                           "chunk_structure": null,
-                          "icon_info": null,
-                          "summary_index_setting": null,
                           "is_published": false,
                           "total_documents": 0,
                           "total_available_documents": 0,
@@ -3174,14 +2918,212 @@
                   }
                 }
               }
-            }
+            },
+            "description": "List of knowledge bases."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "forbidden",
+                  "message": "Forbidden.",
+                  "status": 403
+                }
+              }
+            },
+            "description": "Forbidden - dataset API access or workspace access denied"
           }
         },
+        "summary": "List Knowledge Bases",
+        "tags": [
+          "Knowledge Bases"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl -X GET 'https://{api_base_url}/datasets?page=1&limit=20' \\\n  -H 'Authorization: Bearer {api_key}'"
+          }
+        ],
         "x-mint": {
           "href": "/en/api-reference/knowledge-bases/list-knowledge-bases",
           "metadata": {
             "title": "List Knowledge Bases",
             "sidebarTitle": "List Knowledge Bases"
+          }
+        }
+      },
+      "post": {
+        "description": "Creates an empty knowledge base. Add documents to it with [Create Document by Text](/en/api-reference/documents/create-document-by-text) or [Create Document by File](/en/api-reference/documents/create-document-by-file).",
+        "operationId": "createDataset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetCreatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetDetailResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+                      "name": "Product Documentation",
+                      "description": "Technical documentation for the product API",
+                      "provider": "vendor",
+                      "permission": "only_me",
+                      "data_source_type": null,
+                      "indexing_technique": "high_quality",
+                      "app_count": 0,
+                      "document_count": 0,
+                      "word_count": 0,
+                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "author_name": "admin",
+                      "created_at": 1741267200,
+                      "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "updated_at": 1741267200,
+                      "embedding_model": "text-embedding-3-small",
+                      "embedding_model_provider": "langgenius/openai/openai",
+                      "embedding_available": true,
+                      "retrieval_model_dict": {
+                        "search_method": "semantic_search",
+                        "reranking_enable": false,
+                        "reranking_mode": null,
+                        "reranking_model": {
+                          "reranking_provider_name": "",
+                          "reranking_model_name": ""
+                        },
+                        "weights": null,
+                        "top_k": 3,
+                        "score_threshold_enabled": false,
+                        "score_threshold": null
+                      },
+                      "tags": [],
+                      "doc_form": "text_model",
+                      "external_retrieval_model": null,
+                      "doc_metadata": [],
+                      "built_in_field_enabled": true,
+                      "pipeline_id": null,
+                      "runtime_mode": null,
+                      "chunk_structure": null,
+                      "is_published": false,
+                      "total_documents": 0,
+                      "total_available_documents": 0,
+                      "enable_api": true,
+                      "is_multimodal": false,
+                      "maintainer": "admin"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Knowledge base created successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param` : The embedding or reranking model you specified is not configured or available."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Your subscription's knowledge base request rate limit has been reached."
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_name_duplicate": {
+                    "summary": "dataset_name_duplicate",
+                    "value": {
+                      "status": 409,
+                      "code": "dataset_name_duplicate",
+                      "message": "The dataset name already exists. Please modify your dataset name."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`dataset_name_duplicate` : A knowledge base with the same name already exists."
+          }
+        },
+        "summary": "Create an Empty Knowledge Base",
+        "tags": [
+          "Knowledge Bases"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/knowledge-bases/create-an-empty-knowledge-base",
+          "metadata": {
+            "title": "Create an Empty Knowledge Base",
+            "sidebarTitle": "Create an Empty Knowledge Base"
           }
         }
       }
@@ -3826,32 +3768,137 @@
       }
     },
     "/datasets/{dataset_id}": {
-      "get": {
+      "delete": {
+        "description": "Permanently deletes a knowledge base and all of its documents.",
+        "operationId": "deleteDataset",
+        "parameters": [
+          {
+            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Knowledge base deleted successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : No knowledge base matches `dataset_id`."
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_in_use": {
+                    "summary": "dataset_in_use",
+                    "value": {
+                      "status": 409,
+                      "code": "dataset_in_use",
+                      "message": "The dataset is being used by some apps. Please remove the dataset from the apps before deleting it."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `dataset_in_use` : The knowledge base is used by one or more apps and cannot be deleted."
+          }
+        },
+        "summary": "Delete Knowledge Base",
         "tags": [
           "Knowledge Bases"
         ],
-        "summary": "Get Knowledge Base",
+        "x-mint": {
+          "href": "/en/api-reference/knowledge-bases/delete-knowledge-base",
+          "metadata": {
+            "title": "Delete Knowledge Base",
+            "sidebarTitle": "Delete Knowledge Base"
+          }
+        }
+      },
+      "get": {
         "description": "Returns detailed information about a knowledge base, including its embedding model, retrieval configuration, and document statistics.",
         "operationId": "getDatasetDetail",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Knowledge base details.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Dataset"
+                  "$ref": "#/components/schemas/DatasetDetailWithPartialMembersResponse"
                 },
                 "examples": {
                   "success": {
@@ -3890,15 +3937,12 @@
                       },
                       "tags": [],
                       "doc_form": "text_model",
-                      "external_knowledge_info": null,
                       "external_retrieval_model": null,
                       "doc_metadata": [],
                       "built_in_field_enabled": true,
                       "pipeline_id": null,
                       "runtime_mode": null,
                       "chunk_structure": null,
-                      "icon_info": null,
-                      "summary_index_setting": null,
                       "is_published": false,
                       "total_documents": 0,
                       "total_available_documents": 0,
@@ -3909,10 +3953,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Knowledge base details."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : API access is not enabled for this knowledge base.",
             "content": {
               "application/json": {
                 "examples": {
@@ -3926,10 +3987,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : API access is not enabled for this knowledge base."
           },
           "404": {
-            "description": "`not_found` : No knowledge base matches `dataset_id`.",
             "content": {
               "application/json": {
                 "examples": {
@@ -3943,9 +4004,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : No knowledge base matches `dataset_id`."
           }
         },
+        "summary": "Get Knowledge Base",
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-mint": {
           "href": "/en/api-reference/knowledge-bases/get-knowledge-base",
           "metadata": {
@@ -3955,123 +4021,37 @@
         }
       },
       "patch": {
-        "tags": [
-          "Knowledge Bases"
-        ],
-        "summary": "Update Knowledge Base",
         "description": "Updates a knowledge base. Only the fields included in the request body are changed.",
         "operationId": "updateDataset",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 40,
-                    "description": "Name of the knowledge base."
-                  },
-                  "description": {
-                    "type": "string",
-                    "maxLength": 400,
-                    "description": "Description of the knowledge base."
-                  },
-                  "indexing_technique": {
-                    "type": "string",
-                    "enum": [
-                      "high_quality",
-                      "economy"
-                    ],
-                    "nullable": true,
-                    "description": "`high_quality` uses embedding models for precise search; `economy` uses keyword-based indexing."
-                  },
-                  "permission": {
-                    "type": "string",
-                    "enum": [
-                      "only_me",
-                      "all_team_members",
-                      "partial_members"
-                    ],
-                    "description": "Controls who can access this knowledge base. `only_me` restricts to the creator, `all_team_members` grants access to the entire workspace, `partial_members` grants access to specified members."
-                  },
-                  "embedding_model": {
-                    "type": "string",
-                    "description": "Embedding model name. Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
-                  },
-                  "embedding_model_provider": {
-                    "type": "string",
-                    "description": "Embedding model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). A bare name like `openai` expands to `langgenius/<name>/<name>` and works only for langgenius-published plugins.\n\nGet valid values from the `provider` field of [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "Retrieval model configuration. Controls how chunks are searched and ranked when querying this knowledge base."
-                  },
-                  "partial_member_list": {
-                    "type": "array",
-                    "description": "List of team members with access when `permission` is `partial_members`.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "user_id": {
-                          "type": "string",
-                          "description": "ID of the team member to grant access."
-                        }
-                      }
-                    }
-                  },
-                  "external_retrieval_model": {
-                    "type": "object",
-                    "description": "Retrieval settings for external knowledge bases.",
-                    "properties": {
-                      "top_k": {
-                        "type": "integer",
-                        "description": "Maximum number of results to return."
-                      },
-                      "score_threshold": {
-                        "type": "number",
-                        "description": "Minimum similarity score threshold for filtering results."
-                      },
-                      "score_threshold_enabled": {
-                        "type": "boolean",
-                        "description": "Whether score threshold filtering is enabled."
-                      }
-                    }
-                  },
-                  "external_knowledge_id": {
-                    "type": "string",
-                    "description": "ID of the external knowledge base."
-                  },
-                  "external_knowledge_api_id": {
-                    "type": "string",
-                    "description": "ID of the external knowledge API connection."
-                  }
-                }
+                "$ref": "#/components/schemas/DatasetUpdatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Knowledge base updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Dataset"
+                  "$ref": "#/components/schemas/DatasetDetailWithPartialMembersResponse"
                 },
                 "examples": {
                   "success": {
@@ -4110,15 +4090,12 @@
                       },
                       "tags": [],
                       "doc_form": "text_model",
-                      "external_knowledge_info": null,
                       "external_retrieval_model": null,
                       "doc_metadata": [],
                       "built_in_field_enabled": true,
                       "pipeline_id": null,
                       "runtime_mode": null,
                       "chunk_structure": null,
-                      "icon_info": null,
-                      "summary_index_setting": null,
                       "is_published": false,
                       "total_documents": 0,
                       "total_available_documents": 0,
@@ -4130,10 +4107,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Knowledge base updated successfully."
           },
           "400": {
-            "description": "`invalid_param` : The embedding or reranking model you specified is not configured or available.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4147,10 +4124,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param` : The embedding or reranking model you specified is not configured or available."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4172,10 +4166,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached."
           },
           "404": {
-            "description": "`not_found` : No knowledge base matches `dataset_id`.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4189,88 +4183,19 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : No knowledge base matches `dataset_id`."
           }
         },
+        "summary": "Update Knowledge Base",
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-mint": {
           "href": "/en/api-reference/knowledge-bases/update-knowledge-base",
           "metadata": {
             "title": "Update Knowledge Base",
             "sidebarTitle": "Update Knowledge Base"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Knowledge Bases"
-        ],
-        "summary": "Delete Knowledge Base",
-        "description": "Permanently deletes a knowledge base and all of its documents.",
-        "operationId": "deleteDataset",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Knowledge base deleted successfully."
-          },
-          "403": {
-            "description": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : No knowledge base matches `dataset_id`.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/knowledge-bases/delete-knowledge-base",
-          "metadata": {
-            "title": "Delete Knowledge Base",
-            "sidebarTitle": "Delete Knowledge Base"
           }
         }
       }
@@ -9087,6 +9012,239 @@
         }
       }
     },
+    "/datasets/{dataset_id}/hit-testing": {
+      "post": {
+        "deprecated": true,
+        "description": "Deprecated compatibility endpoint. Searches a knowledge base and returns the chunks most relevant to the query, for both production retrieval and test retrieval.",
+        "operationId": "dataset_hit_testing_f584b2dd",
+        "parameters": [
+          {
+            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HitTestingPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HitTestingResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "query": {
+                        "content": "What is Dify?"
+                      },
+                      "records": [
+                        {
+                          "segment": {
+                            "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                            "position": 1,
+                            "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                            "content": "Dify is an open-source LLM app development platform.",
+                            "sign_content": "",
+                            "answer": "",
+                            "word_count": 9,
+                            "tokens": 12,
+                            "keywords": [
+                              "dify",
+                              "platform",
+                              "llm"
+                            ],
+                            "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                            "index_node_hash": "abc123def456",
+                            "hit_count": 1,
+                            "enabled": true,
+                            "disabled_at": null,
+                            "disabled_by": null,
+                            "status": "completed",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200,
+                            "indexing_at": 1741267200,
+                            "completed_at": 1741267200,
+                            "error": null,
+                            "stopped_at": null,
+                            "document": {
+                              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                              "data_source_type": "upload_file",
+                              "name": "guide.txt",
+                              "doc_type": null,
+                              "doc_metadata": null
+                            }
+                          },
+                          "child_chunks": [],
+                          "score": 0.92,
+                          "tsne_position": null,
+                          "files": [],
+                          "summary": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Retrieval results."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_not_initialized": {
+                    "summary": "dataset_not_initialized",
+                    "value": {
+                      "status": 400,
+                      "code": "dataset_not_initialized",
+                      "message": "The dataset is still being initialized or indexing. Please wait a moment."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Invalid parameter value."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `dataset_not_initialized` : The knowledge base is still initializing or indexing.\n- `provider_not_initialize` : The model provider has no valid credentials configured.\n- `provider_quota_exceeded` : The Dify-hosted model provider quota is exhausted.\n- `model_currently_not_support` : The selected model is not currently supported.\n- `completion_request_error` : The model request failed.\n- `invalid_param` : A request parameter is invalid."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : No knowledge base matches `dataset_id`."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "An internal error occurred."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error` : An internal error occurred during retrieval."
+          }
+        },
+        "summary": "Retrieve Chunks from a Knowledge Base / Test Retrieval",
+        "tags": [
+          "Knowledge Bases"
+        ]
+      }
+    },
     "/datasets/{dataset_id}/metadata": {
       "post": {
         "tags": [
@@ -10526,305 +10684,37 @@
     },
     "/datasets/{dataset_id}/retrieve": {
       "post": {
-        "tags": [
-          "Knowledge Bases"
-        ],
-        "summary": "Retrieve Chunks from a Knowledge Base / Test Retrieval",
         "description": "Searches a knowledge base and returns the chunks most relevant to the query, for both production retrieval and test retrieval.",
         "operationId": "retrieveSegments",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "query"
-                ],
-                "properties": {
-                  "query": {
-                    "type": "string",
-                    "maxLength": 250,
-                    "description": "Search query text."
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "Retrieval model configuration. Controls how chunks are searched and ranked when querying this knowledge base."
-                  },
-                  "attachment_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true,
-                    "description": "List of attachment IDs to include in the retrieval context."
-                  },
-                  "external_retrieval_model": {
-                    "type": "object",
-                    "description": "Retrieval settings for external knowledge bases.",
-                    "properties": {
-                      "top_k": {
-                        "type": "integer",
-                        "description": "Maximum number of results to return."
-                      },
-                      "score_threshold": {
-                        "type": "number",
-                        "description": "Minimum similarity score threshold for filtering results."
-                      },
-                      "score_threshold_enabled": {
-                        "type": "boolean",
-                        "description": "Whether score threshold filtering is enabled."
-                      }
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/HitTestingPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Retrieval results.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "query": {
-                      "type": "object",
-                      "description": "The original query object.",
-                      "properties": {
-                        "content": {
-                          "type": "string",
-                          "description": "The query text."
-                        }
-                      }
-                    },
-                    "records": {
-                      "type": "array",
-                      "description": "List of matched retrieval records.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "segment": {
-                            "type": "object",
-                            "description": "Matched chunk from the knowledge base.",
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "Unique identifier of the chunk."
-                              },
-                              "position": {
-                                "type": "integer",
-                                "description": "Position of the chunk within the document."
-                              },
-                              "document_id": {
-                                "type": "string",
-                                "description": "ID of the document this chunk belongs to."
-                              },
-                              "content": {
-                                "type": "string",
-                                "description": "Text content of the chunk."
-                              },
-                              "sign_content": {
-                                "type": "string",
-                                "description": "Signed content hash for integrity verification."
-                              },
-                              "answer": {
-                                "type": "string",
-                                "description": "Answer content, used in Q&A mode documents."
-                              },
-                              "word_count": {
-                                "type": "integer",
-                                "description": "Word count of the chunk content."
-                              },
-                              "tokens": {
-                                "type": "integer",
-                                "description": "Token count of the chunk content."
-                              },
-                              "keywords": {
-                                "type": "array",
-                                "description": "Keywords associated with this chunk for keyword-based retrieval.",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "index_node_id": {
-                                "type": "string",
-                                "description": "ID of the index node in the vector store."
-                              },
-                              "index_node_hash": {
-                                "type": "string",
-                                "description": "Hash of the indexed content, used to detect changes."
-                              },
-                              "hit_count": {
-                                "type": "integer",
-                                "description": "Number of times this chunk has been matched in retrieval queries."
-                              },
-                              "enabled": {
-                                "type": "boolean",
-                                "description": "Whether the chunk is enabled for retrieval."
-                              },
-                              "disabled_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "Timestamp when the chunk was disabled. `null` if enabled."
-                              },
-                              "disabled_by": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "ID of the user who disabled the chunk. `null` if enabled."
-                              },
-                              "status": {
-                                "type": "string",
-                                "description": "Indexing status of the chunk."
-                              },
-                              "created_by": {
-                                "type": "string",
-                                "description": "ID of the user who created the chunk."
-                              },
-                              "created_at": {
-                                "type": "number",
-                                "description": "Creation timestamp (Unix epoch in seconds)."
-                              },
-                              "indexing_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "Timestamp when indexing started. `null` if not yet started."
-                              },
-                              "completed_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "Timestamp when indexing completed. `null` if not yet completed."
-                              },
-                              "error": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "Error message if indexing failed. `null` when no error."
-                              },
-                              "stopped_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "Timestamp when indexing was stopped. `null` if not stopped."
-                              },
-                              "document": {
-                                "type": "object",
-                                "description": "Parent document information for the matched chunk.",
-                                "properties": {
-                                  "id": {
-                                    "type": "string",
-                                    "description": "Unique identifier of the document."
-                                  },
-                                  "data_source_type": {
-                                    "type": "string",
-                                    "description": "How the document was created."
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "Document name."
-                                  },
-                                  "doc_type": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "Document type classification. `null` if not set."
-                                  },
-                                  "doc_metadata": {
-                                    "type": "object",
-                                    "nullable": true,
-                                    "description": "Metadata values for the document. `null` if no metadata is configured."
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "child_chunks": {
-                            "type": "array",
-                            "description": "Matched child chunks within the chunk, if using hierarchical indexing.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "Unique identifier of the child chunk."
-                                },
-                                "content": {
-                                  "type": "string",
-                                  "description": "Text content of the child chunk."
-                                },
-                                "position": {
-                                  "type": "integer",
-                                  "description": "Position of the child chunk within the parent chunk."
-                                },
-                                "score": {
-                                  "type": "number",
-                                  "description": "Similarity score of the child chunk."
-                                }
-                              }
-                            }
-                          },
-                          "score": {
-                            "type": "number",
-                            "description": "Similarity score."
-                          },
-                          "tsne_position": {
-                            "type": "object",
-                            "nullable": true,
-                            "description": "t-SNE visualization position."
-                          },
-                          "files": {
-                            "type": "array",
-                            "description": "Files attached to this chunk.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "Attachment file identifier."
-                                },
-                                "name": {
-                                  "type": "string",
-                                  "description": "Original file name."
-                                },
-                                "size": {
-                                  "type": "integer",
-                                  "description": "File size in bytes."
-                                },
-                                "extension": {
-                                  "type": "string",
-                                  "description": "File extension."
-                                },
-                                "mime_type": {
-                                  "type": "string",
-                                  "description": "MIME type of the file."
-                                },
-                                "source_url": {
-                                  "type": "string",
-                                  "description": "URL to access the attachment."
-                                }
-                              }
-                            }
-                          },
-                          "summary": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Summary content if retrieved via summary index."
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/HitTestingResponse"
                 },
                 "examples": {
                   "success": {
@@ -10881,10 +10771,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Retrieval results."
           },
           "400": {
-            "description": "- `dataset_not_initialized` : The knowledge base is still initializing or indexing.\n- `provider_not_initialize` : The model provider has no valid credentials configured.\n- `provider_quota_exceeded` : The Dify-hosted model provider quota is exhausted.\n- `model_currently_not_support` : The selected model is not currently supported.\n- `completion_request_error` : The model request failed.\n- `invalid_param` : A request parameter is invalid.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10938,10 +10828,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `dataset_not_initialized` : The knowledge base is still initializing or indexing.\n- `provider_not_initialize` : The model provider has no valid credentials configured.\n- `provider_quota_exceeded` : The Dify-hosted model provider quota is exhausted.\n- `model_currently_not_support` : The selected model is not currently supported.\n- `completion_request_error` : The model request failed.\n- `invalid_param` : A request parameter is invalid."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10963,10 +10870,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : API access is not enabled for this knowledge base.\n- `forbidden` : Your subscription's knowledge base request rate limit has been reached."
           },
           "404": {
-            "description": "`not_found` : No knowledge base matches `dataset_id`.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10980,10 +10887,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : No knowledge base matches `dataset_id`."
           },
           "500": {
-            "description": "`internal_server_error` : An internal error occurred during retrieval.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10997,9 +10904,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`internal_server_error` : An internal error occurred during retrieval."
           }
         },
+        "summary": "Retrieve Chunks from a Knowledge Base / Test Retrieval",
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-mint": {
           "href": "/en/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
           "metadata": {

--- a/ja/api-reference/openapi_service.json
+++ b/ja/api-reference/openapi_service.json
@@ -2789,326 +2789,73 @@
       }
     },
     "/datasets": {
-      "post": {
-        "tags": [
-          "ナレッジベース"
-        ],
-        "summary": "空のナレッジベースを作成",
-        "description": "空のナレッジベースを作成します。ドキュメントを追加するには [テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) または [ファイルからドキュメントを作成](/ja/api-reference/documents/create-document-by-file) を使用します。",
-        "operationId": "createDataset",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 40,
-                    "description": "ナレッジベース名。"
-                  },
-                  "description": {
-                    "type": "string",
-                    "maxLength": 400,
-                    "default": "",
-                    "description": "ナレッジベースの説明です。"
-                  },
-                  "indexing_technique": {
-                    "type": "string",
-                    "enum": [
-                      "high_quality",
-                      "economy"
-                    ],
-                    "nullable": true,
-                    "description": "`high_quality` は埋め込みモデルを使用した精密検索、`economy` はキーワードベースのインデキシングです。"
-                  },
-                  "permission": {
-                    "type": "string",
-                    "enum": [
-                      "only_me",
-                      "all_team_members",
-                      "partial_members"
-                    ],
-                    "default": "only_me",
-                    "description": "このナレッジベースにアクセスできるユーザーを制御します。`only_me` は作成者のみに制限、`all_team_members` はワークスペース全体にアクセスを許可、`partial_members` は指定されたメンバーにアクセスを許可します。"
-                  },
-                  "provider": {
-                    "type": "string",
-                    "enum": [
-                      "vendor",
-                      "external"
-                    ],
-                    "default": "vendor",
-                    "description": "`vendor` は内部ナレッジベース、`external` は外部ナレッジベースです。"
-                  },
-                  "embedding_model": {
-                    "type": "string",
-                    "description": "埋め込みモデル名です。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models) で `model_type=text-embedding` を指定した際の `model` フィールドの値を使用します。"
-                  },
-                  "embedding_model_provider": {
-                    "type": "string",
-                    "description": "埋め込みモデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。`openai` のような短縮名は `langgenius/<name>/<name>` に展開され、langgenius が公開したプラグインでのみ機能します。\n\n有効な値は [利用可能なモデルを取得](/ja/api-reference/models/get-available-models) で `model_type=text-embedding` を指定した際の `provider` フィールドから取得します。"
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "検索モデルの設定です。このナレッジベースをクエリする際のチャンクの検索方法とランキング方法を制御します。"
-                  },
-                  "external_knowledge_api_id": {
-                    "type": "string",
-                    "description": "外部ナレッジ API 接続の ID です。"
-                  },
-                  "external_knowledge_id": {
-                    "type": "string",
-                    "description": "外部ナレッジベースの ID です。"
-                  },
-                  "summary_index_setting": {
-                    "type": "object",
-                    "nullable": true,
-                    "description": "サマリーインデックスの設定です。",
-                    "properties": {
-                      "enable": {
-                        "type": "boolean",
-                        "description": "サマリーインデックスを有効にするかどうかです。"
-                      },
-                      "model_name": {
-                        "type": "string",
-                        "description": "要約生成に使用されるモデルの名前です。"
-                      },
-                      "model_provider_name": {
-                        "type": "string",
-                        "description": "要約生成モデルのプロバイダーです。"
-                      },
-                      "summary_prompt": {
-                        "type": "string",
-                        "description": "要約生成用のカスタムプロンプトテンプレートです。"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "ナレッジベースが正常に作成されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Dataset"
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
-                      "name": "Product Documentation",
-                      "description": "プロダクト API 技術ドキュメント",
-                      "provider": "vendor",
-                      "permission": "only_me",
-                      "data_source_type": null,
-                      "indexing_technique": "high_quality",
-                      "app_count": 0,
-                      "document_count": 0,
-                      "word_count": 0,
-                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "author_name": "admin",
-                      "created_at": 1741267200,
-                      "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "updated_at": 1741267200,
-                      "embedding_model": "text-embedding-3-small",
-                      "embedding_model_provider": "langgenius/openai/openai",
-                      "embedding_available": true,
-                      "retrieval_model_dict": {
-                        "search_method": "semantic_search",
-                        "reranking_enable": false,
-                        "reranking_mode": null,
-                        "reranking_model": {
-                          "reranking_provider_name": "",
-                          "reranking_model_name": ""
-                        },
-                        "weights": null,
-                        "top_k": 3,
-                        "score_threshold_enabled": false,
-                        "score_threshold": null
-                      },
-                      "tags": [],
-                      "doc_form": "text_model",
-                      "external_knowledge_info": null,
-                      "external_retrieval_model": null,
-                      "doc_metadata": [],
-                      "built_in_field_enabled": true,
-                      "pipeline_id": null,
-                      "runtime_mode": null,
-                      "chunk_structure": null,
-                      "icon_info": null,
-                      "summary_index_setting": null,
-                      "is_published": false,
-                      "total_documents": 0,
-                      "total_available_documents": 0,
-                      "enable_api": true,
-                      "is_multimodal": false,
-                      "maintainer": "admin"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 指定した埋め込みモデルまたはリランクモデルが設定されていないか、利用できません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "`dataset_name_duplicate` : 同じ名前のナレッジベースが既に存在します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "dataset_name_duplicate": {
-                    "summary": "dataset_name_duplicate",
-                    "value": {
-                      "status": 409,
-                      "code": "dataset_name_duplicate",
-                      "message": "The dataset name already exists. Please modify your dataset name."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/knowledge-bases/create-an-empty-knowledge-base",
-          "metadata": {
-            "title": "空のナレッジベースを作成",
-            "sidebarTitle": "空のナレッジベースを作成"
-          }
-        }
-      },
       "get": {
-        "tags": [
-          "ナレッジベース"
-        ],
-        "summary": "ナレッジベースリストを取得",
         "description": "ナレッジベースのページネーションリストを返します。任意でキーワードまたはタグでフィルタリングできます。",
         "operationId": "listDatasets",
         "parameters": [
           {
-            "name": "page",
+            "description": "権限に関係なくすべてのナレッジベースを含めるかどうかです。",
             "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 1
-            },
-            "description": "ページ番号。"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 20
-            },
-            "description": "1 ページあたりの件数です。"
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            },
-            "description": "名前でフィルタリングする検索キーワードです。"
-          },
-          {
             "name": "include_all",
-            "in": "query",
+            "required": false,
             "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "権限に関係なくすべてのナレッジベースを含めるかどうかです。"
+              "default": false,
+              "description": "権限に関係なくすべてのナレッジベースを含めるかどうかです。",
+              "type": "boolean"
+            }
           },
           {
-            "name": "tag_ids",
+            "description": "名前でフィルタリングする検索キーワードです。",
             "in": "query",
+            "name": "keyword",
+            "required": false,
             "schema": {
-              "type": "array",
+              "description": "名前でフィルタリングする検索キーワードです。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得するページ番号。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "取得するページ番号。",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "絞り込みに使用するタグ ID。",
+            "in": "query",
+            "name": "tag_ids",
+            "required": false,
+            "schema": {
+              "description": "絞り込みに使用するタグ ID。",
               "items": {
                 "type": "string"
-              }
-            },
-            "style": "form",
-            "explode": true,
-            "description": "フィルタリングに使用するタグ ID です。タグ ID は [ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) から取得します。"
+              },
+              "type": "array"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "ナレッジベースのリストです。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "ナレッジベースオブジェクトの配列です。",
-                      "items": {
-                        "$ref": "#/components/schemas/Dataset"
-                      }
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "次のページにさらに項目が存在するかどうかです。"
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "1 ページあたりの件数です。"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "一致する項目の合計数です。"
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "現在のページ番号です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetListResponse"
                 },
                 "examples": {
                   "success": {
@@ -3117,7 +2864,7 @@
                       "data": [
                         {
                           "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
-                          "name": "Product Documentation",
+                          "name": "製品ドキュメント",
                           "description": "プロダクト API 技術ドキュメント",
                           "provider": "vendor",
                           "permission": "only_me",
@@ -3149,15 +2896,12 @@
                           },
                           "tags": [],
                           "doc_form": "text_model",
-                          "external_knowledge_info": null,
                           "external_retrieval_model": null,
                           "doc_metadata": [],
                           "built_in_field_enabled": true,
                           "pipeline_id": null,
                           "runtime_mode": null,
                           "chunk_structure": null,
-                          "icon_info": null,
-                          "summary_index_setting": null,
                           "is_published": false,
                           "total_documents": 0,
                           "total_available_documents": 0,
@@ -3174,14 +2918,212 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ナレッジベースのリストです。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "forbidden",
+                  "message": "Forbidden.",
+                  "status": 403
+                }
+              }
+            },
+            "description": "アクセス禁止 — ナレッジベース API またはワークスペースへのアクセス権がありません"
           }
         },
+        "summary": "ナレッジベースリストを取得",
+        "tags": [
+          "ナレッジベース"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl -X GET 'https://{api_base_url}/datasets?page=1&limit=20' \\\n  -H 'Authorization: Bearer {api_key}'"
+          }
+        ],
         "x-mint": {
           "href": "/ja/api-reference/knowledge-bases/list-knowledge-bases",
           "metadata": {
             "title": "ナレッジベースリストを取得",
             "sidebarTitle": "ナレッジベースリストを取得"
+          }
+        }
+      },
+      "post": {
+        "description": "空のナレッジベースを作成します。ドキュメントを追加するには [テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) または [ファイルからドキュメントを作成](/ja/api-reference/documents/create-document-by-file) を使用します。",
+        "operationId": "createDataset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetCreatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetDetailResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+                      "name": "製品ドキュメント",
+                      "description": "プロダクト API 技術ドキュメント",
+                      "provider": "vendor",
+                      "permission": "only_me",
+                      "data_source_type": null,
+                      "indexing_technique": "high_quality",
+                      "app_count": 0,
+                      "document_count": 0,
+                      "word_count": 0,
+                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "author_name": "admin",
+                      "created_at": 1741267200,
+                      "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "updated_at": 1741267200,
+                      "embedding_model": "text-embedding-3-small",
+                      "embedding_model_provider": "langgenius/openai/openai",
+                      "embedding_available": true,
+                      "retrieval_model_dict": {
+                        "search_method": "semantic_search",
+                        "reranking_enable": false,
+                        "reranking_mode": null,
+                        "reranking_model": {
+                          "reranking_provider_name": "",
+                          "reranking_model_name": ""
+                        },
+                        "weights": null,
+                        "top_k": 3,
+                        "score_threshold_enabled": false,
+                        "score_threshold": null
+                      },
+                      "tags": [],
+                      "doc_form": "text_model",
+                      "external_retrieval_model": null,
+                      "doc_metadata": [],
+                      "built_in_field_enabled": true,
+                      "pipeline_id": null,
+                      "runtime_mode": null,
+                      "chunk_structure": null,
+                      "is_published": false,
+                      "total_documents": 0,
+                      "total_available_documents": 0,
+                      "enable_api": true,
+                      "is_multimodal": false,
+                      "maintainer": "admin"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "ナレッジベースが正常に作成されました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：指定した埋め込みモデルまたはリランクモデルが設定されていないか、利用できません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_name_duplicate": {
+                    "summary": "dataset_name_duplicate",
+                    "value": {
+                      "status": 409,
+                      "code": "dataset_name_duplicate",
+                      "message": "The dataset name already exists. Please modify your dataset name."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`dataset_name_duplicate`：同じ名前のナレッジベースが既に存在します。"
+          }
+        },
+        "summary": "空のナレッジベースを作成",
+        "tags": [
+          "ナレッジベース"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/knowledge-bases/create-an-empty-knowledge-base",
+          "metadata": {
+            "title": "空のナレッジベースを作成",
+            "sidebarTitle": "空のナレッジベースを作成"
           }
         }
       }
@@ -3826,110 +3768,69 @@
       }
     },
     "/datasets/{dataset_id}": {
-      "get": {
-        "tags": [
-          "ナレッジベース"
-        ],
-        "summary": "ナレッジベース詳細を取得",
-        "description": "ナレッジベースの詳細情報（埋め込みモデル、検索設定、ドキュメント統計を含む）を返します。",
-        "operationId": "getDatasetDetail",
+      "delete": {
+        "description": "ナレッジベースとそのすべてのドキュメントを完全に削除します。",
+        "operationId": "deleteDataset",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": {
-            "description": "ナレッジベースの詳細です。",
+          "204": {
+            "description": "ナレッジベースが正常に削除されました。"
+          },
+          "401": {
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Dataset"
-                },
                 "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
+                  "unauthorized": {
+                    "summary": "unauthorized",
                     "value": {
-                      "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
-                      "name": "Product Documentation",
-                      "description": "プロダクト API 技術ドキュメント",
-                      "provider": "vendor",
-                      "permission": "only_me",
-                      "data_source_type": null,
-                      "indexing_technique": "high_quality",
-                      "app_count": 0,
-                      "document_count": 0,
-                      "word_count": 0,
-                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "author_name": "admin",
-                      "created_at": 1741267200,
-                      "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "updated_at": 1741267200,
-                      "embedding_model": "text-embedding-3-small",
-                      "embedding_model_provider": "langgenius/openai/openai",
-                      "embedding_available": true,
-                      "retrieval_model_dict": {
-                        "search_method": "semantic_search",
-                        "reranking_enable": false,
-                        "reranking_mode": null,
-                        "reranking_model": {
-                          "reranking_provider_name": "",
-                          "reranking_model_name": ""
-                        },
-                        "weights": null,
-                        "top_k": 3,
-                        "score_threshold_enabled": false,
-                        "score_threshold": null
-                      },
-                      "tags": [],
-                      "doc_form": "text_model",
-                      "external_knowledge_info": null,
-                      "external_retrieval_model": null,
-                      "doc_metadata": [],
-                      "built_in_field_enabled": true,
-                      "pipeline_id": null,
-                      "runtime_mode": null,
-                      "chunk_structure": null,
-                      "icon_info": null,
-                      "summary_index_setting": null,
-                      "is_published": false,
-                      "total_documents": 0,
-                      "total_available_documents": 0,
-                      "enable_api": true,
-                      "is_multimodal": false,
-                      "maintainer": "admin"
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
                       "message": "Dataset api access is not enabled."
                     }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "`not_found` : `dataset_id` に一致するナレッジベースがありません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3943,142 +3844,68 @@
                   }
                 }
               }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/knowledge-bases/get-knowledge-base",
-          "metadata": {
-            "title": "ナレッジベース詳細を取得",
-            "sidebarTitle": "ナレッジベース詳細を取得"
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "ナレッジベース"
-        ],
-        "summary": "ナレッジベースを更新",
-        "description": "ナレッジベースを更新します。リクエストボディに含まれるフィールドのみが変更されます。",
-        "operationId": "updateDataset",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
             },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 40,
-                    "description": "ナレッジベース名。"
-                  },
-                  "description": {
-                    "type": "string",
-                    "maxLength": 400,
-                    "description": "ナレッジベースの説明です。"
-                  },
-                  "indexing_technique": {
-                    "type": "string",
-                    "enum": [
-                      "high_quality",
-                      "economy"
-                    ],
-                    "nullable": true,
-                    "description": "`high_quality` は埋め込みモデルを使用した精密検索、`economy` はキーワードベースのインデキシングです。"
-                  },
-                  "permission": {
-                    "type": "string",
-                    "enum": [
-                      "only_me",
-                      "all_team_members",
-                      "partial_members"
-                    ],
-                    "description": "このナレッジベースにアクセスできるユーザーを制御します。`only_me` は作成者のみに制限、`all_team_members` はワークスペース全体にアクセスを許可、`partial_members` は指定されたメンバーにアクセスを許可します。"
-                  },
-                  "embedding_model": {
-                    "type": "string",
-                    "description": "埋め込みモデル名です。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models) で `model_type=text-embedding` を指定した際の `model` フィールドの値を使用します。"
-                  },
-                  "embedding_model_provider": {
-                    "type": "string",
-                    "description": "埋め込みモデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。`openai` のような短縮名は `langgenius/<name>/<name>` に展開され、langgenius が公開したプラグインでのみ機能します。\n\n有効な値は [利用可能なモデルを取得](/ja/api-reference/models/get-available-models) で `model_type=text-embedding` を指定した際の `provider` フィールドから取得します。"
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "検索モデルの設定です。このナレッジベースをクエリする際のチャンクの検索方法とランキング方法を制御します。"
-                  },
-                  "partial_member_list": {
-                    "type": "array",
-                    "description": "`permission` が `partial_members` の場合にアクセス権を持つチームメンバーのリストです。",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "user_id": {
-                          "type": "string",
-                          "description": "アクセス権を付与するチームメンバーの ID です。"
-                        }
-                      }
+            "description": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_in_use": {
+                    "summary": "dataset_in_use",
+                    "value": {
+                      "status": 409,
+                      "code": "dataset_in_use",
+                      "message": "The dataset is being used by some apps. Please remove the dataset from the apps before deleting it."
                     }
-                  },
-                  "external_retrieval_model": {
-                    "type": "object",
-                    "description": "外部ナレッジベースの検索設定です。",
-                    "properties": {
-                      "top_k": {
-                        "type": "integer",
-                        "description": "返す結果の最大数です。"
-                      },
-                      "score_threshold": {
-                        "type": "number",
-                        "description": "結果フィルタリング用の最小関連性スコア閾値です。"
-                      },
-                      "score_threshold_enabled": {
-                        "type": "boolean",
-                        "description": "スコア閾値フィルタリングが有効かどうかです。"
-                      }
-                    }
-                  },
-                  "external_knowledge_id": {
-                    "type": "string",
-                    "description": "外部ナレッジベースの ID です。"
-                  },
-                  "external_knowledge_api_id": {
-                    "type": "string",
-                    "description": "外部ナレッジ API 接続の ID です。"
                   }
                 }
               }
-            }
+            },
+            "description": "- `dataset_in_use`：ナレッジベースは 1 つ以上のアプリで使用されているため削除できません。"
           }
         },
+        "summary": "ナレッジベースを削除",
+        "tags": [
+          "ナレッジベース"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/knowledge-bases/delete-knowledge-base",
+          "metadata": {
+            "title": "ナレッジベースを削除",
+            "sidebarTitle": "ナレッジベースを削除"
+          }
+        }
+      },
+      "get": {
+        "description": "ナレッジベースの詳細情報（埋め込みモデル、検索設定、ドキュメント統計を含む）を返します。",
+        "operationId": "getDatasetDetail",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "ナレッジベースが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Dataset"
+                  "$ref": "#/components/schemas/DatasetDetailWithPartialMembersResponse"
                 },
                 "examples": {
                   "success": {
                     "summary": "レスポンス例",
                     "value": {
                       "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
-                      "name": "Product Documentation",
+                      "name": "製品ドキュメント",
                       "description": "プロダクト API 技術ドキュメント",
                       "provider": "vendor",
                       "permission": "only_me",
@@ -4110,15 +3937,165 @@
                       },
                       "tags": [],
                       "doc_form": "text_model",
-                      "external_knowledge_info": null,
                       "external_retrieval_model": null,
                       "doc_metadata": [],
                       "built_in_field_enabled": true,
                       "pipeline_id": null,
                       "runtime_mode": null,
                       "chunk_structure": null,
-                      "icon_info": null,
-                      "summary_index_setting": null,
+                      "is_published": false,
+                      "total_documents": 0,
+                      "total_available_documents": 0,
+                      "enable_api": true,
+                      "is_multimodal": false,
+                      "maintainer": "admin"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "ナレッジベースの詳細です。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+          }
+        },
+        "summary": "ナレッジベース詳細を取得",
+        "tags": [
+          "ナレッジベース"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/knowledge-bases/get-knowledge-base",
+          "metadata": {
+            "title": "ナレッジベース詳細を取得",
+            "sidebarTitle": "ナレッジベース詳細を取得"
+          }
+        }
+      },
+      "patch": {
+        "description": "ナレッジベースを更新します。リクエストボディに含まれるフィールドのみが変更されます。",
+        "operationId": "updateDataset",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetDetailWithPartialMembersResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+                      "name": "製品ドキュメント",
+                      "description": "プロダクト API 技術ドキュメント",
+                      "provider": "vendor",
+                      "permission": "only_me",
+                      "data_source_type": null,
+                      "indexing_technique": "high_quality",
+                      "app_count": 0,
+                      "document_count": 0,
+                      "word_count": 0,
+                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "author_name": "admin",
+                      "created_at": 1741267200,
+                      "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "updated_at": 1741267200,
+                      "embedding_model": "text-embedding-3-small",
+                      "embedding_model_provider": "langgenius/openai/openai",
+                      "embedding_available": true,
+                      "retrieval_model_dict": {
+                        "search_method": "semantic_search",
+                        "reranking_enable": false,
+                        "reranking_mode": null,
+                        "reranking_model": {
+                          "reranking_provider_name": "",
+                          "reranking_model_name": ""
+                        },
+                        "weights": null,
+                        "top_k": 3,
+                        "score_threshold_enabled": false,
+                        "score_threshold": null
+                      },
+                      "tags": [],
+                      "doc_form": "text_model",
+                      "external_retrieval_model": null,
+                      "doc_metadata": [],
+                      "built_in_field_enabled": true,
+                      "pipeline_id": null,
+                      "runtime_mode": null,
+                      "chunk_structure": null,
                       "is_published": false,
                       "total_documents": 0,
                       "total_available_documents": 0,
@@ -4130,10 +4107,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ナレッジベースが正常に更新されました。"
           },
           "400": {
-            "description": "`invalid_param` : 指定した埋め込みモデルまたはリランクモデルが設定されていないか、利用できません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4147,15 +4124,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：指定した埋め込みモデルまたはリランクモデルが設定されていないか、利用できません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4163,7 +4157,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4172,10 +4166,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "`not_found` : `dataset_id` に一致するナレッジベースがありません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4189,88 +4183,19 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
           }
         },
+        "summary": "ナレッジベースを更新",
+        "tags": [
+          "ナレッジベース"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/knowledge-bases/update-knowledge-base",
           "metadata": {
             "title": "ナレッジベースを更新",
             "sidebarTitle": "ナレッジベースを更新"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "ナレッジベース"
-        ],
-        "summary": "ナレッジベースを削除",
-        "description": "ナレッジベースとそのすべてのドキュメントを完全に削除します。",
-        "operationId": "deleteDataset",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "ナレッジベースが正常に削除されました。"
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : `dataset_id` に一致するナレッジベースがありません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/knowledge-bases/delete-knowledge-base",
-          "metadata": {
-            "title": "ナレッジベースを削除",
-            "sidebarTitle": "ナレッジベースを削除"
           }
         }
       }
@@ -9087,6 +9012,239 @@
         }
       }
     },
+    "/datasets/{dataset_id}/hit-testing": {
+      "post": {
+        "deprecated": true,
+        "description": "非推奨の互換エンドポイントです。ナレッジベースを検索し、クエリに最も関連性の高いチャンクを返します。本番環境の検索とテスト検索の両方に使用できます。",
+        "operationId": "dataset_hit_testing_f584b2dd",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HitTestingPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HitTestingResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "query": {
+                        "content": "Dify とは何ですか？"
+                      },
+                      "records": [
+                        {
+                          "segment": {
+                            "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                            "position": 1,
+                            "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                            "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
+                            "sign_content": "",
+                            "answer": "",
+                            "word_count": 9,
+                            "tokens": 12,
+                            "keywords": [
+                              "dify",
+                              "platform",
+                              "llm"
+                            ],
+                            "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                            "index_node_hash": "abc123def456",
+                            "hit_count": 1,
+                            "enabled": true,
+                            "disabled_at": null,
+                            "disabled_by": null,
+                            "status": "completed",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200,
+                            "indexing_at": 1741267200,
+                            "completed_at": 1741267200,
+                            "error": null,
+                            "stopped_at": null,
+                            "document": {
+                              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                              "data_source_type": "upload_file",
+                              "name": "guide.txt",
+                              "doc_type": null,
+                              "doc_metadata": null
+                            }
+                          },
+                          "child_chunks": [],
+                          "score": 0.92,
+                          "tsne_position": null,
+                          "files": [],
+                          "summary": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "検索結果です。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_not_initialized": {
+                    "summary": "dataset_not_initialized",
+                    "value": {
+                      "status": 400,
+                      "code": "dataset_not_initialized",
+                      "message": "The dataset is still being initialized or indexing. Please wait a moment."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Invalid parameter value."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `dataset_not_initialized`：ナレッジベースはまだ初期化中またはインデキシング中です。\n- `provider_not_initialize`：モデルプロバイダーに有効な認証情報が設定されていません。\n- `provider_quota_exceeded`：Dify がホストするモデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support`：選択したモデルは現在サポートされていません。\n- `completion_request_error`：モデルへのリクエストに失敗しました。\n- `invalid_param`：リクエストパラメータが無効です。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "An internal error occurred."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：検索中に内部エラーが発生しました。"
+          }
+        },
+        "summary": "ナレッジベースからチャンクを取得 / テスト検索",
+        "tags": [
+          "ナレッジベース"
+        ]
+      }
+    },
     "/datasets/{dataset_id}/metadata": {
       "post": {
         "tags": [
@@ -10526,312 +10684,44 @@
     },
     "/datasets/{dataset_id}/retrieve": {
       "post": {
-        "tags": [
-          "ナレッジベース"
-        ],
-        "summary": "ナレッジベースからチャンクを取得 / テスト検索",
         "description": "ナレッジベースを検索し、クエリに最も関連性の高いチャンクを返します。本番環境の検索とテスト検索の両方に使用できます。",
         "operationId": "retrieveSegments",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "query"
-                ],
-                "properties": {
-                  "query": {
-                    "type": "string",
-                    "maxLength": 250,
-                    "description": "検索クエリテキストです。"
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "検索モデルの設定です。このナレッジベースをクエリする際のチャンクの検索方法とランキング方法を制御します。"
-                  },
-                  "attachment_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true,
-                    "description": "検索コンテキストに含める添付ファイル ID のリストです。"
-                  },
-                  "external_retrieval_model": {
-                    "type": "object",
-                    "description": "外部ナレッジベースの検索設定です。",
-                    "properties": {
-                      "top_k": {
-                        "type": "integer",
-                        "description": "返す結果の最大数です。"
-                      },
-                      "score_threshold": {
-                        "type": "number",
-                        "description": "結果をフィルタリングするための最小類似度スコアのしきい値です。"
-                      },
-                      "score_threshold_enabled": {
-                        "type": "boolean",
-                        "description": "スコアしきい値によるフィルタリングを有効にするかどうか。"
-                      }
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/HitTestingPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "検索結果です。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "query": {
-                      "type": "object",
-                      "description": "元のクエリオブジェクトです。",
-                      "properties": {
-                        "content": {
-                          "type": "string",
-                          "description": "クエリテキストです。"
-                        }
-                      }
-                    },
-                    "records": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "segment": {
-                            "type": "object",
-                            "description": "ナレッジベースから一致したチャンクです。",
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "チャンクの一意識別子です。"
-                              },
-                              "position": {
-                                "type": "integer",
-                                "description": "ドキュメント内のチャンクの位置。"
-                              },
-                              "document_id": {
-                                "type": "string",
-                                "description": "このチャンクが属するドキュメントの ID です。"
-                              },
-                              "content": {
-                                "type": "string",
-                                "description": "チャンクのテキスト内容です。"
-                              },
-                              "sign_content": {
-                                "type": "string",
-                                "description": "整合性検証用の署名付きコンテンツハッシュです。"
-                              },
-                              "answer": {
-                                "type": "string",
-                                "description": "回答コンテンツです。Q&A モードのドキュメントで使用されます。"
-                              },
-                              "word_count": {
-                                "type": "integer",
-                                "description": "チャンク内容の単語数です。"
-                              },
-                              "tokens": {
-                                "type": "integer",
-                                "description": "チャンク内容のトークン数です。"
-                              },
-                              "keywords": {
-                                "type": "array",
-                                "description": "キーワードベースの検索のためにこのチャンクに関連付けられたキーワードです。",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "index_node_id": {
-                                "type": "string",
-                                "description": "ベクトルストア内のインデックスノードの ID です。"
-                              },
-                              "index_node_hash": {
-                                "type": "string",
-                                "description": "インデックスされたコンテンツのハッシュです。変更の検出に使用されます。"
-                              },
-                              "hit_count": {
-                                "type": "integer",
-                                "description": "このチャンクが検索クエリでマッチした回数です。"
-                              },
-                              "enabled": {
-                                "type": "boolean",
-                                "description": "このチャンクが検索に対して有効かどうかです。"
-                              },
-                              "disabled_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "チャンクが無効化されたタイムスタンプです。有効な場合は `null` です。"
-                              },
-                              "disabled_by": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "チャンクを無効化したユーザーの ID です。有効な場合は `null` です。"
-                              },
-                              "status": {
-                                "type": "string",
-                                "description": "チャンクのインデックスステータスです。"
-                              },
-                              "created_by": {
-                                "type": "string",
-                                "description": "チャンクを作成したユーザーの ID です。"
-                              },
-                              "created_at": {
-                                "type": "number",
-                                "description": "作成タイムスタンプ（Unix エポック、秒単位）です。"
-                              },
-                              "indexing_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "インデックス作成が開始されたタイムスタンプです。まだ開始されていない場合は `null` です。"
-                              },
-                              "completed_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "インデックス作成が完了したタイムスタンプです。まだ完了していない場合は `null` です。"
-                              },
-                              "error": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "インデックス作成が失敗した場合のエラーメッセージです。エラーなしの場合は `null` です。"
-                              },
-                              "stopped_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "インデックス作成が停止されたタイムスタンプです。停止されていない場合は `null` です。"
-                              },
-                              "document": {
-                                "type": "object",
-                                "description": "マッチしたチャンクの親ドキュメント情報です。",
-                                "properties": {
-                                  "id": {
-                                    "type": "string",
-                                    "description": "ドキュメントの一意識別子です。"
-                                  },
-                                  "data_source_type": {
-                                    "type": "string",
-                                    "description": "ドキュメントの作成方法です。"
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "ドキュメント名です。"
-                                  },
-                                  "doc_type": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "ドキュメントタイプの分類です。未設定の場合は `null` です。"
-                                  },
-                                  "doc_metadata": {
-                                    "type": "object",
-                                    "nullable": true,
-                                    "description": "ドキュメントのメタデータ値です。メタデータが設定されていない場合は `null` です。"
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "child_chunks": {
-                            "type": "array",
-                            "description": "階層インデックスを使用している場合、チャンク内でマッチした子チャンクです。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "子チャンクの一意識別子です。"
-                                },
-                                "content": {
-                                  "type": "string",
-                                  "description": "子チャンクのテキスト内容です。"
-                                },
-                                "position": {
-                                  "type": "integer",
-                                  "description": "親チャンク内の子チャンクの位置です。"
-                                },
-                                "score": {
-                                  "type": "number",
-                                  "description": "子チャンクの関連性スコアです。"
-                                }
-                              }
-                            }
-                          },
-                          "score": {
-                            "type": "number",
-                            "description": "関連性スコアです。"
-                          },
-                          "tsne_position": {
-                            "type": "object",
-                            "nullable": true,
-                            "description": "t-SNE 可視化の位置です。"
-                          },
-                          "files": {
-                            "type": "array",
-                            "description": "このチャンクに添付されたファイルです。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "添付ファイルの識別子です。"
-                                },
-                                "name": {
-                                  "type": "string",
-                                  "description": "元のファイル名です。"
-                                },
-                                "size": {
-                                  "type": "integer",
-                                  "description": "ファイルサイズ（バイト）。"
-                                },
-                                "extension": {
-                                  "type": "string",
-                                  "description": "ファイル拡張子。"
-                                },
-                                "mime_type": {
-                                  "type": "string",
-                                  "description": "ファイルの MIME タイプ。"
-                                },
-                                "source_url": {
-                                  "type": "string",
-                                  "description": "添付ファイルにアクセスする URL です。"
-                                }
-                              }
-                            }
-                          },
-                          "summary": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "要約インデックス経由で取得された場合の要約コンテンツです。"
-                          }
-                        }
-                      },
-                      "description": "一致した検索レコードのリスト。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/HitTestingResponse"
                 },
                 "examples": {
                   "success": {
                     "summary": "レスポンス例",
                     "value": {
                       "query": {
-                        "content": "What is Dify?"
+                        "content": "Dify とは何ですか？"
                       },
                       "records": [
                         {
@@ -10839,7 +10729,7 @@
                             "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
                             "position": 1,
                             "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                            "content": "Dify is an open-source LLM app development platform.",
+                            "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
                             "sign_content": "",
                             "answer": "",
                             "word_count": 9,
@@ -10881,10 +10771,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "検索結果です。"
           },
           "400": {
-            "description": "- `dataset_not_initialized` : ナレッジベースはまだ初期化中またはインデキシング中です。\n- `provider_not_initialize` : モデルプロバイダーに有効な認証情報が設定されていません。\n- `provider_quota_exceeded` : Dify がホストするモデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support` : 選択したモデルは現在サポートされていません。\n- `completion_request_error` : モデルへのリクエストに失敗しました。\n- `invalid_param` : リクエストパラメータが無効です。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10938,15 +10828,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `dataset_not_initialized`：ナレッジベースはまだ初期化中またはインデキシング中です。\n- `provider_not_initialize`：モデルプロバイダーに有効な認証情報が設定されていません。\n- `provider_quota_exceeded`：Dify がホストするモデルプロバイダーのクォータが使い切られました。\n- `model_currently_not_support`：選択したモデルは現在サポートされていません。\n- `completion_request_error`：モデルへのリクエストに失敗しました。\n- `invalid_param`：リクエストパラメータが無効です。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10954,7 +10861,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10963,10 +10870,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "`not_found` : `dataset_id` に一致するナレッジベースがありません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10980,10 +10887,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
           },
           "500": {
-            "description": "`internal_server_error` : 検索中に内部エラーが発生しました。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10997,9 +10904,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`internal_server_error`：検索中に内部エラーが発生しました。"
           }
         },
+        "summary": "ナレッジベースからチャンクを取得 / テスト検索",
+        "tags": [
+          "ナレッジベース"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
           "metadata": {

--- a/zh/api-reference/openapi_service.json
+++ b/zh/api-reference/openapi_service.json
@@ -2789,326 +2789,73 @@
       }
     },
     "/datasets": {
-      "post": {
-        "tags": [
-          "知识库"
-        ],
-        "summary": "创建空知识库",
-        "description": "创建一个空知识库。之后用 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 或 [从文件创建文档](/zh/api-reference/documents/create-document-by-file) 向其中添加文档。",
-        "operationId": "createDataset",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 40,
-                    "description": "知识库名称。"
-                  },
-                  "description": {
-                    "type": "string",
-                    "maxLength": 400,
-                    "default": "",
-                    "description": "知识库描述。"
-                  },
-                  "indexing_technique": {
-                    "type": "string",
-                    "enum": [
-                      "high_quality",
-                      "economy"
-                    ],
-                    "nullable": true,
-                    "description": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
-                  },
-                  "permission": {
-                    "type": "string",
-                    "enum": [
-                      "only_me",
-                      "all_team_members",
-                      "partial_members"
-                    ],
-                    "default": "only_me",
-                    "description": "控制谁可以访问此知识库。`only_me` 仅限创建者，`all_team_members` 授权整个工作区访问，`partial_members` 授权指定成员访问。"
-                  },
-                  "provider": {
-                    "type": "string",
-                    "enum": [
-                      "vendor",
-                      "external"
-                    ],
-                    "default": "vendor",
-                    "description": "`vendor` 为内部知识库，`external` 为外部知识库。"
-                  },
-                  "embedding_model": {
-                    "type": "string",
-                    "description": "嵌入模型名称。使用 [获取可用模型](/zh/api-reference/models/get-available-models) 中 `model_type=text-embedding` 返回的 `model` 字段值。"
-                  },
-                  "embedding_model_provider": {
-                    "type": "string",
-                    "description": "嵌入模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。`openai` 这类简写会展开为 `langgenius/<name>/<name>`，仅对 langgenius 发布的插件有效。\n\n有效取值从 [获取可用模型](/zh/api-reference/models/get-available-models) 中 `model_type=text-embedding` 返回的 `provider` 字段获取。"
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "检索模型配置。控制查询此知识库时如何搜索和排序分段。"
-                  },
-                  "external_knowledge_api_id": {
-                    "type": "string",
-                    "description": "外部知识库 API 连接的 ID。"
-                  },
-                  "external_knowledge_id": {
-                    "type": "string",
-                    "description": "外部知识库的 ID。"
-                  },
-                  "summary_index_setting": {
-                    "type": "object",
-                    "nullable": true,
-                    "description": "摘要索引配置。",
-                    "properties": {
-                      "enable": {
-                        "type": "boolean",
-                        "description": "是否启用摘要索引。"
-                      },
-                      "model_name": {
-                        "type": "string",
-                        "description": "用于生成摘要的模型名称。"
-                      },
-                      "model_provider_name": {
-                        "type": "string",
-                        "description": "摘要生成模型的供应商。"
-                      },
-                      "summary_prompt": {
-                        "type": "string",
-                        "description": "用于摘要生成的自定义提示词模板。"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "知识库创建成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Dataset"
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
-                      "name": "Product Documentation",
-                      "description": "产品 API 技术文档",
-                      "provider": "vendor",
-                      "permission": "only_me",
-                      "data_source_type": null,
-                      "indexing_technique": "high_quality",
-                      "app_count": 0,
-                      "document_count": 0,
-                      "word_count": 0,
-                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "author_name": "admin",
-                      "created_at": 1741267200,
-                      "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "updated_at": 1741267200,
-                      "embedding_model": "text-embedding-3-small",
-                      "embedding_model_provider": "langgenius/openai/openai",
-                      "embedding_available": true,
-                      "retrieval_model_dict": {
-                        "search_method": "semantic_search",
-                        "reranking_enable": false,
-                        "reranking_mode": null,
-                        "reranking_model": {
-                          "reranking_provider_name": "",
-                          "reranking_model_name": ""
-                        },
-                        "weights": null,
-                        "top_k": 3,
-                        "score_threshold_enabled": false,
-                        "score_threshold": null
-                      },
-                      "tags": [],
-                      "doc_form": "text_model",
-                      "external_knowledge_info": null,
-                      "external_retrieval_model": null,
-                      "doc_metadata": [],
-                      "built_in_field_enabled": true,
-                      "pipeline_id": null,
-                      "runtime_mode": null,
-                      "chunk_structure": null,
-                      "icon_info": null,
-                      "summary_index_setting": null,
-                      "is_published": false,
-                      "total_documents": 0,
-                      "total_available_documents": 0,
-                      "enable_api": true,
-                      "is_multimodal": false,
-                      "maintainer": "admin"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 指定的嵌入模型或重排序模型未配置或不可用。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "`dataset_name_duplicate` : 已存在同名知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "dataset_name_duplicate": {
-                    "summary": "dataset_name_duplicate",
-                    "value": {
-                      "status": 409,
-                      "code": "dataset_name_duplicate",
-                      "message": "The dataset name already exists. Please modify your dataset name."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/knowledge-bases/create-an-empty-knowledge-base",
-          "metadata": {
-            "title": "创建空知识库",
-            "sidebarTitle": "创建空知识库"
-          }
-        }
-      },
       "get": {
-        "tags": [
-          "知识库"
-        ],
-        "summary": "获取知识库列表",
         "description": "返回知识库的分页列表，可按关键词或标签筛选。",
         "operationId": "listDatasets",
         "parameters": [
           {
-            "name": "page",
+            "description": "是否包含所有知识库，无论权限如何。",
             "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 1
-            },
-            "description": "页码。"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 20
-            },
-            "description": "每页条目数。"
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            },
-            "description": "按名称筛选的搜索关键词。"
-          },
-          {
             "name": "include_all",
-            "in": "query",
+            "required": false,
             "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "是否包含所有知识库，无论权限如何。"
+              "default": false,
+              "description": "是否包含所有知识库，无论权限如何。",
+              "type": "boolean"
+            }
           },
           {
-            "name": "tag_ids",
+            "description": "按名称筛选的搜索关键词。",
             "in": "query",
+            "name": "keyword",
+            "required": false,
             "schema": {
-              "type": "array",
+              "description": "按名称筛选的搜索关键词。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "每页的项目数量。服务器上限为 `100`。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "每页的项目数量。服务器上限为 `100`。",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "要获取的页码。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "要获取的页码。",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "用于筛选的标签 ID。",
+            "in": "query",
+            "name": "tag_ids",
+            "required": false,
+            "schema": {
+              "description": "用于筛选的标签 ID。",
               "items": {
                 "type": "string"
-              }
-            },
-            "style": "form",
-            "explode": true,
-            "description": "用于筛选的标签 ID。标签 ID 从 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags) 获取。"
+              },
+              "type": "array"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "知识库列表。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "知识库对象数组。",
-                      "items": {
-                        "$ref": "#/components/schemas/Dataset"
-                      }
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "下一页是否还有更多项目。"
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "每页条目数。"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "匹配条目的总数。"
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "当前页码。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetListResponse"
                 },
                 "examples": {
                   "success": {
@@ -3117,7 +2864,7 @@
                       "data": [
                         {
                           "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
-                          "name": "Product Documentation",
+                          "name": "产品文档",
                           "description": "产品 API 技术文档",
                           "provider": "vendor",
                           "permission": "only_me",
@@ -3149,15 +2896,12 @@
                           },
                           "tags": [],
                           "doc_form": "text_model",
-                          "external_knowledge_info": null,
                           "external_retrieval_model": null,
                           "doc_metadata": [],
                           "built_in_field_enabled": true,
                           "pipeline_id": null,
                           "runtime_mode": null,
                           "chunk_structure": null,
-                          "icon_info": null,
-                          "summary_index_setting": null,
                           "is_published": false,
                           "total_documents": 0,
                           "total_available_documents": 0,
@@ -3174,14 +2918,212 @@
                   }
                 }
               }
-            }
+            },
+            "description": "知识库列表。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "forbidden",
+                  "message": "Forbidden.",
+                  "status": 403
+                }
+              }
+            },
+            "description": "禁止访问——未启用知识库 API 或无工作区访问权限"
           }
         },
+        "summary": "获取知识库列表",
+        "tags": [
+          "知识库"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "bash",
+            "label": "cURL",
+            "source": "curl -X GET 'https://{api_base_url}/datasets?page=1&limit=20' \\\n  -H 'Authorization: Bearer {api_key}'"
+          }
+        ],
         "x-mint": {
           "href": "/zh/api-reference/knowledge-bases/list-knowledge-bases",
           "metadata": {
             "title": "获取知识库列表",
             "sidebarTitle": "获取知识库列表"
+          }
+        }
+      },
+      "post": {
+        "description": "创建一个空知识库。之后用 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 或 [从文件创建文档](/zh/api-reference/documents/create-document-by-file) 向其中添加文档。",
+        "operationId": "createDataset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetCreatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetDetailResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+                      "name": "产品文档",
+                      "description": "产品 API 技术文档",
+                      "provider": "vendor",
+                      "permission": "only_me",
+                      "data_source_type": null,
+                      "indexing_technique": "high_quality",
+                      "app_count": 0,
+                      "document_count": 0,
+                      "word_count": 0,
+                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "author_name": "admin",
+                      "created_at": 1741267200,
+                      "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "updated_at": 1741267200,
+                      "embedding_model": "text-embedding-3-small",
+                      "embedding_model_provider": "langgenius/openai/openai",
+                      "embedding_available": true,
+                      "retrieval_model_dict": {
+                        "search_method": "semantic_search",
+                        "reranking_enable": false,
+                        "reranking_mode": null,
+                        "reranking_model": {
+                          "reranking_provider_name": "",
+                          "reranking_model_name": ""
+                        },
+                        "weights": null,
+                        "top_k": 3,
+                        "score_threshold_enabled": false,
+                        "score_threshold": null
+                      },
+                      "tags": [],
+                      "doc_form": "text_model",
+                      "external_retrieval_model": null,
+                      "doc_metadata": [],
+                      "built_in_field_enabled": true,
+                      "pipeline_id": null,
+                      "runtime_mode": null,
+                      "chunk_structure": null,
+                      "is_published": false,
+                      "total_documents": 0,
+                      "total_available_documents": 0,
+                      "enable_api": true,
+                      "is_multimodal": false,
+                      "maintainer": "admin"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "知识库创建成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：指定的嵌入模型或重排序模型未配置或不可用。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_name_duplicate": {
+                    "summary": "dataset_name_duplicate",
+                    "value": {
+                      "status": 409,
+                      "code": "dataset_name_duplicate",
+                      "message": "The dataset name already exists. Please modify your dataset name."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`dataset_name_duplicate`：已存在同名知识库。"
+          }
+        },
+        "summary": "创建空知识库",
+        "tags": [
+          "知识库"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/knowledge-bases/create-an-empty-knowledge-base",
+          "metadata": {
+            "title": "创建空知识库",
+            "sidebarTitle": "创建空知识库"
           }
         }
       }
@@ -3826,110 +3768,69 @@
       }
     },
     "/datasets/{dataset_id}": {
-      "get": {
-        "tags": [
-          "知识库"
-        ],
-        "summary": "获取知识库详情",
-        "description": "返回知识库的详细信息，包括嵌入模型、检索配置和文档统计信息。",
-        "operationId": "getDatasetDetail",
+      "delete": {
+        "description": "永久删除知识库及其所有文档。",
+        "operationId": "deleteDataset",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": {
-            "description": "知识库详情。",
+          "204": {
+            "description": "知识库删除成功。"
+          },
+          "401": {
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Dataset"
-                },
                 "examples": {
-                  "success": {
-                    "summary": "响应示例",
+                  "unauthorized": {
+                    "summary": "unauthorized",
                     "value": {
-                      "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
-                      "name": "Product Documentation",
-                      "description": "产品 API 技术文档",
-                      "provider": "vendor",
-                      "permission": "only_me",
-                      "data_source_type": null,
-                      "indexing_technique": "high_quality",
-                      "app_count": 0,
-                      "document_count": 0,
-                      "word_count": 0,
-                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "author_name": "admin",
-                      "created_at": 1741267200,
-                      "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                      "updated_at": 1741267200,
-                      "embedding_model": "text-embedding-3-small",
-                      "embedding_model_provider": "langgenius/openai/openai",
-                      "embedding_available": true,
-                      "retrieval_model_dict": {
-                        "search_method": "semantic_search",
-                        "reranking_enable": false,
-                        "reranking_mode": null,
-                        "reranking_model": {
-                          "reranking_provider_name": "",
-                          "reranking_model_name": ""
-                        },
-                        "weights": null,
-                        "top_k": 3,
-                        "score_threshold_enabled": false,
-                        "score_threshold": null
-                      },
-                      "tags": [],
-                      "doc_form": "text_model",
-                      "external_knowledge_info": null,
-                      "external_retrieval_model": null,
-                      "doc_metadata": [],
-                      "built_in_field_enabled": true,
-                      "pipeline_id": null,
-                      "runtime_mode": null,
-                      "chunk_structure": null,
-                      "icon_info": null,
-                      "summary_index_setting": null,
-                      "is_published": false,
-                      "total_documents": 0,
-                      "total_available_documents": 0,
-                      "enable_api": true,
-                      "is_multimodal": false,
-                      "maintainer": "admin"
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
                       "message": "Dataset api access is not enabled."
                     }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "`not_found` : 未找到与 `dataset_id` 匹配的知识库。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3943,142 +3844,68 @@
                   }
                 }
               }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/knowledge-bases/get-knowledge-base",
-          "metadata": {
-            "title": "获取知识库详情",
-            "sidebarTitle": "获取知识库详情"
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "知识库"
-        ],
-        "summary": "更新知识库",
-        "description": "更新知识库。仅更改请求体中包含的字段。",
-        "operationId": "updateDataset",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
             },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 40,
-                    "description": "知识库名称。"
-                  },
-                  "description": {
-                    "type": "string",
-                    "maxLength": 400,
-                    "description": "知识库描述。"
-                  },
-                  "indexing_technique": {
-                    "type": "string",
-                    "enum": [
-                      "high_quality",
-                      "economy"
-                    ],
-                    "nullable": true,
-                    "description": "`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
-                  },
-                  "permission": {
-                    "type": "string",
-                    "enum": [
-                      "only_me",
-                      "all_team_members",
-                      "partial_members"
-                    ],
-                    "description": "控制谁可以访问此知识库。`only_me` 仅限创建者，`all_team_members` 授权整个工作区访问，`partial_members` 授权指定成员访问。"
-                  },
-                  "embedding_model": {
-                    "type": "string",
-                    "description": "嵌入模型名称。使用 [获取可用模型](/zh/api-reference/models/get-available-models) 中 `model_type=text-embedding` 返回的 `model` 字段值。"
-                  },
-                  "embedding_model_provider": {
-                    "type": "string",
-                    "description": "嵌入模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。`openai` 这类简写会展开为 `langgenius/<name>/<name>`，仅对 langgenius 发布的插件有效。\n\n有效取值从 [获取可用模型](/zh/api-reference/models/get-available-models) 中 `model_type=text-embedding` 返回的 `provider` 字段获取。"
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "检索模型配置。控制查询此知识库时如何搜索和排序分段。"
-                  },
-                  "partial_member_list": {
-                    "type": "array",
-                    "description": "当 `permission` 为 `partial_members` 时有访问权限的团队成员列表。",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "user_id": {
-                          "type": "string",
-                          "description": "要授予访问权限的团队成员 ID。"
-                        }
-                      }
+            "description": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_in_use": {
+                    "summary": "dataset_in_use",
+                    "value": {
+                      "status": 409,
+                      "code": "dataset_in_use",
+                      "message": "The dataset is being used by some apps. Please remove the dataset from the apps before deleting it."
                     }
-                  },
-                  "external_retrieval_model": {
-                    "type": "object",
-                    "description": "外部知识库的检索设置。",
-                    "properties": {
-                      "top_k": {
-                        "type": "integer",
-                        "description": "返回的最大结果数。"
-                      },
-                      "score_threshold": {
-                        "type": "number",
-                        "description": "用于过滤结果的最低相关性分数阈值。"
-                      },
-                      "score_threshold_enabled": {
-                        "type": "boolean",
-                        "description": "是否启用分数阈值过滤。"
-                      }
-                    }
-                  },
-                  "external_knowledge_id": {
-                    "type": "string",
-                    "description": "外部知识库的 ID。"
-                  },
-                  "external_knowledge_api_id": {
-                    "type": "string",
-                    "description": "外部知识库 API 连接的 ID。"
                   }
                 }
               }
-            }
+            },
+            "description": "- `dataset_in_use`：知识库正被一个或多个应用使用，无法删除。"
           }
         },
+        "summary": "删除知识库",
+        "tags": [
+          "知识库"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/knowledge-bases/delete-knowledge-base",
+          "metadata": {
+            "title": "删除知识库",
+            "sidebarTitle": "删除知识库"
+          }
+        }
+      },
+      "get": {
+        "description": "返回知识库的详细信息，包括嵌入模型、检索配置和文档统计信息。",
+        "operationId": "getDatasetDetail",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "知识库更新成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Dataset"
+                  "$ref": "#/components/schemas/DatasetDetailWithPartialMembersResponse"
                 },
                 "examples": {
                   "success": {
                     "summary": "响应示例",
                     "value": {
                       "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
-                      "name": "Product Documentation",
+                      "name": "产品文档",
                       "description": "产品 API 技术文档",
                       "provider": "vendor",
                       "permission": "only_me",
@@ -4110,15 +3937,165 @@
                       },
                       "tags": [],
                       "doc_form": "text_model",
-                      "external_knowledge_info": null,
                       "external_retrieval_model": null,
                       "doc_metadata": [],
                       "built_in_field_enabled": true,
                       "pipeline_id": null,
                       "runtime_mode": null,
                       "chunk_structure": null,
-                      "icon_info": null,
-                      "summary_index_setting": null,
+                      "is_published": false,
+                      "total_documents": 0,
+                      "total_available_documents": 0,
+                      "enable_api": true,
+                      "is_multimodal": false,
+                      "maintainer": "admin"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "知识库详情。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+          }
+        },
+        "summary": "获取知识库详情",
+        "tags": [
+          "知识库"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/knowledge-bases/get-knowledge-base",
+          "metadata": {
+            "title": "获取知识库详情",
+            "sidebarTitle": "获取知识库详情"
+          }
+        }
+      },
+      "patch": {
+        "description": "更新知识库。仅更改请求体中包含的字段。",
+        "operationId": "updateDataset",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetDetailWithPartialMembersResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "c42e2a6e-40b3-4330-96f8-f1e4d768e8c9",
+                      "name": "产品文档",
+                      "description": "产品 API 技术文档",
+                      "provider": "vendor",
+                      "permission": "only_me",
+                      "data_source_type": null,
+                      "indexing_technique": "high_quality",
+                      "app_count": 0,
+                      "document_count": 0,
+                      "word_count": 0,
+                      "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "author_name": "admin",
+                      "created_at": 1741267200,
+                      "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                      "updated_at": 1741267200,
+                      "embedding_model": "text-embedding-3-small",
+                      "embedding_model_provider": "langgenius/openai/openai",
+                      "embedding_available": true,
+                      "retrieval_model_dict": {
+                        "search_method": "semantic_search",
+                        "reranking_enable": false,
+                        "reranking_mode": null,
+                        "reranking_model": {
+                          "reranking_provider_name": "",
+                          "reranking_model_name": ""
+                        },
+                        "weights": null,
+                        "top_k": 3,
+                        "score_threshold_enabled": false,
+                        "score_threshold": null
+                      },
+                      "tags": [],
+                      "doc_form": "text_model",
+                      "external_retrieval_model": null,
+                      "doc_metadata": [],
+                      "built_in_field_enabled": true,
+                      "pipeline_id": null,
+                      "runtime_mode": null,
+                      "chunk_structure": null,
                       "is_published": false,
                       "total_documents": 0,
                       "total_available_documents": 0,
@@ -4130,10 +4107,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "知识库更新成功。"
           },
           "400": {
-            "description": "`invalid_param` : 指定的嵌入模型或重排序模型未配置或不可用。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4147,15 +4124,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：指定的嵌入模型或重排序模型未配置或不可用。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4163,7 +4157,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4172,10 +4166,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "`not_found` : 未找到与 `dataset_id` 匹配的知识库。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4189,88 +4183,19 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
           }
         },
+        "summary": "更新知识库",
+        "tags": [
+          "知识库"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/knowledge-bases/update-knowledge-base",
           "metadata": {
             "title": "更新知识库",
             "sidebarTitle": "更新知识库"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "知识库"
-        ],
-        "summary": "删除知识库",
-        "description": "永久删除知识库及其所有文档。",
-        "operationId": "deleteDataset",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "知识库删除成功。"
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到与 `dataset_id` 匹配的知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/knowledge-bases/delete-knowledge-base",
-          "metadata": {
-            "title": "删除知识库",
-            "sidebarTitle": "删除知识库"
           }
         }
       }
@@ -9087,6 +9012,239 @@
         }
       }
     },
+    "/datasets/{dataset_id}/hit-testing": {
+      "post": {
+        "deprecated": true,
+        "description": "已弃用的兼容接口。搜索知识库，返回与查询最相关的分段，可用于生产环境检索和测试检索。",
+        "operationId": "dataset_hit_testing_f584b2dd",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HitTestingPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HitTestingResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "query": {
+                        "content": "什么是 Dify？"
+                      },
+                      "records": [
+                        {
+                          "segment": {
+                            "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                            "position": 1,
+                            "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                            "content": "Dify 是一个开源的 LLM 应用开发平台。",
+                            "sign_content": "",
+                            "answer": "",
+                            "word_count": 9,
+                            "tokens": 12,
+                            "keywords": [
+                              "dify",
+                              "platform",
+                              "llm"
+                            ],
+                            "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                            "index_node_hash": "abc123def456",
+                            "hit_count": 1,
+                            "enabled": true,
+                            "disabled_at": null,
+                            "disabled_by": null,
+                            "status": "completed",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200,
+                            "indexing_at": 1741267200,
+                            "completed_at": 1741267200,
+                            "error": null,
+                            "stopped_at": null,
+                            "document": {
+                              "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                              "data_source_type": "upload_file",
+                              "name": "guide.txt",
+                              "doc_type": null,
+                              "doc_metadata": null
+                            }
+                          },
+                          "child_chunks": [],
+                          "score": 0.92,
+                          "tsne_position": null,
+                          "files": [],
+                          "summary": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "检索结果。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "dataset_not_initialized": {
+                    "summary": "dataset_not_initialized",
+                    "value": {
+                      "status": 400,
+                      "code": "dataset_not_initialized",
+                      "message": "The dataset is still being initialized or indexing. Please wait a moment."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "provider_quota_exceeded": {
+                    "summary": "provider_quota_exceeded",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_quota_exceeded",
+                      "message": "Your quota for Dify Hosted Model Provider has been exhausted. Please go to Settings -> Model Provider to complete your own provider credentials."
+                    }
+                  },
+                  "model_currently_not_support": {
+                    "summary": "model_currently_not_support",
+                    "value": {
+                      "status": 400,
+                      "code": "model_currently_not_support",
+                      "message": "Dify Hosted OpenAI trial currently not support the GPT-4 model."
+                    }
+                  },
+                  "completion_request_error": {
+                    "summary": "completion_request_error",
+                    "value": {
+                      "status": 400,
+                      "code": "completion_request_error",
+                      "message": "Completion request failed."
+                    }
+                  },
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Invalid parameter value."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `dataset_not_initialized`：知识库仍在初始化或索引中。\n- `provider_not_initialize`：模型供应商未配置有效凭据。\n- `provider_quota_exceeded`：Dify 托管的模型供应商配额已用尽。\n- `model_currently_not_support`：所选模型当前不受支持。\n- `completion_request_error`：模型请求失败。\n- `invalid_param`：请求参数无效。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "internal_server_error",
+                    "value": {
+                      "status": 500,
+                      "code": "internal_server_error",
+                      "message": "An internal error occurred."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`internal_server_error`：检索过程中发生内部错误。"
+          }
+        },
+        "summary": "从知识库检索分段 / 测试检索",
+        "tags": [
+          "知识库"
+        ]
+      }
+    },
     "/datasets/{dataset_id}/metadata": {
       "post": {
         "tags": [
@@ -10526,312 +10684,44 @@
     },
     "/datasets/{dataset_id}/retrieve": {
       "post": {
-        "tags": [
-          "知识库"
-        ],
-        "summary": "从知识库检索分段 / 测试检索",
         "description": "搜索知识库，返回与查询最相关的分段，可用于生产环境检索和测试检索。",
         "operationId": "retrieveSegments",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "query"
-                ],
-                "properties": {
-                  "query": {
-                    "type": "string",
-                    "maxLength": 250,
-                    "description": "搜索查询文本。"
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "检索模型配置。控制查询此知识库时如何搜索和排序分段。"
-                  },
-                  "attachment_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true,
-                    "description": "要包含在检索上下文中的附件 ID 列表。"
-                  },
-                  "external_retrieval_model": {
-                    "type": "object",
-                    "description": "外部知识库的检索设置。",
-                    "properties": {
-                      "top_k": {
-                        "type": "integer",
-                        "description": "返回结果的最大数量。"
-                      },
-                      "score_threshold": {
-                        "type": "number",
-                        "description": "用于过滤结果的最小相似度分数阈值。"
-                      },
-                      "score_threshold_enabled": {
-                        "type": "boolean",
-                        "description": "是否启用分数阈值过滤。"
-                      }
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/HitTestingPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "检索结果。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "query": {
-                      "type": "object",
-                      "description": "原始查询对象。",
-                      "properties": {
-                        "content": {
-                          "type": "string",
-                          "description": "查询文本。"
-                        }
-                      }
-                    },
-                    "records": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "segment": {
-                            "type": "object",
-                            "description": "从知识库中匹配的分段。",
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "分段的唯一标识符。"
-                              },
-                              "position": {
-                                "type": "integer",
-                                "description": "分段在文档中的位置。"
-                              },
-                              "document_id": {
-                                "type": "string",
-                                "description": "该分段所属文档的 ID。"
-                              },
-                              "content": {
-                                "type": "string",
-                                "description": "分段的文本内容。"
-                              },
-                              "sign_content": {
-                                "type": "string",
-                                "description": "用于完整性验证的签名内容哈希。"
-                              },
-                              "answer": {
-                                "type": "string",
-                                "description": "回答内容，用于问答模式文档。"
-                              },
-                              "word_count": {
-                                "type": "integer",
-                                "description": "分段内容的字数。"
-                              },
-                              "tokens": {
-                                "type": "integer",
-                                "description": "分段内容的令牌数。"
-                              },
-                              "keywords": {
-                                "type": "array",
-                                "description": "与该分段关联的关键词，用于基于关键词的检索。",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "index_node_id": {
-                                "type": "string",
-                                "description": "向量存储中索引节点的 ID。"
-                              },
-                              "index_node_hash": {
-                                "type": "string",
-                                "description": "索引内容的哈希值，用于检测变更。"
-                              },
-                              "hit_count": {
-                                "type": "integer",
-                                "description": "该分段在检索查询中被匹配的次数。"
-                              },
-                              "enabled": {
-                                "type": "boolean",
-                                "description": "该分段是否启用检索。"
-                              },
-                              "disabled_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "分段被禁用的时间戳。启用时为 `null`。"
-                              },
-                              "disabled_by": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "禁用该分段的用户 ID。启用时为 `null`。"
-                              },
-                              "status": {
-                                "type": "string",
-                                "description": "分段的索引状态。"
-                              },
-                              "created_by": {
-                                "type": "string",
-                                "description": "创建该分段的用户 ID。"
-                              },
-                              "created_at": {
-                                "type": "number",
-                                "description": "创建时间戳（Unix 纪元，单位为秒）。"
-                              },
-                              "indexing_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "索引开始的时间戳。尚未开始时为 `null`。"
-                              },
-                              "completed_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "索引完成的时间戳。尚未完成时为 `null`。"
-                              },
-                              "error": {
-                                "type": "string",
-                                "nullable": true,
-                                "description": "索引失败时的错误消息。无错误时为 `null`。"
-                              },
-                              "stopped_at": {
-                                "type": "number",
-                                "nullable": true,
-                                "description": "索引停止的时间戳。未停止时为 `null`。"
-                              },
-                              "document": {
-                                "type": "object",
-                                "description": "匹配分段的父文档信息。",
-                                "properties": {
-                                  "id": {
-                                    "type": "string",
-                                    "description": "文档的唯一标识符。"
-                                  },
-                                  "data_source_type": {
-                                    "type": "string",
-                                    "description": "文档的创建方式。"
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "文档名称。"
-                                  },
-                                  "doc_type": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "description": "文档类型分类。未设置时为 `null`。"
-                                  },
-                                  "doc_metadata": {
-                                    "type": "object",
-                                    "nullable": true,
-                                    "description": "文档的元数据值。未配置元数据时为 `null`。"
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "child_chunks": {
-                            "type": "array",
-                            "description": "使用分层索引时，分段内匹配的子分段。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "子分段的唯一标识符。"
-                                },
-                                "content": {
-                                  "type": "string",
-                                  "description": "子分段的文本内容。"
-                                },
-                                "position": {
-                                  "type": "integer",
-                                  "description": "子分段在父分段中的位置。"
-                                },
-                                "score": {
-                                  "type": "number",
-                                  "description": "子分段的相关性得分。"
-                                }
-                              }
-                            }
-                          },
-                          "score": {
-                            "type": "number",
-                            "description": "相关性得分。"
-                          },
-                          "tsne_position": {
-                            "type": "object",
-                            "nullable": true,
-                            "description": "t-SNE 可视化位置。"
-                          },
-                          "files": {
-                            "type": "array",
-                            "description": "附加到该分段的文件。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "description": "附件文件标识符。"
-                                },
-                                "name": {
-                                  "type": "string",
-                                  "description": "原始文件名。"
-                                },
-                                "size": {
-                                  "type": "integer",
-                                  "description": "文件大小（字节）。"
-                                },
-                                "extension": {
-                                  "type": "string",
-                                  "description": "文件扩展名。"
-                                },
-                                "mime_type": {
-                                  "type": "string",
-                                  "description": "文件的 MIME 类型。"
-                                },
-                                "source_url": {
-                                  "type": "string",
-                                  "description": "访问附件的 URL。"
-                                }
-                              }
-                            }
-                          },
-                          "summary": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "通过摘要索引检索到的摘要内容。"
-                          }
-                        }
-                      },
-                      "description": "匹配的检索记录列表。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/HitTestingResponse"
                 },
                 "examples": {
                   "success": {
                     "summary": "响应示例",
                     "value": {
                       "query": {
-                        "content": "What is Dify?"
+                        "content": "什么是 Dify？"
                       },
                       "records": [
                         {
@@ -10839,7 +10729,7 @@
                             "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
                             "position": 1,
                             "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                            "content": "Dify is an open-source LLM app development platform.",
+                            "content": "Dify 是一个开源的 LLM 应用开发平台。",
                             "sign_content": "",
                             "answer": "",
                             "word_count": 9,
@@ -10881,10 +10771,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "检索结果。"
           },
           "400": {
-            "description": "- `dataset_not_initialized` : 知识库仍在初始化或索引中。\n- `provider_not_initialize` : 模型供应商未配置有效凭据。\n- `provider_quota_exceeded` : Dify 托管的模型供应商配额已用尽。\n- `model_currently_not_support` : 所选模型当前不受支持。\n- `completion_request_error` : 模型请求失败。\n- `invalid_param` : 请求参数无效。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10938,15 +10828,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `dataset_not_initialized`：知识库仍在初始化或索引中。\n- `provider_not_initialize`：模型供应商未配置有效凭据。\n- `provider_quota_exceeded`：Dify 托管的模型供应商配额已用尽。\n- `model_currently_not_support`：所选模型当前不受支持。\n- `completion_request_error`：模型请求失败。\n- `invalid_param`：请求参数无效。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10954,7 +10861,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10963,10 +10870,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "`not_found` : 未找到与 `dataset_id` 匹配的知识库。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10980,10 +10887,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
           },
           "500": {
-            "description": "`internal_server_error` : 检索过程中发生内部错误。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10997,9 +10904,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`internal_server_error`：检索过程中发生内部错误。"
           }
         },
+        "summary": "从知识库检索分段 / 测试检索",
+        "tags": [
+          "知识库"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/knowledge-bases/retrieve-chunks-from-a-knowledge-base-test-retrieval",
           "metadata": {


### PR DESCRIPTION
## Summary

- generate Knowledge Bases operations in the English, Chinese, and Japanese Service API references
- apply the reviewed knowledge overlays from the preceding layer
- leave document, chunk, and knowledge-management operations for later layers

## Validation

- three-locale structural parity — 0 issues