### PR TITLE
docs: generate chunk api references

### DIFF
--- a/en/api-reference/openapi_service.json
+++ b/en/api-reference/openapi_service.json
@@ -6614,398 +6614,86 @@
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/segments": {
-      "post": {
-        "tags": [
-          "Chunks"
-        ],
-        "summary": "Create Chunks",
-        "description": "Create one or more chunks within a document.",
-        "operationId": "createSegments",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents)."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "segments"
-                ],
-                "properties": {
-                  "segments": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "content": {
-                          "type": "string",
-                          "description": "Chunk text content.",
-                          "minLength": 1
-                        },
-                        "answer": {
-                          "type": "string",
-                          "description": "Answer text. Required for Q&A-mode (`qa_model`) documents."
-                        },
-                        "keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "description": "Keywords for the chunk."
-                        },
-                        "attachment_ids": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "description": "Attachment file IDs."
-                        }
-                      },
-                      "required": [
-                        "content"
-                      ]
-                    },
-                    "description": "Array of chunk objects to create.",
-                    "minItems": 1
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Chunks created successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of created chunks.",
-                      "items": {
-                        "$ref": "#/components/schemas/Segment"
-                      }
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "Document chunking mode used by this document."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                          "position": 1,
-                          "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                          "content": "Dify is an open-source LLM app development platform.",
-                          "sign_content": "",
-                          "answer": "",
-                          "word_count": 9,
-                          "tokens": 12,
-                          "keywords": [
-                            "dify",
-                            "platform",
-                            "llm"
-                          ],
-                          "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
-                          "index_node_hash": "abc123def456",
-                          "hit_count": 0,
-                          "enabled": true,
-                          "disabled_at": null,
-                          "disabled_by": null,
-                          "status": "completed",
-                          "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                          "created_at": 1741267200,
-                          "updated_at": 1741267200,
-                          "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                          "indexing_at": 1741267200,
-                          "completed_at": 1741267200,
-                          "error": null,
-                          "stopped_at": null,
-                          "child_chunks": [],
-                          "attachments": [],
-                          "summary": null
-                        }
-                      ],
-                      "doc_form": "text_model"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : A chunk field is invalid (for example, `answer` is required for Q&A-mode documents) or the number of chunks exceeds the per-request limit.\n- Request-body schema validation (such as empty `content`) returns a non-standard body `{\"error\": \"<validation details>\"}` with no `code` or `status` field.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  },
-                  "invalid_param_limit": {
-                    "summary": "invalid_param (segments limit)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Exceeded maximum segments limit of 1000."
-                    }
-                  },
-                  "validation_error": {
-                    "summary": "schema validation (non-standard body)",
-                    "value": {
-                      "error": "1 validation error for SegmentCreatePayload\nsegments.0.content\n  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (upgrade plan)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Document is not completed.\n- `not_found` : Document is disabled.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document is not completed."
-                    }
-                  },
-                  "not_found_4": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document is disabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/chunks/create-chunks",
-          "metadata": {
-            "title": "Create Chunks",
-            "sidebarTitle": "Create Chunks"
-          }
-        }
-      },
       "get": {
-        "tags": [
-          "Chunks"
-        ],
-        "summary": "List Chunks",
         "description": "Returns a paginated list of chunks within a document, optionally filtered by keyword or indexing status.",
         "operationId": "listSegments",
         "parameters": [
           {
+            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents)."
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "page",
+            "description": "Search keyword.",
             "in": "query",
+            "name": "keyword",
+            "required": false,
             "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            },
-            "description": "Page number."
+              "description": "Search keyword.",
+              "type": "string"
+            }
           },
           {
+            "description": "Number of items per page. Server caps at `100`.",
+            "in": "query",
             "name": "limit",
-            "in": "query",
+            "required": false,
             "schema": {
-              "type": "integer",
               "default": 20,
-              "minimum": 1
-            },
-            "description": "Number of items per page. Server caps at `100`."
+              "description": "Number of items per page. Server caps at `100`.",
+              "minimum": 1,
+              "type": "integer"
+            }
           },
           {
-            "name": "status",
+            "description": "Page number to retrieve.",
             "in": "query",
+            "name": "page",
+            "required": false,
             "schema": {
-              "type": "array",
+              "default": 1,
+              "description": "Page number to retrieve.",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter chunks by indexing status, such as `completed`, `indexing`, or `error`.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "Filter chunks by indexing status, such as `completed`, `indexing`, or `error`.",
               "items": {
                 "type": "string"
-              }
-            },
-            "style": "form",
-            "explode": true,
-            "description": "Filter chunks by indexing status, e.g. `completed`, `indexing`, `error`."
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            },
-            "description": "Search keyword."
+              },
+              "type": "array"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "List of chunks.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of chunks.",
-                      "items": {
-                        "$ref": "#/components/schemas/Segment"
-                      }
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "Document chunking mode used by this document."
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "Total number of matching chunks."
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "Whether more items exist on the next page."
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "Number of items per page."
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "Current page number."
-                    }
-                  }
+                  "$ref": "#/components/schemas/SegmentListResponse"
                 },
                 "examples": {
                   "success": {
@@ -7055,10 +6743,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "List of chunks."
           },
           "400": {
-            "description": "`provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.",
             "content": {
               "application/json": {
                 "examples": {
@@ -7072,10 +6760,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : Dataset api access is not enabled.",
             "content": {
               "application/json": {
                 "examples": {
@@ -7089,10 +6794,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled."
           },
           "404": {
-            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -7114,9 +6819,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found."
           }
         },
+        "summary": "List Chunks",
+        "tags": [
+          "Chunks"
+        ],
         "x-mint": {
           "href": "/en/api-reference/chunks/list-chunks",
           "metadata": {
@@ -7124,344 +6834,99 @@
             "sidebarTitle": "List Chunks"
           }
         }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}": {
-      "get": {
-        "tags": [
-          "Chunks"
-        ],
-        "summary": "Get Chunk",
-        "description": "Retrieve the full details of a single chunk.",
-        "operationId": "getSegmentDetail",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents)."
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks)."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Chunk details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/Segment"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "Document chunking mode used by this document."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "data": {
-                        "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                        "position": 1,
-                        "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "content": "Dify is an open-source LLM app development platform.",
-                        "sign_content": "",
-                        "answer": "",
-                        "word_count": 9,
-                        "tokens": 12,
-                        "keywords": [
-                          "dify",
-                          "platform",
-                          "llm"
-                        ],
-                        "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
-                        "index_node_hash": "abc123def456",
-                        "hit_count": 0,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "status": "completed",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "updated_at": 1741267200,
-                        "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "indexing_at": 1741267200,
-                        "completed_at": 1741267200,
-                        "error": null,
-                        "stopped_at": null,
-                        "child_chunks": [],
-                        "attachments": [],
-                        "summary": null
-                      },
-                      "doc_form": "text_model"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : Dataset api access is not enabled.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Segment not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/chunks/get-chunk",
-          "metadata": {
-            "title": "Get Chunk",
-            "sidebarTitle": "Get Chunk"
-          }
-        }
       },
       "post": {
-        "tags": [
-          "Chunks"
-        ],
-        "summary": "Update Chunk",
-        "description": "Update a chunk's fields. The update re-triggers indexing for that chunk.",
-        "operationId": "updateSegment",
+        "description": "Create one or more chunks within a document.",
+        "operationId": "createSegments",
         "parameters": [
           {
+            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents)."
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks)."
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "segment"
-                ],
-                "properties": {
-                  "segment": {
-                    "type": "object",
-                    "properties": {
-                      "content": {
-                        "type": "string",
-                        "description": "Chunk text content."
-                      },
-                      "answer": {
-                        "type": "string",
-                        "description": "Answer text for Q&A-mode (`qa_model`) documents."
-                      },
-                      "keywords": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "description": "Keywords for the chunk."
-                      },
-                      "enabled": {
-                        "type": "boolean",
-                        "description": "Whether the chunk is enabled."
-                      },
-                      "regenerate_child_chunks": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Whether to regenerate child chunks."
-                      },
-                      "attachment_ids": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "description": "Attachment file IDs."
-                      },
-                      "summary": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Summary content for summary index."
-                      }
-                    },
-                    "description": "Chunk data to update."
-                  }
-                }
+                "$ref": "#/components/schemas/SegmentCreatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Chunk updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/Segment"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "Document chunking mode used by this document."
-                    }
-                  }
+                  "$ref": "#/components/schemas/SegmentCreateListResponse"
                 },
                 "examples": {
                   "success": {
                     "summary": "Response Example",
                     "value": {
-                      "data": {
-                        "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                        "position": 1,
-                        "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "content": "Dify is an open-source LLM app development platform.",
-                        "sign_content": "",
-                        "answer": "",
-                        "word_count": 9,
-                        "tokens": 12,
-                        "keywords": [
-                          "dify",
-                          "platform",
-                          "llm"
-                        ],
-                        "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
-                        "index_node_hash": "abc123def456",
-                        "hit_count": 0,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "status": "completed",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "updated_at": 1741267200,
-                        "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "indexing_at": 1741267200,
-                        "completed_at": 1741267200,
-                        "error": null,
-                        "stopped_at": null,
-                        "child_chunks": [],
-                        "attachments": [],
-                        "summary": null
-                      },
+                      "data": [
+                        {
+                          "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                          "position": 1,
+                          "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                          "content": "Dify is an open-source LLM app development platform.",
+                          "sign_content": "",
+                          "answer": "",
+                          "word_count": 9,
+                          "tokens": 12,
+                          "keywords": [
+                            "dify",
+                            "platform",
+                            "llm"
+                          ],
+                          "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                          "index_node_hash": "abc123def456",
+                          "hit_count": 0,
+                          "enabled": true,
+                          "disabled_at": null,
+                          "disabled_by": null,
+                          "status": "completed",
+                          "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                          "created_at": 1741267200,
+                          "updated_at": 1741267200,
+                          "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                          "indexing_at": 1741267200,
+                          "completed_at": 1741267200,
+                          "error": null,
+                          "stopped_at": null,
+                          "child_chunks": [],
+                          "attachments": [],
+                          "summary": null
+                        }
+                      ],
                       "doc_form": "text_model"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "Chunks created successfully."
           },
           "400": {
-            "description": "- `provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : The chunk is indexing or disabled and cannot be updated, or index configuration is invalid.",
             "content": {
               "application/json": {
                 "examples": {
@@ -7473,365 +6938,43 @@
                       "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
                     }
                   },
-                  "invalid_param_state": {
-                    "summary": "invalid_param (state)",
+                  "invalid_param_limit": {
+                    "summary": "invalid_param (segments limit)",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
-                      "message": "Segment is indexing, please try again later"
+                      "message": "Exceeded maximum segments limit of 1000."
+                    }
+                  },
+                  "validation_error": {
+                    "summary": "schema validation (non-standard body)",
+                    "value": {
+                      "error": "1 validation error for SegmentCreatePayload\nsegments.0.content\n  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : A chunk field is invalid (for example, `answer` is required for Q&A-mode documents) or the number of chunks exceeds the per-request limit.\n- Request-body schema validation (such as empty `content`) returns a non-standard body `{\"error\": \"<validation details>\"}` with no `code` or `status` field."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Segment not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/chunks/update-chunk",
-          "metadata": {
-            "title": "Update Chunk",
-            "sidebarTitle": "Update Chunk"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Chunks"
-        ],
-        "summary": "Delete Chunk",
-        "description": "Permanently delete a chunk from the document.",
-        "operationId": "deleteSegment",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents)."
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks)."
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "400": {
-            "description": "- `invalid_param` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : The chunk is already being deleted by a concurrent request.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param_model_setting": {
-                    "summary": "invalid_param (model setting)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  },
-                  "invalid_param_deleting": {
-                    "summary": "invalid_param (deleting)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Segment is deleting."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Segment not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/chunks/delete-chunk",
-          "metadata": {
-            "title": "Delete Chunk",
-            "sidebarTitle": "Delete Chunk"
-          }
-        }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks": {
-      "post": {
-        "tags": [
-          "Chunks"
-        ],
-        "summary": "Create Child Chunk",
-        "description": "Create a child chunk under a parent chunk. Intended for documents that use the parent-child (`hierarchical_model`) chunking mode.",
-        "operationId": "createChildChunk",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents)."
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks)."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "content"
-                ],
-                "properties": {
-                  "content": {
-                    "type": "string",
-                    "description": "Child chunk text content."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Child chunk created successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/ChildChunk"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "data": {
-                        "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
-                        "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                        "content": "Dify is an open-source platform.",
-                        "position": 1,
-                        "word_count": 6,
-                        "type": "customized",
-                        "created_at": 1741267200,
-                        "updated_at": 1741267200
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : Indexing the child chunk in the vector store failed; the message carries the underlying vector-store error.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Vector store operation failed: [Errno 111] Connection refused"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
             "content": {
               "application/json": {
                 "examples": {
@@ -7869,10 +7012,175 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
           },
           "404": {
-            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document is not completed."
+                    }
+                  },
+                  "not_found_4": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document is disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Document is not completed.\n- `not_found` : Document is disabled."
+          }
+        },
+        "summary": "Create Chunks",
+        "tags": [
+          "Chunks"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/chunks/create-chunks",
+          "metadata": {
+            "title": "Create Chunks",
+            "sidebarTitle": "Create Chunks"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}": {
+      "delete": {
+        "description": "Permanently delete a chunk from the document.",
+        "operationId": "deleteSegment",
+        "parameters": [
+          {
+            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "Chunk ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param_model_setting": {
+                    "summary": "invalid_param (model setting)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  },
+                  "invalid_param_deleting": {
+                    "summary": "invalid_param (deleting)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Segment is deleting."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `invalid_param` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : The chunk is already being deleted by a concurrent request."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+          },
+          "404": {
             "content": {
               "application/json": {
                 "examples": {
@@ -7902,133 +7210,510 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found."
           }
         },
+        "summary": "Delete Chunk",
+        "tags": [
+          "Chunks"
+        ],
         "x-mint": {
-          "href": "/en/api-reference/chunks/create-child-chunk",
+          "href": "/en/api-reference/chunks/delete-chunk",
           "metadata": {
-            "title": "Create Child Chunk",
-            "sidebarTitle": "Create Child Chunk"
+            "title": "Delete Chunk",
+            "sidebarTitle": "Delete Chunk"
           }
         }
       },
       "get": {
-        "tags": [
-          "Chunks"
-        ],
-        "summary": "List Child Chunks",
-        "description": "Returns a paginated list of child chunks under a specific parent chunk.",
-        "operationId": "getChildChunks",
+        "description": "Retrieve the full details of a single chunk.",
+        "operationId": "getSegmentDetail",
         "parameters": [
           {
+            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents)."
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks)."
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            },
-            "description": "Page number."
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1
-            },
-            "description": "Number of items per page. Server caps at `100`."
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
               "type": "string"
-            },
-            "description": "Search keyword."
+            }
+          },
+          {
+            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "Chunk ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "List of child chunks.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of child chunks.",
-                      "items": {
-                        "$ref": "#/components/schemas/ChildChunk"
-                      }
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "Total number of child chunks."
-                    },
-                    "total_pages": {
-                      "type": "integer",
-                      "description": "Total number of pages."
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "Current page number."
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "Number of items per page."
+                  "$ref": "#/components/schemas/SegmentDetailResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "data": {
+                        "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                        "position": 1,
+                        "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "content": "Dify is an open-source LLM app development platform.",
+                        "sign_content": "",
+                        "answer": "",
+                        "word_count": 9,
+                        "tokens": 12,
+                        "keywords": [
+                          "dify",
+                          "platform",
+                          "llm"
+                        ],
+                        "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                        "index_node_hash": "abc123def456",
+                        "hit_count": 0,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "status": "completed",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "updated_at": 1741267200,
+                        "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "indexing_at": 1741267200,
+                        "completed_at": 1741267200,
+                        "error": null,
+                        "stopped_at": null,
+                        "child_chunks": [],
+                        "attachments": [],
+                        "summary": null
+                      },
+                      "doc_form": "text_model"
                     }
                   }
+                }
+              }
+            },
+            "description": "Chunk details."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Segment not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found."
+          }
+        },
+        "summary": "Get Chunk",
+        "tags": [
+          "Chunks"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/chunks/get-chunk",
+          "metadata": {
+            "title": "Get Chunk",
+            "sidebarTitle": "Get Chunk"
+          }
+        }
+      },
+      "post": {
+        "description": "Update a chunk's fields. The update re-triggers indexing for that chunk.",
+        "operationId": "updateSegment",
+        "parameters": [
+          {
+            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "Chunk ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SegmentUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SegmentDetailResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "data": {
+                        "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                        "position": 1,
+                        "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "content": "Dify is an open-source LLM app development platform.",
+                        "sign_content": "",
+                        "answer": "",
+                        "word_count": 9,
+                        "tokens": 12,
+                        "keywords": [
+                          "dify",
+                          "platform",
+                          "llm"
+                        ],
+                        "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                        "index_node_hash": "abc123def456",
+                        "hit_count": 0,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "status": "completed",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "updated_at": 1741267200,
+                        "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "indexing_at": 1741267200,
+                        "completed_at": 1741267200,
+                        "error": null,
+                        "stopped_at": null,
+                        "child_chunks": [],
+                        "attachments": [],
+                        "summary": null
+                      },
+                      "doc_form": "text_model"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Chunk updated successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  },
+                  "invalid_param_state": {
+                    "summary": "invalid_param (state)",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Segment is indexing, please try again later"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : The chunk is indexing or disabled and cannot be updated, or index configuration is invalid."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Segment not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found."
+          }
+        },
+        "summary": "Update Chunk",
+        "tags": [
+          "Chunks"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/chunks/update-chunk",
+          "metadata": {
+            "title": "Update Chunk",
+            "sidebarTitle": "Update Chunk"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks": {
+      "get": {
+        "description": "Returns a paginated list of child chunks under a specific parent chunk.",
+        "operationId": "getChildChunks",
+        "parameters": [
+          {
+            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "Chunk ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Search keyword.",
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "description": "Search keyword.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of items per page. Server caps at `100`.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of items per page. Server caps at `100`.",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number to retrieve.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "Page number to retrieve.",
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChildChunkListResponse"
                 },
                 "examples": {
                   "success": {
@@ -8054,10 +7739,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "List of child chunks."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : Dataset api access is not enabled.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8071,10 +7773,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled."
           },
           "404": {
-            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8104,9 +7806,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found."
           }
         },
+        "summary": "List Child Chunks",
+        "tags": [
+          "Chunks"
+        ],
         "x-mint": {
           "href": "/en/api-reference/chunks/list-child-chunks",
           "metadata": {
@@ -8114,89 +7821,61 @@
             "sidebarTitle": "List Child Chunks"
           }
         }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks/{child_chunk_id}": {
-      "patch": {
-        "tags": [
-          "Chunks"
-        ],
-        "summary": "Update Child Chunk",
-        "description": "Update the content of an existing child chunk.",
-        "operationId": "updateChildChunk",
+      },
+      "post": {
+        "description": "Create a child chunk under a parent chunk. Intended for documents that use the parent-child (`hierarchical_model`) chunking mode.",
+        "operationId": "createChildChunk",
         "parameters": [
           {
+            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents)."
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+            "in": "path",
             "name": "segment_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks)."
-          },
-          {
-            "name": "child_chunk_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Child chunk ID."
+              "description": "Chunk ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "content"
-                ],
-                "properties": {
-                  "content": {
-                    "type": "string",
-                    "description": "Child chunk text content."
-                  }
-                }
+                "$ref": "#/components/schemas/ChildChunkCreatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Child chunk updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/ChildChunk"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ChildChunkDetailResponse"
                 },
                 "examples": {
                   "success": {
@@ -8216,13 +7895,21 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Child chunk created successfully."
           },
           "400": {
-            "description": "`invalid_param` : Re-indexing the child chunk in the vector store failed; the message carries the underlying vector-store error.",
             "content": {
               "application/json": {
                 "examples": {
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  },
                   "invalid_param": {
                     "summary": "invalid_param",
                     "value": {
@@ -8233,10 +7920,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize` : The knowledge base uses high-quality indexing but its embedding model is missing or misconfigured.\n- `invalid_param` : Indexing the child chunk in the vector store failed; the message carries the underlying vector-store error."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8274,10 +7978,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
           },
           "404": {
-            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.\n- `not_found` : Child chunk not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8304,92 +8008,74 @@
                       "code": "not_found",
                       "message": "Segment not found."
                     }
-                  },
-                  "not_found_4": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Child chunk not found."
-                    }
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found."
           }
         },
-        "x-mint": {
-          "href": "/en/api-reference/chunks/update-child-chunk",
-          "metadata": {
-            "title": "Update Child Chunk",
-            "sidebarTitle": "Update Child Chunk"
-          }
-        }
-      },
-      "delete": {
+        "summary": "Create Child Chunk",
         "tags": [
           "Chunks"
         ],
-        "summary": "Delete Child Chunk",
+        "x-mint": {
+          "href": "/en/api-reference/chunks/create-child-chunk",
+          "metadata": {
+            "title": "Create Child Chunk",
+            "sidebarTitle": "Create Child Chunk"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks/{child_chunk_id}": {
+      "delete": {
         "description": "Permanently delete a child chunk from its parent chunk.",
         "operationId": "deleteChildChunk",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Child chunk ID returned in `data[].id` by [List Child Chunks](/en/api-reference/chunks/list-child-chunks).",
             "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents)."
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks)."
-          },
-          {
             "name": "child_chunk_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Child chunk ID."
+              "description": "Child chunk ID returned in `data[].id` by [List Child Chunks](/en/api-reference/chunks/list-child-chunks).",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "Chunk ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -8397,7 +8083,6 @@
             "description": "Success."
           },
           "400": {
-            "description": "`invalid_param` : Removing the child chunk index from the vector store failed; the message carries the underlying vector-store error.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8411,10 +8096,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param` : Removing the child chunk index from the vector store failed; the message carries the underlying vector-store error."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8444,10 +8146,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
           },
           "404": {
-            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.\n- `not_found` : Child chunk not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -8485,14 +8187,235 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.\n- `not_found` : Child chunk not found."
           }
         },
+        "summary": "Delete Child Chunk",
+        "tags": [
+          "Chunks"
+        ],
         "x-mint": {
           "href": "/en/api-reference/chunks/delete-child-chunk",
           "metadata": {
             "title": "Delete Child Chunk",
             "sidebarTitle": "Delete Child Chunk"
+          }
+        }
+      },
+      "patch": {
+        "description": "Update the content of an existing child chunk.",
+        "operationId": "updateChildChunk",
+        "parameters": [
+          {
+            "description": "Child chunk ID returned in `data[].id` by [List Child Chunks](/en/api-reference/chunks/list-child-chunks).",
+            "in": "path",
+            "name": "child_chunk_id",
+            "required": true,
+            "schema": {
+              "description": "Child chunk ID returned in `data[].id` by [List Child Chunks](/en/api-reference/chunks/list-child-chunks).",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Knowledge base ID. Obtain it from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Document ID. Obtain it from [List Documents](/en/api-reference/documents/list-documents).",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "Document ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Parent chunk ID. Obtain it from [List Chunks](/en/api-reference/chunks/list-chunks).",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "Chunk ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChildChunkUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChildChunkDetailResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "data": {
+                        "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+                        "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                        "content": "Dify is an open-source platform.",
+                        "position": 1,
+                        "word_count": 6,
+                        "type": "customized",
+                        "created_at": 1741267200,
+                        "updated_at": 1741267200
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Child chunk updated successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Vector store operation failed: [Errno 111] Connection refused"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param` : Re-indexing the child chunk in the vector store failed; the message carries the underlying vector-store error."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (vector space)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden (upgrade plan)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : The capacity of the vector space has reached the limit of your subscription.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Segment not found."
+                    }
+                  },
+                  "not_found_4": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Child chunk not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Dataset not found.\n- `not_found` : Document not found.\n- `not_found` : Segment not found.\n- `not_found` : Child chunk not found."
+          }
+        },
+        "summary": "Update Child Chunk",
+        "tags": [
+          "Chunks"
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/chunks/update-child-chunk",
+          "metadata": {
+            "title": "Update Child Chunk",
+            "sidebarTitle": "Update Child Chunk"
           }
         }
       }

--- a/ja/api-reference/openapi_service.json
+++ b/ja/api-reference/openapi_service.json
@@ -6614,398 +6614,86 @@
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/segments": {
-      "post": {
-        "tags": [
-          "チャンク"
-        ],
-        "summary": "ドキュメントにチャンクを追加",
-        "description": "ドキュメント内に 1 つ以上のチャンクを作成します。",
-        "operationId": "createSegments",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "segments"
-                ],
-                "properties": {
-                  "segments": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "content": {
-                          "type": "string",
-                          "description": "チャンクのテキスト内容です。",
-                          "minLength": 1
-                        },
-                        "answer": {
-                          "type": "string",
-                          "description": "回答テキストです。Q&A モード（`qa_model`）のドキュメントでは必須です。"
-                        },
-                        "keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "description": "チャンクのキーワードです。"
-                        },
-                        "attachment_ids": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "description": "添付ファイル ID です。"
-                        }
-                      },
-                      "required": [
-                        "content"
-                      ]
-                    },
-                    "description": "作成するチャンクオブジェクトの配列です。",
-                    "minItems": 1
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "チャンクが正常に作成されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Segment"
-                      },
-                      "description": "作成されたチャンクのリスト。"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "このドキュメントが使用するドキュメントチャンキングモードです。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                          "position": 1,
-                          "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                          "content": "Dify is an open-source LLM app development platform.",
-                          "sign_content": "",
-                          "answer": "",
-                          "word_count": 9,
-                          "tokens": 12,
-                          "keywords": [
-                            "dify",
-                            "platform",
-                            "llm"
-                          ],
-                          "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
-                          "index_node_hash": "abc123def456",
-                          "hit_count": 0,
-                          "enabled": true,
-                          "disabled_at": null,
-                          "disabled_by": null,
-                          "status": "completed",
-                          "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                          "created_at": 1741267200,
-                          "updated_at": 1741267200,
-                          "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                          "indexing_at": 1741267200,
-                          "completed_at": 1741267200,
-                          "error": null,
-                          "stopped_at": null,
-                          "child_chunks": [],
-                          "attachments": [],
-                          "summary": null
-                        }
-                      ],
-                      "doc_form": "text_model"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `provider_not_initialize` : ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param` : チャンクのフィールドが無効です（例：Q&A モードのドキュメントでは `answer` が必須）。またはチャンク数がリクエストごとの上限を超えています。\n- リクエストボディのスキーマ検証（`content` が空など）では、`code` や `status` を持たない非標準のボディ `{\"error\": \"<検証の詳細>\"}` が返されます。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  },
-                  "invalid_param_limit": {
-                    "summary": "invalid_param (segments limit)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Exceeded maximum segments limit of 1000."
-                    }
-                  },
-                  "validation_error": {
-                    "summary": "schema validation (non-standard body)",
-                    "value": {
-                      "error": "1 validation error for SegmentCreatePayload\nsegments.0.content\n  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (upgrade plan)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。\n- `not_found` : ドキュメントの処理が完了していません。\n- `not_found` : ドキュメントが無効化されています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document is not completed."
-                    }
-                  },
-                  "not_found_4": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document is disabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/chunks/create-chunks",
-          "metadata": {
-            "title": "ドキュメントにチャンクを追加",
-            "sidebarTitle": "ドキュメントにチャンクを追加"
-          }
-        }
-      },
       "get": {
-        "tags": [
-          "チャンク"
-        ],
-        "summary": "チャンク一覧を取得",
         "description": "ドキュメント内のチャンクのページネーションリストを返します。任意でキーワードまたはインデックスステータスでフィルタリングできます。",
         "operationId": "listSegments",
         "parameters": [
           {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "page",
+            "description": "検索キーワードです。",
             "in": "query",
+            "name": "keyword",
+            "required": false,
             "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            },
-            "description": "ページ番号。"
+              "description": "検索キーワードです。",
+              "type": "string"
+            }
           },
           {
+            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+            "in": "query",
             "name": "limit",
-            "in": "query",
+            "required": false,
             "schema": {
-              "type": "integer",
               "default": 20,
-              "minimum": 1
-            },
-            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。"
+              "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+              "minimum": 1,
+              "type": "integer"
+            }
           },
           {
-            "name": "status",
+            "description": "取得するページ番号。",
             "in": "query",
+            "name": "page",
+            "required": false,
             "schema": {
-              "type": "array",
+              "default": 1,
+              "description": "取得するページ番号。",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "`completed`、`indexing`、`error` などのインデックス状態でチャンクを絞り込みます。",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "`completed`、`indexing`、`error` などのインデックス状態でチャンクを絞り込みます。",
               "items": {
                 "type": "string"
-              }
-            },
-            "style": "form",
-            "explode": true,
-            "description": "インデックスステータスでチャンクをフィルタリングします（例：`completed`、`indexing`、`error`）。"
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            },
-            "description": "検索キーワードです。"
+              },
+              "type": "array"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "チャンクのリストです。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Segment"
-                      },
-                      "description": "チャンクのリスト。"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "このドキュメントが使用するドキュメントチャンキングモードです。"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "一致するチャンクの合計数です。"
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "次のページにさらに項目が存在するかどうかです。"
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "1 ページあたりの件数です。"
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "現在のページ番号です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/SegmentListResponse"
                 },
                 "examples": {
                   "success": {
@@ -7016,7 +6704,7 @@
                           "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
                           "position": 1,
                           "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                          "content": "Dify is an open-source LLM app development platform.",
+                          "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
                           "sign_content": "",
                           "answer": "",
                           "word_count": 9,
@@ -7055,10 +6743,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "チャンクのリストです。"
           },
           "400": {
-            "description": "`provider_not_initialize` : ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。",
             "content": {
               "application/json": {
                 "examples": {
@@ -7072,15 +6760,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`provider_not_initialize`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -7089,10 +6794,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -7114,9 +6819,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。"
           }
         },
+        "summary": "チャンク一覧を取得",
+        "tags": [
+          "チャンク"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/chunks/list-chunks",
           "metadata": {
@@ -7124,145 +6834,353 @@
             "sidebarTitle": "チャンク一覧を取得"
           }
         }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}": {
-      "get": {
-        "tags": [
-          "チャンク"
-        ],
-        "summary": "ドキュメント内のチャンク詳細を取得",
-        "description": "1 つのチャンクの詳細をすべて取得します。",
-        "operationId": "getSegmentDetail",
+      },
+      "post": {
+        "description": "ドキュメント内に 1 つ以上のチャンクを作成します。",
+        "operationId": "createSegments",
         "parameters": [
           {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。"
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SegmentCreatePayload"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
-            "description": "チャンクの詳細です。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/Segment"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "このドキュメントが使用するドキュメントチャンキングモードです。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/SegmentCreateListResponse"
                 },
                 "examples": {
                   "success": {
                     "summary": "レスポンス例",
                     "value": {
-                      "data": {
-                        "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                        "position": 1,
-                        "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "content": "Dify is an open-source LLM app development platform.",
-                        "sign_content": "",
-                        "answer": "",
-                        "word_count": 9,
-                        "tokens": 12,
-                        "keywords": [
-                          "dify",
-                          "platform",
-                          "llm"
-                        ],
-                        "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
-                        "index_node_hash": "abc123def456",
-                        "hit_count": 0,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "status": "completed",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "updated_at": 1741267200,
-                        "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "indexing_at": 1741267200,
-                        "completed_at": 1741267200,
-                        "error": null,
-                        "stopped_at": null,
-                        "child_chunks": [],
-                        "attachments": [],
-                        "summary": null
-                      },
+                      "data": [
+                        {
+                          "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                          "position": 1,
+                          "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                          "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
+                          "sign_content": "",
+                          "answer": "",
+                          "word_count": 9,
+                          "tokens": 12,
+                          "keywords": [
+                            "dify",
+                            "platform",
+                            "llm"
+                          ],
+                          "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                          "index_node_hash": "abc123def456",
+                          "hit_count": 0,
+                          "enabled": true,
+                          "disabled_at": null,
+                          "disabled_by": null,
+                          "status": "completed",
+                          "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                          "created_at": 1741267200,
+                          "updated_at": 1741267200,
+                          "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                          "indexing_at": 1741267200,
+                          "completed_at": 1741267200,
+                          "error": null,
+                          "stopped_at": null,
+                          "child_chunks": [],
+                          "attachments": [],
+                          "summary": null
+                        }
+                      ],
                       "doc_form": "text_model"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "チャンクが正常に作成されました。"
           },
           "400": {
-            "description": "`invalid_param` : ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。",
             "content": {
               "application/json": {
                 "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  },
+                  "invalid_param_limit": {
+                    "summary": "invalid_param（チャンク数制限）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                      "message": "Exceeded maximum segments limit of 1000."
+                    }
+                  },
+                  "validation_error": {
+                    "summary": "schema 検証（非標準リクエストボディ）",
+                    "value": {
+                      "error": "1 validation error for SegmentCreatePayload\nsegments.0.content\n  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param`：チャンクのフィールドが無効です（例：Q&A モードのドキュメントでは `answer` が必須）。またはチャンク数がリクエストごとの上限を超えています。\n- リクエストボディのスキーマ検証（`content` が空など）では、`code` や `status` を持たない非標準のボディ `{\"error\": \"<検証の詳細>\"}` が返されます。"
           },
-          "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
+          "401": {
             "content": {
               "application/json": {
                 "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
                       "message": "Dataset api access is not enabled."
                     }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（ベクトル容量制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden（プランのアップグレードが必要）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "この機能を利用するには、有料プランへアップグレードしてください。"
+                    }
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden`：この機能を利用するには、有料プランへアップグレードしてください。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。\n- `not_found` : チャンクが見つかりません。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document is not completed."
+                    }
+                  },
+                  "not_found_4": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document is disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：ドキュメントの処理が完了していません。\n- `not_found`：ドキュメントが無効化されています。"
+          }
+        },
+        "summary": "ドキュメントにチャンクを追加",
+        "tags": [
+          "チャンク"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/chunks/create-chunks",
+          "metadata": {
+            "title": "ドキュメントにチャンクを追加",
+            "sidebarTitle": "ドキュメントにチャンクを追加"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}": {
+      "delete": {
+        "description": "ドキュメントからチャンクを完全に削除します。",
+        "operationId": "deleteSegment",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "チャンク ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param_model_setting": {
+                    "summary": "invalid_param（モデル設定）",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  },
+                  "invalid_param_deleting": {
+                    "summary": "invalid_param（削除中）",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Segment is deleting."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `invalid_param`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param`：チャンクは別の同時リクエストによってすでに削除中です。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+          },
+          "404": {
             "content": {
               "application/json": {
                 "examples": {
@@ -7292,129 +7210,66 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。"
           }
         },
-        "x-mint": {
-          "href": "/ja/api-reference/chunks/get-chunk",
-          "metadata": {
-            "title": "ドキュメント内のチャンク詳細を取得",
-            "sidebarTitle": "ドキュメント内のチャンク詳細を取得"
-          }
-        }
-      },
-      "post": {
+        "summary": "ドキュメント内のチャンクを削除",
         "tags": [
           "チャンク"
         ],
-        "summary": "ドキュメント内のチャンクを更新",
-        "description": "チャンクのフィールドを更新します。この更新により、そのチャンクのインデックス作成が再トリガーされます。",
-        "operationId": "updateSegment",
+        "x-mint": {
+          "href": "/ja/api-reference/chunks/delete-chunk",
+          "metadata": {
+            "title": "ドキュメント内のチャンクを削除",
+            "sidebarTitle": "ドキュメント内のチャンクを削除"
+          }
+        }
+      },
+      "get": {
+        "description": "1 つのチャンクの詳細をすべて取得します。",
+        "operationId": "getSegmentDetail",
         "parameters": [
           {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "segment_id",
+            "description": "チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
             "in": "path",
+            "name": "segment_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "segment"
-                ],
-                "properties": {
-                  "segment": {
-                    "type": "object",
-                    "properties": {
-                      "content": {
-                        "type": "string",
-                        "description": "チャンクのテキスト内容です。"
-                      },
-                      "answer": {
-                        "type": "string",
-                        "description": "Q&A モード（`qa_model`）のドキュメントの回答テキストです。"
-                      },
-                      "keywords": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "description": "チャンクのキーワードです。"
-                      },
-                      "enabled": {
-                        "type": "boolean",
-                        "description": "チャンクが有効かどうかです。"
-                      },
-                      "regenerate_child_chunks": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "子チャンクを再生成するかどうかです。"
-                      },
-                      "attachment_ids": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "description": "添付ファイル ID です。"
-                      },
-                      "summary": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "サマリーインデックスのサマリー内容です。"
-                      }
-                    },
-                    "description": "更新するチャンクデータです。"
-                  }
-                }
-              }
+              "description": "チャンク ID。",
+              "format": "uuid",
+              "type": "string"
             }
           }
-        },
+        ],
         "responses": {
           "200": {
-            "description": "チャンクが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/Segment"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "このドキュメントが使用するドキュメントチャンキングモードです。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/SegmentDetailResponse"
                 },
                 "examples": {
                   "success": {
@@ -7424,7 +7279,7 @@
                         "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
                         "position": 1,
                         "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "content": "Dify is an open-source LLM app development platform.",
+                        "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
                         "sign_content": "",
                         "answer": "",
                         "word_count": 9,
@@ -7458,10 +7313,207 @@
                   }
                 }
               }
-            }
+            },
+            "description": "チャンクの詳細です。"
           },
           "400": {
-            "description": "- `provider_not_initialize` : ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param` : チャンクがインデックス中または無効化されているため更新できません。またはインデックス設定が無効です。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Segment not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。"
+          }
+        },
+        "summary": "ドキュメント内のチャンク詳細を取得",
+        "tags": [
+          "チャンク"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/chunks/get-chunk",
+          "metadata": {
+            "title": "ドキュメント内のチャンク詳細を取得",
+            "sidebarTitle": "ドキュメント内のチャンク詳細を取得"
+          }
+        }
+      },
+      "post": {
+        "description": "チャンクのフィールドを更新します。この更新により、そのチャンクのインデックス作成が再トリガーされます。",
+        "operationId": "updateSegment",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "チャンク ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SegmentUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SegmentDetailResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "data": {
+                        "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                        "position": 1,
+                        "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "content": "Dify はオープンソースの LLM アプリ開発プラットフォームです。",
+                        "sign_content": "",
+                        "answer": "",
+                        "word_count": 9,
+                        "tokens": 12,
+                        "keywords": [
+                          "dify",
+                          "platform",
+                          "llm"
+                        ],
+                        "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                        "index_node_hash": "abc123def456",
+                        "hit_count": 0,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "status": "completed",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "updated_at": 1741267200,
+                        "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "indexing_at": 1741267200,
+                        "completed_at": 1741267200,
+                        "error": null,
+                        "stopped_at": null,
+                        "child_chunks": [],
+                        "attachments": [],
+                        "summary": null
+                      },
+                      "doc_form": "text_model"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "チャンクが正常に更新されました。"
+          },
+          "400": {
             "content": {
               "application/json": {
                 "examples": {
@@ -7474,7 +7526,7 @@
                     }
                   },
                   "invalid_param_state": {
-                    "summary": "invalid_param (state)",
+                    "summary": "invalid_param（状態）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -7483,15 +7535,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param`：チャンクがインデックス中または無効化されているため更新できません。またはインデックス設定が無効です。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -7499,7 +7568,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（ベクトル容量制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -7507,7 +7576,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -7516,10 +7585,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。\n- `not_found` : チャンクが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -7549,26 +7618,14 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。"
           }
         },
+        "summary": "ドキュメント内のチャンクを更新",
+        "tags": [
+          "チャンク"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/chunks/update-chunk",
           "metadata": {
@@ -7576,459 +7633,87 @@
             "sidebarTitle": "ドキュメント内のチャンクを更新"
           }
         }
-      },
-      "delete": {
-        "tags": [
-          "チャンク"
-        ],
-        "summary": "ドキュメント内のチャンクを削除",
-        "description": "ドキュメントからチャンクを完全に削除します。",
-        "operationId": "deleteSegment",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "400": {
-            "description": "- `invalid_param` : ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param` : チャンクは別の同時リクエストによってすでに削除中です。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param_model_setting": {
-                    "summary": "invalid_param (model setting)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  },
-                  "invalid_param_deleting": {
-                    "summary": "invalid_param (deleting)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Segment is deleting."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。\n- `not_found` : チャンクが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Segment not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/chunks/delete-chunk",
-          "metadata": {
-            "title": "ドキュメント内のチャンクを削除",
-            "sidebarTitle": "ドキュメント内のチャンクを削除"
-          }
-        }
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks": {
-      "post": {
-        "tags": [
-          "チャンク"
-        ],
-        "summary": "子チャンクを作成",
-        "description": "親チャンクの下に子チャンクを作成します。親子（`hierarchical_model`）チャンキングモードを使用するドキュメント向けです。",
-        "operationId": "createChildChunk",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "content"
-                ],
-                "properties": {
-                  "content": {
-                    "type": "string",
-                    "description": "子チャンクのテキスト内容です。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "子チャンクが正常に作成されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/ChildChunk"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "data": {
-                        "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
-                        "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                        "content": "Dify is an open-source platform.",
-                        "position": 1,
-                        "word_count": 6,
-                        "type": "customized",
-                        "created_at": 1741267200,
-                        "updated_at": 1741267200
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `provider_not_initialize` : ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param` : ベクトルストアでの子チャンクのインデックス作成に失敗しました。メッセージにはベクトルストアの元のエラーが含まれます。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Vector store operation failed: [Errno 111] Connection refused"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (upgrade plan)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。\n- `not_found` : チャンクが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Segment not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/chunks/create-child-chunk",
-          "metadata": {
-            "title": "子チャンクを作成",
-            "sidebarTitle": "子チャンクを作成"
-          }
-        }
-      },
       "get": {
-        "tags": [
-          "チャンク"
-        ],
-        "summary": "子チャンク一覧を取得",
         "description": "特定の親チャンク配下の子チャンクのページネーションリストを返します。",
         "operationId": "getChildChunks",
         "parameters": [
           {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。"
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            },
-            "description": "ページ番号。"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1
-            },
-            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。"
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
               "type": "string"
-            },
-            "description": "検索キーワードです。"
+            }
+          },
+          {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "チャンク ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "検索キーワードです。",
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "description": "検索キーワードです。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "1 ページあたりの項目数です。サーバーの上限は `100` です。",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得するページ番号。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "取得するページ番号。",
+              "minimum": 1,
+              "type": "integer"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "子チャンクのリストです。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ChildChunk"
-                      },
-                      "description": "子チャンクのリスト。"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "子チャンクの合計数です。"
-                    },
-                    "total_pages": {
-                      "type": "integer",
-                      "description": "合計ページ数です。"
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "現在のページ番号です。"
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "1 ページあたりの件数です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ChildChunkListResponse"
                 },
                 "examples": {
                   "success": {
@@ -8038,7 +7723,7 @@
                         {
                           "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
                           "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                          "content": "Dify is an open-source platform.",
+                          "content": "Dify はオープンソースのプラットフォームです。",
                           "position": 1,
                           "word_count": 6,
                           "type": "customized",
@@ -8054,15 +7739,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "子チャンクのリストです。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8071,10 +7773,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。\n- `not_found` : チャンクが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8104,9 +7806,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。"
           }
         },
+        "summary": "子チャンク一覧を取得",
+        "tags": [
+          "チャンク"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/chunks/list-child-chunks",
           "metadata": {
@@ -8114,89 +7821,61 @@
             "sidebarTitle": "子チャンク一覧を取得"
           }
         }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks/{child_chunk_id}": {
-      "patch": {
-        "tags": [
-          "チャンク"
-        ],
-        "summary": "子チャンクを更新",
-        "description": "既存の子チャンクのコンテンツを更新します。",
-        "operationId": "updateChildChunk",
+      },
+      "post": {
+        "description": "親チャンクの下に子チャンクを作成します。親子（`hierarchical_model`）チャンキングモードを使用するドキュメント向けです。",
+        "operationId": "createChildChunk",
         "parameters": [
           {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+            "in": "path",
             "name": "segment_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。"
-          },
-          {
-            "name": "child_chunk_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "子チャンク ID です。"
+              "description": "チャンク ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "content"
-                ],
-                "properties": {
-                  "content": {
-                    "type": "string",
-                    "description": "子チャンクのテキスト内容です。"
-                  }
-                }
+                "$ref": "#/components/schemas/ChildChunkCreatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "子チャンクが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/ChildChunk"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ChildChunkDetailResponse"
                 },
                 "examples": {
                   "success": {
@@ -8205,7 +7884,7 @@
                       "data": {
                         "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
                         "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                        "content": "Dify is an open-source platform.",
+                        "content": "Dify はオープンソースのプラットフォームです。",
                         "position": 1,
                         "word_count": 6,
                         "type": "customized",
@@ -8216,13 +7895,21 @@
                   }
                 }
               }
-            }
+            },
+            "description": "子チャンクが正常に作成されました。"
           },
           "400": {
-            "description": "`invalid_param` : ベクトルストアでの子チャンクの再インデックスに失敗しました。メッセージにはベクトルストアの元のエラーが含まれます。",
             "content": {
               "application/json": {
                 "examples": {
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  },
                   "invalid_param": {
                     "summary": "invalid_param",
                     "value": {
@@ -8233,15 +7920,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize`：ナレッジベースは高品質インデックスを使用していますが、埋め込みモデルが未設定または誤って設定されています。\n- `invalid_param`：ベクトルストアでの子チャンクのインデックス作成に失敗しました。メッセージにはベクトルストアの元のエラーが含まれます。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8249,7 +7953,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（ベクトル容量制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8257,7 +7961,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8265,19 +7969,19 @@
                     }
                   },
                   "forbidden_4": {
-                    "summary": "forbidden (upgrade plan)",
+                    "summary": "forbidden（プランのアップグレードが必要）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
-                      "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+                      "message": "この機能を利用するには、有料プランへアップグレードしてください。"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden`：この機能を利用するには、有料プランへアップグレードしてください。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。\n- `not_found` : チャンクが見つかりません。\n- `not_found` : 子チャンクが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8304,100 +8008,81 @@
                       "code": "not_found",
                       "message": "Segment not found."
                     }
-                  },
-                  "not_found_4": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Child chunk not found."
-                    }
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : ベクトル空間の使用量を現在確認できません。しばらくしてから再試行してください。Dify Cloud の Sandbox プランでのみ発生します。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。"
           }
         },
