### PR TITLE
docs: generate document api references

### DIFF
--- a/en/api-reference/openapi_service.json
+++ b/en/api-reference/openapi_service.json
@@ -4202,65 +4202,52 @@
     },
     "/datasets/{dataset_id}/document/create-by-file": {
       "post": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Create Document by File",
         "description": "Creates a document in a knowledge base from an uploaded file. Common formats such as PDF, TXT, and DOCX are supported. Indexing runs asynchronously; track it with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status).",
         "operationId": "createDocumentFromFile",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
+                "properties": {
+                  "data": {
+                    "description": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`indexing_technique`, `doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`.",
+                    "type": "string",
+                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB.",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
                 "required": [
                   "file"
                 ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
-                  },
-                  "data": {
-                    "type": "string",
-                    "description": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`indexing_technique`, `doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`.",
-                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
-                  }
-                }
+                "type": "object"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Document created successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "Batch ID for tracking indexing progress."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -4309,10 +4296,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Document created successfully."
           },
           "400": {
-            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The knowledge base is external, `indexing_technique` is required, or `process_rule` is missing.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4358,10 +4345,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The knowledge base is external, `indexing_technique` is required, or `process_rule` is missing."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4399,27 +4403,10 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Knowledge base not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
           },
           "413": {
-            "description": "`file_too_large` : The uploaded file exceeds the maximum size.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4433,204 +4420,63 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "`file_too_large` : The uploaded file exceeds the maximum size."
           }
         },
-        "x-mint": {
-          "href": "/en/api-reference/documents/create-document-by-file",
-          "metadata": {
-            "title": "Create Document by File",
-            "sidebarTitle": "Create Document by File"
-          }
-        },
+        "summary": "Create Document by File",
+        "tags": [
+          "Documents"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/documents/create-document-by-file",
+          "metadata": {
+            "title": "Create Document by File",
+            "sidebarTitle": "Create Document by File"
+          }
+        }
       }
     },
     "/datasets/{dataset_id}/document/create-by-text": {
       "post": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Create Document by Text",
         "description": "Creates a document in a knowledge base from raw text. Indexing runs asynchronously; track it with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status).",
         "operationId": "createDocumentFromText",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "text"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Document name."
-                  },
-                  "text": {
-                    "type": "string",
-                    "description": "Document text content."
-                  },
-                  "indexing_technique": {
-                    "type": "string",
-                    "enum": [
-                      "high_quality",
-                      "economy"
-                    ],
-                    "description": "Required when adding the first document to a knowledge base. Subsequent documents inherit the knowledge base's indexing technique if omitted. `high_quality` uses embedding models for precise search; `economy` uses keyword-based indexing."
-                  },
-                  "doc_form": {
-                    "type": "string",
-                    "enum": [
-                      "text_model",
-                      "hierarchical_model",
-                      "qa_model"
-                    ],
-                    "default": "text_model",
-                    "description": "`text_model` for standard text chunking, `hierarchical_model` for parent-child chunk structure, `qa_model` for question-answer pair extraction."
-                  },
-                  "doc_language": {
-                    "type": "string",
-                    "default": "English",
-                    "description": "Language of the document for processing optimization."
-                  },
-                  "process_rule": {
-                    "type": "object",
-                    "description": "Processing rules for chunking.",
-                    "required": [
-                      "mode"
-                    ],
-                    "properties": {
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "automatic",
-                          "custom",
-                          "hierarchical"
-                        ],
-                        "description": "`automatic` uses built-in rules, `custom` allows manual configuration, `hierarchical` enables parent-child chunk structure (use with `doc_form: hierarchical_model`)."
-                      },
-                      "rules": {
-                        "type": "object",
-                        "properties": {
-                          "pre_processing_rules": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "enum": [
-                                    "remove_stopwords",
-                                    "remove_extra_spaces",
-                                    "remove_urls_emails"
-                                  ],
-                                  "description": "Rule identifier."
-                                },
-                                "enabled": {
-                                  "type": "boolean",
-                                  "description": "Whether this preprocessing rule is enabled."
-                                }
-                              }
-                            }
-                          },
-                          "segmentation": {
-                            "type": "object",
-                            "properties": {
-                              "separator": {
-                                "type": "string",
-                                "default": "\n",
-                                "description": "Custom separator for splitting text."
-                              },
-                              "max_tokens": {
-                                "type": "integer",
-                                "description": "Maximum token count per chunk."
-                              },
-                              "chunk_overlap": {
-                                "type": "integer",
-                                "default": 0,
-                                "description": "Token overlap between chunks."
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "Controls how chunks are searched and ranked when querying this knowledge base."
-                  },
-                  "embedding_model": {
-                    "type": "string",
-                    "description": "Embedding model name. Use the `model` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
-                  },
-                  "embedding_model_provider": {
-                    "type": "string",
-                    "description": "Embedding model provider. Use the `provider` field from [Get Available Models](/en/api-reference/models/get-available-models) with `model_type=text-embedding`."
-                  },
-                  "original_document_id": {
-                    "type": "string",
-                    "description": "Original document ID for versioning. Get it from [List Documents](/en/api-reference/documents/list-documents)."
-                  }
-                }
+                "$ref": "#/components/schemas/DocumentTextCreatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Document created successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "Batch ID for tracking indexing progress."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -4679,10 +4525,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Document created successfully."
           },
           "400": {
-            "description": "- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : `indexing_technique` is required when adding the first document, or `doc_form` is invalid.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4704,10 +4550,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : `indexing_technique` is required when adding the first document, or `doc_form` is invalid."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4745,43 +4608,14 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Knowledge base not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
           }
         },
+        "summary": "Create Document by Text",
+        "tags": [
+          "Documents"
+        ],
         "x-mint": {
           "href": "/en/api-reference/documents/create-document-by-text",
           "metadata": {
@@ -4791,101 +4625,486 @@
         }
       }
     },
-    "/datasets/{dataset_id}/documents": {
-      "get": {
+    "/datasets/{dataset_id}/document/create_by_file": {
+      "post": {
+        "deprecated": true,
+        "description": "Deprecated compatibility endpoint. Creates a document in a knowledge base from an uploaded file. Common formats such as PDF, TXT, and DOCX are supported. Indexing runs asynchronously; track it with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status).",
+        "operationId": "create_document_by_file_75a87285",
+        "parameters": [
+          {
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "description": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`indexing_technique`, `doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`.",
+                    "type": "string",
+                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB.",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 0,
+                        "indexing_status": "indexing",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "indexing",
+                        "word_count": 0,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Document created successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_external": {
+                    "summary": "invalid_param (external)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "External datasets are not supported."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The knowledge base is external, `indexing_technique` is required, or `process_rule` is missing."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (documents limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The number of documents has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_too_large` : The uploaded file exceeds the maximum size."
+          }
+        },
+        "summary": "Create Document by File",
+        "tags": [
+          "Documents"
+        ]
+      }
+    },
+    "/datasets/{dataset_id}/document/create_by_text": {
+      "post": {
+        "deprecated": true,
+        "description": "Deprecated compatibility endpoint. Creates a document in a knowledge base from raw text. Indexing runs asynchronously; track it with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status).",
+        "operationId": "create_document_by_text_deprecated",
+        "parameters": [
+          {
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentTextCreatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 0,
+                        "indexing_status": "indexing",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "indexing",
+                        "word_count": 0,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Document created successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_indexing": {
+                    "summary": "invalid_param (indexing_technique)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "indexing_technique is required."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : `indexing_technique` is required when adding the first document, or `doc_form` is invalid."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (documents limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The number of documents has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : The number of documents has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+          }
+        },
         "tags": [
           "Documents"
         ],
-        "summary": "List Documents",
+        "summary": "Create Document by Text"
+      }
+    },
+    "/datasets/{dataset_id}/documents": {
+      "get": {
         "description": "Returns a paginated list of documents in a knowledge base.",
         "operationId": "listDocuments",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 1
-            },
-            "description": "Page number."
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 20
-            },
-            "description": "Number of items per page. Server caps at `100`."
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
               "type": "string"
-            },
-            "description": "Search keyword to filter by document name."
+            }
           },
           {
-            "name": "status",
+            "description": "Search keyword to filter by document name.",
             "in": "query",
+            "name": "keyword",
+            "required": false,
             "schema": {
-              "type": "string",
+              "description": "Search keyword to filter by document name.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of items per page. Server caps at `100`.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of items per page. Server caps at `100`.",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number to retrieve.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "Page number to retrieve.",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by display status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "Filter by display status.",
               "enum": [
-                "queuing",
-                "indexing",
-                "paused",
-                "error",
+                "archived",
                 "available",
                 "disabled",
-                "archived"
-              ]
-            },
-            "description": "Filter by display status."
+                "error",
+                "indexing",
+                "paused",
+                "queuing"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "List of documents.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "Array of document objects.",
-                      "items": {
-                        "$ref": "#/components/schemas/Document"
-                      }
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "Whether more items exist on the next page."
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "Number of items per page."
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "Total number of matching items."
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "Current page number."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentListResponse"
                 },
                 "examples": {
                   "success": {
@@ -4939,10 +5158,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "List of documents."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : Knowledge base API access is not enabled.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4956,10 +5192,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled."
           },
           "404": {
-            "description": "`not_found` : Knowledge base not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -4973,9 +5209,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Knowledge base not found."
           }
         },
+        "summary": "List Documents",
+        "tags": [
+          "Documents"
+        ],
         "x-mint": {
           "href": "/en/api-reference/documents/list-documents",
           "metadata": {
@@ -4987,64 +5228,62 @@
     },
     "/datasets/{dataset_id}/documents/download-zip": {
       "post": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Download Documents as ZIP",
         "description": "Downloads one or more documents as a single ZIP archive. Only documents that were uploaded as files can be included.",
         "operationId": "downloadDocumentsZip",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 100,
-                    "items": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "description": "Document IDs to include in the archive. Get them from [List Documents](/en/api-reference/documents/list-documents)."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "ZIP archive containing the requested documents.",
-            "content": {
-              "application/zip": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary",
-                  "description": "ZIP archive binary stream."
-                }
+                "$ref": "#/components/schemas/DocumentBatchDownloadZipPayload"
               }
             }
           },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string",
+                  "description": "ZIP archive binary stream."
+                }
+              }
+            },
+            "description": "ZIP archive containing the requested documents."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
           "403": {
-            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : You do not have permission to access this knowledge base.\n- `forbidden` : You do not have permission for one of the requested documents.",
             "content": {
               "application/json": {
                 "examples": {
@@ -5082,10 +5321,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : You do not have permission to access this knowledge base.\n- `forbidden` : You do not have permission for one of the requested documents."
           },
           "404": {
-            "description": "- `not_found` : Document not found.\n- `not_found` : Knowledge base not found. Also returned as \"Only uploaded-file documents can be downloaded as ZIP.\" when a requested document has no uploaded file.",
             "content": {
               "application/json": {
                 "examples": {
@@ -5115,9 +5354,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Document not found.\n- `not_found` : Knowledge base not found. Also returned as \"Only uploaded-file documents can be downloaded as ZIP.\" when a requested document has no uploaded file."
           }
         },
+        "summary": "Download Documents as ZIP",
+        "tags": [
+          "Documents"
+        ],
         "x-mint": {
           "href": "/en/api-reference/documents/download-documents-as-zip",
           "metadata": {
@@ -5320,74 +5564,64 @@
     },
     "/datasets/{dataset_id}/documents/status/{action}": {
       "patch": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Update Document Status in Batch",
-        "description": "Enables, disables, archives, or unarchives multiple documents in one request.",
+        "description": "Enables, disables, archives, or unarchives multiple documents in one request. `document_ids` is optional for compatibility; omitting it or passing an empty array performs no updates and still returns `result: success`.",
         "operationId": "batchUpdateDocumentStatus",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Action to perform: 'enable', 'disable', 'archive', or 'un_archive'",
             "in": "path",
+            "name": "action",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Action to perform: 'enable', 'disable', 'archive', or 'un_archive'",
+              "enum": [
+                "archive",
+                "disable",
+                "enable",
+                "un_archive"
+              ],
+              "type": "string"
+            }
           },
           {
-            "name": "action",
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable",
-                "archive",
-                "un_archive"
-              ]
-            },
-            "description": "`enable` activates documents for retrieval, `disable` deactivates them, `archive` moves them to the archive, `un_archive` restores them from the archive."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Document IDs to update. Get them from [List Documents](/en/api-reference/documents/list-documents)."
+                "$ref": "#/components/schemas/DocumentStatusPayload"
+              },
+              "examples": {
+                "update_documents": {
+                  "summary": "Request Example",
+                  "value": {
+                    "document_ids": [
+                      "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                      "c4c4f9aa-2c9b-4f95-9f5a-2c0f7c3a8f21"
+                    ]
                   }
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Documents updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "Operation result."
-                    }
-                  }
+                  "$ref": "#/components/schemas/SimpleResultResponse"
                 },
                 "examples": {
                   "success": {
@@ -5398,10 +5632,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Documents updated successfully."
           },
           "400": {
-            "description": "`invalid_action` : Invalid action, or a document is in a state that does not allow the action (e.g. still indexing, or not completed).",
             "content": {
               "application/json": {
                 "examples": {
@@ -5415,10 +5649,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_action` : Invalid action, or a document is in a state that does not allow the action (e.g. still indexing, or not completed)."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : Knowledge base API access is not enabled.",
             "content": {
               "application/json": {
                 "examples": {
@@ -5432,10 +5683,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled."
           },
           "404": {
-            "description": "`not_found` : Knowledge base not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -5449,9 +5700,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Knowledge base not found."
           }
         },
+        "summary": "Update Document Status in Batch",
+        "tags": [
+          "Documents"
+        ],
         "x-mint": {
           "href": "/en/api-reference/documents/update-document-status-in-batch",
           "metadata": {
@@ -5463,107 +5719,37 @@
     },
     "/datasets/{dataset_id}/documents/{batch}/indexing-status": {
       "get": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Get Document Indexing Status",
-        "description": "Returns indexing progress for every document in a batch: the current stage and chunk completion counts. Poll until each `indexing_status` reaches `completed` or `error`. Status advances through `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed`.",
+        "description": "Returns indexing progress for every document in a batch: the current stage and chunk completion counts. Poll until each `indexing_status` reaches `completed`, `error`, or `paused`. `completed` and `error` are terminal. The Service API has no resume action for a paused document; resume it in the Dify knowledge-base console, then continue polling this endpoint. The active stages are `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed`. A non-null `stopped_at` records when processing stopped, even though it is not a separate `indexing_status` value.",
         "operationId": "getDocumentIndexingStatus",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Batch ID returned when you create or update a document.",
             "in": "path",
+            "name": "batch",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Batch ID.",
+              "type": "string"
+            }
           },
           {
-            "name": "batch",
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
               "type": "string"
-            },
-            "description": "Batch ID returned when you create or update a document."
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Indexing status for documents in the batch.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of indexing status entries.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "Document identifier."
-                          },
-                          "indexing_status": {
-                            "type": "string",
-                            "description": "Current indexing status: `waiting`, `parsing`, `cleaning`, `splitting`, `indexing`, `completed`, or `error`."
-                          },
-                          "processing_started_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Unix timestamp when processing started."
-                          },
-                          "parsing_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Unix timestamp when parsing completed."
-                          },
-                          "cleaning_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Unix timestamp when cleaning completed."
-                          },
-                          "splitting_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Unix timestamp when splitting completed."
-                          },
-                          "completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Unix timestamp when indexing completed."
-                          },
-                          "paused_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Timestamp when indexing was paused. `null` if not paused."
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Error message if indexing failed. `null` if no error."
-                          },
-                          "stopped_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "Timestamp when indexing was stopped. `null` if not stopped."
-                          },
-                          "completed_segments": {
-                            "type": "integer",
-                            "description": "Number of chunks that have been indexed."
-                          },
-                          "total_segments": {
-                            "type": "integer",
-                            "description": "Total number of chunks to be indexed."
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentStatusListResponse"
                 },
                 "examples": {
                   "success": {
@@ -5589,10 +5775,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Indexing status for documents in the batch."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : Knowledge base API access is not enabled.",
             "content": {
               "application/json": {
                 "examples": {
@@ -5606,10 +5809,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled."
           },
           "404": {
-            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Documents not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -5631,9 +5834,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Documents not found."
           }
         },
+        "summary": "Get Document Indexing Status",
+        "tags": [
+          "Documents"
+        ],
         "x-mint": {
           "href": "/en/api-reference/documents/get-document-indexing-status",
           "metadata": {
@@ -5644,247 +5852,191 @@
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}": {
-      "get": {
+      "delete": {
+        "description": "Permanently deletes a document and all its chunks from the knowledge base.",
+        "operationId": "deleteDocument",
+        "parameters": [
+          {
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "document_indexing": {
+                    "summary": "document_indexing",
+                    "value": {
+                      "status": 400,
+                      "code": "document_indexing",
+                      "message": "Cannot delete document during indexing."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `document_indexing` : The document is still being processed and cannot be deleted."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "archived_document_immutable": {
+                    "summary": "archived_document_immutable",
+                    "value": {
+                      "status": 403,
+                      "code": "archived_document_immutable",
+                      "message": "The archived document is not editable."
+                    }
+                  },
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `archived_document_immutable` : The archived document is not editable.\n- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document Not Exists."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found_2",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : The document does not exist. Also returned as \"Dataset not found.\" when the knowledge base itself does not exist."
+          }
+        },
+        "summary": "Delete Document",
         "tags": [
           "Documents"
         ],
-        "summary": "Get Document",
+        "x-mint": {
+          "href": "/en/api-reference/documents/delete-document",
+          "metadata": {
+            "title": "Delete Document",
+            "sidebarTitle": "Delete Document"
+          }
+        }
+      },
+      "get": {
         "description": "Returns detailed information for a single document.",
         "operationId": "getDocumentDetail",
         "parameters": [
           {
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents)."
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "metadata",
+            "description": "`all` returns all fields including metadata. `only` returns only `id`, `doc_type`, and `doc_metadata`. `without` returns all fields except `doc_metadata`.",
             "in": "query",
+            "name": "metadata",
+            "required": false,
             "schema": {
-              "type": "string",
+              "default": "all",
+              "description": "`all` returns all fields including metadata. `only` returns only `id`, `doc_type`, and `doc_metadata`. `without` returns all fields except `doc_metadata`.",
               "enum": [
                 "all",
                 "only",
                 "without"
               ],
-              "default": "all"
-            },
-            "description": "`all` returns all fields including metadata. `only` returns only `id`, `doc_type`, and `doc_metadata`. `without` returns all fields except `doc_metadata`."
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Document details. The returned fields depend on the `metadata` query parameter.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Document identifier."
-                    },
-                    "position": {
-                      "type": "integer",
-                      "description": "Position index within the knowledge base."
-                    },
-                    "data_source_type": {
-                      "type": "string",
-                      "description": "How the document was uploaded. `upload_file` for file uploads, `notion_import` for Notion imports."
-                    },
-                    "data_source_info": {
-                      "type": "object",
-                      "description": "Data source details. For file uploads, this detail endpoint returns the full file object under `upload_file` (the list endpoint returns only `upload_file_id`).",
-                      "properties": {
-                        "upload_file": {
-                          "type": "object",
-                          "description": "Uploaded file details. Present when `data_source_type` is `upload_file`.",
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "File identifier."
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "Original file name."
-                            },
-                            "size": {
-                              "type": "integer",
-                              "description": "File size in bytes."
-                            },
-                            "extension": {
-                              "type": "string",
-                              "description": "File extension."
-                            },
-                            "mime_type": {
-                              "type": "string",
-                              "description": "File MIME type."
-                            },
-                            "created_by": {
-                              "type": "string",
-                              "description": "ID of the user who uploaded the file."
-                            },
-                            "created_at": {
-                              "type": "integer",
-                              "description": "Unix timestamp of file upload."
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "dataset_process_rule_id": {
-                      "type": "string",
-                      "description": "ID of the processing rule applied to this document."
-                    },
-                    "dataset_process_rule": {
-                      "type": "object",
-                      "description": "Knowledge-base-level processing rule configuration."
-                    },
-                    "document_process_rule": {
-                      "type": "object",
-                      "description": "Document-level processing rule configuration."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Document name."
-                    },
-                    "created_from": {
-                      "type": "string",
-                      "description": "Origin of the document. `api` for API creation, `web` for UI creation."
-                    },
-                    "created_by": {
-                      "type": "string",
-                      "description": "ID of the user who created the document."
-                    },
-                    "created_at": {
-                      "type": "number",
-                      "description": "Unix timestamp of document creation."
-                    },
-                    "tokens": {
-                      "type": "integer",
-                      "description": "Number of tokens in the document."
-                    },
-                    "indexing_status": {
-                      "type": "string",
-                      "description": "Current indexing status, e.g. `waiting`, `parsing`, `cleaning`, `splitting`, `indexing`, `completed`, `error`, `paused`."
-                    },
-                    "error": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Error message if indexing failed, `null` otherwise."
-                    },
-                    "enabled": {
-                      "type": "boolean",
-                      "description": "Whether the document is enabled for retrieval."
-                    },
-                    "disabled_at": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "Unix timestamp when the document was disabled, `null` if enabled."
-                    },
-                    "disabled_by": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "ID of the user who disabled the document, `null` if enabled."
-                    },
-                    "archived": {
-                      "type": "boolean",
-                      "description": "Whether the document is archived."
-                    },
-                    "display_status": {
-                      "type": "string",
-                      "description": "Display-friendly indexing status for the UI."
-                    },
-                    "hit_count": {
-                      "type": "integer",
-                      "description": "Number of times this document has been retrieved."
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "Document chunking mode. `text_model` for standard text, `hierarchical_model` for parent-child, `qa_model` for QA pairs."
-                    },
-                    "doc_language": {
-                      "type": "string",
-                      "description": "Language of the document content."
-                    },
-                    "doc_type": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Document type classification, `null` if not set."
-                    },
-                    "doc_metadata": {
-                      "type": "array",
-                      "description": "Custom metadata key-value pairs for this document.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "Metadata field identifier."
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "Metadata field name."
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "Metadata field type."
-                          },
-                          "value": {
-                            "type": "string",
-                            "description": "Metadata field value for this document."
-                          }
-                        }
-                      }
-                    },
-                    "completed_at": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "Unix timestamp when processing completed, `null` if not yet completed."
-                    },
-                    "updated_at": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "Unix timestamp of last update, `null` if never updated."
-                    },
-                    "indexing_latency": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "Time taken for indexing in seconds, `null` if not completed."
-                    },
-                    "segment_count": {
-                      "type": "integer",
-                      "description": "Number of chunks in the document."
-                    },
-                    "average_segment_length": {
-                      "type": "number",
-                      "description": "Average character length of chunks."
-                    },
-                    "summary_index_status": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Status of summary indexing, `null` if summary index is not enabled."
-                    },
-                    "need_summary": {
-                      "type": "boolean",
-                      "description": "Whether the document needs summary generation."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentDetailResponse"
                 },
                 "examples": {
                   "success": {
@@ -5948,10 +6100,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Document details. The returned fields depend on the `metadata` query parameter."
           },
           "400": {
-            "description": "`invalid_metadata` : The `metadata` query parameter value is invalid (must be `all`, `only`, or `without`).",
             "content": {
               "application/json": {
                 "examples": {
@@ -5960,15 +6112,32 @@
                     "value": {
                       "status": 400,
                       "code": "invalid_metadata",
-                      "message": "Invalid metadata value: only"
+                      "message": "Invalid metadata value."
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_metadata` : The `metadata` query parameter value is invalid (must be `all`, `only`, or `without`)."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : You do not have permission to access this document.\n- `forbidden` : Knowledge base API access is not enabled.",
             "content": {
               "application/json": {
                 "examples": {
@@ -5990,10 +6159,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : You do not have permission to access this document.\n- `forbidden` : Knowledge base API access is not enabled."
           },
           "404": {
-            "description": "`not_found` : Document not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -6007,9 +6176,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Document not found."
           }
         },
+        "summary": "Get Document",
+        "tags": [
+          "Documents"
+        ],
         "x-mint": {
           "href": "/en/api-reference/documents/get-document",
           "metadata": {
@@ -6018,173 +6192,61 @@
           }
         }
       },
-      "delete": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Delete Document",
-        "description": "Permanently deletes a document and all its chunks from the knowledge base.",
-        "operationId": "deleteDocument",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents)."
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "403": {
-            "description": "- `archived_document_immutable` : The archived document is not editable.\n- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "archived_document_immutable": {
-                    "summary": "archived_document_immutable",
-                    "value": {
-                      "status": 403,
-                      "code": "archived_document_immutable",
-                      "message": "The archived document is not editable."
-                    }
-                  },
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : The document does not exist. Also returned as \"Dataset not found.\" when the knowledge base itself does not exist.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document Not Exists."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found_2",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/documents/delete-document",
-          "metadata": {
-            "title": "Delete Document",
-            "sidebarTitle": "Delete Document"
-          }
-        }
-      },
       "patch": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Update Document",
-        "description": "Updates a document by uploading a new file, then re-indexes it. This is the canonical endpoint for file-based document updates. Track progress with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status).",
+        "description": "Updates a document and re-indexes it. Send `file` to replace the source file, `data` to change processing settings, or both. If `file` is omitted, Dify reprocesses the existing source with the supplied or current settings; an empty multipart request re-indexes it with the current settings. Track progress with the returned `batch` ID via [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status).",
         "operationId": "updateDocument",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents)."
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
                 "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
-                  },
                   "data": {
-                    "type": "string",
                     "description": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`.",
+                    "type": "string",
                     "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB.",
+                    "format": "binary",
+                    "type": "string"
                   }
-                }
+                },
+                "type": "object"
               }
             }
-          }
+          },
+          "required": false
         },
         "responses": {
           "200": {
-            "description": "Document updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "Batch ID for tracking indexing progress."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -6233,10 +6295,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Document updated successfully."
           },
           "400": {
-            "description": "- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The document is not available for update (only available documents can be updated).",
             "content": {
               "application/json": {
                 "examples": {
@@ -6274,10 +6336,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The document is not available for update (only available documents can be updated)."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -6307,10 +6386,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
           },
           "404": {
-            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -6332,10 +6411,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found."
           },
           "413": {
-            "description": "`file_too_large` : The uploaded file exceeds the maximum size.",
             "content": {
               "application/json": {
                 "examples": {
@@ -6349,10 +6428,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`file_too_large` : The uploaded file exceeds the maximum size."
           },
           "415": {
-            "description": "`unsupported_file_type` : The uploaded file's type is not supported.",
             "content": {
               "application/json": {
                 "examples": {
@@ -6366,85 +6445,64 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "`unsupported_file_type` : The uploaded file's type is not supported."
           }
         },
-        "x-mint": {
-          "href": "/en/api-reference/documents/update-document",
-          "metadata": {
-            "title": "Update Document",
-            "sidebarTitle": "Update Document"
-          }
-        },
+        "summary": "Update Document",
+        "tags": [
+          "Documents"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request PATCH \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/documents/{document_id}' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/documents/update-document",
+          "metadata": {
+            "title": "Update Document",
+            "sidebarTitle": "Update Document"
+          }
+        }
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/download": {
       "get": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Download Document",
         "description": "Returns a signed URL for downloading a document's original uploaded file.",
         "operationId": "downloadDocument",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents)."
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Download URL generated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "url": {
-                      "type": "string",
-                      "description": "Signed URL to download the original uploaded file."
-                    }
-                  }
+                  "$ref": "#/components/schemas/UrlResponse"
                 },
                 "examples": {
                   "success": {
@@ -6455,10 +6513,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Download URL generated successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : You do not have permission to access this document.\n- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -6488,10 +6563,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : You do not have permission to access this document.\n- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
           },
           "404": {
-            "description": "`not_found` : Document not found. Also returned as \"Uploaded file not found.\" when the stored file is missing, and \"Document does not have an uploaded file to download.\" for non-file documents.",
             "content": {
               "application/json": {
                 "examples": {
@@ -6521,9 +6596,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Document not found. Also returned as \"Uploaded file not found.\" when the stored file is missing, and \"Document does not have an uploaded file to download.\" for non-file documents."
           }
         },
+        "summary": "Download Document",
+        "tags": [
+          "Documents"
+        ],
         "x-mint": {
           "href": "/en/api-reference/documents/download-document",
           "metadata": {
@@ -8419,72 +8499,61 @@
     },
     "/datasets/{dataset_id}/documents/{document_id}/update-by-file": {
       "post": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Update Document by File",
-        "description": "Deprecated. Use [Update Document](/en/api-reference/documents/update-document) instead. Updates a document by uploading a new file, then re-indexes it.",
+        "deprecated": true,
+        "description": "Deprecated file-update route. Send `file` to replace the source file, `data` to change processing settings, or both. If `file` is omitted, Dify reprocesses the existing source with the supplied or current settings; an empty multipart request re-indexes it with the current settings. Use [Update Document](/en/api-reference/documents/update-document) instead.",
         "operationId": "updateDocumentByFile",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents)."
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
                 "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB."
-                  },
                   "data": {
-                    "type": "string",
                     "description": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`.",
+                    "type": "string",
                     "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB.",
+                    "format": "binary",
+                    "type": "string"
                   }
-                }
+                },
+                "type": "object"
               }
             }
-          }
+          },
+          "required": false
         },
         "responses": {
           "200": {
-            "description": "Document updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "Batch ID for tracking indexing progress."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -8533,10 +8602,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Document updated successfully."
           },
           "400": {
-            "description": "- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The document is not available for update (only available documents can be updated).",
             "content": {
               "application/json": {
                 "examples": {
@@ -8574,10 +8643,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The document is not available for update (only available documents can be updated)."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8607,10 +8693,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
           },
           "404": {
-            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8632,10 +8718,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found."
           },
           "413": {
-            "description": "`file_too_large` : The uploaded file exceeds the maximum size.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8649,10 +8735,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`file_too_large` : The uploaded file exceeds the maximum size."
           },
           "415": {
-            "description": "`unsupported_file_type` : The uploaded file's type is not supported.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8666,27 +8752,14 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "`unsupported_file_type` : The uploaded file's type is not supported."
           }
         },
-        "deprecated": true,
+        "summary": "Update Document by File",
+        "tags": [
+          "Documents"
+        ],
         "x-mint": {
           "href": "/en/api-reference/documents/update-document-by-file",
           "metadata": {
@@ -8698,152 +8771,48 @@
     },
     "/datasets/{dataset_id}/documents/{document_id}/update-by-text": {
       "post": {
-        "tags": [
-          "Documents"
-        ],
-        "summary": "Update Document by Text",
         "description": "Updates a document's text content, name, or processing configuration. Re-indexes the document when its text changes.",
         "operationId": "updateDocumentByText",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents)."
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Document name. Required when `text` is provided."
-                  },
-                  "text": {
-                    "type": "string",
-                    "description": "Document text content."
-                  },
-                  "process_rule": {
-                    "type": "object",
-                    "description": "Processing rules for chunking.",
-                    "required": [
-                      "mode"
-                    ],
-                    "properties": {
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "automatic",
-                          "custom",
-                          "hierarchical"
-                        ],
-                        "description": "`automatic` uses built-in rules, `custom` allows manual configuration, `hierarchical` enables parent-child chunk structure (use with `doc_form: hierarchical_model`)."
-                      },
-                      "rules": {
-                        "type": "object",
-                        "properties": {
-                          "pre_processing_rules": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "enum": [
-                                    "remove_stopwords",
-                                    "remove_extra_spaces",
-                                    "remove_urls_emails"
-                                  ],
-                                  "description": "Rule identifier."
-                                },
-                                "enabled": {
-                                  "type": "boolean",
-                                  "description": "Whether this preprocessing rule is enabled."
-                                }
-                              }
-                            }
-                          },
-                          "segmentation": {
-                            "type": "object",
-                            "properties": {
-                              "separator": {
-                                "type": "string",
-                                "default": "\n",
-                                "description": "Custom separator for splitting text."
-                              },
-                              "max_tokens": {
-                                "type": "integer",
-                                "description": "Maximum token count per chunk."
-                              },
-                              "chunk_overlap": {
-                                "type": "integer",
-                                "default": 0,
-                                "description": "Token overlap between chunks."
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "doc_form": {
-                    "type": "string",
-                    "enum": [
-                      "text_model",
-                      "hierarchical_model",
-                      "qa_model"
-                    ],
-                    "default": "text_model",
-                    "description": "`text_model` for standard text chunking, `hierarchical_model` for parent-child chunk structure, `qa_model` for question-answer pair extraction."
-                  },
-                  "doc_language": {
-                    "type": "string",
-                    "default": "English",
-                    "description": "Language of the document for processing optimization."
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "Controls how chunks are searched and ranked when querying this knowledge base."
-                  }
-                }
+                "$ref": "#/components/schemas/DocumentTextUpdate"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Document updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "Batch ID for tracking indexing progress."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -8892,10 +8861,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Document updated successfully."
           },
           "400": {
-            "description": "- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : `name` is required when `text` is provided, or `doc_form` is invalid.\n- `invalid_param` : The document is not available for update (only available documents can be updated).",
             "content": {
               "application/json": {
                 "examples": {
@@ -8925,10 +8894,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : `name` is required when `text` is provided, or `doc_form` is invalid.\n- `invalid_param` : The document is not available for update (only available documents can be updated)."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8958,10 +8944,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
           },
           "404": {
-            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8983,26 +8969,14 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found."
           }
         },
+        "summary": "Update Document by Text",
+        "tags": [
+          "Documents"
+        ],
         "x-mint": {
           "href": "/en/api-reference/documents/update-document-by-text",
           "metadata": {
@@ -9010,6 +8984,449 @@
             "sidebarTitle": "Update Document by Text"
           }
         }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/update_by_file": {
+      "post": {
+        "deprecated": true,
+        "description": "Deprecated file-update route. Send `file` to replace the source file, `data` to change processing settings, or both. If `file` is omitted, Dify reprocesses the existing source with the supplied or current settings; an empty multipart request re-indexes it with the current settings. Use [Update Document](/en/api-reference/documents/update-document) instead.",
+        "operationId": "update_document_by_file_deprecated_5dc5fe59",
+        "parameters": [
+          {
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "description": "JSON string containing configuration. Accepts the same fields as [Create Document by Text](/en/api-reference/documents/create-document-by-text) (`doc_form`, `doc_language`, `process_rule`, `retrieval_model`, `embedding_model`, `embedding_model_provider`) except `name` and `text`.",
+                    "type": "string",
+                    "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "File to upload, capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments). On Dify Cloud, Professional and Team plans raise the cap to 50 MB.",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Document updated successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_not_available": {
+                    "summary": "invalid_param (not available)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Document is not available"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `too_many_files` : Only one file is allowed per request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `provider_not_initialize` : No model provider credentials are configured for the workspace.\n- `invalid_param` : The document is not available for update (only available documents can be updated)."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found."
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_too_large` : The uploaded file exceeds the maximum size."
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`unsupported_file_type` : The uploaded file's type is not supported."
+          }
+        },
+        "summary": "Update Document by File",
+        "tags": [
+          "Documents"
+        ]
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/update_by_text": {
+      "post": {
+        "deprecated": true,
+        "description": "Deprecated compatibility endpoint. Updates a document's text content, name, or processing configuration. Re-indexes the document when its text changes.",
+        "operationId": "update_document_by_text_deprecated",
+        "parameters": [
+          {
+            "description": "Knowledge base ID. From [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Document ID. From [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentTextUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Document updated successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Knowledge base API access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : Document not found."
+          }
+        },
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Update Document by Text"
       }
     },
     "/datasets/{dataset_id}/hit-testing": {

--- a/ja/api-reference/openapi_service.json
+++ b/ja/api-reference/openapi_service.json
@@ -4202,65 +4202,52 @@
     },
     "/datasets/{dataset_id}/document/create-by-file": {
       "post": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ファイルからドキュメントを作成",
-        "description": "アップロードしたファイルからナレッジベースにドキュメントを作成します。PDF、TXT、DOCX などの一般的な形式をサポートします。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメント埋め込みステータス（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。",
+        "description": "アップロードしたファイルからナレッジベースにドキュメントを作成します。PDF、TXT、DOCX などの一般的な形式をサポートします。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。",
         "operationId": "createDocumentFromFile",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
+                "properties": {
+                  "data": {
+                    "description": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。",
+                    "type": "string",
+                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
                 "required": [
                   "file"
                 ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
-                  },
-                  "data": {
-                    "type": "string",
-                    "description": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。",
-                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
-                  }
-                }
+                "type": "object"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "ドキュメントが正常に作成されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -4309,10 +4296,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ドキュメントが正常に作成されました。"
           },
           "400": {
-            "description": "- `no_file_uploaded` : リクエストにファイルが提供されていません。\n- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : ナレッジベースが外部です。`indexing_technique` が必須、または `process_rule` がありません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4349,7 +4336,7 @@
                     }
                   },
                   "invalid_param_external": {
-                    "summary": "invalid_param (external)",
+                    "summary": "invalid_param（外部ナレッジベース）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -4358,15 +4345,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `no_file_uploaded`：リクエストにファイルが提供されていません。\n- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：ナレッジベースが外部です。`indexing_technique` が必須、または `process_rule` がありません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4374,7 +4378,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（ベクトル容量制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4382,7 +4386,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (documents limit)",
+                    "summary": "forbidden（ドキュメント数制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4390,7 +4394,7 @@
                     }
                   },
                   "forbidden_4": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4399,27 +4403,10 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "413": {
-            "description": "`file_too_large` : ファイルサイズが上限を超えています。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4433,204 +4420,63 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "`file_too_large`：ファイルサイズが上限を超えています。"
           }
         },
-        "x-mint": {
-          "href": "/ja/api-reference/documents/create-document-by-file",
-          "metadata": {
-            "title": "ファイルからドキュメントを作成",
-            "sidebarTitle": "ファイルからドキュメントを作成"
-          }
-        },
+        "summary": "ファイルからドキュメントを作成",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/documents/create-document-by-file",
+          "metadata": {
+            "title": "ファイルからドキュメントを作成",
+            "sidebarTitle": "ファイルからドキュメントを作成"
+          }
+        }
       }
     },
     "/datasets/{dataset_id}/document/create-by-text": {
       "post": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "テキストからドキュメントを作成",
-        "description": "生のテキストからナレッジベースにドキュメントを作成します。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメント埋め込みステータス（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。",
+        "description": "生のテキストからナレッジベースにドキュメントを作成します。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。",
         "operationId": "createDocumentFromText",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "text"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "ドキュメント名です。"
-                  },
-                  "text": {
-                    "type": "string",
-                    "description": "ドキュメントのテキスト内容です。"
-                  },
-                  "indexing_technique": {
-                    "type": "string",
-                    "enum": [
-                      "high_quality",
-                      "economy"
-                    ],
-                    "description": "ナレッジベースに最初のドキュメントを追加する際に必須です。以降のドキュメントでは省略するとナレッジベースのインデックス方式を継承します。`high_quality` は埋め込みモデルによる精密検索、`economy` はキーワードベースのインデックスを使用します。"
-                  },
-                  "doc_form": {
-                    "type": "string",
-                    "enum": [
-                      "text_model",
-                      "hierarchical_model",
-                      "qa_model"
-                    ],
-                    "default": "text_model",
-                    "description": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。"
-                  },
-                  "doc_language": {
-                    "type": "string",
-                    "default": "English",
-                    "description": "処理最適化のためのドキュメント言語です。"
-                  },
-                  "process_rule": {
-                    "type": "object",
-                    "description": "チャンキングの処理ルールです。",
-                    "required": [
-                      "mode"
-                    ],
-                    "properties": {
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "automatic",
-                          "custom",
-                          "hierarchical"
-                        ],
-                        "description": "`automatic` は組み込みルールを使用、`custom` は手動設定が可能、`hierarchical` は親子チャンク構造を有効にします（`doc_form: hierarchical_model` と組み合わせて使用）。"
-                      },
-                      "rules": {
-                        "type": "object",
-                        "properties": {
-                          "pre_processing_rules": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "enum": [
-                                    "remove_stopwords",
-                                    "remove_extra_spaces",
-                                    "remove_urls_emails"
-                                  ],
-                                  "description": "ルール識別子です。"
-                                },
-                                "enabled": {
-                                  "type": "boolean",
-                                  "description": "この前処理ルールが有効かどうかです。"
-                                }
-                              }
-                            }
-                          },
-                          "segmentation": {
-                            "type": "object",
-                            "properties": {
-                              "separator": {
-                                "type": "string",
-                                "default": "\n",
-                                "description": "テキスト分割用のカスタムセパレーターです。"
-                              },
-                              "max_tokens": {
-                                "type": "integer",
-                                "description": "チャンクあたりの最大トークン数です。"
-                              },
-                              "chunk_overlap": {
-                                "type": "integer",
-                                "default": 0,
-                                "description": "チャンク間のトークンオーバーラップです。"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "このナレッジベースをクエリする際のチャンクの検索方法とランキング方法を制御します。"
-                  },
-                  "embedding_model": {
-                    "type": "string",
-                    "description": "埋め込みモデル名です。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models) で `model_type=text-embedding` を指定した際の `model` フィールドの値を使用します。"
-                  },
-                  "embedding_model_provider": {
-                    "type": "string",
-                    "description": "埋め込みモデルプロバイダーです。[利用可能なモデルを取得](/ja/api-reference/models/get-available-models) で `model_type=text-embedding` を指定した際の `provider` フィールドの値を使用します。"
-                  },
-                  "original_document_id": {
-                    "type": "string",
-                    "description": "バージョン管理用の元ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-                  }
-                }
+                "$ref": "#/components/schemas/DocumentTextCreatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "ドキュメントが正常に作成されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -4679,10 +4525,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ドキュメントが正常に作成されました。"
           },
           "400": {
-            "description": "- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : 最初のドキュメント追加時には `indexing_technique` が必須です。または `doc_form` が無効です。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4695,7 +4541,7 @@
                     }
                   },
                   "invalid_param_indexing": {
-                    "summary": "invalid_param (indexing_technique)",
+                    "summary": "invalid_param（インデックス方式）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -4704,15 +4550,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：最初のドキュメント追加時には `indexing_technique` が必須です。または `doc_form` が無効です。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4720,7 +4583,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（ベクトル容量制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4728,7 +4591,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (documents limit)",
+                    "summary": "forbidden（ドキュメント数制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4736,7 +4599,7 @@
                     }
                   },
                   "forbidden_4": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4745,43 +4608,14 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           }
         },