-        "x-mint": {
-          "href": "/ja/api-reference/chunks/update-child-chunk",
-          "metadata": {
-            "title": "子チャンクを更新",
-            "sidebarTitle": "子チャンクを更新"
-          }
-        }
-      },
-      "delete": {
+        "summary": "子チャンクを作成",
         "tags": [
           "チャンク"
         ],
-        "summary": "子チャンクを削除",
+        "x-mint": {
+          "href": "/ja/api-reference/chunks/create-child-chunk",
+          "metadata": {
+            "title": "子チャンクを作成",
+            "sidebarTitle": "子チャンクを作成"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks/{child_chunk_id}": {
+      "delete": {
         "description": "親チャンクから子チャンクを完全に削除します。",
         "operationId": "deleteChildChunk",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "[子チャンクを一覧表示](/ja/api-reference/chunks/list-child-chunks) が返す `data[].id` の子チャンク ID。",
             "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。"
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。"
-          },
-          {
             "name": "child_chunk_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "子チャンク ID です。"
+              "description": "[子チャンクを一覧表示](/ja/api-reference/chunks/list-child-chunks) が返す `data[].id` の子チャンク ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "チャンク ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
-            "description": "Success."
+            "description": "成功。"
           },
           "400": {
-            "description": "`invalid_param` : ベクトルストアからの子チャンクインデックスの削除に失敗しました。メッセージにはベクトルストアの元のエラーが含まれます。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8411,15 +8096,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：ベクトルストアからの子チャンクインデックスの削除に失敗しました。メッセージにはベクトルストアの元のエラーが含まれます。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8427,7 +8129,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8435,19 +8137,19 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (upgrade plan)",
+                    "summary": "forbidden（プランのアップグレードが必要）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
-                      "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+                      "message": "この機能を利用するには、有料プランへアップグレードしてください。"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden`：この機能を利用するには、有料プランへアップグレードしてください。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : ドキュメントが見つかりません。\n- `not_found` : チャンクが見つかりません。\n- `not_found` : 子チャンクが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8485,14 +8187,235 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。\n- `not_found`：子チャンクが見つかりません。"
           }
         },
+        "summary": "子チャンクを削除",
+        "tags": [
+          "チャンク"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/chunks/delete-child-chunk",
           "metadata": {
             "title": "子チャンクを削除",
             "sidebarTitle": "子チャンクを削除"
+          }
+        }
+      },
+      "patch": {
+        "description": "既存の子チャンクのコンテンツを更新します。",
+        "operationId": "updateChildChunk",
+        "parameters": [
+          {
+            "description": "[子チャンクを一覧表示](/ja/api-reference/chunks/list-child-chunks) が返す `data[].id` の子チャンク ID。",
+            "in": "path",
+            "name": "child_chunk_id",
+            "required": true,
+            "schema": {
+              "description": "[子チャンクを一覧表示](/ja/api-reference/chunks/list-child-chunks) が返す `data[].id` の子チャンク ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ドキュメント ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) から取得します。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "ドキュメント ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "親チャンク ID です。[チャンク一覧を取得](/ja/api-reference/chunks/list-chunks) から取得します。",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "チャンク ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChildChunkUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChildChunkDetailResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "data": {
+                        "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+                        "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                        "content": "Dify はオープンソースのプラットフォームです。",
+                        "position": 1,
+                        "word_count": 6,
+                        "type": "customized",
+                        "created_at": 1741267200,
+                        "updated_at": 1741267200
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "子チャンクが正常に更新されました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Vector store operation failed: [Errno 111] Connection refused"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：ベクトルストアでの子チャンクの再インデックスに失敗しました。メッセージにはベクトルストアの元のエラーが含まれます。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（ベクトル容量制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden（プランのアップグレードが必要）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "この機能を利用するには、有料プランへアップグレードしてください。"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：ベクトル空間の容量がサブスクリプションの上限に達しました。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。\n- `forbidden`：この機能を利用するには、有料プランへアップグレードしてください。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Segment not found."
+                    }
+                  },
+                  "not_found_4": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Child chunk not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：ドキュメントが見つかりません。\n- `not_found`：チャンクが見つかりません。\n- `not_found`：子チャンクが見つかりません。"
+          }
+        },
+        "summary": "子チャンクを更新",
+        "tags": [
+          "チャンク"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/chunks/update-child-chunk",
+          "metadata": {
+            "title": "子チャンクを更新",
+            "sidebarTitle": "子チャンクを更新"
           }
         }
       }