+        "summary": "テキストからドキュメントを作成",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/documents/create-document-by-text",
           "metadata": {
@@ -4791,101 +4625,486 @@
         }
       }
     },
-    "/datasets/{dataset_id}/documents": {
-      "get": {
+    "/datasets/{dataset_id}/document/create_by_file": {
+      "post": {
+        "deprecated": true,
+        "description": "非推奨の互換エンドポイントです。アップロードしたファイルからナレッジベースにドキュメントを作成します。PDF、TXT、DOCX などの一般的な形式をサポートします。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。",
+        "operationId": "create_document_by_file_75a87285",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "description": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。",
+                    "type": "string",
+                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 0,
+                        "indexing_status": "indexing",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "indexing",
+                        "word_count": 0,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "ドキュメントが正常に作成されました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_external": {
+                    "summary": "invalid_param（外部ナレッジベース）",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "External datasets are not supported."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `no_file_uploaded`：リクエストにファイルが提供されていません。\n- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：ナレッジベースが外部です。`indexing_technique` が必須、または `process_rule` がありません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（ベクトル容量制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（ドキュメント数制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The number of documents has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_too_large`：ファイルサイズが上限を超えています。"
+          }
+        },
+        "summary": "ファイルからドキュメントを作成",
+        "tags": [
+          "ドキュメント"
+        ]
+      }
+    },
+    "/datasets/{dataset_id}/document/create_by_text": {
+      "post": {
+        "deprecated": true,
+        "description": "非推奨の互換エンドポイントです。生のテキストからナレッジベースにドキュメントを作成します。インデックスは非同期で実行されます。返された `batch` ID を使って [ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で追跡します。",
+        "operationId": "create_document_by_text_deprecated",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentTextCreatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 0,
+                        "indexing_status": "indexing",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "indexing",
+                        "word_count": 0,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "ドキュメントが正常に作成されました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_indexing": {
+                    "summary": "invalid_param（インデックス方式）",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "indexing_technique is required."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：最初のドキュメント追加時には `indexing_technique` が必須です。または `doc_form` が無効です。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（ベクトル容量制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（ドキュメント数制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The number of documents has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：ドキュメント数がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+          }
+        },
         "tags": [
           "ドキュメント"
         ],
-        "summary": "ナレッジベースのドキュメントリストを取得",
+        "summary": "テキストからドキュメントを作成"
+      }
+    },
+    "/datasets/{dataset_id}/documents": {
+      "get": {
         "description": "ナレッジベース内のドキュメントのページネーションされた一覧を返します。",
         "operationId": "listDocuments",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 1
-            },
-            "description": "ページ番号。"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 20
-            },
-            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。"
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
               "type": "string"
-            },
-            "description": "ドキュメント名でフィルタリングするための検索キーワードです。"
+            }
           },
           {
-            "name": "status",
+            "description": "ドキュメント名でフィルタリングするための検索キーワードです。",
             "in": "query",
+            "name": "keyword",
+            "required": false,
             "schema": {
-              "type": "string",
+              "description": "ドキュメント名でフィルタリングするための検索キーワードです。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得するページ番号。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "取得するページ番号。",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "表示ステータスでフィルタリングします。",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "表示ステータスでフィルタリングします。",
               "enum": [
-                "queuing",
-                "indexing",
-                "paused",
-                "error",
+                "archived",
                 "available",
                 "disabled",
-                "archived"
-              ]
-            },
-            "description": "表示ステータスでフィルタリングします。"
+                "error",
+                "indexing",
+                "paused",
+                "queuing"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "ドキュメントのリストです。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "ドキュメントオブジェクトの配列です。",
-                      "items": {
-                        "$ref": "#/components/schemas/Document"
-                      }
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "次のページにさらに項目が存在するかどうかです。"
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "1 ページあたりの件数です。"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "一致する項目の合計数です。"
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "現在のページ番号です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentListResponse"
                 },
                 "examples": {
                   "success": {
@@ -4939,15 +5158,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ドキュメントのリストです。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4956,10 +5192,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           },
           "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4973,9 +5209,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。"
           }
         },
+        "summary": "ナレッジベースのドキュメントリストを取得",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/documents/list-documents",
           "metadata": {
@@ -4987,69 +5228,67 @@
     },
     "/datasets/{dataset_id}/documents/download-zip": {
       "post": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ドキュメントを一括ダウンロード（ZIP）",
         "description": "1 つ以上のドキュメントを単一の ZIP アーカイブとしてダウンロードします。ファイルとしてアップロードされたドキュメントのみ含められます。",
-        "operationId": "downloadDocumentsZipJa",
+        "operationId": "downloadDocumentsZip",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 100,
-                    "items": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "description": "アーカイブに含めるドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "リクエストされたドキュメントを含む ZIP アーカイブです。",
-            "content": {
-              "application/zip": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary",
-                  "description": "ZIP アーカイブのバイナリストリームです。"
-                }
+                "$ref": "#/components/schemas/DocumentBatchDownloadZipPayload"
               }
             }
           },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string",
+                  "description": "ZIP アーカイブのバイナリストリームです。"
+                }
+              }
+            },
+            "description": "リクエストされたドキュメントを含む ZIP アーカイブです。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden` : このナレッジベースにアクセスする権限がありません。\n- `forbidden` : リクエストされたドキュメントのいずれかにアクセスする権限がありません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5057,7 +5296,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5065,7 +5304,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (dataset permission)",
+                    "summary": "forbidden（ナレッジベース権限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5073,7 +5312,7 @@
                     }
                   },
                   "forbidden_4": {
-                    "summary": "forbidden (document permission)",
+                    "summary": "forbidden（ドキュメント権限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5082,10 +5321,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden`：このナレッジベースにアクセスする権限がありません。\n- `forbidden`：リクエストされたドキュメントのいずれかにアクセスする権限がありません。"
           },
           "404": {
-            "description": "- `not_found` : ドキュメントが見つかりません。\n- `not_found` : ナレッジベースが見つかりません。 リクエストしたドキュメントにアップロード済みファイルがない場合は \"Only uploaded-file documents can be downloaded as ZIP.\" が返ります。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5115,9 +5354,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ドキュメントが見つかりません。\n- `not_found`：ナレッジベースが見つかりません。 リクエストしたドキュメントがアップロードファイル由来でない場合も、アップロードファイルのドキュメントだけが ZIP ダウンロード対象であることを示すエラーが返ります。"
           }
         },
+        "summary": "ドキュメントを一括ダウンロード（ZIP）",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/documents/download-documents-as-zip",
           "metadata": {
@@ -5320,74 +5564,64 @@
     },
     "/datasets/{dataset_id}/documents/status/{action}": {
       "patch": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ドキュメントステータスを一括更新",
-        "description": "複数のドキュメントを 1 回のリクエストで有効化、無効化、アーカイブ、またはアーカイブ解除します。",
+        "description": "複数のドキュメントを 1 回のリクエストで有効化、無効化、アーカイブ、またはアーカイブ解除します。互換性のため `document_ids` は任意です。省略するか空配列を渡すと更新は行われませんが、`result: success` が返ります。",
         "operationId": "batchUpdateDocumentStatus",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "実行する操作：`enable`、`disable`、`archive`、`un_archive`。",
             "in": "path",
+            "name": "action",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "実行する操作：`enable`、`disable`、`archive`、`un_archive`。",
+              "enum": [
+                "archive",
+                "disable",
+                "enable",
+                "un_archive"
+              ],
+              "type": "string"
+            }
           },
           {
-            "name": "action",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable",
-                "archive",
-                "un_archive"
-              ]
-            },
-            "description": "`enable` はドキュメントを検索対象として有効化し、`disable` は無効化し、`archive` はアーカイブに移動し、`un_archive` はアーカイブから復元します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "更新するドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+                "$ref": "#/components/schemas/DocumentStatusPayload"
+              },
+              "examples": {
+                "update_documents": {
+                  "summary": "リクエスト例",
+                  "value": {
+                    "document_ids": [
+                      "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                      "c4c4f9aa-2c9b-4f95-9f5a-2c0f7c3a8f21"
+                    ]
                   }
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "ドキュメントが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作結果です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/SimpleResultResponse"
                 },
                 "examples": {
                   "success": {
@@ -5398,10 +5632,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ドキュメントが正常に更新されました。"
           },
           "400": {
-            "description": "`invalid_action` : アクションが無効です。またはドキュメントがアクションを許可しない状態です（インデックス中、または未完了など）。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5415,15 +5649,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_action`：アクションが無効です。またはドキュメントがアクションを許可しない状態です（インデックス中、または未完了など）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5432,10 +5683,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           },
           "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5449,9 +5700,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。"
           }
         },
+        "summary": "ドキュメントステータスを一括更新",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/documents/update-document-status-in-batch",
           "metadata": {
@@ -5463,107 +5719,37 @@
     },
     "/datasets/{dataset_id}/documents/{batch}/indexing-status": {
       "get": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ドキュメント埋め込みステータス（進捗）を取得",
-        "description": "バッチ内のすべてのドキュメントのインデックス進捗（現在の段階とチャンク完了数）を返します。各 `indexing_status` が `completed` または `error` に達するまでポーリングします。ステータスは `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed` の順に進みます。",
+        "description": "バッチ内の各ドキュメントについて、現在の段階とチャンク完了数を返します。各 `indexing_status` が `completed`、`error`、または `paused` になるまでポーリングしてください。`completed` と `error` は終端状態です。Service API には一時停止したドキュメントを再開する操作がありません。Dify のナレッジベース画面で再開してから、このエンドポイントのポーリングを続けてください。実行中の段階は `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed` と進みます。`stopped_at` が null でない場合は処理の停止時刻を示しますが、`stopped` は独立した `indexing_status` 値ではありません。",
         "operationId": "getDocumentIndexingStatus",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ドキュメントの作成時または更新時に返されるバッチ ID です。",
             "in": "path",
+            "name": "batch",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "バッチ ID。",
+              "type": "string"
+            }
           },
           {
-            "name": "batch",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
               "type": "string"
-            },
-            "description": "ドキュメントの作成時または更新時に返されるバッチ ID です。"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "バッチ内のドキュメントのインデックス状態です。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "ドキュメント識別子です。"
-                          },
-                          "indexing_status": {
-                            "type": "string",
-                            "description": "現在のインデックスステータスです：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、または `error`。"
-                          },
-                          "processing_started_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "処理開始時の Unix タイムスタンプです。"
-                          },
-                          "parsing_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "解析完了時の Unix タイムスタンプです。"
-                          },
-                          "cleaning_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "クリーニング完了時の Unix タイムスタンプです。"
-                          },
-                          "splitting_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "分割完了時の Unix タイムスタンプです。"
-                          },
-                          "completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "インデックス完了時の Unix タイムスタンプです。"
-                          },
-                          "paused_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "インデキシングが一時停止されたタイムスタンプ。一時停止されていない場合は `null`。"
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "インデキシングが失敗した場合のエラーメッセージ。エラーがない場合は `null`。"
-                          },
-                          "stopped_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "インデキシングが停止されたタイムスタンプ。停止されていない場合は `null`。"
-                          },
-                          "completed_segments": {
-                            "type": "integer",
-                            "description": "インデックス済みのチャンク数です。"
-                          },
-                          "total_segments": {
-                            "type": "integer",
-                            "description": "インデックス対象のチャンクの合計数です。"
-                          }
-                        }
-                      },
-                      "description": "インデキシングステータスエントリのリスト。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentStatusListResponse"
                 },
                 "examples": {
                   "success": {
@@ -5589,15 +5775,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "バッチ内のドキュメントのインデックス状態です。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5606,10 +5809,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5631,260 +5834,209 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
           }
         },
+        "summary": "ドキュメントのインデックス状態（進捗）を取得",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/documents/get-document-indexing-status",
           "metadata": {
-            "title": "ドキュメント埋め込みステータス（進捗）を取得",
-            "sidebarTitle": "ドキュメント埋め込みステータス（進捗）を取得"
+            "title": "ドキュメントのインデックス状態（進捗）を取得",
+            "sidebarTitle": "ドキュメントのインデックス状態（進捗）を取得"
           }
         }
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}": {
-      "get": {
+      "delete": {
+        "description": "ナレッジベースからドキュメントとそのすべてのチャンクを完全に削除します。",
+        "operationId": "deleteDocument",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "document_indexing": {
+                    "summary": "document_indexing",
+                    "value": {
+                      "status": 400,
+                      "code": "document_indexing",
+                      "message": "Cannot delete document during indexing."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `document_indexing`：ドキュメントは処理中のため削除できません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "archived_document_immutable": {
+                    "summary": "archived_document_immutable",
+                    "value": {
+                      "status": 403,
+                      "code": "archived_document_immutable",
+                      "message": "The archived document is not editable."
+                    }
+                  },
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `archived_document_immutable`：アーカイブされたドキュメントは編集できません。\n- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document Not Exists."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found_2",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：ドキュメントが存在しません。 ナレッジベース自体が存在しない場合も、ナレッジベースが見つからないことを示すエラーが返ります。"
+          }
+        },
+        "summary": "ドキュメントを削除",
         "tags": [
           "ドキュメント"
         ],
-        "summary": "ドキュメント詳細を取得",
+        "x-mint": {
+          "href": "/ja/api-reference/documents/delete-document",
+          "metadata": {
+            "title": "ドキュメントを削除",
+            "sidebarTitle": "ドキュメントを削除"
+          }
+        }
+      },
+      "get": {
         "description": "1 つのドキュメントの詳細情報を返します。",
         "operationId": "getDocumentDetail",
         "parameters": [
           {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "metadata",
+            "description": "`all` はメタデータを含むすべてのフィールドを返します。`only` は `id`、`doc_type`、`doc_metadata` のみを返します。`without` は `doc_metadata` を除くすべてのフィールドを返します。",
             "in": "query",
+            "name": "metadata",
+            "required": false,
             "schema": {
-              "type": "string",
+              "default": "all",
+              "description": "`all` はメタデータを含むすべてのフィールドを返します。`only` は `id`、`doc_type`、`doc_metadata` のみを返します。`without` は `doc_metadata` を除くすべてのフィールドを返します。",
               "enum": [
                 "all",
                 "only",
                 "without"
               ],
-              "default": "all"
-            },
-            "description": "`all` はメタデータを含むすべてのフィールドを返します。`only` は `id`、`doc_type`、`doc_metadata` のみを返します。`without` は `doc_metadata` を除くすべてのフィールドを返します。"
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "ドキュメントの詳細です。返されるフィールドは `metadata` クエリパラメータによって異なります。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "ドキュメント識別子です。"
-                    },
-                    "position": {
-                      "type": "integer",
-                      "description": "ナレッジベース内の位置インデックスです。"
-                    },
-                    "data_source_type": {
-                      "type": "string",
-                      "description": "ドキュメントのアップロード方法です。ファイルアップロードの場合は `upload_file`、Notion インポートの場合は `notion_import` です。"
-                    },
-                    "data_source_info": {
-                      "type": "object",
-                      "description": "データソースの詳細です。ファイルアップロードの場合、この詳細エンドポイントは `upload_file` 配下に完全なファイルオブジェクトを返します（リストエンドポイントは `upload_file_id` のみを返します）。",
-                      "properties": {
-                        "upload_file": {
-                          "type": "object",
-                          "description": "アップロードされたファイルの詳細です。`data_source_type` が `upload_file` の場合に返されます。",
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "ファイル識別子です。"
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "元のファイル名です。"
-                            },
-                            "size": {
-                              "type": "integer",
-                              "description": "ファイルサイズ（バイト単位）です。"
-                            },
-                            "extension": {
-                              "type": "string",
-                              "description": "ファイル拡張子です。"
-                            },
-                            "mime_type": {
-                              "type": "string",
-                              "description": "ファイルの MIME タイプです。"
-                            },
-                            "created_by": {
-                              "type": "string",
-                              "description": "ファイルをアップロードしたユーザーの ID です。"
-                            },
-                            "created_at": {
-                              "type": "integer",
-                              "description": "ファイルアップロードの Unix タイムスタンプです。"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "dataset_process_rule_id": {
-                      "type": "string",
-                      "description": "このドキュメントに適用された処理ルールの ID です。"
-                    },
-                    "dataset_process_rule": {
-                      "type": "object",
-                      "description": "ナレッジベースレベルの処理ルール設定です。"
-                    },
-                    "document_process_rule": {
-                      "type": "object",
-                      "description": "ドキュメントレベルの処理ルール設定です。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "ドキュメント名です。"
-                    },
-                    "created_from": {
-                      "type": "string",
-                      "description": "ドキュメントの作成元です。API で作成した場合は `api`、UI で作成した場合は `web` です。"
-                    },
-                    "created_by": {
-                      "type": "string",
-                      "description": "ドキュメントを作成したユーザーの ID です。"
-                    },
-                    "created_at": {
-                      "type": "number",
-                      "description": "ドキュメント作成の Unix タイムスタンプです。"
-                    },
-                    "tokens": {
-                      "type": "integer",
-                      "description": "ドキュメント内のトークン数です。"
-                    },
-                    "indexing_status": {
-                      "type": "string",
-                      "description": "現在のインデックスステータスです（例：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、`error`、`paused`）。"
-                    },
-                    "error": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "インデックス作成が失敗した場合のエラーメッセージです。それ以外は `null` です。"
-                    },
-                    "enabled": {
-                      "type": "boolean",
-                      "description": "このドキュメントが検索に対して有効かどうかです。"
-                    },
-                    "disabled_at": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "ドキュメントが無効化された Unix タイムスタンプです。有効な場合は `null` です。"
-                    },
-                    "disabled_by": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "ドキュメントを無効化したユーザーの ID です。有効な場合は `null` です。"
-                    },
-                    "archived": {
-                      "type": "boolean",
-                      "description": "ドキュメントがアーカイブ済みかどうかです。"
-                    },
-                    "display_status": {
-                      "type": "string",
-                      "description": "UI 向けの表示用インデックスステータスです。"
-                    },
-                    "hit_count": {
-                      "type": "integer",
-                      "description": "このドキュメントが検索された回数です。"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "ドキュメントのチャンキングモードです。`text_model` は標準テキスト、`hierarchical_model` は親子構造、`qa_model` は QA ペアを示します。"
-                    },
-                    "doc_language": {
-                      "type": "string",
-                      "description": "ドキュメント内容の言語です。"
-                    },
-                    "doc_type": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "ドキュメントタイプの分類です。未設定の場合は `null` です。"
-                    },
-                    "doc_metadata": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "メタデータフィールドの識別子です。"
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "メタデータフィールド名です。"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "メタデータフィールドの種類です。"
-                          },
-                          "value": {
-                            "type": "string",
-                            "description": "このドキュメントのメタデータフィールド値。"
-                          }
-                        }
-                      },
-                      "description": "このドキュメントのカスタムメタデータキーバリューペア。"
-                    },
-                    "completed_at": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "処理が完了した Unix タイムスタンプです。まだ完了していない場合は `null` です。"
-                    },
-                    "updated_at": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "最終更新の Unix タイムスタンプです。更新されたことがない場合は `null` です。"
-                    },
-                    "indexing_latency": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "インデックス作成にかかった時間（秒）です。未完了の場合は `null` です。"
-                    },
-                    "segment_count": {
-                      "type": "integer",
-                      "description": "ドキュメント内のチャンク数です。"
-                    },
-                    "average_segment_length": {
-                      "type": "number",
-                      "description": "チャンクの平均文字長です。"
-                    },
-                    "summary_index_status": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "要約インデックスのステータスです。要約インデックスが有効でない場合は `null` です。"
-                    },
-                    "need_summary": {
-                      "type": "boolean",
-                      "description": "このドキュメントが要約生成を必要とするかどうかです。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentDetailResponse"
                 },
                 "examples": {
                   "success": {
@@ -5948,10 +6100,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ドキュメントの詳細です。返されるフィールドは `metadata` クエリパラメータによって異なります。"
           },
           "400": {
-            "description": "`invalid_metadata` : `metadata` クエリパラメータの値が無効です（`all`、`only`、`without` のいずれかである必要があります）。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5960,20 +6112,37 @@
                     "value": {
                       "status": 400,
                       "code": "invalid_metadata",
-                      "message": "Invalid metadata value: only"
+                      "message": "Invalid metadata value."
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_metadata`：`metadata` クエリパラメータの値が無効です（`all`、`only`、`without` のいずれかである必要があります）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このドキュメントにアクセスする権限がありません。\n- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (no permission)",
+                    "summary": "forbidden（権限なし）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5981,7 +6150,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5990,10 +6159,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このドキュメントにアクセスする権限がありません。\n- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           },
           "404": {
-            "description": "`not_found` : ドキュメントが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6007,9 +6176,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ドキュメントが見つかりません。"
           }
         },
+        "summary": "ドキュメント詳細を取得",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/documents/get-document",
           "metadata": {
@@ -6018,173 +6192,61 @@
           }
         }
       },
-      "delete": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ドキュメントを削除",
-        "description": "ナレッジベースからドキュメントとそのすべてのチャンクを完全に削除します。",
-        "operationId": "deleteDocument",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "403": {
-            "description": "- `archived_document_immutable` : アーカイブされたドキュメントは編集できません。\n- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "archived_document_immutable": {
-                    "summary": "archived_document_immutable",
-                    "value": {
-                      "status": 403,
-                      "code": "archived_document_immutable",
-                      "message": "The archived document is not editable."
-                    }
-                  },
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ドキュメントが存在しません。 ナレッジベース自体が存在しない場合は \"Dataset not found.\" が返ります。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document Not Exists."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found_2",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/documents/delete-document",
-          "metadata": {
-            "title": "ドキュメントを削除",
-            "sidebarTitle": "ドキュメントを削除"
-          }
-        }
-      },
       "patch": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ドキュメントを更新",
-        "description": "新しいファイルをアップロードしてドキュメントを更新し、再インデックスします。これはファイルベースのドキュメント更新の正規エンドポイントです。返された `batch` ID を使って [ドキュメント埋め込みステータス（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status) で進捗を追跡します。",
+        "description": "ドキュメントを更新して再インデックスします。`file` で元ファイルを置き換え、`data` で処理設定を変更できます。両方の指定も可能です。`file` を省略すると、指定した設定または現在の設定で既存の元ファイルを再処理します。空の multipart リクエストでは現在の設定で再インデックスします。返された `batch` ID を使って[ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status)で進捗を追跡してください。",
         "operationId": "updateDocument",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
                 "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
-                  },
                   "data": {
-                    "type": "string",
                     "description": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。",
+                    "type": "string",
                     "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。",
+                    "format": "binary",
+                    "type": "string"
                   }
-                }
+                },
+                "type": "object"
               }
             }
-          }
+          },
+          "required": false
         },
         "responses": {
           "200": {
-            "description": "ドキュメントが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -6233,10 +6295,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ドキュメントが正常に更新されました。"
           },
           "400": {
-            "description": "- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6265,7 +6327,7 @@
                     }
                   },
                   "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
+                    "summary": "invalid_param（利用不可）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -6274,15 +6336,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6290,7 +6369,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（ベクトル容量制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6298,7 +6377,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6307,10 +6386,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6332,10 +6411,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
           },
           "413": {
-            "description": "`file_too_large` : ファイルサイズが上限を超えています。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6349,10 +6428,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`file_too_large`：ファイルサイズが上限を超えています。"
           },
           "415": {
-            "description": "`unsupported_file_type` : 許可されていないファイルタイプです。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6366,85 +6445,64 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "`unsupported_file_type`：許可されていないファイルタイプです。"
           }
         },
-        "x-mint": {
-          "href": "/ja/api-reference/documents/update-document",
-          "metadata": {
-            "title": "ドキュメントを更新",
-            "sidebarTitle": "ドキュメントを更新"
-          }
-        },
+        "summary": "ドキュメントを更新",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request PATCH \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/documents/{document_id}' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/documents/update-document",
+          "metadata": {
+            "title": "ドキュメントを更新",
+            "sidebarTitle": "ドキュメントを更新"
+          }
+        }
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/download": {
       "get": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ドキュメントをダウンロード",
         "description": "ドキュメントの元のアップロードファイルをダウンロードするための署名付き URL を返します。",
-        "operationId": "downloadDocumentJa",
+        "operationId": "downloadDocument",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "ダウンロード URL が正常に生成されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "url": {
-                      "type": "string",
-                      "description": "元のアップロードファイルをダウンロードするための署名付き URL です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/UrlResponse"
                 },
                 "examples": {
                   "success": {
@@ -6455,15 +6513,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ダウンロード URL が正常に生成されました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このドキュメントにアクセスする権限がありません。\n- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (no permission)",
+                    "summary": "forbidden（権限なし）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6471,7 +6546,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6479,7 +6554,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6488,10 +6563,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このドキュメントにアクセスする権限がありません。\n- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "`not_found` : ドキュメントが見つかりません。 保存ファイルが見つからない場合は \"Uploaded file not found.\"、ファイル以外のドキュメントでは \"Document does not have an uploaded file to download.\" が返ります。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6521,9 +6596,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ドキュメントが見つかりません。 保存ファイルがない場合はアップロード済みファイルが見つからないことを示すエラー、ファイル以外のドキュメントではダウンロード可能なアップロードファイルがないことを示すエラーが返ります。"
           }
         },
+        "summary": "ドキュメントをダウンロード",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/documents/download-document",
           "metadata": {
@@ -8419,72 +8499,61 @@
     },
     "/datasets/{dataset_id}/documents/{document_id}/update-by-file": {
       "post": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "ファイルでドキュメントを更新",
-        "description": "非推奨です。代わりに [ドキュメントを更新](/ja/api-reference/documents/update-document) を使用してください。新しいファイルをアップロードしてドキュメントを更新し、再インデックスします。",
+        "deprecated": true,
+        "description": "非推奨のファイル更新ルートです。`file` で元ファイルを置き換え、`data` で処理設定を変更できます。両方の指定も可能です。`file` を省略すると、指定した設定または現在の設定で既存の元ファイルを再処理します。空の multipart リクエストでは現在の設定で再インデックスします。[ドキュメントを更新](/ja/api-reference/documents/update-document)を使用してください。",
         "operationId": "updateDocumentByFile",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
                 "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。"
-                  },
                   "data": {
-                    "type": "string",
                     "description": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。",
+                    "type": "string",
                     "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。",
+                    "format": "binary",
+                    "type": "string"
                   }
-                }
+                },
+                "type": "object"
               }
             }
-          }
+          },
+          "required": false
         },
         "responses": {
           "200": {
-            "description": "ドキュメントが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -8533,10 +8602,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ドキュメントが正常に更新されました。"
           },
           "400": {
-            "description": "- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8565,7 +8634,7 @@
                     }
                   },
                   "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
+                    "summary": "invalid_param（利用不可）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -8574,15 +8643,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8590,7 +8676,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（ベクトル容量制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8598,7 +8684,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8607,10 +8693,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8632,10 +8718,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
           },
           "413": {
-            "description": "`file_too_large` : ファイルサイズが上限を超えています。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8649,10 +8735,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`file_too_large`：ファイルサイズが上限を超えています。"
           },
           "415": {
-            "description": "`unsupported_file_type` : 許可されていないファイルタイプです。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8666,27 +8752,14 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "`unsupported_file_type`：許可されていないファイルタイプです。"
           }
         },
-        "deprecated": true,
+        "summary": "ファイルでドキュメントを更新",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/documents/update-document-by-file",
           "metadata": {
@@ -8698,152 +8771,48 @@
     },
     "/datasets/{dataset_id}/documents/{document_id}/update-by-text": {
       "post": {
-        "tags": [
-          "ドキュメント"
-        ],
-        "summary": "テキストでドキュメントを更新",
         "description": "ドキュメントのテキスト内容、名前、または処理設定を更新します。テキストが変更されると、ドキュメントを再インデックスします。",
         "operationId": "updateDocumentByText",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "ドキュメント名です。`text` を指定する場合は必須です。"
-                  },
-                  "text": {
-                    "type": "string",
-                    "description": "ドキュメントのテキスト内容です。"
-                  },
-                  "process_rule": {
-                    "type": "object",
-                    "description": "チャンキングの処理ルールです。",
-                    "required": [
-                      "mode"
-                    ],
-                    "properties": {
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "automatic",
-                          "custom",
-                          "hierarchical"
-                        ],
-                        "description": "`automatic` は組み込みルールを使用、`custom` は手動設定が可能、`hierarchical` は親子チャンク構造を有効にします（`doc_form: hierarchical_model` と組み合わせて使用）。"
-                      },
-                      "rules": {
-                        "type": "object",
-                        "properties": {
-                          "pre_processing_rules": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "enum": [
-                                    "remove_stopwords",
-                                    "remove_extra_spaces",
-                                    "remove_urls_emails"
-                                  ],
-                                  "description": "ルール識別子です。"
-                                },
-                                "enabled": {
-                                  "type": "boolean",
-                                  "description": "この前処理ルールが有効かどうかです。"
-                                }
-                              }
-                            }
-                          },
-                          "segmentation": {
-                            "type": "object",
-                            "properties": {
-                              "separator": {
-                                "type": "string",
-                                "default": "\n",
-                                "description": "テキスト分割用のカスタムセパレーターです。"
-                              },
-                              "max_tokens": {
-                                "type": "integer",
-                                "description": "チャンクあたりの最大トークン数です。"
-                              },
-                              "chunk_overlap": {
-                                "type": "integer",
-                                "default": 0,
-                                "description": "チャンク間のトークンオーバーラップです。"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "doc_form": {
-                    "type": "string",
-                    "enum": [
-                      "text_model",
-                      "hierarchical_model",
-                      "qa_model"
-                    ],
-                    "default": "text_model",
-                    "description": "`text_model` は標準テキストチャンキング、`hierarchical_model` は親子チャンク構造、`qa_model` は質問・回答ペアの抽出です。"
-                  },
-                  "doc_language": {
-                    "type": "string",
-                    "default": "English",
-                    "description": "処理最適化のためのドキュメント言語です。"
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "このナレッジベースをクエリする際のチャンクの検索方法とランキング方法を制御します。"
-                  }
-                }
+                "$ref": "#/components/schemas/DocumentTextUpdate"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "ドキュメントが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "インデックス進捗を追跡するためのバッチ ID です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -8892,10 +8861,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ドキュメントが正常に更新されました。"
           },
           "400": {
-            "description": "- `provider_not_initialize` : ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param` : `text` を指定する場合は `name` が必須です。または `doc_form` が無効です。\n- `invalid_param` : ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8908,7 +8877,7 @@
                     }
                   },
                   "invalid_param_name": {
-                    "summary": "invalid_param (name required)",
+                    "summary": "invalid_param（名前が必要）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -8916,7 +8885,7 @@
                     }
                   },
                   "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