--- a/zh/api-reference/openapi_service.json
+++ b/zh/api-reference/openapi_service.json
@@ -6614,398 +6614,86 @@
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/segments": {
-      "post": {
-        "tags": [
-          "分段"
-        ],
-        "summary": "向文档添加分段",
-        "description": "在文档中创建一个或多个分段。",
-        "operationId": "createSegments",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "segments"
-                ],
-                "properties": {
-                  "segments": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "content": {
-                          "type": "string",
-                          "description": "分段文本内容。",
-                          "minLength": 1
-                        },
-                        "answer": {
-                          "type": "string",
-                          "description": "答案文本。问答模式（`qa_model`）文档必填。"
-                        },
-                        "keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "description": "分段的关键词。"
-                        },
-                        "attachment_ids": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "description": "附件文件 ID。"
-                        }
-                      },
-                      "required": [
-                        "content"
-                      ]
-                    },
-                    "description": "要创建的分段对象数组。",
-                    "minItems": 1
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "分段创建成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Segment"
-                      },
-                      "description": "已创建的分段列表。"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "该文档使用的分块模式。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "data": [
-                        {
-                          "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                          "position": 1,
-                          "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                          "content": "Dify is an open-source LLM app development platform.",
-                          "sign_content": "",
-                          "answer": "",
-                          "word_count": 9,
-                          "tokens": 12,
-                          "keywords": [
-                            "dify",
-                            "platform",
-                            "llm"
-                          ],
-                          "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
-                          "index_node_hash": "abc123def456",
-                          "hit_count": 0,
-                          "enabled": true,
-                          "disabled_at": null,
-                          "disabled_by": null,
-                          "status": "completed",
-                          "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                          "created_at": 1741267200,
-                          "updated_at": 1741267200,
-                          "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                          "indexing_at": 1741267200,
-                          "completed_at": 1741267200,
-                          "error": null,
-                          "stopped_at": null,
-                          "child_chunks": [],
-                          "attachments": [],
-                          "summary": null
-                        }
-                      ],
-                      "doc_form": "text_model"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `provider_not_initialize` : 知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param` : 某个分段字段无效（例如 Q&A 模式的文档要求提供 `answer`），或分段数量超出单次请求上限。\n- 请求体 schema 校验失败（例如 `content` 为空）时返回非标准响应体 `{\"error\": \"<校验详情>\"}`，不含 `code` 或 `status` 字段。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  },
-                  "invalid_param_limit": {
-                    "summary": "invalid_param (segments limit)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Exceeded maximum segments limit of 1000."
-                    }
-                  },
-                  "validation_error": {
-                    "summary": "schema validation (non-standard body)",
-                    "value": {
-                      "error": "1 validation error for SegmentCreatePayload\nsegments.0.content\n  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (upgrade plan)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。\n- `not_found` : 文档尚未处理完成。\n- `not_found` : 文档已被禁用。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document is not completed."
-                    }
-                  },
-                  "not_found_4": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document is disabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/chunks/create-chunks",
-          "metadata": {
-            "title": "向文档添加分段",
-            "sidebarTitle": "向文档添加分段"
-          }
-        }
-      },
       "get": {
-        "tags": [
-          "分段"
-        ],
-        "summary": "从文档获取分段",
         "description": "返回文档内分段的分页列表，可按关键词或索引状态筛选。",
         "operationId": "listSegments",
         "parameters": [
           {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "page",
+            "description": "搜索关键词。",
             "in": "query",
+            "name": "keyword",
+            "required": false,
             "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            },
-            "description": "页码。"
+              "description": "搜索关键词。",
+              "type": "string"
+            }
           },
           {
+            "description": "每页的项目数量。服务器上限为 `100`。",
+            "in": "query",
             "name": "limit",
-            "in": "query",
+            "required": false,
             "schema": {
-              "type": "integer",
               "default": 20,
-              "minimum": 1
-            },
-            "description": "每页的项目数量。服务器上限为 `100`。"
+              "description": "每页的项目数量。服务器上限为 `100`。",
+              "minimum": 1,
+              "type": "integer"
+            }
           },
           {
-            "name": "status",
+            "description": "要获取的页码。",
             "in": "query",
+            "name": "page",
+            "required": false,
             "schema": {
-              "type": "array",
+              "default": 1,
+              "description": "要获取的页码。",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "按索引状态筛选分段，例如 `completed`、`indexing` 或 `error`。",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "按索引状态筛选分段，例如 `completed`、`indexing` 或 `error`。",
               "items": {
                 "type": "string"
-              }
-            },
-            "style": "form",
-            "explode": true,
-            "description": "按索引状态筛选分段，例如 `completed`、`indexing`、`error`。"
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            },
-            "description": "搜索关键词。"
+              },
+              "type": "array"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "分段列表。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Segment"
-                      },
-                      "description": "分段列表。"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "该文档使用的分块模式。"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "匹配的分段总数。"
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "下一页是否还有更多项目。"
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "每页条目数。"
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "当前页码。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/SegmentListResponse"
                 },
                 "examples": {
                   "success": {
@@ -7016,7 +6704,7 @@
                           "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
                           "position": 1,
                           "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                          "content": "Dify is an open-source LLM app development platform.",
+                          "content": "Dify 是一个开源的 LLM 应用开发平台。",
                           "sign_content": "",
                           "answer": "",
                           "word_count": 9,
@@ -7055,10 +6743,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "分段列表。"
           },
           "400": {
-            "description": "`provider_not_initialize` : 知识库使用高质量索引，但其嵌入模型缺失或配置有误。",
             "content": {
               "application/json": {
                 "examples": {
@@ -7072,15 +6760,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`provider_not_initialize`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -7089,10 +6794,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。",
             "content": {
               "application/json": {
                 "examples": {
@@ -7114,9 +6819,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。"
           }
         },
+        "summary": "从文档获取分段",
+        "tags": [
+          "分段"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/chunks/list-chunks",
           "metadata": {
@@ -7124,145 +6834,353 @@
             "sidebarTitle": "从文档获取分段"
           }
         }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}": {
-      "get": {
-        "tags": [
-          "分段"
-        ],
-        "summary": "获取文档中的分段详情",
-        "description": "获取单个分段的完整详情。",
-        "operationId": "getSegmentDetail",
+      },
+      "post": {
+        "description": "在文档中创建一个或多个分段。",
+        "operationId": "createSegments",
         "parameters": [
           {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。"
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SegmentCreatePayload"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
-            "description": "分段详情。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/Segment"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "该文档使用的分块模式。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/SegmentCreateListResponse"
                 },
                 "examples": {
                   "success": {
                     "summary": "响应示例",
                     "value": {
-                      "data": {
-                        "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                        "position": 1,
-                        "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "content": "Dify is an open-source LLM app development platform.",
-                        "sign_content": "",
-                        "answer": "",
-                        "word_count": 9,
-                        "tokens": 12,
-                        "keywords": [
-                          "dify",
-                          "platform",
-                          "llm"
-                        ],
-                        "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
-                        "index_node_hash": "abc123def456",
-                        "hit_count": 0,
-                        "enabled": true,
-                        "disabled_at": null,
-                        "disabled_by": null,
-                        "status": "completed",
-                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "created_at": 1741267200,
-                        "updated_at": 1741267200,
-                        "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
-                        "indexing_at": 1741267200,
-                        "completed_at": 1741267200,
-                        "error": null,
-                        "stopped_at": null,
-                        "child_chunks": [],
-                        "attachments": [],
-                        "summary": null
-                      },
+                      "data": [
+                        {
+                          "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                          "position": 1,
+                          "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                          "content": "Dify 是一个开源的 LLM 应用开发平台。",
+                          "sign_content": "",
+                          "answer": "",
+                          "word_count": 9,
+                          "tokens": 12,
+                          "keywords": [
+                            "dify",
+                            "platform",
+                            "llm"
+                          ],
+                          "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                          "index_node_hash": "abc123def456",
+                          "hit_count": 0,
+                          "enabled": true,
+                          "disabled_at": null,
+                          "disabled_by": null,
+                          "status": "completed",
+                          "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                          "created_at": 1741267200,
+                          "updated_at": 1741267200,
+                          "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                          "indexing_at": 1741267200,
+                          "completed_at": 1741267200,
+                          "error": null,
+                          "stopped_at": null,
+                          "child_chunks": [],
+                          "attachments": [],
+                          "summary": null
+                        }
+                      ],
                       "doc_form": "text_model"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "分段创建成功。"
           },
           "400": {
-            "description": "`invalid_param` : 知识库使用高质量索引，但其嵌入模型缺失或配置有误。",
             "content": {
               "application/json": {
                 "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  },
+                  "invalid_param_limit": {
+                    "summary": "invalid_param（分段数量限制）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                      "message": "Exceeded maximum segments limit of 1000."
+                    }
+                  },
+                  "validation_error": {
+                    "summary": "schema 校验（非标准请求体）",
+                    "value": {
+                      "error": "1 validation error for SegmentCreatePayload\nsegments.0.content\n  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param`：某个分段字段无效（例如 Q&A 模式的文档要求提供 `answer`），或分段数量超出单次请求上限。\n- 请求体 schema 校验失败（例如 `content` 为空）时返回非标准响应体 `{\"error\": \"<校验详情>\"}`，不含 `code` 或 `status` 字段。"
           },
-          "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
+          "401": {
             "content": {
               "application/json": {
                 "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
                       "message": "Dataset api access is not enabled."
                     }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（向量空间限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden（需要升级套餐）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+                    }
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。\n- `forbidden`：请升级到付费套餐以使用此功能。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。\n- `not_found` : 未找到分段。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document is not completed."
+                    }
+                  },
+                  "not_found_4": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document is disabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：文档尚未处理完成。\n- `not_found`：文档已被禁用。"
+          }
+        },
+        "summary": "向文档添加分段",
+        "tags": [
+          "分段"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/chunks/create-chunks",
+          "metadata": {
+            "title": "向文档添加分段",
+            "sidebarTitle": "向文档添加分段"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}": {
+      "delete": {
+        "description": "从文档中永久删除一个分段。",
+        "operationId": "deleteSegment",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "分段 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param_model_setting": {
+                    "summary": "invalid_param（模型设置）",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  },
+                  "invalid_param_deleting": {
+                    "summary": "invalid_param（正在删除）",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Segment is deleting."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `invalid_param`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param`：该分段正在被另一并发请求删除。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+          },
+          "404": {
             "content": {
               "application/json": {
                 "examples": {
@@ -7292,129 +7210,66 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。"
           }
         },
-        "x-mint": {
-          "href": "/zh/api-reference/chunks/get-chunk",
-          "metadata": {
-            "title": "获取文档中的分段详情",
-            "sidebarTitle": "获取文档中的分段详情"
-          }
-        }
-      },
-      "post": {
+        "summary": "删除文档中的分段",
         "tags": [
           "分段"
         ],
-        "summary": "更新文档中的分段",
-        "description": "更新分段的字段。更新会为该分段重新触发索引。",
-        "operationId": "updateSegment",
+        "x-mint": {
+          "href": "/zh/api-reference/chunks/delete-chunk",
+          "metadata": {
+            "title": "删除文档中的分段",
+            "sidebarTitle": "删除文档中的分段"
+          }
+        }
+      },
+      "get": {
+        "description": "获取单个分段的完整详情。",
+        "operationId": "getSegmentDetail",
         "parameters": [
           {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "segment_id",
+            "description": "分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
             "in": "path",
+            "name": "segment_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "segment"
-                ],
-                "properties": {
-                  "segment": {
-                    "type": "object",
-                    "properties": {
-                      "content": {
-                        "type": "string",
-                        "description": "分段文本内容。"
-                      },
-                      "answer": {
-                        "type": "string",
-                        "description": "问答模式（`qa_model`）文档的答案文本。"
-                      },
-                      "keywords": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "description": "分段的关键词。"
-                      },
-                      "enabled": {
-                        "type": "boolean",
-                        "description": "分段是否已启用。"
-                      },
-                      "regenerate_child_chunks": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "是否重新生成子分段。"
-                      },
-                      "attachment_ids": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "description": "附件文件 ID。"
-                      },
-                      "summary": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "摘要索引的摘要内容。"
-                      }
-                    },
-                    "description": "要更新的分段数据。"
-                  }
-                }
-              }
+              "description": "分段 ID。",
+              "format": "uuid",
+              "type": "string"
             }
           }
-        },
+        ],
         "responses": {
           "200": {
-            "description": "分段更新成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/Segment"
-                    },
-                    "doc_form": {
-                      "type": "string",
-                      "description": "该文档使用的分块模式。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/SegmentDetailResponse"
                 },
                 "examples": {
                   "success": {
@@ -7424,7 +7279,7 @@
                         "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
                         "position": 1,
                         "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
-                        "content": "Dify is an open-source LLM app development platform.",
+                        "content": "Dify 是一个开源的 LLM 应用开发平台。",
                         "sign_content": "",
                         "answer": "",
                         "word_count": 9,
@@ -7458,10 +7313,207 @@
                   }
                 }
               }
-            }
+            },
+            "description": "分段详情。"
           },
           "400": {
-            "description": "- `provider_not_initialize` : 知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param` : 分段正在索引中或已被禁用，无法更新，或索引配置无效。",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Segment not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。"
+          }
+        },
+        "summary": "获取文档中的分段详情",
+        "tags": [
+          "分段"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/chunks/get-chunk",
+          "metadata": {
+            "title": "获取文档中的分段详情",
+            "sidebarTitle": "获取文档中的分段详情"
+          }
+        }
+      },
+      "post": {
+        "description": "更新分段的字段。更新会为该分段重新触发索引。",
+        "operationId": "updateSegment",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "分段 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SegmentUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SegmentDetailResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "data": {
+                        "id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                        "position": 1,
+                        "document_id": "a8e0e5b5-78c6-4130-a5ce-25feb0e0b4ac",
+                        "content": "Dify 是一个开源的 LLM 应用开发平台。",
+                        "sign_content": "",
+                        "answer": "",
+                        "word_count": 9,
+                        "tokens": 12,
+                        "keywords": [
+                          "dify",
+                          "platform",
+                          "llm"
+                        ],
+                        "index_node_id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+                        "index_node_hash": "abc123def456",
+                        "hit_count": 0,
+                        "enabled": true,
+                        "disabled_at": null,
+                        "disabled_by": null,
+                        "status": "completed",
+                        "created_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "created_at": 1741267200,
+                        "updated_at": 1741267200,
+                        "updated_by": "ad313dd6-ef04-4dd1-a5b0-c0f0b9e2e7e4",
+                        "indexing_at": 1741267200,
+                        "completed_at": 1741267200,
+                        "error": null,
+                        "stopped_at": null,
+                        "child_chunks": [],
+                        "attachments": [],
+                        "summary": null
+                      },
+                      "doc_form": "text_model"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "分段更新成功。"
+          },
+          "400": {
             "content": {
               "application/json": {
                 "examples": {
@@ -7474,7 +7526,7 @@
                     }
                   },
                   "invalid_param_state": {
-                    "summary": "invalid_param (state)",
+                    "summary": "invalid_param（状态）",
                     "value": {
                       "status": 400,
                       "code": "invalid_param",
@@ -7483,15 +7535,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param`：分段正在索引中或已被禁用，无法更新，或索引配置无效。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -7499,7 +7568,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（向量空间限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -7507,7 +7576,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -7516,10 +7585,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。\n- `not_found` : 未找到分段。",
             "content": {
               "application/json": {
                 "examples": {
@@ -7549,26 +7618,14 @@
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。"
           }
         },
+        "summary": "更新文档中的分段",
+        "tags": [
+          "分段"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/chunks/update-chunk",
           "metadata": {
@@ -7576,459 +7633,87 @@
             "sidebarTitle": "更新文档中的分段"
           }
         }
-      },
-      "delete": {
-        "tags": [
-          "分段"
-        ],
-        "summary": "删除文档中的分段",
-        "description": "从文档中永久删除一个分段。",
-        "operationId": "deleteSegment",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "400": {
-            "description": "- `invalid_param` : 知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param` : 该分段正在被另一并发请求删除。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param_model_setting": {
-                    "summary": "invalid_param (model setting)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  },
-                  "invalid_param_deleting": {
-                    "summary": "invalid_param (deleting)",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Segment is deleting."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。\n- `not_found` : 未找到分段。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Segment not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/chunks/delete-chunk",
-          "metadata": {
-            "title": "删除文档中的分段",
-            "sidebarTitle": "删除文档中的分段"
-          }
-        }
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks": {
-      "post": {
-        "tags": [
-          "分段"
-        ],
-        "summary": "创建子分段",
-        "description": "在父分段下创建子分段。适用于使用父子（`hierarchical_model`）分块模式的文档。",
-        "operationId": "createChildChunk",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "content"
-                ],
-                "properties": {
-                  "content": {
-                    "type": "string",
-                    "description": "子分段文本内容。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "子分段创建成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/ChildChunk"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "data": {
-                        "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
-                        "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                        "content": "Dify is an open-source platform.",
-                        "position": 1,
-                        "word_count": 6,
-                        "type": "customized",
-                        "created_at": 1741267200,
-                        "updated_at": 1741267200
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "- `provider_not_initialize` : 知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param` : 在向量库中为子分段建立索引失败；错误信息中会携带底层向量库的报错。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "provider_not_initialize": {
-                    "summary": "provider_not_initialize",
-                    "value": {
-                      "status": 400,
-                      "code": "provider_not_initialize",
-                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
-                    }
-                  },
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Vector store operation failed: [Errno 111] Connection refused"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (vector space)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "The capacity of the vector space has reached the limit of your subscription."
-                    }
-                  },
-                  "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  },
-                  "forbidden_4": {
-                    "summary": "forbidden (upgrade plan)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。\n- `not_found` : 未找到分段。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found_1": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  },
-                  "not_found_2": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Document not found."
-                    }
-                  },
-                  "not_found_3": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Segment not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/chunks/create-child-chunk",
-          "metadata": {
-            "title": "创建子分段",
-            "sidebarTitle": "创建子分段"
-          }
-        }
-      },
       "get": {
-        "tags": [
-          "分段"
-        ],
-        "summary": "获取子分段",
         "description": "返回特定父分段下子分段的分页列表。",
         "operationId": "getChildChunks",
         "parameters": [
           {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。"
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
-            },
-            "description": "页码。"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "minimum": 1
-            },
-            "description": "每页的项目数量。服务器上限为 `100`。"
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
               "type": "string"
-            },
-            "description": "搜索关键词。"
+            }
+          },
+          {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "分段 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "搜索关键词。",
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "description": "搜索关键词。",
+              "type": "string"
+            }
+          },
+          {
+            "description": "每页的项目数量。服务器上限为 `100`。",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "每页的项目数量。服务器上限为 `100`。",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "要获取的页码。",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "要获取的页码。",
+              "minimum": 1,
+              "type": "integer"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "子分段列表。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ChildChunk"
-                      },
-                      "description": "子分段列表。"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "子分段总数。"
-                    },
-                    "total_pages": {
-                      "type": "integer",
-                      "description": "总页数。"
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "当前页码。"
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "description": "每页条目数。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ChildChunkListResponse"
                 },
                 "examples": {
                   "success": {
@@ -8038,7 +7723,7 @@
                         {
                           "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
                           "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                          "content": "Dify is an open-source platform.",
+                          "content": "Dify 是一个开源平台。",
                           "position": 1,
                           "word_count": 6,
                           "type": "customized",
@@ -8054,15 +7739,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "子分段列表。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8071,10 +7773,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。\n- `not_found` : 未找到分段。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8104,9 +7806,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。"
           }
         },
+        "summary": "获取子分段",
+        "tags": [
+          "分段"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/chunks/list-child-chunks",
           "metadata": {
@@ -8114,89 +7821,61 @@
             "sidebarTitle": "获取子分段"
           }
         }
-      }
-    },
-    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks/{child_chunk_id}": {
-      "patch": {
-        "tags": [
-          "分段"
-        ],
-        "summary": "更新子分段",
-        "description": "更新现有子分段的内容。",
-        "operationId": "updateChildChunk",
+      },
+      "post": {
+        "description": "在父分段下创建子分段。适用于使用父子（`hierarchical_model`）分块模式的文档。",
+        "operationId": "createChildChunk",
         "parameters": [
           {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
             "name": "dataset_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
             "name": "document_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
+            "description": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+            "in": "path",
             "name": "segment_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。"
-          },
-          {
-            "name": "child_chunk_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "子分段 ID。"
+              "description": "分段 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "content"
-                ],
-                "properties": {
-                  "content": {
-                    "type": "string",
-                    "description": "子分段文本内容。"
-                  }
-                }
+                "$ref": "#/components/schemas/ChildChunkCreatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "子分段更新成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/ChildChunk"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ChildChunkDetailResponse"
                 },
                 "examples": {
                   "success": {
@@ -8205,7 +7884,7 @@
                       "data": {
                         "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
                         "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
-                        "content": "Dify is an open-source platform.",
+                        "content": "Dify 是一个开源平台。",
                         "position": 1,
                         "word_count": 6,
                         "type": "customized",
@@ -8216,13 +7895,21 @@
                   }
                 }
               }
-            }
+            },
+            "description": "子分段创建成功。"
           },
           "400": {
-            "description": "`invalid_param` : 在向量库中重新索引子分段失败；错误信息中会携带底层向量库的报错。",
             "content": {
               "application/json": {
                 "examples": {
+                  "provider_not_initialize": {
+                    "summary": "provider_not_initialize",
+                    "value": {
+                      "status": 400,
+                      "code": "provider_not_initialize",
+                      "message": "No Embedding Model available. Please configure a valid provider in the Settings -> Model Provider."
+                    }
+                  },
                   "invalid_param": {
                     "summary": "invalid_param",
                     "value": {
@@ -8233,15 +7920,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `provider_not_initialize`：知识库使用高质量索引，但其嵌入模型缺失或配置有误。\n- `invalid_param`：在向量库中为子分段建立索引失败；错误信息中会携带底层向量库的报错。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 向量空间容量已达到您订阅套餐的上限。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8249,7 +7953,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (vector space)",
+                    "summary": "forbidden（向量空间限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8257,7 +7961,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8265,7 +7969,7 @@
                     }
                   },
                   "forbidden_4": {
-                    "summary": "forbidden (upgrade plan)",
+                    "summary": "forbidden（需要升级套餐）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8274,10 +7978,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。\n- `forbidden`：请升级到付费套餐以使用此功能。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。\n- `not_found` : 未找到分段。\n- `not_found` : 未找到子分段。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8304,100 +8008,81 @@
                       "code": "not_found",
                       "message": "Segment not found."
                     }
-                  },
-                  "not_found_4": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Child chunk not found."
-                    }
                   }
                 }
               }