+                    "summary": "invalid_param（利用不可）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -8925,15 +8894,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：`text` を指定する場合は `name` が必須です。または `doc_form` が無効です。\n- `invalid_param`：ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8941,7 +8927,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（ベクトル容量制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8949,7 +8935,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8958,10 +8944,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8983,26 +8969,14 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
           }
         },
+        "summary": "テキストでドキュメントを更新",
+        "tags": [
+          "ドキュメント"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/documents/update-document-by-text",
           "metadata": {
@@ -9010,6 +8984,449 @@
             "sidebarTitle": "テキストでドキュメントを更新"
           }
         }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/update_by_file": {
+      "post": {
+        "deprecated": true,
+        "description": "非推奨のファイル更新ルートです。`file` で元ファイルを置き換え、`data` で処理設定を変更できます。両方の指定も可能です。`file` を省略すると、指定した設定または現在の設定で既存の元ファイルを再処理します。空の multipart リクエストでは現在の設定で再インデックスします。[ドキュメントを更新](/ja/api-reference/documents/update-document)を使用してください。",
+        "operationId": "update_document_by_file_deprecated_5dc5fe59",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "description": "設定情報を含む JSON 文字列です。[テキストからドキュメントを作成](/ja/api-reference/documents/create-document-by-text) と同じフィールド（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`）を受け付けますが、`name` と `text` は除きます。",
+                    "type": "string",
+                    "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "アップロードするファイルです。デフォルトの上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。Dify Cloud の Professional と Team プランでは上限が 50 MB になります。",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "ドキュメントが正常に更新されました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_not_available": {
+                    "summary": "invalid_param（利用不可）",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Document is not available"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `provider_not_initialize`：ワークスペースにモデルプロバイダーの認証情報が設定されていません。\n- `invalid_param`：ドキュメントが更新できる状態ではありません（利用可能なドキュメントのみ更新できます）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（ベクトル容量制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_too_large`：ファイルサイズが上限を超えています。"
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`unsupported_file_type`：許可されていないファイルタイプです。"
+          }
+        },
+        "summary": "ファイルでドキュメントを更新",
+        "tags": [
+          "ドキュメント"
+        ]
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/update_by_text": {
+      "post": {
+        "deprecated": true,
+        "description": "非推奨の互換エンドポイントです。ドキュメントのテキスト内容、名前、または処理設定を更新します。テキストが変更されると、ドキュメントを再インデックスします。",
+        "operationId": "update_document_by_text_deprecated",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentTextUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "ドキュメントが正常に更新されました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（ベクトル容量制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
+          }
+        },
+        "tags": [
+          "ドキュメント"
+        ],
+        "summary": "テキストでドキュメントを更新"
       }
     },
     "/datasets/{dataset_id}/hit-testing": {

--- a/zh/api-reference/openapi_service.json
+++ b/zh/api-reference/openapi_service.json
@@ -4202,65 +4202,52 @@
     },
     "/datasets/{dataset_id}/document/create-by-file": {
       "post": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "从文件创建文档",
-        "description": "在知识库中通过上传文件创建文档。支持 PDF、TXT、DOCX 等常见格式。索引异步进行；使用返回的 `batch` ID 通过 [获取文档嵌入状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。",
+        "description": "在知识库中通过上传文件创建文档。支持 PDF、TXT、DOCX 等常见格式。索引异步进行；使用返回的 `batch` ID 通过 [获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。",
         "operationId": "createDocumentFromFile",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
+                "properties": {
+                  "data": {
+                    "description": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。",
+                    "type": "string",
+                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
                 "required": [
                   "file"
                 ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
-                  },
-                  "data": {
-                    "type": "string",
-                    "description": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。",
-                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
-                  }
-                }
+                "type": "object"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "文档创建成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "用于跟踪索引进度的批次 ID。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -4309,10 +4296,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "文档创建成功。"
           },
           "400": {
-            "description": "- `no_file_uploaded` : 请求中未提供文件。\n- `too_many_files` : 每次请求仅允许一个文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 该知识库为外部知识库、缺少 `indexing_technique`，或缺少 `process_rule`。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4349,7 +4336,7 @@
                     }
                   },
                   "invalid_param_external": {
-                    "summary": "invalid_param (external)",
+                    "summary": "invalid_param（外部知识库）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -4358,15 +4345,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `no_file_uploaded`：请求中未提供文件。\n- `too_many_files`：每次请求仅允许一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：该知识库为外部知识库、缺少 `indexing_technique`，或缺少 `process_rule`。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 文档数量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4374,7 +4378,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（向量空间限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4382,7 +4386,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (documents limit)",
+                    "summary": "forbidden（文档数量限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4390,7 +4394,7 @@
                     }
                   },
                   "forbidden_4": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4399,27 +4403,10 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：文档数量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "413": {
-            "description": "`file_too_large` : 上传的文件超出最大大小限制。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4433,204 +4420,63 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "`file_too_large`：上传的文件超出最大大小限制。"
           }
         },
-        "x-mint": {
-          "href": "/zh/api-reference/documents/create-document-by-file",
-          "metadata": {
-            "title": "从文件创建文档",
-            "sidebarTitle": "从文件创建文档"
-          }
-        },
+        "summary": "从文件创建文档",
+        "tags": [
+          "文档"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/documents/create-document-by-file",
+          "metadata": {
+            "title": "从文件创建文档",
+            "sidebarTitle": "从文件创建文档"
+          }
+        }
       }
     },
     "/datasets/{dataset_id}/document/create-by-text": {
       "post": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "从文本创建文档",
-        "description": "在知识库中通过纯文本创建文档。索引异步进行；使用返回的 `batch` ID 通过 [获取文档嵌入状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。",
+        "description": "在知识库中通过纯文本创建文档。索引异步进行；使用返回的 `batch` ID 通过 [获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。",
         "operationId": "createDocumentFromText",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "text"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "文档名称。"
-                  },
-                  "text": {
-                    "type": "string",
-                    "description": "文档文本内容。"
-                  },
-                  "indexing_technique": {
-                    "type": "string",
-                    "enum": [
-                      "high_quality",
-                      "economy"
-                    ],
-                    "description": "向知识库添加首个文档时必填。后续文档如果省略此字段，将继承知识库的索引方式。`high_quality` 使用嵌入模型进行精确搜索；`economy` 使用基于关键词的索引。"
-                  },
-                  "doc_form": {
-                    "type": "string",
-                    "enum": [
-                      "text_model",
-                      "hierarchical_model",
-                      "qa_model"
-                    ],
-                    "default": "text_model",
-                    "description": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。"
-                  },
-                  "doc_language": {
-                    "type": "string",
-                    "default": "English",
-                    "description": "用于处理优化的文档语言。"
-                  },
-                  "process_rule": {
-                    "type": "object",
-                    "description": "分块处理规则。",
-                    "required": [
-                      "mode"
-                    ],
-                    "properties": {
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "automatic",
-                          "custom",
-                          "hierarchical"
-                        ],
-                        "description": "`automatic` 使用内置规则，`custom` 允许手动配置，`hierarchical` 启用父子分段结构（配合 `doc_form: hierarchical_model` 使用）。"
-                      },
-                      "rules": {
-                        "type": "object",
-                        "properties": {
-                          "pre_processing_rules": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "enum": [
-                                    "remove_stopwords",
-                                    "remove_extra_spaces",
-                                    "remove_urls_emails"
-                                  ],
-                                  "description": "规则标识符。"
-                                },
-                                "enabled": {
-                                  "type": "boolean",
-                                  "description": "该预处理规则是否启用。"
-                                }
-                              }
-                            }
-                          },
-                          "segmentation": {
-                            "type": "object",
-                            "properties": {
-                              "separator": {
-                                "type": "string",
-                                "default": "\n",
-                                "description": "用于拆分文本的自定义分隔符。"
-                              },
-                              "max_tokens": {
-                                "type": "integer",
-                                "description": "每个分段的最大令牌数。"
-                              },
-                              "chunk_overlap": {
-                                "type": "integer",
-                                "default": 0,
-                                "description": "分段之间的令牌重叠数。"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "控制查询此知识库时如何搜索和排序分段。"
-                  },
-                  "embedding_model": {
-                    "type": "string",
-                    "description": "嵌入模型名称。使用 [获取可用模型](/zh/api-reference/models/get-available-models) 中 `model_type=text-embedding` 返回的 `model` 字段值。"
-                  },
-                  "embedding_model_provider": {
-                    "type": "string",
-                    "description": "嵌入模型供应商。使用 [获取可用模型](/zh/api-reference/models/get-available-models) 中 `model_type=text-embedding` 返回的 `provider` 字段值。"
-                  },
-                  "original_document_id": {
-                    "type": "string",
-                    "description": "用于版本控制的原始文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-                  }
-                }
+                "$ref": "#/components/schemas/DocumentTextCreatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "文档创建成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "用于跟踪索引进度的批次 ID。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -4679,10 +4525,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "文档创建成功。"
           },
           "400": {
-            "description": "- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 添加首个文档时必须提供 `indexing_technique`，或 `doc_form` 无效。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4695,7 +4541,7 @@
                     }
                   },
                   "invalid_param_indexing": {
-                    "summary": "invalid_param (indexing_technique)",
+                    "summary": "invalid_param（索引方式）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -4704,15 +4550,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：添加首个文档时必须提供 `indexing_technique`，或 `doc_form` 无效。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 文档数量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4720,7 +4583,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（向量空间限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4728,7 +4591,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (documents limit)",
+                    "summary": "forbidden（文档数量限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4736,7 +4599,7 @@
                     }
                   },
                   "forbidden_4": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4745,43 +4608,14 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：文档数量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           }
         },
+        "summary": "从文本创建文档",
+        "tags": [
+          "文档"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/documents/create-document-by-text",
           "metadata": {
@@ -4791,101 +4625,486 @@
         }
       }
     },
-    "/datasets/{dataset_id}/documents": {
-      "get": {
+    "/datasets/{dataset_id}/document/create_by_file": {
+      "post": {
+        "deprecated": true,
+        "description": "已弃用的兼容接口。在知识库中通过上传文件创建文档。支持 PDF、TXT、DOCX 等常见格式。索引异步进行；使用返回的 `batch` ID 通过 [获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。",
+        "operationId": "create_document_by_file_75a87285",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "description": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`indexing_technique`、`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。",
+                    "type": "string",
+                    "example": "{\"indexing_technique\":\"high_quality\",\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 0,
+                        "indexing_status": "indexing",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "indexing",
+                        "word_count": 0,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "文档创建成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "no_file_uploaded": {
+                    "summary": "no_file_uploaded",
+                    "value": {
+                      "status": 400,
+                      "code": "no_file_uploaded",
+                      "message": "Please upload your file."
+                    }
+                  },
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_external": {
+                    "summary": "invalid_param（外部知识库）",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "External datasets are not supported."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `no_file_uploaded`：请求中未提供文件。\n- `too_many_files`：每次请求仅允许一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：该知识库为外部知识库、缺少 `indexing_technique`，或缺少 `process_rule`。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（向量空间限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（文档数量限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The number of documents has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：文档数量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_too_large`：上传的文件超出最大大小限制。"
+          }
+        },
+        "summary": "从文件创建文档",
+        "tags": [
+          "文档"
+        ]
+      }
+    },
+    "/datasets/{dataset_id}/document/create_by_text": {
+      "post": {
+        "deprecated": true,
+        "description": "已弃用的兼容接口。在知识库中通过纯文本创建文档。索引异步进行；使用返回的 `batch` ID 通过 [获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪。",
+        "operationId": "create_document_by_text_deprecated",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentTextCreatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 0,
+                        "indexing_status": "indexing",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "indexing",
+                        "word_count": 0,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "文档创建成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_indexing": {
+                    "summary": "invalid_param（索引方式）",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "indexing_technique is required."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：添加首个文档时必须提供 `indexing_technique`，或 `doc_form` 无效。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（向量空间限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（文档数量限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The number of documents has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：文档数量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+          }
+        },
         "tags": [
           "文档"
         ],
-        "summary": "获取知识库的文档列表",
+        "summary": "从文本创建文档"
+      }
+    },
+    "/datasets/{dataset_id}/documents": {
+      "get": {
         "description": "返回知识库中文档的分页列表。",
         "operationId": "listDocuments",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 1
-            },
-            "description": "页码。"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 20
-            },
-            "description": "每页的项目数量。服务器上限为 `100`。"
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
               "type": "string"
-            },
-            "description": "按文档名称筛选的搜索关键词。"
+            }
           },
           {
-            "name": "status",
+            "description": "按文档名称筛选的搜索关键词。",
             "in": "query",
+            "name": "keyword",
+            "required": false,
             "schema": {
-              "type": "string",
+              "description": "按文档名称筛选的搜索关键词。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "每页的项目数量。服务器上限为 `100`。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "每页的项目数量。服务器上限为 `100`。",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "要获取的页码。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "要获取的页码。",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "按显示状态筛选。",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "按显示状态筛选。",
               "enum": [
-                "queuing",
-                "indexing",
-                "paused",
-                "error",
+                "archived",
                 "available",
                 "disabled",
-                "archived"
-              ]
-            },
-            "description": "按显示状态筛选。"
+                "error",
+                "indexing",
+                "paused",
+                "queuing"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "文档列表。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "文档对象数组。",
-                      "items": {
-                        "$ref": "#/components/schemas/Document"
-                      }
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "下一页是否还有更多项目。"
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "每页条目数。"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "匹配条目的总数。"
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "当前页码。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentListResponse"
                 },
                 "examples": {
                   "success": {
@@ -4939,15 +5158,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "文档列表。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -4956,10 +5192,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           },
           "404": {
-            "description": "`not_found` : 知识库未找到。",
             "content": {
               "application/json": {
                 "examples": {
@@ -4973,9 +5209,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：知识库未找到。"
           }
         },
+        "summary": "获取知识库的文档列表",
+        "tags": [
+          "文档"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/documents/list-documents",
           "metadata": {
@@ -4987,69 +5228,67 @@
     },
     "/datasets/{dataset_id}/documents/download-zip": {
       "post": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "批量下载文档（ZIP）",
         "description": "将一个或多个文档下载为单个 ZIP 压缩包。仅可包含以文件形式上传的文档。",
-        "operationId": "downloadDocumentsZipZh",
+        "operationId": "downloadDocumentsZip",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 100,
-                    "items": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "description": "要包含在压缩包中的文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "包含所请求文档的 ZIP 压缩包。",
-            "content": {
-              "application/zip": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary",
-                  "description": "ZIP 压缩包二进制流。"
-                }
+                "$ref": "#/components/schemas/DocumentBatchDownloadZipPayload"
               }
             }
           },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string",
+                  "description": "ZIP 压缩包二进制流。"
+                }
+              }
+            },
+            "description": "包含所请求文档的 ZIP 压缩包。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。\n- `forbidden` : 你没有访问此知识库的权限。\n- `forbidden` : 你对请求的某个文档没有访问权限。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5057,7 +5296,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5065,7 +5304,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (dataset permission)",
+                    "summary": "forbidden（知识库权限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5073,7 +5312,7 @@
                     }
                   },
                   "forbidden_4": {
-                    "summary": "forbidden (document permission)",
+                    "summary": "forbidden（文档权限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5082,10 +5321,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。\n- `forbidden`：你没有访问此知识库的权限。\n- `forbidden`：你对请求的某个文档没有访问权限。"
           },
           "404": {
-            "description": "- `not_found` : 未找到文档。\n- `not_found` : 未找到知识库。 请求的文档没有已上传的文件时，也会返回 \"Only uploaded-file documents can be downloaded as ZIP.\"。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5115,9 +5354,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到文档。\n- `not_found`：未找到知识库。 请求的文档不是通过上传文件创建时，也会返回仅上传文件类文档可打包下载的错误。"
           }
         },