-            }
-          },
-          "503": {
-            "description": "`service_unavailable` : 暂时无法确认向量空间用量，稍后重试即可。仅在 Dify Cloud Sandbox 套餐下出现。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "service_unavailable": {
-                    "summary": "service_unavailable",
-                    "value": {
-                      "status": 503,
-                      "code": "service_unavailable",
-                      "message": "Unable to verify vector space usage right now. Please try again later."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。"
           }
         },
-        "x-mint": {
-          "href": "/zh/api-reference/chunks/update-child-chunk",
-          "metadata": {
-            "title": "更新子分段",
-            "sidebarTitle": "更新子分段"
-          }
-        }
-      },
-      "delete": {
+        "summary": "创建子分段",
         "tags": [
           "分段"
         ],
-        "summary": "删除子分段",
+        "x-mint": {
+          "href": "/zh/api-reference/chunks/create-child-chunk",
+          "metadata": {
+            "title": "创建子分段",
+            "sidebarTitle": "创建子分段"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks/{child_chunk_id}": {
+      "delete": {
         "description": "从父分段中永久删除一个子分段。",
         "operationId": "deleteChildChunk",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "子分段 ID，来自[获取子分段](/zh/api-reference/chunks/list-child-chunks) 返回的 `data[].id`。",
             "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "document_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。"
-          },
-          {
-            "name": "segment_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。"
-          },
-          {
             "name": "child_chunk_id",
-            "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "子分段 ID。"
+              "description": "子分段 ID，来自[获取子分段](/zh/api-reference/chunks/list-child-chunks) 返回的 `data[].id`。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "分段 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
-            "description": "Success."
+            "description": "成功。"
           },
           "400": {
-            "description": "`invalid_param` : 从向量库中移除子分段索引失败；错误信息中会携带底层向量库的报错。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8411,15 +8096,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：从向量库中移除子分段索引失败；错误信息中会携带底层向量库的报错。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。\n- `forbidden` : To unlock this feature and elevate your Dify experience, please upgrade to a paid plan.",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8427,7 +8129,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8435,7 +8137,7 @@
                     }
                   },
                   "forbidden_3": {
-                    "summary": "forbidden (upgrade plan)",
+                    "summary": "forbidden（需要升级套餐）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -8444,10 +8146,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。\n- `forbidden`：请升级到付费套餐以使用此功能。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : 未找到文档。\n- `not_found` : 未找到分段。\n- `not_found` : 未找到子分段。",
             "content": {
               "application/json": {
                 "examples": {
@@ -8485,14 +8187,235 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。\n- `not_found`：未找到子分段。"
           }
         },
+        "summary": "删除子分段",
+        "tags": [
+          "分段"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/chunks/delete-child-chunk",
           "metadata": {
             "title": "删除子分段",
             "sidebarTitle": "删除子分段"
+          }
+        }
+      },
+      "patch": {
+        "description": "更新现有子分段的内容。",
+        "operationId": "updateChildChunk",
+        "parameters": [
+          {
+            "description": "子分段 ID，来自[获取子分段](/zh/api-reference/chunks/list-child-chunks) 返回的 `data[].id`。",
+            "in": "path",
+            "name": "child_chunk_id",
+            "required": true,
+            "schema": {
+              "description": "子分段 ID，来自[获取子分段](/zh/api-reference/chunks/list-child-chunks) 返回的 `data[].id`。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "文档 ID。从 [获取知识库的文档列表](/zh/api-reference/documents/list-documents) 获取。",
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "description": "文档 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "父分段 ID。来自 [从文档获取分段](/zh/api-reference/chunks/list-chunks)。",
+            "in": "path",
+            "name": "segment_id",
+            "required": true,
+            "schema": {
+              "description": "分段 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChildChunkUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChildChunkDetailResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "data": {
+                        "id": "d7e8f9a0-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+                        "segment_id": "f3d1c7be-9f3a-40d8-8eb8-3a1ef9c3f2c1",
+                        "content": "Dify 是一个开源平台。",
+                        "position": 1,
+                        "word_count": 6,
+                        "type": "customized",
+                        "created_at": 1741267200,
+                        "updated_at": 1741267200
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "子分段更新成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Vector store operation failed: [Errno 111] Connection refused"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：在向量库中重新索引子分段失败；错误信息中会携带底层向量库的报错。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（向量空间限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "The capacity of the vector space has reached the limit of your subscription."
+                    }
+                  },
+                  "forbidden_3": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  },
+                  "forbidden_4": {
+                    "summary": "forbidden（需要升级套餐）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "To unlock this feature and elevate your Dify experience, please upgrade to a paid plan."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：向量空间容量已达到您订阅套餐的上限。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。\n- `forbidden`：请升级到付费套餐以使用此功能。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found_1": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  },
+                  "not_found_2": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Document not found."
+                    }
+                  },
+                  "not_found_3": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Segment not found."
+                    }
+                  },
+                  "not_found_4": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Child chunk not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：未找到文档。\n- `not_found`：未找到分段。\n- `not_found`：未找到子分段。"
+          }
+        },
+        "summary": "更新子分段",
+        "tags": [
+          "分段"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/chunks/update-child-chunk",
+          "metadata": {
+            "title": "更新子分段",
+            "sidebarTitle": "更新子分段"
           }
         }
       }


### PR DESCRIPTION
## Summary

- generate chunk operations in the English, Chinese, and Japanese Service API references
- align chunk creation, update, deletion, retrieval, and child-chunk contracts
- leave metadata, tag, model, and pipeline operations for the next layer

## Validation

- three-locale structural parity — 0 issues