+        "summary": "批量下载文档（ZIP）",
+        "tags": [
+          "文档"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/documents/download-documents-as-zip",
           "metadata": {
@@ -5320,74 +5564,64 @@
     },
     "/datasets/{dataset_id}/documents/status/{action}": {
       "patch": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "批量更新文档状态",
-        "description": "在一次请求中批量启用、禁用、归档或取消归档多个文档。",
+        "description": "在一次请求中批量启用、禁用、归档或取消归档多个文档。为保持兼容，`document_ids` 为可选字段；省略该字段或传入空数组时不会更新任何文档，但仍返回 `result: success`。",
         "operationId": "batchUpdateDocumentStatus",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "要执行的操作：`enable`、`disable`、`archive` 或 `un_archive`。",
             "in": "path",
+            "name": "action",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "要执行的操作：`enable`、`disable`、`archive` 或 `un_archive`。",
+              "enum": [
+                "archive",
+                "disable",
+                "enable",
+                "un_archive"
+              ],
+              "type": "string"
+            }
           },
           {
-            "name": "action",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable",
-                "archive",
-                "un_archive"
-              ]
-            },
-            "description": "`enable` 启用文档以供检索，`disable` 停用，`archive` 移入归档，`un_archive` 从归档中恢复。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "document_ids"
-                ],
-                "properties": {
-                  "document_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "要更新的文档 ID。文档 ID 从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+                "$ref": "#/components/schemas/DocumentStatusPayload"
+              },
+              "examples": {
+                "update_documents": {
+                  "summary": "请求示例",
+                  "value": {
+                    "document_ids": [
+                      "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                      "c4c4f9aa-2c9b-4f95-9f5a-2c0f7c3a8f21"
+                    ]
                   }
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "文档更新成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作结果。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/SimpleResultResponse"
                 },
                 "examples": {
                   "success": {
@@ -5398,10 +5632,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "文档更新成功。"
           },
           "400": {
-            "description": "`invalid_action` : 操作无效，或某个文档处于不允许该操作的状态（例如仍在索引中或尚未处理完成）。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5415,15 +5649,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_action`：操作无效，或某个文档处于不允许该操作的状态（例如仍在索引中或尚未处理完成）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5432,10 +5683,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           },
           "404": {
-            "description": "`not_found` : 知识库未找到。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5449,9 +5700,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：知识库未找到。"
           }
         },
+        "summary": "批量更新文档状态",
+        "tags": [
+          "文档"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/documents/update-document-status-in-batch",
           "metadata": {
@@ -5463,107 +5719,37 @@
     },
     "/datasets/{dataset_id}/documents/{batch}/indexing-status": {
       "get": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "获取文档嵌入状态（进度）",
-        "description": "返回批次中每个文档的索引进度：当前阶段和分段完成计数。轮询直到每个 `indexing_status` 变为 `completed` 或 `error`。状态按 `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed` 推进。",
+        "description": "返回批次中每个文档的索引进度，包括当前阶段和分段完成计数。轮询直到每个 `indexing_status` 变为 `completed`、`error` 或 `paused`。`completed` 和 `error` 为终态。Service API 没有恢复暂停文档的操作；请在 Dify 知识库控制台恢复文档，再继续轮询此端点。活动阶段按 `waiting` → `parsing` → `cleaning` → `splitting` → `indexing` → `completed` 推进。`stopped_at` 非空时记录处理停止时间，但 `stopped` 并不是独立的 `indexing_status` 值。",
         "operationId": "getDocumentIndexingStatus",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "创建或更新文档时返回的批次 ID。",
             "in": "path",
+            "name": "batch",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "批次 ID。",
+              "type": "string"
+            }
           },
           {
-            "name": "batch",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
               "type": "string"
-            },
-            "description": "创建或更新文档时返回的批次 ID。"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "批次中文档的索引状态。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "文档标识符。"
-                          },
-                          "indexing_status": {
-                            "type": "string",
-                            "description": "当前索引状态：`waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed` 或 `error`。"
-                          },
-                          "processing_started_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "处理开始的 Unix 时间戳。"
-                          },
-                          "parsing_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "解析完成的 Unix 时间戳。"
-                          },
-                          "cleaning_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "清洗完成的 Unix 时间戳。"
-                          },
-                          "splitting_completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "拆分完成的 Unix 时间戳。"
-                          },
-                          "completed_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "索引完成的 Unix 时间戳。"
-                          },
-                          "paused_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "索引暂停的时间戳。未暂停时为 `null`。"
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "索引失败时的错误信息。无错误时为 `null`。"
-                          },
-                          "stopped_at": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "索引停止的时间戳。未停止时为 `null`。"
-                          },
-                          "completed_segments": {
-                            "type": "integer",
-                            "description": "已索引的分段数。"
-                          },
-                          "total_segments": {
-                            "type": "integer",
-                            "description": "待索引的分段总数。"
-                          }
-                        }
-                      },
-                      "description": "索引状态条目列表。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentStatusListResponse"
                 },
                 "examples": {
                   "success": {
@@ -5589,15 +5775,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "批次中文档的索引状态。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5606,10 +5809,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5631,260 +5834,209 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
           }
         },
+        "summary": "获取文档索引状态（进度）",
+        "tags": [
+          "文档"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/documents/get-document-indexing-status",
           "metadata": {
-            "title": "获取文档嵌入状态（进度）",
-            "sidebarTitle": "获取文档嵌入状态（进度）"
+            "title": "获取文档索引状态（进度）",
+            "sidebarTitle": "获取文档索引状态（进度）"
           }
         }
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}": {
-      "get": {
+      "delete": {
+        "description": "从知识库中永久删除文档及其所有分段。",
+        "operationId": "deleteDocument",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "document_indexing": {
+                    "summary": "document_indexing",
+                    "value": {
+                      "status": 400,
+                      "code": "document_indexing",
+                      "message": "Cannot delete document during indexing."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `document_indexing`：文档仍在处理中，无法删除。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "archived_document_immutable": {
+                    "summary": "archived_document_immutable",
+                    "value": {
+                      "status": 403,
+                      "code": "archived_document_immutable",
+                      "message": "The archived document is not editable."
+                    }
+                  },
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `archived_document_immutable`：已归档的文档不可编辑。\n- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document Not Exists."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found_2",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：文档不存在。 知识库本身不存在时，也会返回未找到知识库的错误。"
+          }
+        },
+        "summary": "删除文档",
         "tags": [
           "文档"
         ],
-        "summary": "获取文档详情",
+        "x-mint": {
+          "href": "/zh/api-reference/documents/delete-document",
+          "metadata": {
+            "title": "删除文档",
+            "sidebarTitle": "删除文档"
+          }
+        }
+      },
+      "get": {
         "description": "返回单个文档的详细信息。",
         "operationId": "getDocumentDetail",
         "parameters": [
           {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "metadata",
+            "description": "`all` 返回所有字段（包括元数据）。`only` 仅返回 `id`、`doc_type` 和 `doc_metadata`。`without` 返回除 `doc_metadata` 外的所有字段。",
             "in": "query",
+            "name": "metadata",
+            "required": false,
             "schema": {
-              "type": "string",
+              "default": "all",
+              "description": "`all` 返回所有字段（包括元数据）。`only` 仅返回 `id`、`doc_type` 和 `doc_metadata`。`without` 返回除 `doc_metadata` 外的所有字段。",
               "enum": [
                 "all",
                 "only",
                 "without"
               ],
-              "default": "all"
-            },
-            "description": "`all` 返回所有字段（包括元数据）。`only` 仅返回 `id`、`doc_type` 和 `doc_metadata`。`without` 返回除 `doc_metadata` 外的所有字段。"
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "文档详情。返回的字段取决于 `metadata` 查询参数。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "文档标识符。"
-                    },
-                    "position": {
-                      "type": "integer",
-                      "description": "在知识库中的位置索引。"
-                    },
-                    "data_source_type": {
-                      "type": "string",
-                      "description": "文档的上传方式。文件上传为 `upload_file`，Notion 导入为 `notion_import`。"
-                    },
-                    "data_source_info": {
-                      "type": "object",
-                      "description": "数据源详情。文件上传时，此详情接口在 `upload_file` 下返回完整的文件对象，而列表接口仅返回 `upload_file_id`。",
-                      "properties": {
-                        "upload_file": {
-                          "type": "object",
-                          "description": "上传文件的详情。当 `data_source_type` 为 `upload_file` 时返回。",
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "文件标识符。"
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "原始文件名。"
-                            },
-                            "size": {
-                              "type": "integer",
-                              "description": "文件大小（字节）。"
-                            },
-                            "extension": {
-                              "type": "string",
-                              "description": "文件扩展名。"
-                            },
-                            "mime_type": {
-                              "type": "string",
-                              "description": "文件的 MIME 类型。"
-                            },
-                            "created_by": {
-                              "type": "string",
-                              "description": "上传该文件的用户 ID。"
-                            },
-                            "created_at": {
-                              "type": "integer",
-                              "description": "文件上传的 Unix 时间戳。"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "dataset_process_rule_id": {
-                      "type": "string",
-                      "description": "应用于该文档的处理规则 ID。"
-                    },
-                    "dataset_process_rule": {
-                      "type": "object",
-                      "description": "知识库级别的处理规则配置。"
-                    },
-                    "document_process_rule": {
-                      "type": "object",
-                      "description": "文档级别的处理规则配置。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "文档名称。"
-                    },
-                    "created_from": {
-                      "type": "string",
-                      "description": "文档来源。通过 API 创建时为 `api`，通过 UI 创建时为 `web`。"
-                    },
-                    "created_by": {
-                      "type": "string",
-                      "description": "创建该文档的用户 ID。"
-                    },
-                    "created_at": {
-                      "type": "number",
-                      "description": "文档创建的 Unix 时间戳。"
-                    },
-                    "tokens": {
-                      "type": "integer",
-                      "description": "文档中的令牌数。"
-                    },
-                    "indexing_status": {
-                      "type": "string",
-                      "description": "当前索引状态，例如 `waiting`、`parsing`、`cleaning`、`splitting`、`indexing`、`completed`、`error`、`paused`。"
-                    },
-                    "error": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "索引失败时的错误消息，否则为 `null`。"
-                    },
-                    "enabled": {
-                      "type": "boolean",
-                      "description": "该文档是否启用检索。"
-                    },
-                    "disabled_at": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "文档被禁用的 Unix 时间戳，启用时为 `null`。"
-                    },
-                    "disabled_by": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "禁用该文档的用户 ID，启用时为 `null`。"
-                    },
-                    "archived": {
-                      "type": "boolean",
-                      "description": "文档是否已归档。"
-                    },
-                    "display_status": {
-                      "type": "string",
-                      "description": "适合 UI 显示的索引状态。"
-                    },
-                    "hit_count": {
-                      "type": "integer",
-                      "description": "该文档被检索的次数。"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "文档分块模式。`text_model` 表示标准文本，`hierarchical_model` 表示父子结构，`qa_model` 表示问答对。"
-                    },
-                    "doc_language": {
-                      "type": "string",
-                      "description": "文档内容的语言。"
-                    },
-                    "doc_type": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "文档类型分类，未设置时为 `null`。"
-                    },
-                    "doc_metadata": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "元数据字段标识符。"
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "元数据字段名称。"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "元数据字段类型。"
-                          },
-                          "value": {
-                            "type": "string",
-                            "description": "此文档的元数据字段值。"
-                          }
-                        }
-                      },
-                      "description": "此文档的自定义元数据键值对。"
-                    },
-                    "completed_at": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "处理完成的 Unix 时间戳，尚未完成时为 `null`。"
-                    },
-                    "updated_at": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "最后更新的 Unix 时间戳，从未更新时为 `null`。"
-                    },
-                    "indexing_latency": {
-                      "type": "number",
-                      "nullable": true,
-                      "description": "索引耗时（秒），未完成时为 `null`。"
-                    },
-                    "segment_count": {
-                      "type": "integer",
-                      "description": "文档中的分段数。"
-                    },
-                    "average_segment_length": {
-                      "type": "number",
-                      "description": "分段的平均字符长度。"
-                    },
-                    "summary_index_status": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "摘要索引的状态，未启用摘要索引时为 `null`。"
-                    },
-                    "need_summary": {
-                      "type": "boolean",
-                      "description": "该文档是否需要生成摘要。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentDetailResponse"
                 },
                 "examples": {
                   "success": {
@@ -5948,10 +6100,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "文档详情。返回的字段取决于 `metadata` 查询参数。"
           },
           "400": {
-            "description": "`invalid_metadata` : `metadata` 查询参数的值无效（必须为 `all`、`only` 或 `without`）。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5960,20 +6112,37 @@
                     "value": {
                       "status": 400,
                       "code": "invalid_metadata",
-                      "message": "Invalid metadata value: only"
+                      "message": "Invalid metadata value."
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_metadata`：`metadata` 查询参数的值无效（必须为 `all`、`only` 或 `without`）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 你没有访问此文档的权限。\n- `forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (no permission)",
+                    "summary": "forbidden（无权限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5981,7 +6150,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5990,10 +6159,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：你没有访问此文档的权限。\n- `forbidden`：该知识库未启用 API 访问。"
           },
           "404": {
-            "description": "`not_found` : 未找到文档。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6007,9 +6176,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到文档。"
           }
         },
+        "summary": "获取文档详情",
+        "tags": [
+          "文档"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/documents/get-document",
           "metadata": {
@@ -6018,173 +6192,61 @@
           }
         }
       },
-      "delete": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "删除文档",
-        "description": "从知识库中永久删除文档及其所有分段。",
-        "operationId": "deleteDocument",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "403": {
-            "description": "- `archived_document_immutable` : 已归档的文档不可编辑。\n- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "archived_document_immutable": {
-                    "summary": "archived_document_immutable",
-                    "value": {
-                      "status": 403,
-                      "code": "archived_document_immutable",
-                      "message": "The archived document is not editable."
-                    }
-                  },
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 文档不存在。 知识库本身不存在时，也会返回 \"Dataset not found.\"。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document Not Exists."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found_2",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/documents/delete-document",
-          "metadata": {
-            "title": "删除文档",
-            "sidebarTitle": "删除文档"
-          }
-        }
-      },
       "patch": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "更新文档",
-        "description": "通过上传新文件更新文档，然后重新索引。这是基于文件更新文档的规范端点。使用返回的 `batch` ID 通过 [获取文档嵌入状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪进度。",
+        "description": "更新文档并重新索引。传入 `file` 可替换源文件，传入 `data` 可修改处理设置，也可同时传入两者。省略 `file` 时，Dify 使用提供的设置或当前设置重新处理现有源文件；空的 multipart 请求会使用当前设置重新索引。使用返回的 `batch` ID 通过 [获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status) 跟踪进度。",
         "operationId": "updateDocument",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
                 "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
-                  },
                   "data": {
-                    "type": "string",
                     "description": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。",
+                    "type": "string",
                     "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。",
+                    "format": "binary",
+                    "type": "string"
                   }
-                }
+                },
+                "type": "object"
               }
             }
-          }
+          },
+          "required": false
         },
         "responses": {
           "200": {
-            "description": "文档更新成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "用于跟踪索引进度的批次 ID。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -6233,10 +6295,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "文档更新成功。"
           },
           "400": {
-            "description": "- `too_many_files` : 每次请求仅允许一个文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 文档不可用，无法更新（仅可更新处于可用状态的文档）。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6265,7 +6327,7 @@
                     }
                   },
                   "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
+                    "summary": "invalid_param（不可用）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -6274,15 +6336,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `too_many_files`：每次请求仅允许一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：文档不可用，无法更新（仅可更新处于可用状态的文档）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6290,7 +6369,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（向量空间限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6298,7 +6377,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6307,10 +6386,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6332,10 +6411,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
           },
           "413": {
-            "description": "`file_too_large` : 上传的文件超出最大大小限制。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6349,10 +6428,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`file_too_large`：上传的文件超出最大大小限制。"
           },
           "415": {
-            "description": "`unsupported_file_type` : 上传文件的类型不受支持。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6366,85 +6445,64 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "`unsupported_file_type`：上传文件的类型不受支持。"
           }
         },
-        "x-mint": {
-          "href": "/zh/api-reference/documents/update-document",
-          "metadata": {
-            "title": "更新文档",
-            "sidebarTitle": "更新文档"
-          }
-        },
+        "summary": "更新文档",
+        "tags": [
+          "文档"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request PATCH \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/documents/{document_id}' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/documents/update-document",
+          "metadata": {
+            "title": "更新文档",
+            "sidebarTitle": "更新文档"
+          }
+        }
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/download": {
       "get": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "下载文档",
         "description": "返回用于下载文档原始上传文件的签名 URL。",
-        "operationId": "downloadDocumentZh",
+        "operationId": "downloadDocument",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "下载 URL 生成成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "url": {
-                      "type": "string",
-                      "description": "用于下载原始上传文件的签名 URL。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/UrlResponse"
                 },
                 "examples": {
                   "success": {
@@ -6455,15 +6513,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "下载 URL 生成成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 你没有访问此文档的权限。\n- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (no permission)",
+                    "summary": "forbidden（无权限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6471,7 +6546,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6479,7 +6554,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -6488,10 +6563,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：你没有访问此文档的权限。\n- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "`not_found` : 未找到文档。 存储文件缺失时也会返回 \"Uploaded file not found.\"；非文件类文档则返回 \"Document does not have an uploaded file to download.\"。",
             "content": {
               "application/json": {
                 "examples": {
@@ -6521,9 +6596,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到文档。 存储文件缺失时也会返回未找到上传文件的错误；非文件类文档则返回该文档没有可下载上传文件的错误。"
           }
         },
+        "summary": "下载文档",
+        "tags": [
+          "文档"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/documents/download-document",
           "metadata": {
@@ -8419,72 +8499,61 @@
     },
     "/datasets/{dataset_id}/documents/{document_id}/update-by-file": {
       "post": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "用文件更新文档",
-        "description": "已弃用。改用 [更新文档](/zh/api-reference/documents/update-document)。通过上传新文件更新文档，然后重新索引。",
+        "deprecated": true,
+        "description": "已废弃的文件更新路由。传入 `file` 可替换源文件，传入 `data` 可修改处理设置，也可同时传入两者。省略 `file` 时，Dify 使用提供的设置或当前设置重新处理现有源文件；空的 multipart 请求会使用当前设置重新索引。请改用[更新文档](/zh/api-reference/documents/update-document)。",
         "operationId": "updateDocumentByFile",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
                 "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。"
-                  },
                   "data": {
-                    "type": "string",
                     "description": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。",
+                    "type": "string",
                     "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。",
+                    "format": "binary",
+                    "type": "string"
                   }
-                }
+                },
+                "type": "object"
               }
             }
-          }
+          },
+          "required": false
         },
         "responses": {
           "200": {
-            "description": "文档更新成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "用于跟踪索引进度的批次 ID。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -8533,10 +8602,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "文档更新成功。"
           },
           "400": {
-            "description": "- `too_many_files` : 每次请求仅允许一个文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 文档不可用，无法更新（仅可更新处于可用状态的文档）。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8565,7 +8634,7 @@
                     }
                   },
                   "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
+                    "summary": "invalid_param（不可用）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -8574,15 +8643,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `too_many_files`：每次请求仅允许一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：文档不可用，无法更新（仅可更新处于可用状态的文档）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8590,7 +8676,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（向量空间限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8598,7 +8684,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8607,10 +8693,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8632,10 +8718,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
           },
           "413": {
-            "description": "`file_too_large` : 上传的文件超出最大大小限制。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8649,10 +8735,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`file_too_large`：上传的文件超出最大大小限制。"
           },
           "415": {
-            "description": "`unsupported_file_type` : 上传文件的类型不受支持。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8666,27 +8752,14 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "`unsupported_file_type`：上传文件的类型不受支持。"
           }
         },
-        "deprecated": true,
+        "summary": "用文件更新文档",
+        "tags": [
+          "文档"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/documents/update-document-by-file",
           "metadata": {
@@ -8698,152 +8771,48 @@
     },
     "/datasets/{dataset_id}/documents/{document_id}/update-by-text": {
       "post": {
-        "tags": [
-          "文档"
-        ],
-        "summary": "用文本更新文档",
         "description": "更新文档的文本内容、名称或处理配置。文本变更时会重新索引文档。",
         "operationId": "updateDocumentByText",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "document_id",
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
             "in": "path",
+            "name": "document_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "文档名称。当提供 `text` 时必填。"
-                  },
-                  "text": {
-                    "type": "string",
-                    "description": "文档文本内容。"
-                  },
-                  "process_rule": {
-                    "type": "object",
-                    "description": "分块处理规则。",
-                    "required": [
-                      "mode"
-                    ],
-                    "properties": {
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "automatic",
-                          "custom",
-                          "hierarchical"
-                        ],
-                        "description": "`automatic` 使用内置规则，`custom` 允许手动配置，`hierarchical` 启用父子分段结构（配合 `doc_form: hierarchical_model` 使用）。"
-                      },
-                      "rules": {
-                        "type": "object",
-                        "properties": {
-                          "pre_processing_rules": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "enum": [
-                                    "remove_stopwords",
-                                    "remove_extra_spaces",
-                                    "remove_urls_emails"
-                                  ],
-                                  "description": "规则标识符。"
-                                },
-                                "enabled": {
-                                  "type": "boolean",
-                                  "description": "该预处理规则是否启用。"
-                                }
-                              }
-                            }
-                          },
-                          "segmentation": {
-                            "type": "object",
-                            "properties": {
-                              "separator": {
-                                "type": "string",
-                                "default": "\n",
-                                "description": "用于拆分文本的自定义分隔符。"
-                              },
-                              "max_tokens": {
-                                "type": "integer",
-                                "description": "每个分段的最大令牌数。"
-                              },
-                              "chunk_overlap": {
-                                "type": "integer",
-                                "default": 0,
-                                "description": "分段之间的令牌重叠数。"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "doc_form": {
-                    "type": "string",
-                    "enum": [
-                      "text_model",
-                      "hierarchical_model",
-                      "qa_model"
-                    ],
-                    "default": "text_model",
-                    "description": "`text_model` 为标准文本分段，`hierarchical_model` 为父子分段结构，`qa_model` 为问答对提取。"
-                  },
-                  "doc_language": {
-                    "type": "string",
-                    "default": "English",
-                    "description": "用于处理优化的文档语言。"
-                  },
-                  "retrieval_model": {
-                    "$ref": "#/components/schemas/RetrievalModel",
-                    "description": "控制查询此知识库时如何搜索和排序分段。"
-                  }
-                }
+                "$ref": "#/components/schemas/DocumentTextUpdate"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "文档更新成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "document": {
-                      "$ref": "#/components/schemas/Document"
-                    },
-                    "batch": {
-                      "type": "string",
-                      "description": "用于跟踪索引进度的批次 ID。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
                 },
                 "examples": {
                   "success": {
@@ -8892,10 +8861,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "文档更新成功。"
           },
           "400": {
-            "description": "- `provider_not_initialize` : 工作空间未配置模型供应商凭据。\n- `invalid_param` : 提供 `text` 时必须提供 `name`，或 `doc_form` 无效。\n- `invalid_param` : 文档不可用，无法更新（仅可更新处于可用状态的文档）。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8908,7 +8877,7 @@
                     }
                   },
                   "invalid_param_name": {
-                    "summary": "invalid_param (name required)",
+                    "summary": "invalid_param（名称必填）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -8916,7 +8885,7 @@
                     }
                   },
                   "invalid_param_not_available": {
-                    "summary": "invalid_param (not available)",
+                    "summary": "invalid_param（不可用）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -8925,15 +8894,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：提供 `text` 时必须提供 `name`，或 `doc_form` 无效。\n- `invalid_param`：文档不可用，无法更新（仅可更新处于可用状态的文档）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8941,7 +8927,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（向量空间限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8949,7 +8935,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8958,10 +8944,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8983,26 +8969,14 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
           }
         },
+        "summary": "用文本更新文档",
+        "tags": [
+          "文档"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/documents/update-document-by-text",
           "metadata": {
@@ -9010,6 +8984,449 @@
             "sidebarTitle": "用文本更新文档"
           }
         }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/update_by_file": {
+      "post": {
+        "deprecated": true,
+        "description": "已废弃的文件更新路由。传入 `file` 可替换源文件，传入 `data` 可修改处理设置，也可同时传入两者。省略 `file` 时，Dify 使用提供的设置或当前设置重新处理现有源文件；空的 multipart 请求会使用当前设置重新索引。请改用[更新文档](/zh/api-reference/documents/update-document)。",
+        "operationId": "update_document_by_file_deprecated_5dc5fe59",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "description": "包含配置信息的 JSON 字符串。接受与 [从文本创建文档](/zh/api-reference/documents/create-document-by-text) 相同的字段（`doc_form`、`doc_language`、`process_rule`、`retrieval_model`、`embedding_model`、`embedding_model_provider`），但不包括 `name` 和 `text`。",
+                    "type": "string",
+                    "example": "{\"doc_form\":\"text_model\",\"doc_language\":\"English\",\"process_rule\":{\"mode\":\"automatic\"}}"
+                  },
+                  "file": {
+                    "description": "要上传的文件，默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。Dify Cloud 的 Professional 和 Team 套餐上限为 50 MB。",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "文档更新成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "too_many_files": {
+                    "summary": "too_many_files",
+                    "value": {
+                      "status": 400,
+                      "code": "too_many_files",
+                      "message": "Only one file is allowed."
+                    }
+                  },
+                  "filename_not_exists_error": {
+                    "summary": "filename_not_exists_error",
+                    "value": {
+                      "status": 400,
+                      "code": "filename_not_exists_error",
+                      "message": "The specified filename does not exist."
+                    }
+                  },
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials."
+                    }
+                  },
+                  "invalid_param_not_available": {
+                    "summary": "invalid_param（不可用）",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Document is not available"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `too_many_files`：每次请求仅允许一个文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `provider_not_initialize`：工作空间未配置模型供应商凭据。\n- `invalid_param`：文档不可用，无法更新（仅可更新处于可用状态的文档）。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（向量空间限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "file_too_large": {
+                    "summary": "file_too_large",
+                    "value": {
+                      "status": 413,
+                      "code": "file_too_large",
+                      "message": "File size exceeded."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`file_too_large`：上传的文件超出最大大小限制。"
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unsupported_file_type": {
+                    "summary": "unsupported_file_type",
+                    "value": {
+                      "status": 415,
+                      "code": "unsupported_file_type",
+                      "message": "File type not allowed."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`unsupported_file_type`：上传文件的类型不受支持。"
+          }
+        },
+        "summary": "用文件更新文档",
+        "tags": [
+          "文档"
+        ]
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/update_by_text": {
+      "post": {
+        "deprecated": true,
+        "description": "已弃用的兼容接口。更新文档的文本内容、名称或处理配置。文本变更时会重新索引文档。",
+        "operationId": "update_document_by_text_deprecated",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentTextUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentAndBatchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "document": {
+                        "id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "position": 1,
+                        "data_source_type": "upload_file",
+                        "data_source_info": {
+                          "upload_file_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                        },
+                        "data_source_detail_dict": {
+                          "upload_file": {
+                            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "guide.txt",
+                            "size": 2048,
+                            "extension": "txt",
+                            "mime_type": "text/plain",
+                            "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                            "created_at": 1741267200
+                          }
+                        },
+                        "dataset_process_rule_id": "e1f2a3b4-c5d6-7890-ef12-345678901234",
+                        "name": "guide.txt",
+                        "created_from": "api",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "tokens": 512,
+                        "indexing_status": "completed",
+                        "error": null,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "archived": false,
+                        "display_status": "available",
+                        "word_count": 350,
+                        "hit_count": 0,
+                        "doc_form": "text_model",
+                        "doc_metadata": [],
+                        "summary_index_status": null,
+                        "need_summary": false
+                      },
+                      "batch": "20250306150245647595"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "文档更新成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（向量空间限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
+          }
+        },
+        "tags": [
+          "文档"
+        ],
+        "summary": "用文本更新文档"
       }
     },
     "/datasets/{dataset_id}/hit-testing": {


### PR DESCRIPTION
## Summary

- generate document operations in the English, Chinese, and Japanese Service API references
- cover document creation, indexing, status, update, deletion, and pipeline tracking contracts
- leave chunk and knowledge-management operations for later layers

## Validation

- three-locale structural parity — 0 issues