### PR TITLE
docs: generate knowledge management references

### DIFF
--- a/en/api-reference/openapi_service.json
+++ b/en/api-reference/openapi_service.json
@@ -3130,71 +3130,34 @@
     },
     "/datasets/pipeline/file-upload": {
       "post": {
-        "tags": [
-          "Knowledge Pipeline"
-        ],
-        "summary": "Upload Pipeline File",
         "description": "Uploads a file for use in a knowledge pipeline. Use the returned `id` as the `reference` of a `local_file` item in [Run Pipeline](/en/api-reference/knowledge-pipeline/run-pipeline).",
         "operationId": "uploadPipelineFile",
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
+                "properties": {
+                  "file": {
+                    "description": "The file to upload, as one `multipart/form-data` part. Document files are capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments).\n\nOn Dify Cloud, Professional and Team plans raise the document cap to 50 MB. Images, audio, and video follow their own limits: 10 MB, 50 MB, and 100 MB by default.",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
                 "required": [
                   "file"
                 ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "The file to upload, as one `multipart/form-data` part. Document files are capped at 15 MB by default.\n\nSelf-hosted deployments adjust the limit with the `UPLOAD_FILE_SIZE_LIMIT` [environment variable](/en/self-host/deploy/configuration/environments).\n\nOn Dify Cloud, Professional and Team plans raise the document cap to 50 MB. Images, audio, and video follow their own limits: 10 MB, 50 MB, and 100 MB by default."
-                  }
-                }
+                "type": "object"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
-            "description": "File uploaded successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Unique identifier of the uploaded file."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Original file name."
-                    },
-                    "size": {
-                      "type": "integer",
-                      "description": "File size in bytes."
-                    },
-                    "extension": {
-                      "type": "string",
-                      "description": "File extension."
-                    },
-                    "mime_type": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "MIME type of the file. May be `null` if the upload did not include one."
-                    },
-                    "created_by": {
-                      "type": "string",
-                      "description": "ID of the user who uploaded the file."
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Upload timestamp in ISO 8601 format. May be `null` while the record is being created."
-                    }
-                  }
+                  "$ref": "#/components/schemas/PipelineUploadFileResponse"
                 },
                 "examples": {
                   "success": {
@@ -3211,10 +3174,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "File uploaded successfully."
           },
           "400": {
-            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `too_many_files` : Only one file is allowed per request.",
             "content": {
               "application/json": {
                 "examples": {
@@ -3244,10 +3207,39 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `no_file_uploaded` : No file was provided in the request.\n- `filename_not_exists_error` : The uploaded file has no filename.\n- `too_many_files` : Only one file is allowed per request."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "forbidden",
+                  "message": "Forbidden.",
+                  "status": 403
+                }
+              }
+            },
+            "description": "Forbidden - dataset API access or workspace access denied"
           },
           "413": {
-            "description": "`file_too_large` : The file exceeds the upload size limit.",
             "content": {
               "application/json": {
                 "examples": {
@@ -3261,10 +3253,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`file_too_large` : The file exceeds the upload size limit."
           },
           "415": {
-            "description": "`unsupported_file_type` : The file type is not supported.",
             "content": {
               "application/json": {
                 "examples": {
@@ -3278,157 +3270,121 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`unsupported_file_type` : The file type is not supported."
           }
         },
-        "x-mint": {
-          "href": "/en/api-reference/knowledge-pipeline/upload-pipeline-file",
-          "metadata": {
-            "title": "Upload Pipeline File",
-            "sidebarTitle": "Upload Pipeline File"
-          }
-        },
+        "summary": "Upload Pipeline File",
+        "tags": [
+          "Knowledge Pipeline"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/en/api-reference/knowledge-pipeline/upload-pipeline-file",
+          "metadata": {
+            "title": "Upload Pipeline File",
+            "sidebarTitle": "Upload Pipeline File"
+          }
+        }
       }
     },
     "/datasets/tags": {
-      "post": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Create Knowledge Tag",
-        "description": "Create a tag for organizing knowledge bases.",
-        "operationId": "createKnowledgeTag",
+      "delete": {
+        "description": "Permanently delete a knowledge base tag. Does not delete the knowledge bases that were tagged.",
+        "operationId": "deleteKnowledgeTag",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "Tag name. Must be unique within the workspace."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Tag created successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Tag identifier."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Tag display name."
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "Tag type. Always `knowledge` for knowledge base tags."
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Number of knowledge bases bound to this tag."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
-                      "type": "knowledge",
-                      "binding_count": "0"
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/TagDeletePayload"
               }
             }
           },
-          "400": {
-            "description": "`invalid_param` : A knowledge tag with the same name already exists.",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "401": {
             "content": {
               "application/json": {
                 "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
+                  "unauthorized": {
+                    "summary": "unauthorized",
                     "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Tag name already exists"
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden` : Your workspace role does not permit editing these resources."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Tag not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : The specified tag does not exist."
           }
         },
+        "summary": "Delete Knowledge Tag",
+        "tags": [
+          "Tags"
+        ],
         "x-mint": {
-          "href": "/en/api-reference/tags/create-knowledge-tag",
+          "href": "/en/api-reference/tags/delete-knowledge-tag",
           "metadata": {
-            "title": "Create Knowledge Tag",
-            "sidebarTitle": "Create Knowledge Tag"
+            "title": "Delete Knowledge Tag",
+            "sidebarTitle": "Delete Knowledge Tag"
           }
         }
       },
       "get": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "List Knowledge Tags",
         "description": "Returns all knowledge base tags in the workspace.",
         "operationId": "getKnowledgeTags",
         "responses": {
           "200": {
-            "description": "List of tags.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "description": "Tag identifier."
-                      },
-                      "name": {
-                        "type": "string",
-                        "description": "Tag display name."
-                      },
-                      "type": {
-                        "type": "string",
-                        "description": "Tag type. Always `knowledge` for knowledge base tags."
-                      },
-                      "binding_count": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Number of knowledge bases bound to this tag."
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/KnowledgeTagListResponse"
                 },
                 "examples": {
                   "success": {
@@ -3444,9 +3400,43 @@
                   }
                 }
               }
-            }
+            },
+            "description": "List of tags."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "forbidden",
+                  "message": "Forbidden.",
+                  "status": 403
+                }
+              }
+            },
+            "description": "Forbidden - dataset API access or workspace access denied"
           }
         },
+        "summary": "List Knowledge Tags",
+        "tags": [
+          "Tags"
+        ],
         "x-mint": {
           "href": "/en/api-reference/tags/list-knowledge-tags",
           "metadata": {
@@ -3456,64 +3446,24 @@
         }
       },
       "patch": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Update Knowledge Tag",
         "description": "Rename a knowledge base tag.",
         "operationId": "updateKnowledgeTag",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id",
-                  "name"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "ID of the tag to rename. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags)."
-                  },
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "New name for the tag. Must be unique within the workspace."
-                  }
-                }
+                "$ref": "#/components/schemas/TagUpdatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Tag updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Tag identifier."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Tag display name."
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "Tag type. Always `knowledge` for knowledge base tags."
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Number of knowledge bases bound to this tag."
-                    }
-                  }
+                  "$ref": "#/components/schemas/KnowledgeTagResponse"
                 },
                 "examples": {
                   "success": {
@@ -3527,10 +3477,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Tag updated successfully."
           },
           "400": {
-            "description": "`invalid_param` : A knowledge tag with the same name already exists.",
             "content": {
               "application/json": {
                 "examples": {
@@ -3544,10 +3494,44 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param` : A knowledge tag with the same name already exists."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden` : Your workspace role does not permit editing these resources."
           },
           "404": {
-            "description": "`not_found` : The specified tag does not exist.",
             "content": {
               "application/json": {
                 "examples": {
@@ -3561,9 +3545,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : The specified tag does not exist."
           }
         },
+        "summary": "Update Knowledge Tag",
+        "tags": [
+          "Tags"
+        ],
         "x-mint": {
           "href": "/en/api-reference/tags/update-knowledge-tag",
           "metadata": {
@@ -3572,105 +3561,159 @@
           }
         }
       },
-      "delete": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Delete Knowledge Tag",
-        "description": "Permanently delete a knowledge base tag. Does not delete the knowledge bases that were tagged.",
-        "operationId": "deleteKnowledgeTag",
+      "post": {
+        "description": "Create a tag for organizing knowledge bases.",
+        "operationId": "createKnowledgeTag",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "ID of the tag to delete. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags)."
-                  }
-                }
+                "$ref": "#/components/schemas/TagCreatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : The specified tag does not exist.",
+          "200": {
             "content": {
               "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeTagResponse"
+                },
                 "examples": {
-                  "not_found": {
-                    "summary": "not_found",
+                  "success": {
+                    "summary": "Response Example",
                     "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Tag not found"
+                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                      "name": "Product Docs",
+                      "type": "knowledge",
+                      "binding_count": "0"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "Tag created successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Tag name already exists"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param` : A knowledge tag with the same name already exists."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden` : Your workspace role does not permit editing these resources."
           }
         },
+        "summary": "Create Knowledge Tag",
+        "tags": [
+          "Tags"
+        ],
         "x-mint": {
-          "href": "/en/api-reference/tags/delete-knowledge-tag",
+          "href": "/en/api-reference/tags/create-knowledge-tag",
           "metadata": {
-            "title": "Delete Knowledge Tag",
-            "sidebarTitle": "Delete Knowledge Tag"
+            "title": "Create Knowledge Tag",
+            "sidebarTitle": "Create Knowledge Tag"
           }
         }
       }
     },
     "/datasets/tags/binding": {
       "post": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Create Tag Binding",
         "description": "Bind one or more tags to a knowledge base. A knowledge base can have multiple tags.",
         "operationId": "bindTagsToDataset",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "tag_ids",
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "IDs of the tags to bind. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags). Unknown tag IDs are silently ignored."
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "Knowledge base to bind the tags to. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-                  }
-                }
+                "$ref": "#/components/schemas/TagBindingPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "204": {
             "description": "Success."
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden` : Your workspace role does not permit editing these resources."
+          },
           "404": {
-            "description": "`not_found` : The target knowledge base does not exist.",
             "content": {
               "application/json": {
                 "examples": {
@@ -3684,9 +3727,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : The target knowledge base does not exist."
           }
         },
+        "summary": "Create Tag Binding",
+        "tags": [
+          "Tags"
+        ],
         "x-mint": {
           "href": "/en/api-reference/tags/create-tag-binding",
           "metadata": {
@@ -3698,50 +3746,57 @@
     },
     "/datasets/tags/unbinding": {
       "post": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Delete Tag Binding",
         "description": "Remove one or more tags from a knowledge base.",
         "operationId": "unbindTagFromDataset",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "Tag IDs to unbind. Required unless the legacy `tag_id` is provided. See [List Knowledge Type Tags](/en/api-reference/tags/list-knowledge-tags)."
-                  },
-                  "tag_id": {
-                    "type": "string",
-                    "deprecated": true,
-                    "description": "Legacy single-tag form. Normalized into `tag_ids` server-side. Use `tag_ids` for new integrations."
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "Knowledge base to unbind the tags from. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-                  }
-                }
+                "$ref": "#/components/schemas/TagUnbindingPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "204": {
             "description": "Success."
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden` : Your workspace role does not permit editing these resources."
+          },
           "404": {
-            "description": "`not_found` : The target knowledge base does not exist.",
             "content": {
               "application/json": {
                 "examples": {
@@ -3755,9 +3810,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : The target knowledge base does not exist."
           }
         },
+        "summary": "Delete Tag Binding",
+        "tags": [
+          "Tags"
+        ],
         "x-mint": {
           "href": "/en/api-reference/tags/delete-tag-binding",
           "metadata": {
@@ -5373,98 +5433,37 @@
     },
     "/datasets/{dataset_id}/documents/metadata": {
       "post": {
-        "tags": [
-          "Metadata"
-        ],
-        "summary": "Update Document Metadata in Batch",
         "description": "Update metadata values for multiple documents in a single request.",
         "operationId": "batchUpdateDocumentMetadata",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "operation_data"
-                ],
-                "properties": {
-                  "operation_data": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "document_id",
-                        "metadata_list"
-                      ],
-                      "properties": {
-                        "document_id": {
-                          "type": "string",
-                          "description": "ID of the document to update. See [List Documents](/en/api-reference/documents/list-documents)."
-                        },
-                        "metadata_list": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "id",
-                              "name"
-                            ],
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "Metadata field ID. See [List Metadata Fields](/en/api-reference/metadata/list-metadata-fields)."
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "Metadata field name."
-                              },
-                              "value": {
-                                "description": "Metadata value. Can be a string, number, or `null`."
-                              }
-                            }
-                          },
-                          "description": "Metadata fields to set on the document."
-                        },
-                        "partial_update": {
-                          "type": "boolean",
-                          "default": false,
-                          "description": "Whether to partially update metadata, keeping existing values for unspecified fields."
-                        }
-                      }
-                    },
-                    "description": "Document metadata update operations, one entry per document."
-                  }
-                }
+                "$ref": "#/components/schemas/MetadataOperationData"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Document metadata updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "Operation result."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataActionResponse"
                 },
                 "examples": {
                   "success": {
@@ -5475,10 +5474,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Document metadata updated successfully."
           },
           "400": {
-            "description": "`invalid_param` : Another metadata operation is already running for a document in this request.",
             "content": {
               "application/json": {
                 "examples": {
@@ -5492,10 +5491,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param` : Another metadata operation is already running for a document in this request."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -5517,10 +5533,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
           },
           "404": {
-            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : A document referenced in `operation_data` does not exist in this knowledge base.\n- `not_found` : A metadata field referenced in `metadata_list` does not exist in this knowledge base.",
             "content": {
               "application/json": {
                 "examples": {
@@ -5550,9 +5566,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Knowledge base not found.\n- `not_found` : A document referenced in `operation_data` does not exist in this knowledge base.\n- `not_found` : A metadata field referenced in `metadata_list` does not exist in this knowledge base."
           }
         },
+        "summary": "Update Document Metadata in Batch",
+        "tags": [
+          "Metadata"
+        ],
         "x-mint": {
           "href": "/en/api-reference/metadata/update-document-metadata-in-batch",
           "metadata": {
@@ -9586,75 +9607,145 @@
       }
     },
     "/datasets/{dataset_id}/metadata": {
-      "post": {
+      "get": {
+        "description": "Returns all metadata fields for the knowledge base, both custom and built-in, with the count of documents using each field.",
+        "operationId": "listMetadataFields",
+        "parameters": [
+          {
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetMetadataListResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Response Example",
+                    "value": {
+                      "doc_metadata": [
+                        {
+                          "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+                          "name": "author",
+                          "type": "string",
+                          "count": 3
+                        }
+                      ],
+                      "built_in_field_enabled": true
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Metadata fields for the knowledge base."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Dataset not found."
+          }
+        },
+        "summary": "List Metadata Fields",
         "tags": [
           "Metadata"
         ],
-        "summary": "Create Metadata Field",
+        "x-mint": {
+          "href": "/en/api-reference/metadata/list-metadata-fields",
+          "metadata": {
+            "title": "List Metadata Fields",
+            "sidebarTitle": "List Metadata Fields"
+          }
+        }
+      },
+      "post": {
         "description": "Create a custom metadata field for annotating documents in the knowledge base with structured information.",
         "operationId": "createMetadataField",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "type",
-                  "name"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "string",
-                      "number",
-                      "time"
-                    ],
-                    "description": "`string` for text values, `number` for numeric values, `time` for date/time values."
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Name for the metadata field. Must be unique among the knowledge base's fields and at most 255 characters."
-                  }
-                }
+                "$ref": "#/components/schemas/MetadataArgs"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
-            "description": "Metadata field created successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Metadata field identifier."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Metadata field name."
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "Metadata field type."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataResponse"
                 },
                 "examples": {
                   "success": {
@@ -9667,10 +9758,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Metadata field created successfully."
           },
           "400": {
-            "description": "`invalid_param` : The metadata name already exists, exceeds 255 characters, or conflicts with a built-in field.",
             "content": {
               "application/json": {
                 "examples": {
@@ -9684,10 +9775,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param` : The metadata name already exists, exceeds 255 characters, or conflicts with a built-in field."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -9709,10 +9817,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
           },
           "404": {
-            "description": "`not_found` : Dataset not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -9726,9 +9834,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Dataset not found."
           }
         },
+        "summary": "Create Metadata Field",
+        "tags": [
+          "Metadata"
+        ],
         "x-mint": {
           "href": "/en/api-reference/metadata/create-metadata-field",
           "metadata": {
@@ -9736,174 +9849,31 @@
             "sidebarTitle": "Create Metadata Field"
           }
         }
-      },
-      "get": {
-        "tags": [
-          "Metadata"
-        ],
-        "summary": "List Metadata Fields",
-        "description": "Returns all metadata fields for the knowledge base, both custom and built-in, with the count of documents using each field.",
-        "operationId": "listMetadataFields",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Metadata fields for the knowledge base.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "doc_metadata": {
-                      "type": "array",
-                      "description": "List of metadata field definitions.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "Metadata field identifier."
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "Metadata field name."
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "Metadata field type."
-                          },
-                          "count": {
-                            "type": "integer",
-                            "description": "Number of documents using this metadata field."
-                          }
-                        }
-                      }
-                    },
-                    "built_in_field_enabled": {
-                      "type": "boolean",
-                      "description": "Whether built-in metadata fields are enabled for this knowledge base."
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Response Example",
-                    "value": {
-                      "doc_metadata": [
-                        {
-                          "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
-                          "name": "author",
-                          "type": "string",
-                          "count": 3
-                        }
-                      ],
-                      "built_in_field_enabled": true
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "`forbidden` : Dataset api access is not enabled.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Dataset not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/metadata/list-metadata-fields",
-          "metadata": {
-            "title": "List Metadata Fields",
-            "sidebarTitle": "List Metadata Fields"
-          }
-        }
       }
     },
     "/datasets/{dataset_id}/metadata/built-in": {
       "get": {
-        "tags": [
-          "Metadata"
-        ],
-        "summary": "Get Built-in Metadata Fields",
         "description": "Returns the built-in metadata fields provided by the system.",
         "operationId": "getBuiltInMetadataFields",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Built-in metadata fields.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "fields": {
-                      "type": "array",
-                      "description": "List of system-provided metadata fields.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "Built-in field identifier. `document_name` for the document title, `uploader` for the creator, `upload_date` for creation time, `last_update_date` for last modification time, `source` for the document origin."
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "Field data type. `string` for text values, `time` for date/time values."
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataBuiltInFieldsResponse"
                 },
                 "examples": {
                   "success": {
@@ -9935,10 +9905,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Built-in metadata fields."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : Dataset api access is not enabled.",
             "content": {
               "application/json": {
                 "examples": {
@@ -9952,26 +9939,14 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Dataset not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled."
           }
         },
+        "summary": "Get Built-in Metadata Fields",
+        "tags": [
+          "Metadata"
+        ],
         "x-mint": {
           "href": "/en/api-reference/metadata/get-built-in-metadata-fields",
           "metadata": {
@@ -9983,50 +9958,41 @@
     },
     "/datasets/{dataset_id}/metadata/built-in/{action}": {
       "post": {
-        "tags": [
-          "Metadata"
-        ],
-        "summary": "Update Built-in Metadata Field",
         "description": "Enable or disable built-in metadata fields for the knowledge base.",
         "operationId": "toggleBuiltInMetadataField",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "`enable` to activate built-in metadata fields, `disable` to deactivate them.",
             "in": "path",
+            "name": "action",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "`enable` to activate built-in metadata fields, `disable` to deactivate them.",
+              "enum": [
+                "disable",
+                "enable"
+              ],
+              "type": "string"
+            }
           },
           {
-            "name": "action",
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            },
-            "description": "`enable` to activate built-in metadata fields, `disable` to deactivate them."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Built-in metadata field toggled successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "Operation result."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataActionResponse"
                 },
                 "examples": {
                   "success": {
@@ -10037,10 +10003,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Built-in metadata field toggled successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10062,10 +10045,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
           },
           "404": {
-            "description": "`not_found` : Dataset not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10079,9 +10062,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Dataset not found."
           }
         },
+        "summary": "Update Built-in Metadata Field",
+        "tags": [
+          "Metadata"
+        ],
         "x-mint": {
           "href": "/en/api-reference/metadata/update-built-in-metadata-field",
           "metadata": {
@@ -10092,75 +10080,152 @@
       }
     },
     "/datasets/{dataset_id}/metadata/{metadata_id}": {
-      "patch": {
+      "delete": {
+        "description": "Permanently delete a custom metadata field. Documents that used the field lose their values for it.",
+        "operationId": "deleteMetadataField",
+        "parameters": [
+          {
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ID of the metadata field to delete. See [List Metadata Fields](/en/api-reference/metadata/list-metadata-fields).",
+            "in": "path",
+            "name": "metadata_id",
+            "required": true,
+            "schema": {
+              "description": "Metadata field ID.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden (api access)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden (rate limit)",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found` : Dataset not found."
+          }
+        },
+        "summary": "Delete Metadata Field",
         "tags": [
           "Metadata"
         ],
-        "summary": "Update Metadata Field",
+        "x-mint": {
+          "href": "/en/api-reference/metadata/delete-metadata-field",
+          "metadata": {
+            "title": "Delete Metadata Field",
+            "sidebarTitle": "Delete Metadata Field"
+          }
+        }
+      },
+      "patch": {
         "description": "Rename a custom metadata field.",
         "operationId": "updateMetadataField",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "metadata_id",
+            "description": "ID of the metadata field to rename. See [List Metadata Fields](/en/api-reference/metadata/list-metadata-fields).",
             "in": "path",
+            "name": "metadata_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ID of the metadata field to rename. See [List Metadata Fields](/en/api-reference/metadata/list-metadata-fields)."
+              "description": "Metadata field ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "New name for the field. Must be unique among the knowledge base's fields and at most 255 characters."
-                  }
-                }
+                "$ref": "#/components/schemas/MetadataUpdatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Metadata field updated successfully.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Metadata field identifier."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Metadata field name."
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "Metadata field type."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataResponse"
                 },
                 "examples": {
                   "success": {
@@ -10173,10 +10238,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Metadata field updated successfully."
           },
           "400": {
-            "description": "`invalid_param` : The metadata name already exists, exceeds 255 characters, or conflicts with a built-in field.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10190,10 +10255,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param` : The metadata name already exists, exceeds 255 characters, or conflicts with a built-in field."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10215,10 +10297,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription."
           },
           "404": {
-            "description": "`not_found` : Dataset not found.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10232,9 +10314,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : Dataset not found."
           }
         },
+        "summary": "Update Metadata Field",
+        "tags": [
+          "Metadata"
+        ],
         "x-mint": {
           "href": "/en/api-reference/metadata/update-metadata-field",
           "metadata": {
@@ -10242,186 +10329,42 @@
             "sidebarTitle": "Update Metadata Field"
           }
         }
-      },
-      "delete": {
-        "tags": [
-          "Metadata"
-        ],
-        "summary": "Delete Metadata Field",
-        "description": "Permanently delete a custom metadata field. Documents that used the field lose their values for it.",
-        "operationId": "deleteMetadataField",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
-          },
-          {
-            "name": "metadata_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ID of the metadata field to delete. See [List Metadata Fields](/en/api-reference/metadata/list-metadata-fields)."
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "403": {
-            "description": "- `forbidden` : Dataset api access is not enabled.\n- `forbidden` : Sorry, you have reached the knowledge base request rate limit of your subscription.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Dataset not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/en/api-reference/metadata/delete-metadata-field",
-          "metadata": {
-            "title": "Delete Metadata Field",
-            "sidebarTitle": "Delete Metadata Field"
-          }
-        }
       }
     },
     "/datasets/{dataset_id}/pipeline/datasource-plugins": {
       "get": {
-        "tags": [
-          "Knowledge Pipeline"
-        ],
-        "summary": "List Datasource Plugins",
         "description": "Returns the datasource nodes configured in the knowledge pipeline, each with the plugin it uses and the metadata needed to run it.",
         "operationId": "listDatasourcePlugins",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "is_published",
+            "description": "Whether to retrieve nodes from the published or draft pipeline. `true` returns nodes from the published version, `false` returns nodes from the draft.",
             "in": "query",
+            "name": "is_published",
+            "required": false,
             "schema": {
-              "type": "boolean",
-              "default": true
-            },
-            "description": "Whether to read nodes from the published pipeline version rather than the draft."
+              "default": true,
+              "description": "Whether to retrieve nodes from the published or draft pipeline. `true` returns nodes from the published version, `false` returns nodes from the draft.",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "List of datasource nodes configured in the pipeline.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "node_id": {
-                        "type": "string",
-                        "description": "ID of the datasource node in the pipeline workflow. Pass this as `node_id` to [Run Datasource Node](/en/api-reference/knowledge-pipeline/run-datasource-node), or as `start_node_id` to [Run Pipeline](/en/api-reference/knowledge-pipeline/run-pipeline)."
-                      },
-                      "plugin_id": {
-                        "type": "string",
-                        "description": "ID of the datasource plugin providing this node."
-                      },
-                      "provider_name": {
-                        "type": "string",
-                        "description": "Provider name registered by the datasource plugin."
-                      },
-                      "datasource_type": {
-                        "type": "string",
-                        "description": "Type of datasource. One of `local_file`, `online_document`, `online_drive`, `website_crawl`."
-                      },
-                      "title": {
-                        "type": "string",
-                        "description": "Display title configured for the node."
-                      },
-                      "user_input_variables": {
-                        "type": "array",
-                        "description": "Pipeline input variables the caller must supply for this datasource, derived from `{{#...#}}` references in the node's datasource parameters. Each item follows the pipeline variable schema used by the workflow.",
-                        "items": {
-                          "type": "object",
-                          "additionalProperties": true
-                        }
-                      },
-                      "credentials": {
-                        "type": "array",
-                        "description": "Credentials available for authenticating with this datasource.",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "Credential ID. Pass this as `credential_id` to [Run Datasource Node](/en/api-reference/knowledge-pipeline/run-datasource-node) or in per-item `credential_id` fields of [Run Pipeline](/en/api-reference/knowledge-pipeline/run-pipeline)."
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "Display name of the credential."
-                            },
-                            "type": {
-                              "type": "string",
-                              "description": "Credential type defined by the datasource plugin."
-                            },
-                            "is_default": {
-                              "type": "boolean",
-                              "description": "Whether this credential is the default for the provider."
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasourcePluginListResponse"
                 },
                 "examples": {
                   "success": {
@@ -10447,10 +10390,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "List of datasource nodes configured in the pipeline."
           },
           "400": {
-            "description": "`invalid_param` : The knowledge base has no processing pipeline configured.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10464,10 +10407,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param` : The knowledge base has no processing pipeline configured."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : API access is not enabled for this knowledge base.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10481,10 +10441,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : API access is not enabled for this knowledge base."
           },
           "404": {
-            "description": "`not_found` : No knowledge base matches `dataset_id`.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10498,9 +10458,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : No knowledge base matches `dataset_id`."
           }
         },
+        "summary": "List Datasource Plugins",
+        "tags": [
+          "Knowledge Pipeline"
+        ],
         "x-mint": {
           "href": "/en/api-reference/knowledge-pipeline/list-datasource-plugins",
           "metadata": {
@@ -10512,88 +10477,60 @@
     },
     "/datasets/{dataset_id}/pipeline/datasource/nodes/{node_id}/run": {
       "post": {
-        "tags": [
-          "Knowledge Pipeline"
-        ],
-        "summary": "Run Datasource Node",
         "description": "Runs a single datasource node in the knowledge pipeline and streams its execution events.",
         "operationId": "runDatasourceNode",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "node_id",
+            "description": "ID of the datasource node to run, from [List Datasource Plugins](/en/api-reference/knowledge-pipeline/list-datasource-plugins).",
             "in": "path",
+            "name": "node_id",
             "required": true,
             "schema": {
+              "description": "ID of the datasource node to execute.",
               "type": "string"
-            },
-            "description": "ID of the datasource node to run, from [List Datasource Plugins](/en/api-reference/knowledge-pipeline/list-datasource-plugins)."
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "inputs",
-                  "datasource_type",
-                  "is_published"
-                ],
-                "properties": {
-                  "inputs": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "Input variables for the datasource node."
-                  },
-                  "datasource_type": {
-                    "type": "string",
-                    "enum": [
-                      "online_document",
-                      "local_file",
-                      "website_crawl",
-                      "online_drive"
-                    ],
-                    "description": "Type of the datasource."
-                  },
-                  "credential_id": {
-                    "type": "string",
-                    "nullable": true,
-                    "description": "ID of the credential to authenticate with the datasource, from the `credentials` array of [List Datasource Plugins](/en/api-reference/knowledge-pipeline/list-datasource-plugins)."
-                  },
-                  "is_published": {
-                    "type": "boolean",
-                    "description": "Whether to run the published version of the node instead of the draft."
-                  }
-                }
+                "$ref": "#/components/schemas/DatasourceNodeRunPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Streaming response with node execution events.",
             "content": {
               "text/event-stream": {
                 "schema": {
                   "type": "string",
-                  "description": "Server-Sent Events stream of node execution progress and results. See [SSE Streaming](/en/api-reference/guides/streaming) for parsing."
+                  "description": "A Server-Sent Events stream of the draft pipeline run. Parse `data:` records using the [SSE Streaming guide](/en/api-reference/guides/streaming). Common events include `workflow_started`, `node_started`, `node_finished`, `workflow_finished`, and `error`; event payloads use the same workflow envelope documented for workflow streams."
+                },
+                "examples": {
+                  "successfulStream": {
+                    "summary": "Response example - successful stream",
+                    "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"Datasource\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+                  }
                 }
               }
-            }
+            },
+            "description": "Streaming response with node execution events."
           },
           "400": {
-            "description": "`invalid_param` : The knowledge base has no processing pipeline configured, or the request body failed validation.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10607,10 +10544,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param` : The knowledge base has no processing pipeline configured, or the request body failed validation."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : API access is not enabled for this knowledge base.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10624,10 +10578,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : API access is not enabled for this knowledge base."
           },
           "404": {
-            "description": "`not_found` : No knowledge base matches `dataset_id`.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10641,9 +10595,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : No knowledge base matches `dataset_id`."
           }
         },
+        "summary": "Run Datasource Node",
+        "tags": [
+          "Knowledge Pipeline"
+        ],
         "x-mint": {
           "href": "/en/api-reference/knowledge-pipeline/run-datasource-node",
           "metadata": {
@@ -10655,183 +10614,26 @@
     },
     "/datasets/{dataset_id}/pipeline/run": {
       "post": {
-        "tags": [
-          "Knowledge Pipeline"
-        ],
-        "summary": "Run Pipeline",
-        "description": "Runs the full knowledge pipeline over one or more datasources. `response_mode` selects a streaming or blocking response.",
+        "description": "Runs the full knowledge pipeline over one or more datasources. Published runs are queued and always return batch metadata as JSON. Draft runs support blocking JSON and streaming Server-Sent Events. For a published run, pass the returned `batch` to [Get Document Indexing Status](/en/api-reference/documents/get-document-indexing-status) and poll until every document reaches `completed`, `error`, or `paused`.",
         "operationId": "runPipeline",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID, from [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "inputs",
-                  "datasource_type",
-                  "datasource_info_list",
-                  "start_node_id",
-                  "is_published",
-                  "response_mode"
-                ],
-                "properties": {
-                  "inputs": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "Key-value pairs for pipeline input variables defined in the workflow. Pass `{}` if the pipeline has no input variables."
-                  },
-                  "datasource_type": {
-                    "type": "string",
-                    "enum": [
-                      "local_file",
-                      "online_document",
-                      "website_crawl",
-                      "online_drive"
-                    ],
-                    "description": "Type of the datasource. Determines which fields are expected in `datasource_info_list` items."
-                  },
-                  "datasource_info_list": {
-                    "type": "array",
-                    "description": "List of datasource objects to process. The expected item structure depends on `datasource_type`.",
-                    "items": {
-                      "oneOf": [
-                        {
-                          "title": "Local File",
-                          "type": "object",
-                          "required": [
-                            "reference"
-                          ],
-                          "properties": {
-                            "reference": {
-                              "type": "string",
-                              "description": "Use the `id` returned by the [Upload Pipeline File](/en/api-reference/knowledge-pipeline/upload-pipeline-file) endpoint. `related_id` is accepted as an alias."
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "Document title. Defaults to `\"untitled\"`."
-                            }
-                          }
-                        },
-                        {
-                          "title": "Online Document",
-                          "type": "object",
-                          "required": [
-                            "workspace_id",
-                            "page"
-                          ],
-                          "properties": {
-                            "workspace_id": {
-                              "type": "string",
-                              "description": "ID of the workspace or database in the external platform (e.g., a Notion workspace ID)."
-                            },
-                            "page": {
-                              "type": "object",
-                              "description": "Page details.",
-                              "required": [
-                                "page_id",
-                                "type"
-                              ],
-                              "properties": {
-                                "page_id": {
-                                  "type": "string",
-                                  "description": "Page identifier."
-                                },
-                                "type": {
-                                  "type": "string",
-                                  "description": "Page type defined by the datasource plugin (e.g., `\"page\"`, `\"database\"`)."
-                                },
-                                "page_name": {
-                                  "type": "string",
-                                  "description": "Display name. Defaults to `\"untitled\"`."
-                                }
-                              }
-                            },
-                            "credential_id": {
-                              "type": "string",
-                              "description": "Credential for authenticating with the external platform. Managed via the Dify console. If omitted, the provider's default credential is used."
-                            }
-                          }
-                        },
-                        {
-                          "title": "Website Crawl",
-                          "type": "object",
-                          "required": [
-                            "url"
-                          ],
-                          "properties": {
-                            "url": {
-                              "type": "string",
-                              "description": "URL to crawl."
-                            },
-                            "title": {
-                              "type": "string",
-                              "description": "Used as the document name. Defaults to `\"untitled\"`."
-                            }
-                          }
-                        },
-                        {
-                          "title": "Online Drive",
-                          "type": "object",
-                          "required": [
-                            "id",
-                            "type"
-                          ],
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "File or folder ID."
-                            },
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "file",
-                                "folder"
-                              ],
-                              "description": "Whether this entry is a single file or a folder to expand."
-                            },
-                            "bucket": {
-                              "type": "string",
-                              "description": "Storage bucket name. Required by some drive providers (e.g., S3-compatible stores); omit if the provider does not use buckets."
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "File name. Defaults to `\"untitled\"`."
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "start_node_id": {
-                    "type": "string",
-                    "description": "ID of the node to start execution from, from [List Datasource Plugins](/en/api-reference/knowledge-pipeline/list-datasource-plugins)."
-                  },
-                  "is_published": {
-                    "type": "boolean",
-                    "description": "Whether to run the published version of the pipeline instead of the current draft. Run the draft to test unpublished changes."
-                  },
-                  "response_mode": {
-                    "type": "string",
-                    "enum": [
-                      "streaming",
-                      "blocking"
-                    ],
-                    "description": "Response mode for the pipeline execution. `streaming` returns a Server-Sent Events stream, `blocking` waits and returns the complete result."
-                  }
-                }
+                "$ref": "#/components/schemas/PipelineRunApiEntity"
               },
               "examples": {
                 "local_file": {
@@ -10846,7 +10648,7 @@
                       }
                     ],
                     "start_node_id": "1719288585006",
-                    "is_published": true,
+                    "is_published": false,
                     "response_mode": "blocking"
                   }
                 },
@@ -10867,7 +10669,7 @@
                       }
                     ],
                     "start_node_id": "1719288585006",
-                    "is_published": true,
+                    "is_published": false,
                     "response_mode": "streaming"
                   }
                 },
@@ -10907,27 +10709,47 @@
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Pipeline execution result. Format depends on `response_mode`: streaming returns a `text/event-stream`, blocking returns a JSON object.",
             "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "Server-Sent Events stream. Returned when `response_mode` is `streaming`; see [SSE Streaming](/en/api-reference/guides/streaming) for the wire format.\n\nKey events:\n\n- `workflow_started`: execution began\n- `node_started` / `node_finished`: per-node progress with `node_id`, `node_type`, `status`, `inputs`, `outputs`\n- `workflow_finished`: final result with `status`, `outputs`, `total_tokens`, `elapsed_time`\n- `ping`: keepalive"
-                }
-              },
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "description": "Complete pipeline execution result. Returned when `response_mode` is `blocking`.",
-                  "additionalProperties": true
+                  "$ref": "#/components/schemas/PipelineRunJsonResponse",
+                  "description": "JSON result for a published run, or for a draft run in `blocking` mode."
                 },
                 "examples": {
-                  "success": {
-                    "summary": "Blocking Response Example",
+                  "published": {
+                    "summary": "Published Pipeline Response",
+                    "value": {
+                      "batch": "20260825143015948271",
+                      "dataset": {
+                        "id": "c9f5e6f0-d10a-4f57-a1d8-a4b63f8459f4",
+                        "name": "Product docs",
+                        "description": "Product documentation",
+                        "chunk_structure": "text_model"
+                      },
+                      "documents": [
+                        {
+                          "id": "9af03c49-30c4-4d64-a605-17f3171fbf9a",
+                          "position": 1,
+                          "data_source_type": "local_file",
+                          "data_source_info": {
+                            "reference": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "quarterly-report.pdf"
+                          },
+                          "name": "quarterly-report.pdf",
+                          "indexing_status": "waiting",
+                          "error": null,
+                          "enabled": true
+                        }
+                      ]
+                    }
+                  },
+                  "draft_blocking": {
+                    "summary": "Draft Blocking Response",
                     "value": {
                       "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
                       "workflow_run_id": "f1e2d3c4-b5a6-7890-abcd-ef0987654321",
@@ -10936,16 +10758,33 @@
                         "status": "succeeded",
                         "outputs": {},
                         "created_at": 1741267200,
-                        "finished_at": 1741267210
+                        "finished_at": 1741267210,
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "error": null,
+                        "elapsed_time": 10.0,
+                        "total_tokens": 0,
+                        "total_steps": 1
                       }
                     }
                   }
                 }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "A Server-Sent Events stream of the draft pipeline run. Parse `data:` records using the [SSE Streaming guide](/en/api-reference/guides/streaming). Common events include `workflow_started`, `node_started`, `node_finished`, `workflow_finished`, and `error`; event payloads use the same workflow envelope documented for workflow streams."
+                },
+                "examples": {
+                  "successfulStream": {
+                    "summary": "Response example - successful stream",
+                    "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"Datasource\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+                  }
+                }
               }
-            }
+            },
+            "description": "Pipeline execution result. Published runs return queued batch metadata as JSON. Draft runs return Server-Sent Events in `streaming` mode or a workflow result as JSON in `blocking` mode."
           },
           "400": {
-            "description": "`invalid_param` : The knowledge base has no processing pipeline configured, or the request body failed validation.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10959,10 +10798,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param` : The knowledge base has no processing pipeline configured, or the request body failed validation."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : API access is not enabled for this knowledge base.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10976,10 +10832,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden` : API access is not enabled for this knowledge base."
           },
           "404": {
-            "description": "`not_found` : No knowledge base matches `dataset_id`.",
             "content": {
               "application/json": {
                 "examples": {
@@ -10993,10 +10849,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found` : No knowledge base matches `dataset_id`."
           },
           "500": {
-            "description": "`pipeline_run_error` : Pipeline execution failed.",
             "content": {
               "application/json": {
                 "examples": {
@@ -11010,9 +10866,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`pipeline_run_error` : Pipeline execution failed."
           }
         },
+        "summary": "Run Pipeline",
+        "tags": [
+          "Knowledge Pipeline"
+        ],
         "x-mint": {
           "href": "/en/api-reference/knowledge-pipeline/run-pipeline",
           "metadata": {
@@ -11263,54 +11124,27 @@
     },
     "/datasets/{dataset_id}/tags": {
       "get": {
-        "tags": [
-          "Tags"
-        ],
-        "summary": "Get Knowledge Base Tags",
         "description": "Returns the tags bound to a knowledge base.",
         "operationId": "queryDatasetTags",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases).",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Knowledge base ID. See [List Knowledge Bases](/en/api-reference/knowledge-bases/list-knowledge-bases)."
+              "description": "Knowledge base ID.",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Tags bound to the knowledge base.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of tags bound to this knowledge base.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "Tag identifier."
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "Tag display name."
-                          }
-                        }
-                      }
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "Total number of tags bound to this knowledge base."
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetBoundTagListResponse"
                 },
                 "examples": {
                   "success": {
@@ -11327,10 +11161,27 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Tags bound to the knowledge base."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           },
           "403": {
-            "description": "`forbidden` : Dataset api access is not enabled.",
             "content": {
               "application/json": {
                 "examples": {
@@ -11344,26 +11195,14 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : Dataset not found.",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden` : Dataset api access is not enabled."
           }
         },
+        "summary": "Get Knowledge Base Tags",
+        "tags": [
+          "Tags"
+        ],
         "x-mint": {
           "href": "/en/api-reference/tags/get-knowledge-base-tags",
           "metadata": {
@@ -14465,164 +14304,34 @@
     },
     "/workspaces/current/models/model-types/{model_type}": {
       "get": {
-        "tags": [
-          "Models"
-        ],
-        "summary": "Get Available Models",
         "description": "Returns the available models of a given type. Use it to find the `text-embedding` and `rerank` models to configure on a knowledge base.",
         "operationId": "getAvailableModels",
         "parameters": [
           {
-            "name": "model_type",
+            "description": "Type of model to retrieve.",
             "in": "path",
+            "name": "model_type",
             "required": true,
             "schema": {
-              "type": "string",
+              "description": "Type of model to retrieve.",
               "enum": [
-                "text-embedding",
-                "rerank",
                 "llm",
-                "tts",
+                "moderation",
+                "rerank",
                 "speech2text",
-                "moderation"
-              ]
-            },
-            "description": "Type of model to retrieve. For knowledge base configuration, use `text-embedding` for embedding models or `rerank` for reranking models."
+                "text-embedding",
+                "tts"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Available models for the specified type.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of model providers with their available models.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "provider": {
-                            "type": "string",
-                            "description": "Model provider identifier, formatted as `organization/plugin_name/provider_name` (e.g. `langgenius/openai/openai`). Legacy providers may return the bare short form (e.g. `openai`)."
-                          },
-                          "label": {
-                            "type": "object",
-                            "description": "Localized display name of the provider.",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "English display name."
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "Chinese display name."
-                              }
-                            }
-                          },
-                          "icon_small": {
-                            "type": "object",
-                            "description": "URL of the provider's small icon.",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "Small icon URL."
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "Chinese icon URL."
-                              }
-                            }
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "Provider status. `active` when credentials are configured and valid."
-                          },
-                          "models": {
-                            "type": "array",
-                            "description": "List of available models from this provider.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "model": {
-                                  "type": "string",
-                                  "description": "Model identifier. Use this as the `embedding_model` value when creating or updating a knowledge base."
-                                },
-                                "label": {
-                                  "type": "object",
-                                  "description": "Localized display name of the model.",
-                                  "properties": {
-                                    "en_US": {
-                                      "type": "string",
-                                      "description": "English model name."
-                                    },
-                                    "zh_Hans": {
-                                      "type": "string",
-                                      "description": "Chinese model name."
-                                    }
-                                  }
-                                },
-                                "model_type": {
-                                  "type": "string",
-                                  "description": "Type of the model, matching the `model_type` path parameter."
-                                },
-                                "features": {
-                                  "type": "array",
-                                  "nullable": true,
-                                  "description": "Supported features of the model, `null` if none.",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "fetch_from": {
-                                  "type": "string",
-                                  "description": "Where the model definition comes from. `predefined-model` for built-in models, `customizable-model` for user-configured models."
-                                },
-                                "model_properties": {
-                                  "type": "object",
-                                  "description": "Model-specific properties such as `context_size`."
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "description": "Model availability status. `active` when ready to use."
-                                },
-                                "deprecated": {
-                                  "type": "boolean",
-                                  "description": "Whether the model is deprecated."
-                                },
-                                "load_balancing_enabled": {
-                                  "type": "boolean",
-                                  "description": "Whether load balancing is enabled for the model."
-                                },
-                                "has_invalid_load_balancing_configs": {
-                                  "type": "boolean",
-                                  "description": "Whether the model has invalid load-balancing configurations."
-                                }
-                              }
-                            }
-                          },
-                          "tenant_id": {
-                            "type": "string",
-                            "description": "Workspace ID the provider configuration belongs to."
-                          },
-                          "icon_small_dark": {
-                            "type": "object",
-                            "description": "Dark-mode icon URLs; `null` when the provider has none.",
-                            "properties": {
-                              "en_US": {
-                                "type": "string"
-                              },
-                              "zh_Hans": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/ProviderWithModelsListResponse"
                 },
                 "examples": {
                   "success": {
@@ -14667,9 +14376,31 @@
                   }
                 }
               }
-            }
+            },
+            "description": "Available models for the specified type."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized` : The `Authorization` header is missing, malformed, or contains an invalid API key."
           }
         },
+        "summary": "Get Available Models",
+        "tags": [
+          "Models"
+        ],
         "x-mint": {
           "href": "/en/api-reference/models/get-available-models",
           "metadata": {

--- a/ja/api-reference/openapi_service.json
+++ b/ja/api-reference/openapi_service.json
@@ -3130,71 +3130,34 @@
     },
     "/datasets/pipeline/file-upload": {
       "post": {
-        "tags": [
-          "ナレッジパイプライン"
-        ],
-        "summary": "パイプラインファイルをアップロード",
         "description": "ナレッジパイプラインで使用するファイルをアップロードします。返された `id` を [パイプラインを実行](/ja/api-reference/knowledge-pipeline/run-pipeline) の `local_file` アイテムの `reference` として使用します。",
-        "operationId": "uploadPipelineFileJa",
+        "operationId": "uploadPipelineFile",
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
+                "properties": {
+                  "file": {
+                    "description": "アップロードするファイル。`multipart/form-data` の 1 パートとして送信します。ドキュメントファイルのデフォルト上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。\n\nDify Cloud の Professional と Team プランではドキュメントの上限が 50 MB になります。画像・音声・動画ファイルには別の上限があり、デフォルトはそれぞれ 10 MB、50 MB、100 MB です。",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
                 "required": [
                   "file"
                 ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "アップロードするファイル。`multipart/form-data` の 1 パートとして送信します。ドキュメントファイルのデフォルト上限は 15 MB です。\n\nセルフホスト環境では `UPLOAD_FILE_SIZE_LIMIT` [環境変数](/ja/self-host/deploy/configuration/environments) で調整できます。\n\nDify Cloud の Professional と Team プランではドキュメントの上限が 50 MB になります。画像・音声・動画ファイルには別の上限があり、デフォルトはそれぞれ 10 MB、50 MB、100 MB です。"
-                  }
-                }
+                "type": "object"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
-            "description": "ファイルが正常にアップロードされました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "アップロードされたファイルの一意識別子です。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "元のファイル名です。"
-                    },
-                    "size": {
-                      "type": "integer",
-                      "description": "ファイルサイズ（バイト）。"
-                    },
-                    "extension": {
-                      "type": "string",
-                      "description": "ファイル拡張子。"
-                    },
-                    "mime_type": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "ファイルの MIME タイプです。アップロードに MIME タイプが含まれない場合、`null` となることがあります。"
-                    },
-                    "created_by": {
-                      "type": "string",
-                      "description": "ファイルをアップロードしたユーザーの ID。"
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "アップロードのタイムスタンプ（ISO 8601 形式）です。レコード作成中は `null` となることがあります。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/PipelineUploadFileResponse"
                 },
                 "examples": {
                   "success": {
@@ -3211,10 +3174,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ファイルが正常にアップロードされました。"
           },
           "400": {
-            "description": "- `no_file_uploaded` : リクエストにファイルが提供されていません。\n- `filename_not_exists_error` : アップロードされたファイルにファイル名がありません。\n- `too_many_files` : 1 回のリクエストにつき 1 ファイルのみ許可されています。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3244,10 +3207,39 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `no_file_uploaded`：リクエストにファイルが提供されていません。\n- `filename_not_exists_error`：アップロードされたファイルにファイル名がありません。\n- `too_many_files`：1 回のリクエストにつき 1 ファイルのみ許可されています。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "forbidden",
+                  "message": "Forbidden.",
+                  "status": 403
+                }
+              }
+            },
+            "description": "アクセス禁止 — ナレッジベース API またはワークスペースへのアクセス権がありません"
           },
           "413": {
-            "description": "`file_too_large` : ファイルサイズの上限を超えています。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3261,10 +3253,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`file_too_large`：ファイルサイズの上限を超えています。"
           },
           "415": {
-            "description": "`unsupported_file_type` : 許可されていないファイルタイプです。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3278,157 +3270,121 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`unsupported_file_type`：許可されていないファイルタイプです。"
           }
         },
-        "x-mint": {
-          "href": "/ja/api-reference/knowledge-pipeline/upload-pipeline-file",
-          "metadata": {
-            "title": "パイプラインファイルをアップロード",
-            "sidebarTitle": "パイプラインファイルをアップロード"
-          }
-        },
+        "summary": "パイプラインファイルをアップロード",
+        "tags": [
+          "ナレッジパイプライン"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/knowledge-pipeline/upload-pipeline-file",
+          "metadata": {
+            "title": "パイプラインファイルをアップロード",
+            "sidebarTitle": "パイプラインファイルをアップロード"
+          }
+        }
       }
     },
     "/datasets/tags": {
-      "post": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "ナレッジベースタグを作成",
-        "description": "ナレッジベースを整理するためのタグを作成します。",
-        "operationId": "createKnowledgeTag",
+      "delete": {
+        "description": "ナレッジベースタグを完全に削除します。タグ付けされたナレッジベース自体は削除されません。",
+        "operationId": "deleteKnowledgeTag",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "タグ名です。ワークスペース内で一意である必要があります。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "タグが正常に作成されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "タグ識別子です。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "タグの表示名です。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "このタグにバインドされたナレッジベースの数です。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
-                      "type": "knowledge",
-                      "binding_count": "0"
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/TagDeletePayload"
               }
             }
           },
-          "400": {
-            "description": "`invalid_param` : 同じ名前のナレッジタグが既に存在します。",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "成功。"
+          },
+          "401": {
             "content": {
               "application/json": {
                 "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
+                  "unauthorized": {
+                    "summary": "unauthorized",
                     "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Tag name already exists"
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden`：ワークスペースでこれらのリソースを編集する権限がありません。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Tag not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：指定されたタグが存在しません。"
           }
         },
+        "summary": "ナレッジベースタグを削除",
+        "tags": [
+          "タグ管理"
+        ],
         "x-mint": {
-          "href": "/ja/api-reference/tags/create-knowledge-tag",
+          "href": "/ja/api-reference/tags/delete-knowledge-tag",
           "metadata": {
-            "title": "ナレッジベースタグを作成",
-            "sidebarTitle": "ナレッジベースタグを作成"
+            "title": "ナレッジベースタグを削除",
+            "sidebarTitle": "ナレッジベースタグを削除"
           }
         }
       },
       "get": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "ナレッジベースタグリストを取得",
         "description": "ワークスペース内のすべてのナレッジベースタグを返します。",
         "operationId": "getKnowledgeTags",
         "responses": {
           "200": {
-            "description": "タグのリストです。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "description": "タグ識別子です。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "description": "タグの表示名です。"
-                      },
-                      "type": {
-                        "type": "string",
-                        "description": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
-                      },
-                      "binding_count": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "このタグにバインドされたナレッジベースの数です。"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/KnowledgeTagListResponse"
                 },
                 "examples": {
                   "success": {
@@ -3436,7 +3392,7 @@
                     "value": [
                       {
                         "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                        "name": "Product Docs",
+                        "name": "製品ドキュメント",
                         "type": "knowledge",
                         "binding_count": "0"
                       }
@@ -3444,9 +3400,43 @@
                   }
                 }
               }
-            }
+            },
+            "description": "タグのリストです。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "forbidden",
+                  "message": "Forbidden.",
+                  "status": 403
+                }
+              }
+            },
+            "description": "アクセス禁止 — ナレッジベース API またはワークスペースへのアクセス権がありません"
           }
         },
+        "summary": "ナレッジベースタグリストを取得",
+        "tags": [
+          "タグ管理"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/tags/list-knowledge-tags",
           "metadata": {
@@ -3456,81 +3446,41 @@
         }
       },
       "patch": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "ナレッジベースタグを変更",
         "description": "ナレッジベースタグの名前を変更します。",
         "operationId": "updateKnowledgeTag",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id",
-                  "name"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "名前を変更するタグの ID です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。"
-                  },
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "タグの新しい名前です。ワークスペース内で一意である必要があります。"
-                  }
-                }
+                "$ref": "#/components/schemas/TagUpdatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "タグが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "タグ識別子です。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "タグの表示名です。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "タグタイプです。ナレッジベースタグの場合は常に `knowledge` です。"
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "このタグにバインドされたナレッジベースの数です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/KnowledgeTagResponse"
                 },
                 "examples": {
                   "success": {
                     "summary": "レスポンス例",
                     "value": {
                       "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
+                      "name": "製品ドキュメント",
                       "type": "knowledge",
                       "binding_count": "0"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "タグが正常に更新されました。"
           },
           "400": {
-            "description": "`invalid_param` : 同じ名前のナレッジタグが既に存在します。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3544,10 +3494,44 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：同じ名前のナレッジタグが既に存在します。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden`：ワークスペースでこれらのリソースを編集する権限がありません。"
           },
           "404": {
-            "description": "`not_found` : 指定されたタグが存在しません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3561,9 +3545,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：指定されたタグが存在しません。"
           }
         },
+        "summary": "ナレッジベースタグを変更",
+        "tags": [
+          "タグ管理"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/tags/update-knowledge-tag",
           "metadata": {
@@ -3572,105 +3561,159 @@
           }
         }
       },
-      "delete": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "ナレッジベースタグを削除",
-        "description": "ナレッジベースタグを完全に削除します。タグ付けされたナレッジベース自体は削除されません。",
-        "operationId": "deleteKnowledgeTag",
+      "post": {
+        "description": "ナレッジベースを整理するためのタグを作成します。",
+        "operationId": "createKnowledgeTag",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "削除するタグの ID です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。"
-                  }
-                }
+                "$ref": "#/components/schemas/TagCreatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : 指定されたタグが存在しません。",
+          "200": {
             "content": {
               "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeTagResponse"
+                },
                 "examples": {
-                  "not_found": {
-                    "summary": "not_found",
+                  "success": {
+                    "summary": "レスポンス例",
                     "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Tag not found"
+                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                      "name": "製品ドキュメント",
+                      "type": "knowledge",
+                      "binding_count": "0"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "タグが正常に作成されました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Tag name already exists"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：同じ名前のナレッジタグが既に存在します。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden`：ワークスペースでこれらのリソースを編集する権限がありません。"
           }
         },
+        "summary": "ナレッジベースタグを作成",
+        "tags": [
+          "タグ管理"
+        ],
         "x-mint": {
-          "href": "/ja/api-reference/tags/delete-knowledge-tag",
+          "href": "/ja/api-reference/tags/create-knowledge-tag",
           "metadata": {
-            "title": "ナレッジベースタグを削除",
-            "sidebarTitle": "ナレッジベースタグを削除"
+            "title": "ナレッジベースタグを作成",
+            "sidebarTitle": "ナレッジベースタグを作成"
           }
         }
       }
     },
     "/datasets/tags/binding": {
       "post": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "タグをナレッジベースにバインド",
         "description": "ナレッジベースに 1 つ以上のタグをバインドします。ナレッジベースには複数のタグを設定できます。",
         "operationId": "bindTagsToDataset",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "tag_ids",
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "バインドするタグの ID です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。 不明なタグ ID はエラーにならず無視されます。"
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "タグをバインドするナレッジベースです。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
-                  }
-                }
+                "$ref": "#/components/schemas/TagBindingPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "204": {
-            "description": "Success."
+            "description": "成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden`：ワークスペースでこれらのリソースを編集する権限がありません。"
           },
           "404": {
-            "description": "`not_found` : 対象のナレッジベースが存在しません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3684,9 +3727,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：対象のナレッジベースが存在しません。"
           }
         },
+        "summary": "タグをナレッジベースにバインド",
+        "tags": [
+          "タグ管理"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/tags/create-tag-binding",
           "metadata": {
@@ -3698,50 +3746,57 @@
     },
     "/datasets/tags/unbinding": {
       "post": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "タグとナレッジベースのバインドを解除",
         "description": "ナレッジベースから 1 つまたは複数のタグを削除します。",
         "operationId": "unbindTagFromDataset",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "バインド解除するタグ ID のリストです。旧版の `tag_id` を指定しない限り必須です。[ナレッジベースタグリストを取得](/ja/api-reference/tags/list-knowledge-tags) を参照してください。"
-                  },
-                  "tag_id": {
-                    "type": "string",
-                    "deprecated": true,
-                    "description": "旧版の単一タグ用フィールドです。サーバーサイドで `tag_ids` に正規化されます。新規連携では `tag_ids` を使用してください。"
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "タグのバインドを解除するナレッジベースです。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
-                  }
-                }
+                "$ref": "#/components/schemas/TagUnbindingPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "204": {
-            "description": "Success."
+            "description": "成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden`：ワークスペースでこれらのリソースを編集する権限がありません。"
           },
           "404": {
-            "description": "`not_found` : 対象のナレッジベースが存在しません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3755,9 +3810,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：対象のナレッジベースが存在しません。"
           }
         },
+        "summary": "タグとナレッジベースのバインドを解除",
+        "tags": [
+          "タグ管理"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/tags/delete-tag-binding",
           "metadata": {
@@ -5373,98 +5433,37 @@
     },
     "/datasets/{dataset_id}/documents/metadata": {
       "post": {
-        "tags": [
-          "メタデータ"
-        ],
-        "summary": "ドキュメントメタデータを一括更新",
         "description": "複数のドキュメントのメタデータ値を 1 回のリクエストで更新します。",
-        "operationId": "batchUpdateDocumentMetadataJa",
+        "operationId": "batchUpdateDocumentMetadata",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "operation_data"
-                ],
-                "properties": {
-                  "operation_data": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "document_id",
-                        "metadata_list"
-                      ],
-                      "properties": {
-                        "document_id": {
-                          "type": "string",
-                          "description": "更新するドキュメントの ID です。[ナレッジベースのドキュメントリストを取得](/ja/api-reference/documents/list-documents) を参照してください。"
-                        },
-                        "metadata_list": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "id",
-                              "name"
-                            ],
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "メタデータフィールド ID です。[メタデータフィールドリストを取得](/ja/api-reference/metadata/list-metadata-fields) を参照してください。"
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "メタデータフィールド名です。"
-                              },
-                              "value": {
-                                "description": "メタデータ値。文字列、数値、または `null` を指定できます。"
-                              }
-                            }
-                          },
-                          "description": "ドキュメントに設定するメタデータフィールドです。"
-                        },
-                        "partial_update": {
-                          "type": "boolean",
-                          "default": false,
-                          "description": "メタデータを部分的に更新し、未指定フィールドの既存の値を保持するかどうかです。"
-                        }
-                      }
-                    },
-                    "description": "ドキュメントメタデータの更新操作です。ドキュメントごとに 1 エントリです。"
-                  }
-                }
+                "$ref": "#/components/schemas/MetadataOperationData"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "ドキュメントメタデータが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作結果です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataActionResponse"
                 },
                 "examples": {
                   "success": {
@@ -5475,10 +5474,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ドキュメントメタデータが正常に更新されました。"
           },
           "400": {
-            "description": "`invalid_param` : このリクエスト内のドキュメントで別のメタデータ操作が実行中です。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5492,15 +5491,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：このリクエスト内のドキュメントで別のメタデータ操作が実行中です。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5508,7 +5524,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5517,15 +5533,15 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "- `not_found` : ナレッジベースが見つかりません。\n- `not_found` : `operation_data` で参照されたドキュメントがこのナレッジベースに存在しません。\n- `not_found` : `metadata_list` で参照されたメタデータフィールドがこのナレッジベースに存在しません。",
             "content": {
               "application/json": {
                 "examples": {
                   "not_found_1": {
-                    "summary": "not_found (knowledge base)",
+                    "summary": "not_found（ナレッジベース）",
                     "value": {
                       "status": 404,
                       "code": "not_found",
@@ -5550,9 +5566,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。\n- `not_found`：`operation_data` で参照されたドキュメントがこのナレッジベースに存在しません。\n- `not_found`：`metadata_list` で参照されたメタデータフィールドがこのナレッジベースに存在しません。"
           }
         },
+        "summary": "ドキュメントメタデータを一括更新",
+        "tags": [
+          "メタデータ"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/metadata/update-document-metadata-in-batch",
           "metadata": {
@@ -9586,214 +9607,28 @@
       }
     },
     "/datasets/{dataset_id}/metadata": {
-      "post": {
-        "tags": [
-          "メタデータ"
-        ],
-        "summary": "メタデータフィールドを作成",
-        "description": "ナレッジベース内のドキュメントを構造化情報でアノテーションするための、カスタムメタデータフィールドを作成します。",
-        "operationId": "createMetadataFieldJa",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "type",
-                  "name"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "string",
-                      "number",
-                      "time"
-                    ],
-                    "description": "`string` はテキスト値、`number` は数値、`time` は日付/時刻値です。"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "メタデータフィールドの名前です。ナレッジベースのフィールド内で一意であり、255 文字以内である必要があります。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "メタデータフィールドが正常に作成されました。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "メタデータフィールドの識別子です。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "メタデータフィールド名です。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "メタデータフィールドの種類です。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "レスポンス例",
-                    "value": {
-                      "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
-                      "name": "author",
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : メタデータ名が既に存在する、255 文字を超えている、または組み込みフィールドと競合しています。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Metadata name already exists."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/metadata/create-metadata-field",
-          "metadata": {
-            "title": "メタデータフィールドを作成",
-            "sidebarTitle": "メタデータフィールドを作成"
-          }
-        }
-      },
       "get": {
-        "tags": [
-          "メタデータ"
-        ],
-        "summary": "メタデータフィールドリストを取得",
         "description": "ナレッジベースのすべてのメタデータフィールド（カスタムと組み込みの両方）を、各フィールドを使用しているドキュメント数とともに返します。",
-        "operationId": "listMetadataFieldsJa",
+        "operationId": "listMetadataFields",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "ナレッジベースのメタデータフィールドです。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "doc_metadata": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "メタデータフィールドの識別子です。"
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "メタデータフィールド名です。"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "メタデータフィールドの種類です。"
-                          },
-                          "count": {
-                            "type": "integer",
-                            "description": "このメタデータフィールドを使用しているドキュメント数です。"
-                          }
-                        }
-                      },
-                      "description": "メタデータフィールド定義のリスト。"
-                    },
-                    "built_in_field_enabled": {
-                      "type": "boolean",
-                      "description": "このナレッジベースで組み込みメタデータフィールドが有効かどうかです。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataListResponse"
                 },
                 "examples": {
                   "success": {
@@ -9812,15 +9647,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ナレッジベースのメタデータフィールドです。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -9829,10 +9681,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           },
           "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -9846,9 +9698,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。"
           }
         },
+        "summary": "メタデータフィールドリストを取得",
+        "tags": [
+          "メタデータ"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/metadata/list-metadata-fields",
           "metadata": {
@@ -9856,54 +9713,167 @@
             "sidebarTitle": "メタデータフィールドリストを取得"
           }
         }
+      },
+      "post": {
+        "description": "ナレッジベース内のドキュメントを構造化情報でアノテーションするための、カスタムメタデータフィールドを作成します。",
+        "operationId": "createMetadataField",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetMetadataResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "レスポンス例",
+                    "value": {
+                      "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+                      "name": "author",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "メタデータフィールドが正常に作成されました。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Metadata name already exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：メタデータ名が既に存在する、255 文字を超えている、または組み込みフィールドと競合しています。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。"
+          }
+        },
+        "summary": "メタデータフィールドを作成",
+        "tags": [
+          "メタデータ"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/metadata/create-metadata-field",
+          "metadata": {
+            "title": "メタデータフィールドを作成",
+            "sidebarTitle": "メタデータフィールドを作成"
+          }
+        }
       }
     },
     "/datasets/{dataset_id}/metadata/built-in": {
       "get": {
-        "tags": [
-          "メタデータ"
-        ],
-        "summary": "組み込みメタデータフィールドを取得",
         "description": "システムが提供する組み込みメタデータフィールドを返します。",
-        "operationId": "getBuiltInMetadataFieldsJa",
+        "operationId": "getBuiltInMetadataFields",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "組み込みメタデータフィールドです。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "fields": {
-                      "type": "array",
-                      "description": "システム提供のメタデータフィールドのリストです。",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "組み込みフィールド識別子です。`document_name` はドキュメントタイトル、`uploader` は作成者、`upload_date` は作成日時、`last_update_date` は最終更新日時、`source` はドキュメントの出典を示します。"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "フィールドのデータ型です。テキスト値の場合は `string`、日時値の場合は `time` です。"
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataBuiltInFieldsResponse"
                 },
                 "examples": {
                   "success": {
@@ -9935,15 +9905,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "組み込みメタデータフィールドです。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -9952,26 +9939,14 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           }
         },
+        "summary": "組み込みメタデータフィールドを取得",
+        "tags": [
+          "メタデータ"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/metadata/get-built-in-metadata-fields",
           "metadata": {
@@ -9983,50 +9958,41 @@
     },
     "/datasets/{dataset_id}/metadata/built-in/{action}": {
       "post": {
-        "tags": [
-          "メタデータ"
-        ],
-        "summary": "組み込みメタデータフィールドを更新",
         "description": "ナレッジベースの組み込みメタデータフィールドを有効または無効にします。",
-        "operationId": "toggleBuiltInMetadataFieldJa",
+        "operationId": "toggleBuiltInMetadataField",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "`enable` で内蔵メタデータフィールドを有効化、`disable` で無効化します。",
             "in": "path",
+            "name": "action",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+              "description": "`enable` で内蔵メタデータフィールドを有効化、`disable` で無効化します。",
+              "enum": [
+                "disable",
+                "enable"
+              ],
+              "type": "string"
+            }
           },
           {
-            "name": "action",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            },
-            "description": "`enable` で内蔵メタデータフィールドを有効化、`disable` で無効化します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "組み込みメタデータフィールドの切り替えに成功しました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作結果です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataActionResponse"
                 },
                 "examples": {
                   "success": {
@@ -10037,15 +10003,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "組み込みメタデータフィールドの切り替えに成功しました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10053,7 +10036,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10062,10 +10045,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10079,9 +10062,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。"
           }
         },
+        "summary": "組み込みメタデータフィールドを更新",
+        "tags": [
+          "メタデータ"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/metadata/update-built-in-metadata-field",
           "metadata": {
@@ -10092,75 +10080,152 @@
       }
     },
     "/datasets/{dataset_id}/metadata/{metadata_id}": {
-      "patch": {
-        "tags": [
-          "メタデータ"
-        ],
-        "summary": "メタデータフィールドを更新",
-        "description": "カスタムメタデータフィールドの名前を変更します。",
-        "operationId": "updateMetadataFieldJa",
+      "delete": {
+        "description": "カスタムメタデータフィールドを完全に削除します。このフィールドを使用していたドキュメントは、それに対応する値を失います。",
+        "operationId": "deleteMetadataField",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "metadata_id",
+            "description": "削除するメタデータフィールドの ID です。[メタデータフィールドリストを取得](/ja/api-reference/metadata/list-metadata-fields) を参照してください。",
             "in": "path",
+            "name": "metadata_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "名前を変更するメタデータフィールドの ID です。[メタデータフィールドリストを取得](/ja/api-reference/metadata/list-metadata-fields) を参照してください。"
+              "description": "メタデータフィールド ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "フィールドの新しい名前です。ナレッジベースのフィールド内で一意であり、255 文字以内である必要があります。"
+        "responses": {
+          "204": {
+            "description": "成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
                   }
                 }
               }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API アクセス）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（レート制限）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。"
+          }
+        },
+        "summary": "メタデータフィールドを削除",
+        "tags": [
+          "メタデータ"
+        ],
+        "x-mint": {
+          "href": "/ja/api-reference/metadata/delete-metadata-field",
+          "metadata": {
+            "title": "メタデータフィールドを削除",
+            "sidebarTitle": "メタデータフィールドを削除"
+          }
+        }
+      },
+      "patch": {
+        "description": "カスタムメタデータフィールドの名前を変更します。",
+        "operationId": "updateMetadataField",
+        "parameters": [
+          {
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "名前を変更するメタデータフィールドの ID です。[メタデータフィールドリストを取得](/ja/api-reference/metadata/list-metadata-fields) を参照してください。",
+            "in": "path",
+            "name": "metadata_id",
+            "required": true,
+            "schema": {
+              "description": "メタデータフィールド ID。",
+              "format": "uuid",
+              "type": "string"
             }
           }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataUpdatePayload"
+              }
+            }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "メタデータフィールドが正常に更新されました。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "メタデータフィールドの識別子です。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "メタデータフィールド名です。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "メタデータフィールドの種類です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataResponse"
                 },
                 "examples": {
                   "success": {
@@ -10173,10 +10238,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "メタデータフィールドが正常に更新されました。"
           },
           "400": {
-            "description": "`invalid_param` : メタデータ名が既に存在する、255 文字を超えている、または組み込みフィールドと競合しています。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10190,15 +10255,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：メタデータ名が既に存在する、255 文字を超えている、または組み込みフィールドと競合しています。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10206,7 +10288,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（レート制限）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10215,10 +10297,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden`：サブスクリプションのナレッジベースリクエストのレート制限に達しました。"
           },
           "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10232,9 +10314,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：ナレッジベースが見つかりません。"
           }
         },
+        "summary": "メタデータフィールドを更新",
+        "tags": [
+          "メタデータ"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/metadata/update-metadata-field",
           "metadata": {
@@ -10242,186 +10329,42 @@
             "sidebarTitle": "メタデータフィールドを更新"
           }
         }
-      },
-      "delete": {
-        "tags": [
-          "メタデータ"
-        ],
-        "summary": "メタデータフィールドを削除",
-        "description": "カスタムメタデータフィールドを完全に削除します。このフィールドを使用していたドキュメントは、それに対応する値を失います。",
-        "operationId": "deleteMetadataFieldJa",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
-          },
-          {
-            "name": "metadata_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "削除するメタデータフィールドの ID です。[メタデータフィールドリストを取得](/ja/api-reference/metadata/list-metadata-fields) を参照してください。"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "403": {
-            "description": "- `forbidden` : このナレッジベースでは API アクセスが有効になっていません。\n- `forbidden` : サブスクリプションのナレッジベースリクエストのレート制限に達しました。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/ja/api-reference/metadata/delete-metadata-field",
-          "metadata": {
-            "title": "メタデータフィールドを削除",
-            "sidebarTitle": "メタデータフィールドを削除"
-          }
-        }
       }
     },
     "/datasets/{dataset_id}/pipeline/datasource-plugins": {
       "get": {
-        "tags": [
-          "ナレッジパイプライン"
-        ],
-        "summary": "データソースプラグインリストを取得",
         "description": "ナレッジパイプラインに設定されたデータソースノードを、それぞれが使用するプラグインとノードの実行に必要なメタデータとともに返します。",
-        "operationId": "listDatasourcePluginsJa",
+        "operationId": "listDatasourcePlugins",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "is_published",
+            "description": "公開済みまたはドラフトのナレッジパイプラインからノードを取得するかどうか。`true` は公開済みバージョン、`false` はドラフトのノードを返します。",
             "in": "query",
+            "name": "is_published",
+            "required": false,
             "schema": {
-              "type": "boolean",
-              "default": true
-            },
-            "description": "ドラフトではなく公開済みパイプラインバージョンからノードを読み取るかどうかを指定します。"
+              "default": true,
+              "description": "公開済みまたはドラフトのナレッジパイプラインからノードを取得するかどうか。`true` は公開済みバージョン、`false` はドラフトのノードを返します。",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "パイプラインに設定されているデータソースノードのリストです。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "node_id": {
-                        "type": "string",
-                        "description": "パイプラインワークフロー内のデータソースノードの ID です。 [データソースノードを実行](/ja/api-reference/knowledge-pipeline/run-datasource-node) では `node_id` として、 [パイプラインを実行](/ja/api-reference/knowledge-pipeline/run-pipeline) では `start_node_id` として渡します。"
-                      },
-                      "plugin_id": {
-                        "type": "string",
-                        "description": "このノードを提供するデータソースプラグインの ID です。"
-                      },
-                      "provider_name": {
-                        "type": "string",
-                        "description": "データソースプラグインが登録するプロバイダー名です。"
-                      },
-                      "datasource_type": {
-                        "type": "string",
-                        "description": "データソースのタイプです。`local_file`、`online_document`、`online_drive`、`website_crawl` のいずれかです。"
-                      },
-                      "title": {
-                        "type": "string",
-                        "description": "ノードに設定されている表示タイトルです。"
-                      },
-                      "user_input_variables": {
-                        "type": "array",
-                        "description": "このデータソースに対して呼び出し元が指定するパイプライン入力変数です。ノードのデータソースパラメータ内の `{{#...#}}` 参照から導出されます。各要素はワークフローが使用するパイプライン変数のスキーマに従います。",
-                        "items": {
-                          "type": "object",
-                          "additionalProperties": true
-                        }
-                      },
-                      "credentials": {
-                        "type": "array",
-                        "description": "このデータソースの認証に利用できる資格情報のリストです。",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "資格情報の ID です。 [データソースノードを実行](/ja/api-reference/knowledge-pipeline/run-datasource-node) では `credential_id` として、 [パイプラインを実行](/ja/api-reference/knowledge-pipeline/run-pipeline) の各データソース項目の `credential_id` フィールドとして渡します。"
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "資格情報の表示名です。"
-                            },
-                            "type": {
-                              "type": "string",
-                              "description": "データソースプラグインが定義する資格情報のタイプです。"
-                            },
-                            "is_default": {
-                              "type": "boolean",
-                              "description": "この資格情報がプロバイダーのデフォルトかどうかを示します。"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasourcePluginListResponse"
                 },
                 "examples": {
                   "success": {
@@ -10432,12 +10375,12 @@
                         "plugin_id": "langgenius/notion_datasource",
                         "provider_name": "notion",
                         "datasource_type": "online_document",
-                        "title": "Notion Documents",
+                        "title": "Notion ドキュメント",
                         "user_input_variables": [],
                         "credentials": [
                           {
                             "id": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
-                            "name": "Production Notion",
+                            "name": "本番環境の Notion",
                             "type": "api-key",
                             "is_default": true
                           }
@@ -10447,10 +10390,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "パイプラインに設定されているデータソースノードのリストです。"
           },
           "400": {
-            "description": "`invalid_param` : このナレッジベースには処理パイプラインが設定されていません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10464,15 +10407,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：このナレッジベースには処理パイプラインが設定されていません。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10481,10 +10441,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           },
           "404": {
-            "description": "`not_found` : `dataset_id` に一致するナレッジベースがありません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10498,9 +10458,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
           }
         },
+        "summary": "データソースプラグインリストを取得",
+        "tags": [
+          "ナレッジパイプライン"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/knowledge-pipeline/list-datasource-plugins",
           "metadata": {
@@ -10512,88 +10477,60 @@
     },
     "/datasets/{dataset_id}/pipeline/datasource/nodes/{node_id}/run": {
       "post": {
-        "tags": [
-          "ナレッジパイプライン"
-        ],
-        "summary": "データソースノードを実行",
         "description": "ナレッジパイプライン内の単一のデータソースノードを実行し、その実行イベントをストリーミングします。",
-        "operationId": "runDatasourceNodeJa",
+        "operationId": "runDatasourceNode",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "node_id",
+            "description": "実行するデータソースノードの ID です。[データソースプラグインリストを取得](/ja/api-reference/knowledge-pipeline/list-datasource-plugins) から取得します。",
             "in": "path",
+            "name": "node_id",
             "required": true,
             "schema": {
+              "description": "実行するデータソースノード ID。",
               "type": "string"
-            },
-            "description": "実行するデータソースノードの ID です。[データソースプラグインリストを取得](/ja/api-reference/knowledge-pipeline/list-datasource-plugins) から取得します。"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "inputs",
-                  "datasource_type",
-                  "is_published"
-                ],
-                "properties": {
-                  "inputs": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "データソースノードの入力変数です。"
-                  },
-                  "datasource_type": {
-                    "type": "string",
-                    "enum": [
-                      "online_document",
-                      "local_file",
-                      "website_crawl",
-                      "online_drive"
-                    ],
-                    "description": "データソースの種類です。"
-                  },
-                  "credential_id": {
-                    "type": "string",
-                    "nullable": true,
-                    "description": "データソースとの認証に使用する認証情報の ID です。[データソースプラグインリストを取得](/ja/api-reference/knowledge-pipeline/list-datasource-plugins) の `credentials` 配列から取得します。"
-                  },
-                  "is_published": {
-                    "type": "boolean",
-                    "description": "ドラフトではなくノードの公開バージョンを実行するかどうかを指定します。"
-                  }
-                }
+                "$ref": "#/components/schemas/DatasourceNodeRunPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "ノード実行イベントを含むストリーミングレスポンスです。",
             "content": {
               "text/event-stream": {
                 "schema": {
                   "type": "string",
-                  "description": "ノード実行の進捗と結果を含む Server-Sent Events ストリームです。解析については [ストリーミングレスポンスの処理](/ja/api-reference/guides/streaming) を参照してください。"
+                  "description": "ドラフトのナレッジパイプライン実行を配信する Server-Sent Events ストリームです。[SSE ストリーミングガイド](/ja/api-reference/guides/streaming)に従って `data:` レコードを解析してください。主なイベントは `workflow_started`、`node_started`、`node_finished`、`workflow_finished`、`error` で、ワークフローイベントストリームと同じエンベロープ形式を使用します。"
+                },
+                "examples": {
+                  "successfulStream": {
+                    "summary": "レスポンス例 - 成功したストリーム",
+                    "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"データソース\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+                  }
                 }
               }
-            }
+            },
+            "description": "ノード実行イベントを含むストリーミングレスポンスです。"
           },
           "400": {
-            "description": "`invalid_param` : このナレッジベースには処理パイプラインが設定されていない、またはリクエストボディの検証に失敗しました。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10607,15 +10544,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：このナレッジベースには処理パイプラインが設定されていない、またはリクエストボディの検証に失敗しました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10624,10 +10578,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           },
           "404": {
-            "description": "`not_found` : `dataset_id` に一致するナレッジベースがありません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10641,9 +10595,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
           }
         },
+        "summary": "データソースノードを実行",
+        "tags": [
+          "ナレッジパイプライン"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/knowledge-pipeline/run-datasource-node",
           "metadata": {
@@ -10655,183 +10614,26 @@
     },
     "/datasets/{dataset_id}/pipeline/run": {
       "post": {
-        "tags": [
-          "ナレッジパイプライン"
-        ],
-        "summary": "パイプラインを実行",
-        "description": "1 つ以上のデータソースに対して完全なナレッジパイプラインを実行します。`response_mode` でストリーミングまたはブロッキングのレスポンスを選択します。",
-        "operationId": "runPipelineJa",
+        "description": "1 つ以上のデータソースに対してナレッジパイプライン全体を実行します。公開済みの実行はキューに追加され、常にバッチメタデータを JSON で返します。ドラフトの実行では、ブロッキング JSON とストリーミング Server-Sent Events を利用できます。 公開済み実行では、返された `batch` を[ドキュメントのインデックス状態（進捗）を取得](/ja/api-reference/documents/get-document-indexing-status)に渡し、すべてのドキュメントが `completed`、`error`、または `paused` になるまでポーリングしてください。",
+        "operationId": "runPipeline",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) から取得します。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "inputs",
-                  "datasource_type",
-                  "datasource_info_list",
-                  "start_node_id",
-                  "is_published",
-                  "response_mode"
-                ],
-                "properties": {
-                  "inputs": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "パイプライン入力変数のキーと値のペア。ワークフローで定義されたパイプライン変数に対応します。入力変数がない場合は `{}` を渡してください。"
-                  },
-                  "datasource_type": {
-                    "type": "string",
-                    "enum": [
-                      "local_file",
-                      "online_document",
-                      "website_crawl",
-                      "online_drive"
-                    ],
-                    "description": "データソースのタイプ。`datasource_info_list` の各項目に必要なフィールドを決定します。"
-                  },
-                  "datasource_info_list": {
-                    "type": "array",
-                    "description": "処理対象のデータソースオブジェクトのリストです。項目の構造は `datasource_type` によって異なります。",
-                    "items": {
-                      "oneOf": [
-                        {
-                          "title": "Local File",
-                          "type": "object",
-                          "required": [
-                            "reference"
-                          ],
-                          "properties": {
-                            "reference": {
-                              "type": "string",
-                              "description": "[パイプラインファイルアップロード](/ja/api-reference/knowledge-pipeline/upload-pipeline-file) エンドポイントから返される `id` を使用してください。`related_id` もエイリアスとして使用可能です。"
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "ドキュメントのタイトルです。デフォルトは `\"untitled\"` です。"
-                            }
-                          }
-                        },
-                        {
-                          "title": "Online Document",
-                          "type": "object",
-                          "required": [
-                            "workspace_id",
-                            "page"
-                          ],
-                          "properties": {
-                            "workspace_id": {
-                              "type": "string",
-                              "description": "外部プラットフォームのワークスペースまたはデータベース ID（例：Notion のワークスペース ID）。"
-                            },
-                            "page": {
-                              "type": "object",
-                              "description": "ページの詳細です。",
-                              "required": [
-                                "page_id",
-                                "type"
-                              ],
-                              "properties": {
-                                "page_id": {
-                                  "type": "string",
-                                  "description": "ページ識別子です。"
-                                },
-                                "type": {
-                                  "type": "string",
-                                  "description": "データソースプラグインで定義されたページタイプ（例：`\"page\"`、`\"database\"`）。"
-                                },
-                                "page_name": {
-                                  "type": "string",
-                                  "description": "表示名です。デフォルトは `\"untitled\"` です。"
-                                }
-                              }
-                            },
-                            "credential_id": {
-                              "type": "string",
-                              "description": "外部プラットフォームとの認証用クレデンシャルです。Dify コンソールで管理します。省略した場合、プロバイダーのデフォルトクレデンシャルが使用されます。"
-                            }
-                          }
-                        },
-                        {
-                          "title": "Website Crawl",
-                          "type": "object",
-                          "required": [
-                            "url"
-                          ],
-                          "properties": {
-                            "url": {
-                              "type": "string",
-                              "description": "クロール対象の URL です。"
-                            },
-                            "title": {
-                              "type": "string",
-                              "description": "ドキュメント名として使用されます。デフォルトは `\"untitled\"` です。"
-                            }
-                          }
-                        },
-                        {
-                          "title": "Online Drive",
-                          "type": "object",
-                          "required": [
-                            "id",
-                            "type"
-                          ],
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "ファイルまたはフォルダの ID です。"
-                            },
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "file",
-                                "folder"
-                              ],
-                              "description": "この項目が単一ファイルか、展開対象のフォルダかを指定します。"
-                            },
-                            "bucket": {
-                              "type": "string",
-                              "description": "ストレージバケット名です。一部のドライブプロバイダー（S3 互換ストレージなど）で必要です。プロバイダーがバケットを使用しない場合は省略できます。"
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "ファイル名です。デフォルトは `\"untitled\"` です。"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "start_node_id": {
-                    "type": "string",
-                    "description": "実行を開始するノードの ID です。[データソースプラグインリストを取得](/ja/api-reference/knowledge-pipeline/list-datasource-plugins) から取得します。"
-                  },
-                  "is_published": {
-                    "type": "boolean",
-                    "description": "現在のドラフトではなくパイプラインの公開バージョンを実行するかどうかを指定します。未公開の変更をテストするにはドラフトを実行します。"
-                  },
-                  "response_mode": {
-                    "type": "string",
-                    "enum": [
-                      "streaming",
-                      "blocking"
-                    ],
-                    "description": "パイプライン実行のレスポンスモードです。`streaming` は Server-Sent Events ストリームを返し、`blocking` は完了まで待機して完全な結果を返します。"
-                  }
-                }
+                "$ref": "#/components/schemas/PipelineRunApiEntity"
               },
               "examples": {
                 "local_file": {
@@ -10846,7 +10648,7 @@
                       }
                     ],
                     "start_node_id": "1719288585006",
-                    "is_published": true,
+                    "is_published": false,
                     "response_mode": "blocking"
                   }
                 },
@@ -10861,13 +10663,13 @@
                         "page": {
                           "page_id": "pg-def456",
                           "type": "page",
-                          "page_name": "Product Roadmap"
+                          "page_name": "製品ロードマップ"
                         },
                         "credential_id": "cred-789xyz"
                       }
                     ],
                     "start_node_id": "1719288585006",
-                    "is_published": true,
+                    "is_published": false,
                     "response_mode": "streaming"
                   }
                 },
@@ -10879,7 +10681,7 @@
                     "datasource_info_list": [
                       {
                         "url": "https://example.com/docs/getting-started",
-                        "title": "Getting Started Guide"
+                        "title": "はじめにガイド"
                       }
                     ],
                     "start_node_id": "1719288585006",
@@ -10907,27 +10709,47 @@
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "パイプライン実行結果。フォーマットは `response_mode` に依存します：ストリーミングは `text/event-stream` を返し、ブロッキングは完全な JSON 結果を返します。",
             "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "Server-Sent Events ストリームです。`response_mode` が `streaming` の場合に返されます。ワイヤーフォーマットについては [ストリーミングレスポンスの処理](/ja/api-reference/guides/streaming) を参照してください。\n\n主なイベント：\n\n- `workflow_started`：実行開始\n- `node_started` / `node_finished`：ノードごとの進捗（`node_id`、`node_type`、`status`、`inputs`、`outputs` を含む）\n- `workflow_finished`：最終結果（`status`、`outputs`、`total_tokens`、`elapsed_time` を含む）\n- `ping`：キープアライブ"
-                }
-              },
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "description": "パイプライン実行の完全な結果です。`response_mode` が `blocking` の場合に返されます。",
-                  "additionalProperties": true
+                  "$ref": "#/components/schemas/PipelineRunJsonResponse",
+                  "description": "公開済み実行の JSON 結果、またはドラフト実行を `blocking` モードで実行した場合の JSON 結果です。"
                 },
                 "examples": {
-                  "success": {
-                    "summary": "Blocking Response Example",
+                  "published": {
+                    "summary": "公開済みパイプラインのレスポンス",
+                    "value": {
+                      "batch": "20260825143015948271",
+                      "dataset": {
+                        "id": "c9f5e6f0-d10a-4f57-a1d8-a4b63f8459f4",
+                        "name": "製品ドキュメント",
+                        "description": "製品の説明資料",
+                        "chunk_structure": "text_model"
+                      },
+                      "documents": [
+                        {
+                          "id": "9af03c49-30c4-4d64-a605-17f3171fbf9a",
+                          "position": 1,
+                          "data_source_type": "local_file",
+                          "data_source_info": {
+                            "reference": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "quarterly-report.pdf"
+                          },
+                          "name": "quarterly-report.pdf",
+                          "indexing_status": "waiting",
+                          "error": null,
+                          "enabled": true
+                        }
+                      ]
+                    }
+                  },
+                  "draft_blocking": {
+                    "summary": "ドラフトのブロッキングレスポンス",
                     "value": {
                       "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
                       "workflow_run_id": "f1e2d3c4-b5a6-7890-abcd-ef0987654321",
@@ -10936,16 +10758,33 @@
                         "status": "succeeded",
                         "outputs": {},
                         "created_at": 1741267200,
-                        "finished_at": 1741267210
+                        "finished_at": 1741267210,
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "error": null,
+                        "elapsed_time": 10.0,
+                        "total_tokens": 0,
+                        "total_steps": 1
                       }
                     }
                   }
                 }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "ドラフトのナレッジパイプライン実行を配信する Server-Sent Events ストリームです。[SSE ストリーミングガイド](/ja/api-reference/guides/streaming)に従って `data:` レコードを解析してください。主なイベントは `workflow_started`、`node_started`、`node_finished`、`workflow_finished`、`error` で、ワークフローイベントストリームと同じエンベロープ形式を使用します。"
+                },
+                "examples": {
+                  "successfulStream": {
+                    "summary": "レスポンス例 - 成功したストリーム",
+                    "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"データソース\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+                  }
+                }
               }
-            }
+            },
+            "description": "パイプラインの実行結果。公開済みの実行はキューに追加されたバッチメタデータを JSON で返します。ドラフトの実行は、`streaming` モードでは Server-Sent Events、`blocking` モードではワークフロー結果を JSON で返します。"
           },
           "400": {
-            "description": "`invalid_param` : このナレッジベースには処理パイプラインが設定されていない、またはリクエストボディの検証に失敗しました。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10959,15 +10798,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：このナレッジベースには処理パイプラインが設定されていない、またはリクエストボディの検証に失敗しました。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10976,10 +10832,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           },
           "404": {
-            "description": "`not_found` : `dataset_id` に一致するナレッジベースがありません。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10993,10 +10849,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：`dataset_id` に一致するナレッジベースがありません。"
           },
           "500": {
-            "description": "`pipeline_run_error` : パイプライン実行に失敗しました。",
             "content": {
               "application/json": {
                 "examples": {
@@ -11010,9 +10866,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`pipeline_run_error`：パイプライン実行に失敗しました。"
           }
         },
+        "summary": "パイプラインを実行",
+        "tags": [
+          "ナレッジパイプライン"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/knowledge-pipeline/run-pipeline",
           "metadata": {
@@ -11263,54 +11124,27 @@
     },
     "/datasets/{dataset_id}/tags": {
       "get": {
-        "tags": [
-          "タグ管理"
-        ],
-        "summary": "ナレッジベースにバインドされたタグを取得",
         "description": "ナレッジベースにバインドされたタグを返します。",
         "operationId": "queryDatasetTags",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "ナレッジベース ID です。[ナレッジベースリストを取得](/ja/api-reference/knowledge-bases/list-knowledge-bases) を参照してください。"
+              "description": "ナレッジベース ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "ナレッジベースにバインドされたタグです。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "タグ識別子です。"
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "タグの表示名です。"
-                          }
-                        }
-                      },
-                      "description": "このナレッジベースにバインドされたタグのリスト。"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "このナレッジベースにバインドされたタグの合計数です。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetBoundTagListResponse"
                 },
                 "examples": {
                   "success": {
@@ -11319,7 +11153,7 @@
                       "data": [
                         {
                           "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                          "name": "Product Docs"
+                          "name": "製品ドキュメント"
                         }
                       ],
                       "total": 1
@@ -11327,15 +11161,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "ナレッジベースにバインドされたタグです。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           },
           "403": {
-            "description": "`forbidden` : このナレッジベースでは API アクセスが有効になっていません。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API アクセス）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -11344,26 +11195,14 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : ナレッジベースが見つかりません。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden`：このナレッジベースでは API アクセスが有効になっていません。"
           }
         },
+        "summary": "ナレッジベースにバインドされたタグを取得",
+        "tags": [
+          "タグ管理"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/tags/get-knowledge-base-tags",
           "metadata": {
@@ -14465,164 +14304,34 @@
     },
     "/workspaces/current/models/model-types/{model_type}": {
       "get": {
-        "tags": [
-          "モデル"
-        ],
-        "summary": "利用可能なモデルを取得",
         "description": "指定したタイプの利用可能なモデルを返します。ナレッジベースに設定する `text-embedding` モデルと `rerank` モデルを見つけるために使用します。",
-        "operationId": "getAvailableModelsJa",
+        "operationId": "getAvailableModels",
         "parameters": [
           {
-            "name": "model_type",
+            "description": "取得するモデルの種類。",
             "in": "path",
+            "name": "model_type",
             "required": true,
             "schema": {
-              "type": "string",
+              "description": "取得するモデルの種類。",
               "enum": [
-                "text-embedding",
-                "rerank",
                 "llm",
-                "tts",
+                "moderation",
+                "rerank",
                 "speech2text",
-                "moderation"
-              ]
-            },
-            "description": "取得するモデルのタイプです。ナレッジベースの設定には、埋め込みモデルの場合は `text-embedding`、リランキングモデルの場合は `rerank` を使用します。"
+                "text-embedding",
+                "tts"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "指定された種類で利用可能なモデルです。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "利用可能なモデルを持つモデルプロバイダーのリストです。",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "provider": {
-                            "type": "string",
-                            "description": "モデルプロバイダーの識別子です。`organization/plugin_name/provider_name` の形式です（例：`langgenius/openai/openai`）。以前のプロバイダーでは短縮形（例：`openai`）が返される場合があります。"
-                          },
-                          "label": {
-                            "type": "object",
-                            "description": "プロバイダーのローカライズ表示名です。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "英語表示名。"
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "中国語表示名。"
-                              }
-                            }
-                          },
-                          "icon_small": {
-                            "type": "object",
-                            "description": "プロバイダーの小アイコンの URL です。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "小アイコン URL。"
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "中国語アイコンの URL。"
-                              }
-                            }
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "プロバイダーのステータスです。認証情報が設定済みで有効な場合は `active` です。"
-                          },
-                          "models": {
-                            "type": "array",
-                            "description": "このプロバイダーから利用可能なモデルのリストです。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "model": {
-                                  "type": "string",
-                                  "description": "モデル識別子です。ナレッジベースの作成または更新時に `embedding_model` の値として使用します。"
-                                },
-                                "label": {
-                                  "type": "object",
-                                  "description": "モデルのローカライズ表示名です。",
-                                  "properties": {
-                                    "en_US": {
-                                      "type": "string",
-                                      "description": "英語モデル名。"
-                                    },
-                                    "zh_Hans": {
-                                      "type": "string",
-                                      "description": "中国語モデル名。"
-                                    }
-                                  }
-                                },
-                                "model_type": {
-                                  "type": "string",
-                                  "description": "モデルのタイプです。`model_type` パスパラメータと一致します。"
-                                },
-                                "features": {
-                                  "type": "array",
-                                  "nullable": true,
-                                  "description": "モデルがサポートする機能です。なしの場合は `null` です。",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "fetch_from": {
-                                  "type": "string",
-                                  "description": "モデル定義の取得元です。`predefined-model` は組み込みモデル、`customizable-model` はユーザー設定モデルを示します。"
-                                },
-                                "model_properties": {
-                                  "type": "object",
-                                  "description": "`context_size` などのモデル固有のプロパティです。"
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "description": "モデルの利用可能ステータスです。使用可能な場合は `active` です。"
-                                },
-                                "deprecated": {
-                                  "type": "boolean",
-                                  "description": "モデルが非推奨かどうか。"
-                                },
-                                "load_balancing_enabled": {
-                                  "type": "boolean",
-                                  "description": "モデルのロードバランシングが有効かどうか。"
-                                },
-                                "has_invalid_load_balancing_configs": {
-                                  "type": "boolean",
-                                  "description": "モデルに無効なロードバランシング設定があるかどうか。"
-                                }
-                              }
-                            }
-                          },
-                          "tenant_id": {
-                            "type": "string",
-                            "description": "このプロバイダー設定が属するワークスペース ID。"
-                          },
-                          "icon_small_dark": {
-                            "type": "object",
-                            "description": "ダークモード用アイコンの URL。プロバイダーにない場合は `null`。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string"
-                              },
-                              "zh_Hans": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/ProviderWithModelsListResponse"
                 },
                 "examples": {
                   "success": {
@@ -14667,9 +14376,31 @@
                   }
                 }
               }
-            }
+            },
+            "description": "指定された種類で利用可能なモデルです。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` ヘッダーがない、形式が正しくない、または API キーが無効です。"
           }
         },
+        "summary": "利用可能なモデルを取得",
+        "tags": [
+          "モデル"
+        ],
         "x-mint": {
           "href": "/ja/api-reference/models/get-available-models",
           "metadata": {

--- a/zh/api-reference/openapi_service.json
+++ b/zh/api-reference/openapi_service.json
@@ -3130,71 +3130,34 @@
     },
     "/datasets/pipeline/file-upload": {
       "post": {
-        "tags": [
-          "知识流水线"
-        ],
-        "summary": "上传流水线文件",
         "description": "上传文件以在知识流水线中使用。将返回的 `id` 用作 [运行流水线](/zh/api-reference/knowledge-pipeline/run-pipeline) 中 `local_file` 项的 `reference`。",
-        "operationId": "uploadPipelineFileZh",
+        "operationId": "uploadPipelineFile",
         "requestBody": {
-          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
+                "properties": {
+                  "file": {
+                    "description": "要上传的文件，作为 `multipart/form-data` 的一个部分。文档文件默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。\n\nDify Cloud 的 Professional 和 Team 套餐的文档上限为 50 MB。图片、音频、视频文件各有独立上限，默认分别为 10 MB、50 MB、100 MB。",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
                 "required": [
                   "file"
                 ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "要上传的文件，作为 `multipart/form-data` 的一个部分。文档文件默认上限 15 MB。\n\n自部署可通过 `UPLOAD_FILE_SIZE_LIMIT` [环境变量](/zh/self-host/deploy/configuration/environments) 调整。\n\nDify Cloud 的 Professional 和 Team 套餐的文档上限为 50 MB。图片、音频、视频文件各有独立上限，默认分别为 10 MB、50 MB、100 MB。"
-                  }
-                }
+                "type": "object"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
-            "description": "文件上传成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "已上传文件的唯一标识符。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "原始文件名。"
-                    },
-                    "size": {
-                      "type": "integer",
-                      "description": "文件大小（字节）。"
-                    },
-                    "extension": {
-                      "type": "string",
-                      "description": "文件扩展名。"
-                    },
-                    "mime_type": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "文件的 MIME 类型。若上传未包含 MIME 类型则可能为 `null`。"
-                    },
-                    "created_by": {
-                      "type": "string",
-                      "description": "上传文件的用户 ID。"
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "上传时间戳（ISO 8601 格式）。在记录创建过程中可能为 `null`。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/PipelineUploadFileResponse"
                 },
                 "examples": {
                   "success": {
@@ -3211,10 +3174,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "文件上传成功。"
           },
           "400": {
-            "description": "- `no_file_uploaded` : 请求中未提供文件。\n- `filename_not_exists_error` : 上传的文件没有文件名。\n- `too_many_files` : 每次请求仅允许一个文件。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3244,10 +3207,39 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `no_file_uploaded`：请求中未提供文件。\n- `filename_not_exists_error`：上传的文件没有文件名。\n- `too_many_files`：每次请求仅允许一个文件。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "forbidden",
+                  "message": "Forbidden.",
+                  "status": 403
+                }
+              }
+            },
+            "description": "禁止访问——未启用知识库 API 或无工作区访问权限"
           },
           "413": {
-            "description": "`file_too_large` : 文件超出上传大小限制。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3261,10 +3253,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`file_too_large`：文件超出上传大小限制。"
           },
           "415": {
-            "description": "`unsupported_file_type` : 不支持的文件类型。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3278,157 +3270,121 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`unsupported_file_type`：不支持的文件类型。"
           }
         },
-        "x-mint": {
-          "href": "/zh/api-reference/knowledge-pipeline/upload-pipeline-file",
-          "metadata": {
-            "title": "上传流水线文件",
-            "sidebarTitle": "上传流水线文件"
-          }
-        },
+        "summary": "上传流水线文件",
+        "tags": [
+          "知识流水线"
+        ],
         "x-codeSamples": [
           {
             "lang": "bash",
             "label": "cURL",
             "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
           }
-        ]
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/knowledge-pipeline/upload-pipeline-file",
+          "metadata": {
+            "title": "上传流水线文件",
+            "sidebarTitle": "上传流水线文件"
+          }
+        }
       }
     },
     "/datasets/tags": {
-      "post": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "创建知识库标签",
-        "description": "创建用于组织知识库的标签。",
-        "operationId": "createKnowledgeTag",
+      "delete": {
+        "description": "永久删除知识库标签。不会删除已被标记的知识库。",
+        "operationId": "deleteKnowledgeTag",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "标签名称。在工作空间内必须唯一。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "标签创建成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "标签标识符。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "标签显示名称。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "标签类型。知识库标签始终为 `knowledge`。"
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "绑定到该标签的知识库数量。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
-                      "type": "knowledge",
-                      "binding_count": "0"
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/TagDeletePayload"
               }
             }
           },
-          "400": {
-            "description": "`invalid_param` : 已存在同名的知识库标签。",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "成功。"
+          },
+          "401": {
             "content": {
               "application/json": {
                 "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
+                  "unauthorized": {
+                    "summary": "unauthorized",
                     "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Tag name already exists"
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden`：您的工作区角色没有编辑这些资源的权限。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Tag not found"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：指定的标签不存在。"
           }
         },
+        "summary": "删除知识库标签",
+        "tags": [
+          "标签"
+        ],
         "x-mint": {
-          "href": "/zh/api-reference/tags/create-knowledge-tag",
+          "href": "/zh/api-reference/tags/delete-knowledge-tag",
           "metadata": {
-            "title": "创建知识库标签",
-            "sidebarTitle": "创建知识库标签"
+            "title": "删除知识库标签",
+            "sidebarTitle": "删除知识库标签"
           }
         }
       },
       "get": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "获取知识库标签列表",
         "description": "返回工作空间中所有的知识库标签。",
         "operationId": "getKnowledgeTags",
         "responses": {
           "200": {
-            "description": "标签列表。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "description": "标签标识符。"
-                      },
-                      "name": {
-                        "type": "string",
-                        "description": "标签显示名称。"
-                      },
-                      "type": {
-                        "type": "string",
-                        "description": "标签类型。知识库标签始终为 `knowledge`。"
-                      },
-                      "binding_count": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "绑定到该标签的知识库数量。"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/KnowledgeTagListResponse"
                 },
                 "examples": {
                   "success": {
@@ -3436,7 +3392,7 @@
                     "value": [
                       {
                         "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                        "name": "Product Docs",
+                        "name": "产品文档",
                         "type": "knowledge",
                         "binding_count": "0"
                       }
@@ -3444,9 +3400,43 @@
                   }
                 }
               }
-            }
+            },
+            "description": "标签列表。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "forbidden",
+                  "message": "Forbidden.",
+                  "status": 403
+                }
+              }
+            },
+            "description": "禁止访问——未启用知识库 API 或无工作区访问权限"
           }
         },
+        "summary": "获取知识库标签列表",
+        "tags": [
+          "标签"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/tags/list-knowledge-tags",
           "metadata": {
@@ -3456,81 +3446,41 @@
         }
       },
       "patch": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "修改知识库标签",
         "description": "重命名知识库标签。",
         "operationId": "updateKnowledgeTag",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id",
-                  "name"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "要重命名的标签 ID。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。"
-                  },
-                  "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 50,
-                    "description": "标签的新名称。在工作空间内必须唯一。"
-                  }
-                }
+                "$ref": "#/components/schemas/TagUpdatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "标签更新成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "标签标识符。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "标签显示名称。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "标签类型。知识库标签始终为 `knowledge`。"
-                    },
-                    "binding_count": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "绑定到该标签的知识库数量。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/KnowledgeTagResponse"
                 },
                 "examples": {
                   "success": {
                     "summary": "响应示例",
                     "value": {
                       "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                      "name": "Product Docs",
+                      "name": "产品文档",
                       "type": "knowledge",
                       "binding_count": "0"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "标签更新成功。"
           },
           "400": {
-            "description": "`invalid_param` : 已存在同名的知识库标签。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3544,10 +3494,44 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：已存在同名的知识库标签。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden`：您的工作区角色没有编辑这些资源的权限。"
           },
           "404": {
-            "description": "`not_found` : 指定的标签不存在。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3561,9 +3545,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：指定的标签不存在。"
           }
         },
+        "summary": "修改知识库标签",
+        "tags": [
+          "标签"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/tags/update-knowledge-tag",
           "metadata": {
@@ -3572,105 +3561,159 @@
           }
         }
       },
-      "delete": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "删除知识库标签",
-        "description": "永久删除知识库标签。不会删除已被标记的知识库。",
-        "operationId": "deleteKnowledgeTag",
+      "post": {
+        "description": "创建用于组织知识库的标签。",
+        "operationId": "createKnowledgeTag",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "tag_id"
-                ],
-                "properties": {
-                  "tag_id": {
-                    "type": "string",
-                    "description": "要删除的标签 ID。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。"
-                  }
-                }
+                "$ref": "#/components/schemas/TagCreatePayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "404": {
-            "description": "`not_found` : 指定的标签不存在。",
+          "200": {
             "content": {
               "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeTagResponse"
+                },
                 "examples": {
-                  "not_found": {
-                    "summary": "not_found",
+                  "success": {
+                    "summary": "响应示例",
                     "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Tag not found"
+                      "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+                      "name": "产品文档",
+                      "type": "knowledge",
+                      "binding_count": "0"
                     }
                   }
                 }
               }
-            }
+            },
+            "description": "标签创建成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Tag name already exists"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：已存在同名的知识库标签。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden`：您的工作区角色没有编辑这些资源的权限。"
           }
         },
+        "summary": "创建知识库标签",
+        "tags": [
+          "标签"
+        ],
         "x-mint": {
-          "href": "/zh/api-reference/tags/delete-knowledge-tag",
+          "href": "/zh/api-reference/tags/create-knowledge-tag",
           "metadata": {
-            "title": "删除知识库标签",
-            "sidebarTitle": "删除知识库标签"
+            "title": "创建知识库标签",
+            "sidebarTitle": "创建知识库标签"
           }
         }
       }
     },
     "/datasets/tags/binding": {
       "post": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "绑定标签到知识库",
         "description": "将一个或多个标签绑定到知识库。一个知识库可以有多个标签。",
         "operationId": "bindTagsToDataset",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "tag_ids",
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "要绑定的标签 ID。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。 未知的标签 ID 会被忽略，不会报错。"
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "要绑定标签的知识库。参见 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases)。"
-                  }
-                }
+                "$ref": "#/components/schemas/TagBindingPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "204": {
-            "description": "Success."
+            "description": "成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden`：您的工作区角色没有编辑这些资源的权限。"
           },
           "404": {
-            "description": "`not_found` : 目标知识库不存在。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3684,9 +3727,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：目标知识库不存在。"
           }
         },
+        "summary": "绑定标签到知识库",
+        "tags": [
+          "标签"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/tags/create-tag-binding",
           "metadata": {
@@ -3698,50 +3746,57 @@
     },
     "/datasets/tags/unbinding": {
       "post": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "解除标签与知识库的绑定",
         "description": "从知识库中移除一个或多个标签。",
         "operationId": "unbindTagFromDataset",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "target_id"
-                ],
-                "properties": {
-                  "tag_ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "description": "要解绑的标签 ID 列表。未提供旧版 `tag_id` 时必填。参见 [获取知识库标签列表](/zh/api-reference/tags/list-knowledge-tags)。"
-                  },
-                  "tag_id": {
-                    "type": "string",
-                    "deprecated": true,
-                    "description": "旧版单标签字段。服务端将其归一化为 `tag_ids`。新接入应使用 `tag_ids`。"
-                  },
-                  "target_id": {
-                    "type": "string",
-                    "description": "要解绑标签的知识库。参见 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases)。"
-                  }
-                }
+                "$ref": "#/components/schemas/TagUnbindingPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "204": {
-            "description": "Success."
+            "description": "成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden": {
+                    "summary": "forbidden",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "You don't have the permission to access the requested resource. It is either read-protected or not readable by the server."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`forbidden`：您的工作区角色没有编辑这些资源的权限。"
           },
           "404": {
-            "description": "`not_found` : 目标知识库不存在。",
             "content": {
               "application/json": {
                 "examples": {
@@ -3755,9 +3810,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：目标知识库不存在。"
           }
         },
+        "summary": "解除标签与知识库的绑定",
+        "tags": [
+          "标签"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/tags/delete-tag-binding",
           "metadata": {
@@ -5373,98 +5433,37 @@
     },
     "/datasets/{dataset_id}/documents/metadata": {
       "post": {
-        "tags": [
-          "元数据"
-        ],
-        "summary": "批量更新文档元数据",
         "description": "在一次请求中批量更新多个文档的元数据值。",
-        "operationId": "batchUpdateDocumentMetadataZh",
+        "operationId": "batchUpdateDocumentMetadata",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "operation_data"
-                ],
-                "properties": {
-                  "operation_data": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "document_id",
-                        "metadata_list"
-                      ],
-                      "properties": {
-                        "document_id": {
-                          "type": "string",
-                          "description": "要更新的文档 ID。参见 [获取知识库的文档列表](/zh/api-reference/documents/list-documents)。"
-                        },
-                        "metadata_list": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "required": [
-                              "id",
-                              "name"
-                            ],
-                            "properties": {
-                              "id": {
-                                "type": "string",
-                                "description": "元数据字段 ID。参见 [获取元数据字段列表](/zh/api-reference/metadata/list-metadata-fields)。"
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "元数据字段名称。"
-                              },
-                              "value": {
-                                "description": "元数据值。可以是字符串、数字或 `null`。"
-                              }
-                            }
-                          },
-                          "description": "要设置到文档的元数据字段。"
-                        },
-                        "partial_update": {
-                          "type": "boolean",
-                          "default": false,
-                          "description": "是否部分更新元数据，保留未指定字段的现有值。"
-                        }
-                      }
-                    },
-                    "description": "文档元数据更新操作，每个文档一个条目。"
-                  }
-                }
+                "$ref": "#/components/schemas/MetadataOperationData"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "文档元数据更新成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作结果。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataActionResponse"
                 },
                 "examples": {
                   "success": {
@@ -5475,10 +5474,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "文档元数据更新成功。"
           },
           "400": {
-            "description": "`invalid_param` : 本次请求中的文档已有另一个元数据操作正在进行。",
             "content": {
               "application/json": {
                 "examples": {
@@ -5492,15 +5491,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：本次请求中的文档已有另一个元数据操作正在进行。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5508,7 +5524,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -5517,15 +5533,15 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "- `not_found` : 未找到知识库。\n- `not_found` : `operation_data` 中引用的文档在该知识库中不存在。\n- `not_found` : `metadata_list` 中引用的元数据字段在该知识库中不存在。",
             "content": {
               "application/json": {
                 "examples": {
                   "not_found_1": {
-                    "summary": "not_found (knowledge base)",
+                    "summary": "not_found（知识库）",
                     "value": {
                       "status": 404,
                       "code": "not_found",
@@ -5550,9 +5566,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。\n- `not_found`：`operation_data` 中引用的文档在该知识库中不存在。\n- `not_found`：`metadata_list` 中引用的元数据字段在该知识库中不存在。"
           }
         },
+        "summary": "批量更新文档元数据",
+        "tags": [
+          "元数据"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/metadata/update-document-metadata-in-batch",
           "metadata": {
@@ -9586,214 +9607,28 @@
       }
     },
     "/datasets/{dataset_id}/metadata": {
-      "post": {
-        "tags": [
-          "元数据"
-        ],
-        "summary": "创建元数据字段",
-        "description": "为知识库创建自定义元数据字段，用于给文档标注结构化信息。",
-        "operationId": "createMetadataFieldZh",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "type",
-                  "name"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "string",
-                      "number",
-                      "time"
-                    ],
-                    "description": "`string` 为文本值，`number` 为数值，`time` 为日期/时间值。"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "元数据字段的名称。在知识库的字段中必须唯一，且不超过 255 个字符。"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "元数据字段创建成功。",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "元数据字段标识符。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "元数据字段名称。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "元数据字段类型。"
-                    }
-                  }
-                },
-                "examples": {
-                  "success": {
-                    "summary": "响应示例",
-                    "value": {
-                      "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
-                      "name": "author",
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_param` : 元数据名称已存在、超过 255 个字符，或与内置字段冲突。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "invalid_param": {
-                    "summary": "invalid_param",
-                    "value": {
-                      "status": 400,
-                      "code": "invalid_param",
-                      "message": "Metadata name already exists."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/metadata/create-metadata-field",
-          "metadata": {
-            "title": "创建元数据字段",
-            "sidebarTitle": "创建元数据字段"
-          }
-        }
-      },
       "get": {
-        "tags": [
-          "元数据"
-        ],
-        "summary": "获取元数据字段列表",
         "description": "返回知识库的所有元数据字段（包括自定义和内置字段），以及使用每个字段的文档数量。",
-        "operationId": "listMetadataFieldsZh",
+        "operationId": "listMetadataFields",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "知识库的元数据字段。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "doc_metadata": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "元数据字段标识符。"
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "元数据字段名称。"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "元数据字段类型。"
-                          },
-                          "count": {
-                            "type": "integer",
-                            "description": "使用该元数据字段的文档数量。"
-                          }
-                        }
-                      },
-                      "description": "元数据字段定义列表。"
-                    },
-                    "built_in_field_enabled": {
-                      "type": "boolean",
-                      "description": "该知识库是否启用了内置元数据字段。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataListResponse"
                 },
                 "examples": {
                   "success": {
@@ -9812,15 +9647,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "知识库的元数据字段。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -9829,10 +9681,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           },
           "404": {
-            "description": "`not_found` : 未找到知识库。",
             "content": {
               "application/json": {
                 "examples": {
@@ -9846,9 +9698,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。"
           }
         },
+        "summary": "获取元数据字段列表",
+        "tags": [
+          "元数据"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/metadata/list-metadata-fields",
           "metadata": {
@@ -9856,54 +9713,167 @@
             "sidebarTitle": "获取元数据字段列表"
           }
         }
+      },
+      "post": {
+        "description": "为知识库创建自定义元数据字段，用于给文档标注结构化信息。",
+        "operationId": "createMetadataField",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetMetadataResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "响应示例",
+                    "value": {
+                      "id": "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+                      "name": "author",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "元数据字段创建成功。"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "invalid_param": {
+                    "summary": "invalid_param",
+                    "value": {
+                      "status": 400,
+                      "code": "invalid_param",
+                      "message": "Metadata name already exists."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "`invalid_param`：元数据名称已存在、超过 255 个字符，或与内置字段冲突。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到知识库。"
+          }
+        },
+        "summary": "创建元数据字段",
+        "tags": [
+          "元数据"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/metadata/create-metadata-field",
+          "metadata": {
+            "title": "创建元数据字段",
+            "sidebarTitle": "创建元数据字段"
+          }
+        }
       }
     },
     "/datasets/{dataset_id}/metadata/built-in": {
       "get": {
-        "tags": [
-          "元数据"
-        ],
-        "summary": "获取内置元数据字段",
         "description": "返回系统提供的内置元数据字段。",
-        "operationId": "getBuiltInMetadataFieldsZh",
+        "operationId": "getBuiltInMetadataFields",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "内置元数据字段。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "fields": {
-                      "type": "array",
-                      "description": "系统提供的元数据字段列表。",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "内置字段标识符。`document_name` 表示文档标题，`uploader` 表示创建者，`upload_date` 表示创建时间，`last_update_date` 表示最后修改时间，`source` 表示文档来源。"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "字段数据类型。文本值为 `string`，日期/时间值为 `time`。"
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataBuiltInFieldsResponse"
                 },
                 "examples": {
                   "success": {
@@ -9935,15 +9905,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "内置元数据字段。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -9952,26 +9939,14 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           }
         },
+        "summary": "获取内置元数据字段",
+        "tags": [
+          "元数据"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/metadata/get-built-in-metadata-fields",
           "metadata": {
@@ -9983,50 +9958,41 @@
     },
     "/datasets/{dataset_id}/metadata/built-in/{action}": {
       "post": {
-        "tags": [
-          "元数据"
-        ],
-        "summary": "更新内置元数据字段",
         "description": "启用或禁用知识库的内置元数据字段。",
-        "operationId": "toggleBuiltInMetadataFieldZh",
+        "operationId": "toggleBuiltInMetadataField",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "`enable` 启用内置元数据字段，`disable` 停用内置元数据字段。",
             "in": "path",
+            "name": "action",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "`enable` 启用内置元数据字段，`disable` 停用内置元数据字段。",
+              "enum": [
+                "disable",
+                "enable"
+              ],
+              "type": "string"
+            }
           },
           {
-            "name": "action",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "enum": [
-                "enable",
-                "disable"
-              ]
-            },
-            "description": "`enable` 启用内置元数据字段，`disable` 停用内置元数据字段。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "内置元数据字段切换成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "result": {
-                      "type": "string",
-                      "description": "操作结果。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataActionResponse"
                 },
                 "examples": {
                   "success": {
@@ -10037,15 +10003,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "内置元数据字段切换成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10053,7 +10036,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10062,10 +10045,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "`not_found` : 未找到知识库。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10079,9 +10062,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。"
           }
         },
+        "summary": "更新内置元数据字段",
+        "tags": [
+          "元数据"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/metadata/update-built-in-metadata-field",
           "metadata": {
@@ -10092,75 +10080,152 @@
       }
     },
     "/datasets/{dataset_id}/metadata/{metadata_id}": {
-      "patch": {
-        "tags": [
-          "元数据"
-        ],
-        "summary": "更新元数据字段",
-        "description": "重命名自定义元数据字段。",
-        "operationId": "updateMetadataFieldZh",
+      "delete": {
+        "description": "永久删除自定义元数据字段。使用过该字段的文档将丢失其对应的值。",
+        "operationId": "deleteMetadataField",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "metadata_id",
+            "description": "要删除的元数据字段 ID。参见 [获取元数据字段列表](/zh/api-reference/metadata/list-metadata-fields)。",
             "in": "path",
+            "name": "metadata_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "要重命名的元数据字段 ID。参见 [获取元数据字段列表](/zh/api-reference/metadata/list-metadata-fields)。"
+              "description": "元数据字段 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "字段的新名称。在知识库的字段中必须唯一，且不超过 255 个字符。"
+        "responses": {
+          "204": {
+            "description": "成功。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
                   }
                 }
               }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "forbidden_1": {
+                    "summary": "forbidden（API 访问）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Dataset api access is not enabled."
+                    }
+                  },
+                  "forbidden_2": {
+                    "summary": "forbidden（速率限制）",
+                    "value": {
+                      "status": 403,
+                      "code": "forbidden",
+                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "not_found": {
+                    "summary": "not_found",
+                    "value": {
+                      "status": 404,
+                      "code": "not_found",
+                      "message": "Dataset not found."
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `not_found`：未找到知识库。"
+          }
+        },
+        "summary": "删除元数据字段",
+        "tags": [
+          "元数据"
+        ],
+        "x-mint": {
+          "href": "/zh/api-reference/metadata/delete-metadata-field",
+          "metadata": {
+            "title": "删除元数据字段",
+            "sidebarTitle": "删除元数据字段"
+          }
+        }
+      },
+      "patch": {
+        "description": "重命名自定义元数据字段。",
+        "operationId": "updateMetadataField",
+        "parameters": [
+          {
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "要重命名的元数据字段 ID。参见 [获取元数据字段列表](/zh/api-reference/metadata/list-metadata-fields)。",
+            "in": "path",
+            "name": "metadata_id",
+            "required": true,
+            "schema": {
+              "description": "元数据字段 ID。",
+              "format": "uuid",
+              "type": "string"
             }
           }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataUpdatePayload"
+              }
+            }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "元数据字段更新成功。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "元数据字段标识符。"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "元数据字段名称。"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "元数据字段类型。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetMetadataResponse"
                 },
                 "examples": {
                   "success": {
@@ -10173,10 +10238,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "元数据字段更新成功。"
           },
           "400": {
-            "description": "`invalid_param` : 元数据名称已存在、超过 255 个字符，或与内置字段冲突。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10190,15 +10255,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：元数据名称已存在、超过 255 个字符，或与内置字段冲突。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden_1": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10206,7 +10288,7 @@
                     }
                   },
                   "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
+                    "summary": "forbidden（速率限制）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10215,10 +10297,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。\n- `forbidden`：已达到您订阅套餐的知识库请求速率限制。"
           },
           "404": {
-            "description": "`not_found` : 未找到知识库。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10232,9 +10314,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到知识库。"
           }
         },
+        "summary": "更新元数据字段",
+        "tags": [
+          "元数据"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/metadata/update-metadata-field",
           "metadata": {
@@ -10242,186 +10329,42 @@
             "sidebarTitle": "更新元数据字段"
           }
         }
-      },
-      "delete": {
-        "tags": [
-          "元数据"
-        ],
-        "summary": "删除元数据字段",
-        "description": "永久删除自定义元数据字段。使用过该字段的文档将丢失其对应的值。",
-        "operationId": "deleteMetadataFieldZh",
-        "parameters": [
-          {
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
-          },
-          {
-            "name": "metadata_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "要删除的元数据字段 ID。参见 [获取元数据字段列表](/zh/api-reference/metadata/list-metadata-fields)。"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success."
-          },
-          "403": {
-            "description": "- `forbidden` : 该知识库未启用 API 访问。\n- `forbidden` : 已达到您订阅套餐的知识库请求速率限制。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "forbidden_1": {
-                    "summary": "forbidden (api access)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Dataset api access is not enabled."
-                    }
-                  },
-                  "forbidden_2": {
-                    "summary": "forbidden (rate limit)",
-                    "value": {
-                      "status": 403,
-                      "code": "forbidden",
-                      "message": "Sorry, you have reached the knowledge base request rate limit of your subscription."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-mint": {
-          "href": "/zh/api-reference/metadata/delete-metadata-field",
-          "metadata": {
-            "title": "删除元数据字段",
-            "sidebarTitle": "删除元数据字段"
-          }
-        }
       }
     },
     "/datasets/{dataset_id}/pipeline/datasource-plugins": {
       "get": {
-        "tags": [
-          "知识流水线"
-        ],
-        "summary": "获取数据源插件列表",
         "description": "返回知识流水线中已配置的数据源节点，每个节点包含其使用的插件，以及运行该节点所需的元数据。",
-        "operationId": "listDatasourcePluginsZh",
+        "operationId": "listDatasourcePlugins",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "is_published",
+            "description": "是否从已发布或草稿知识流水线中获取节点。`true` 返回已发布版本的节点，`false` 返回草稿版本的节点。",
             "in": "query",
+            "name": "is_published",
+            "required": false,
             "schema": {
-              "type": "boolean",
-              "default": true
-            },
-            "description": "是否读取已发布流水线版本的节点，而非草稿版本。"
+              "default": true,
+              "description": "是否从已发布或草稿知识流水线中获取节点。`true` 返回已发布版本的节点，`false` 返回草稿版本的节点。",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "流水线中已配置的数据源节点列表。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "node_id": {
-                        "type": "string",
-                        "description": "流水线工作流中数据源节点的 ID。调用 [执行数据源节点](/zh/api-reference/knowledge-pipeline/run-datasource-node) 时作为 `node_id` 传入，或调用 [运行流水线](/zh/api-reference/knowledge-pipeline/run-pipeline) 时作为 `start_node_id` 传入。"
-                      },
-                      "plugin_id": {
-                        "type": "string",
-                        "description": "提供该节点的数据源插件的 ID。"
-                      },
-                      "provider_name": {
-                        "type": "string",
-                        "description": "数据源插件注册的提供商名称。"
-                      },
-                      "datasource_type": {
-                        "type": "string",
-                        "description": "数据源类型。取值为 `local_file`、`online_document`、`online_drive`、`website_crawl` 之一。"
-                      },
-                      "title": {
-                        "type": "string",
-                        "description": "为该节点配置的显示标题。"
-                      },
-                      "user_input_variables": {
-                        "type": "array",
-                        "description": "调用方需要为该数据源提供的流水线输入变量，来自节点数据源参数中 `{{#...#}}` 引用的变量。每一项遵循工作流使用的流水线变量结构。",
-                        "items": {
-                          "type": "object",
-                          "additionalProperties": true
-                        }
-                      },
-                      "credentials": {
-                        "type": "array",
-                        "description": "可用于对该数据源进行认证的凭证列表。",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "凭证 ID。调用 [执行数据源节点](/zh/api-reference/knowledge-pipeline/run-datasource-node) 时作为 `credential_id` 传入，或作为 [运行流水线](/zh/api-reference/knowledge-pipeline/run-pipeline) 各数据源项中的 `credential_id` 字段。"
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "凭证的显示名称。"
-                            },
-                            "type": {
-                              "type": "string",
-                              "description": "数据源插件定义的凭证类型。"
-                            },
-                            "is_default": {
-                              "type": "boolean",
-                              "description": "该凭证是否为提供商的默认凭证。"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasourcePluginListResponse"
                 },
                 "examples": {
                   "success": {
@@ -10432,12 +10375,12 @@
                         "plugin_id": "langgenius/notion_datasource",
                         "provider_name": "notion",
                         "datasource_type": "online_document",
-                        "title": "Notion Documents",
+                        "title": "Notion 文档",
                         "user_input_variables": [],
                         "credentials": [
                           {
                             "id": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
-                            "name": "Production Notion",
+                            "name": "生产环境 Notion",
                             "type": "api-key",
                             "is_default": true
                           }
@@ -10447,10 +10390,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "流水线中已配置的数据源节点列表。"
           },
           "400": {
-            "description": "`invalid_param` : 该知识库未配置处理流水线。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10464,15 +10407,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：该知识库未配置处理流水线。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10481,10 +10441,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           },
           "404": {
-            "description": "`not_found` : 未找到与 `dataset_id` 匹配的知识库。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10498,9 +10458,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
           }
         },
+        "summary": "获取数据源插件列表",
+        "tags": [
+          "知识流水线"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/knowledge-pipeline/list-datasource-plugins",
           "metadata": {
@@ -10512,88 +10477,60 @@
     },
     "/datasets/{dataset_id}/pipeline/datasource/nodes/{node_id}/run": {
       "post": {
-        "tags": [
-          "知识流水线"
-        ],
-        "summary": "执行数据源节点",
         "description": "运行知识流水线中的单个数据源节点，并流式返回其执行事件。",
-        "operationId": "runDatasourceNodeZh",
+        "operationId": "runDatasourceNode",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "name": "node_id",
+            "description": "要运行的数据源节点 ID，来自 [获取数据源插件列表](/zh/api-reference/knowledge-pipeline/list-datasource-plugins)。",
             "in": "path",
+            "name": "node_id",
             "required": true,
             "schema": {
+              "description": "要执行的数据源节点 ID。",
               "type": "string"
-            },
-            "description": "要运行的数据源节点 ID，来自 [获取数据源插件列表](/zh/api-reference/knowledge-pipeline/list-datasource-plugins)。"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "inputs",
-                  "datasource_type",
-                  "is_published"
-                ],
-                "properties": {
-                  "inputs": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "数据源节点的输入变量。"
-                  },
-                  "datasource_type": {
-                    "type": "string",
-                    "enum": [
-                      "online_document",
-                      "local_file",
-                      "website_crawl",
-                      "online_drive"
-                    ],
-                    "description": "数据源类型。"
-                  },
-                  "credential_id": {
-                    "type": "string",
-                    "nullable": true,
-                    "description": "用于向数据源认证的凭证 ID，来自 [获取数据源插件列表](/zh/api-reference/knowledge-pipeline/list-datasource-plugins) 的 `credentials` 数组。"
-                  },
-                  "is_published": {
-                    "type": "boolean",
-                    "description": "是否运行节点的已发布版本，而非草稿版本。"
-                  }
-                }
+                "$ref": "#/components/schemas/DatasourceNodeRunPayload"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "包含节点执行事件的流式响应。",
             "content": {
               "text/event-stream": {
                 "schema": {
                   "type": "string",
-                  "description": "包含节点执行进度和结果的 Server-Sent Events 流。解析方式参见 [SSE 流式传输](/zh/api-reference/guides/streaming)。"
+                  "description": "草稿知识流水线运行的 Server-Sent Events 流。按 [SSE 流式传输指南](/zh/api-reference/guides/streaming) 解析 `data:` 记录。常见事件包括 `workflow_started`、`node_started`、`node_finished`、`workflow_finished` 和 `error`；事件载荷使用与工作流事件流相同的封装格式。"
+                },
+                "examples": {
+                  "successfulStream": {
+                    "summary": "响应示例 - 成功事件流",
+                    "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"数据源\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+                  }
                 }
               }
-            }
+            },
+            "description": "包含节点执行事件的流式响应。"
           },
           "400": {
-            "description": "`invalid_param` : 该知识库未配置处理流水线，或请求体校验失败。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10607,15 +10544,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：该知识库未配置处理流水线，或请求体校验失败。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10624,10 +10578,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           },
           "404": {
-            "description": "`not_found` : 未找到与 `dataset_id` 匹配的知识库。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10641,9 +10595,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
           }
         },
+        "summary": "执行数据源节点",
+        "tags": [
+          "知识流水线"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/knowledge-pipeline/run-datasource-node",
           "metadata": {
@@ -10655,183 +10614,26 @@
     },
     "/datasets/{dataset_id}/pipeline/run": {
       "post": {
-        "tags": [
-          "知识流水线"
-        ],
-        "summary": "运行流水线",
-        "description": "对一个或多个数据源运行完整的知识流水线。`response_mode` 选择流式或阻塞响应。",
-        "operationId": "runPipelineZh",
+        "description": "对一个或多个数据源运行完整的知识流水线。已发布运行会进入队列，并始终以 JSON 返回批次元数据；草稿运行支持阻塞 JSON 和流式 Server-Sent Events。 对已发布运行，将返回的 `batch` 传给[获取文档索引状态（进度）](/zh/api-reference/documents/get-document-indexing-status)，轮询直到所有文档达到 `completed`、`error` 或 `paused`。",
+        "operationId": "runPipeline",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "inputs",
-                  "datasource_type",
-                  "datasource_info_list",
-                  "start_node_id",
-                  "is_published",
-                  "response_mode"
-                ],
-                "properties": {
-                  "inputs": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "流水线输入变量的键值对，对应工作流中定义的流水线变量。如果流水线没有输入变量，传 `{}`。"
-                  },
-                  "datasource_type": {
-                    "type": "string",
-                    "enum": [
-                      "local_file",
-                      "online_document",
-                      "website_crawl",
-                      "online_drive"
-                    ],
-                    "description": "数据源类型。决定 `datasource_info_list` 中条目所需的字段。"
-                  },
-                  "datasource_info_list": {
-                    "type": "array",
-                    "description": "待处理的数据源对象列表。条目结构取决于 `datasource_type`。",
-                    "items": {
-                      "oneOf": [
-                        {
-                          "title": "Local File",
-                          "type": "object",
-                          "required": [
-                            "reference"
-                          ],
-                          "properties": {
-                            "reference": {
-                              "type": "string",
-                              "description": "使用 [上传流水线文件](/zh/api-reference/knowledge-pipeline/upload-pipeline-file) 端点返回的 `id`。`related_id` 可作为别名使用。"
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "文档标题。默认为 `\"untitled\"`。"
-                            }
-                          }
-                        },
-                        {
-                          "title": "Online Document",
-                          "type": "object",
-                          "required": [
-                            "workspace_id",
-                            "page"
-                          ],
-                          "properties": {
-                            "workspace_id": {
-                              "type": "string",
-                              "description": "外部平台中的工作空间或数据库 ID（例如 Notion 工作空间 ID）。"
-                            },
-                            "page": {
-                              "type": "object",
-                              "description": "页面详情。",
-                              "required": [
-                                "page_id",
-                                "type"
-                              ],
-                              "properties": {
-                                "page_id": {
-                                  "type": "string",
-                                  "description": "页面标识符。"
-                                },
-                                "type": {
-                                  "type": "string",
-                                  "description": "由数据源插件定义的页面类型（例如 `\"page\"`、`\"database\"`）。"
-                                },
-                                "page_name": {
-                                  "type": "string",
-                                  "description": "显示名称。默认为 `\"untitled\"`。"
-                                }
-                              }
-                            },
-                            "credential_id": {
-                              "type": "string",
-                              "description": "用于与外部平台认证的凭证。通过 Dify 控制台管理。如省略，则使用该供应商的默认凭证。"
-                            }
-                          }
-                        },
-                        {
-                          "title": "Website Crawl",
-                          "type": "object",
-                          "required": [
-                            "url"
-                          ],
-                          "properties": {
-                            "url": {
-                              "type": "string",
-                              "description": "待爬取的 URL。"
-                            },
-                            "title": {
-                              "type": "string",
-                              "description": "用作文档名称。默认为 `\"untitled\"`。"
-                            }
-                          }
-                        },
-                        {
-                          "title": "Online Drive",
-                          "type": "object",
-                          "required": [
-                            "id",
-                            "type"
-                          ],
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "文件或文件夹 ID。"
-                            },
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "file",
-                                "folder"
-                              ],
-                              "description": "该条目是单个文件还是待展开的文件夹。"
-                            },
-                            "bucket": {
-                              "type": "string",
-                              "description": "存储桶名称。部分存储供应商需要此字段（例如 S3 兼容存储）；如果供应商不使用存储桶，可省略。"
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "文件名称。默认为 `\"untitled\"`。"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "start_node_id": {
-                    "type": "string",
-                    "description": "开始执行的节点 ID，来自 [获取数据源插件列表](/zh/api-reference/knowledge-pipeline/list-datasource-plugins)。"
-                  },
-                  "is_published": {
-                    "type": "boolean",
-                    "description": "是否运行流水线的已发布版本，而非当前草稿。运行草稿可测试未发布的更改。"
-                  },
-                  "response_mode": {
-                    "type": "string",
-                    "enum": [
-                      "streaming",
-                      "blocking"
-                    ],
-                    "description": "流水线执行的响应模式。`streaming` 返回服务器发送事件流，`blocking` 等待并返回完整结果。"
-                  }
-                }
+                "$ref": "#/components/schemas/PipelineRunApiEntity"
               },
               "examples": {
                 "local_file": {
@@ -10846,7 +10648,7 @@
                       }
                     ],
                     "start_node_id": "1719288585006",
-                    "is_published": true,
+                    "is_published": false,
                     "response_mode": "blocking"
                   }
                 },
@@ -10861,13 +10663,13 @@
                         "page": {
                           "page_id": "pg-def456",
                           "type": "page",
-                          "page_name": "Product Roadmap"
+                          "page_name": "产品路线图"
                         },
                         "credential_id": "cred-789xyz"
                       }
                     ],
                     "start_node_id": "1719288585006",
-                    "is_published": true,
+                    "is_published": false,
                     "response_mode": "streaming"
                   }
                 },
@@ -10879,7 +10681,7 @@
                     "datasource_info_list": [
                       {
                         "url": "https://example.com/docs/getting-started",
-                        "title": "Getting Started Guide"
+                        "title": "入门指南"
                       }
                     ],
                     "start_node_id": "1719288585006",
@@ -10907,27 +10709,47 @@
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "流水线执行结果。格式取决于 `response_mode`：流式返回 `text/event-stream`，阻塞返回完整的 JSON 结果。",
             "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "string",
-                  "description": "Server-Sent Events 流。当 `response_mode` 为 `streaming` 时返回；线路格式参见 [SSE 流式传输](/zh/api-reference/guides/streaming)。\n\n主要事件：\n\n- `workflow_started`：执行开始\n- `node_started` / `node_finished`：逐节点进度，包含 `node_id`、`node_type`、`status`、`inputs`、`outputs`\n- `workflow_finished`：最终结果，包含 `status`、`outputs`、`total_tokens`、`elapsed_time`\n- `ping`：心跳保活"
-                }
-              },
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "description": "完整的流水线执行结果。当 `response_mode` 为 `blocking` 时返回。",
-                  "additionalProperties": true
+                  "$ref": "#/components/schemas/PipelineRunJsonResponse",
+                  "description": "已发布运行的 JSON 结果，或草稿运行在 `blocking` 模式下的 JSON 结果。"
                 },
                 "examples": {
-                  "success": {
-                    "summary": "Blocking Response Example",
+                  "published": {
+                    "summary": "已发布流水线响应",
+                    "value": {
+                      "batch": "20260825143015948271",
+                      "dataset": {
+                        "id": "c9f5e6f0-d10a-4f57-a1d8-a4b63f8459f4",
+                        "name": "产品文档",
+                        "description": "产品说明文档",
+                        "chunk_structure": "text_model"
+                      },
+                      "documents": [
+                        {
+                          "id": "9af03c49-30c4-4d64-a605-17f3171fbf9a",
+                          "position": 1,
+                          "data_source_type": "local_file",
+                          "data_source_info": {
+                            "reference": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                            "name": "quarterly-report.pdf"
+                          },
+                          "name": "quarterly-report.pdf",
+                          "indexing_status": "waiting",
+                          "error": null,
+                          "enabled": true
+                        }
+                      ]
+                    }
+                  },
+                  "draft_blocking": {
+                    "summary": "草稿阻塞响应",
                     "value": {
                       "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
                       "workflow_run_id": "f1e2d3c4-b5a6-7890-abcd-ef0987654321",
@@ -10936,16 +10758,33 @@
                         "status": "succeeded",
                         "outputs": {},
                         "created_at": 1741267200,
-                        "finished_at": 1741267210
+                        "finished_at": 1741267210,
+                        "workflow_id": "7c3e33d4-2a8b-4e5f-9b1a-d3c6e8f12345",
+                        "error": null,
+                        "elapsed_time": 10.0,
+                        "total_tokens": 0,
+                        "total_steps": 1
                       }
                     }
                   }
                 }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "草稿知识流水线运行的 Server-Sent Events 流。按 [SSE 流式传输指南](/zh/api-reference/guides/streaming) 解析 `data:` 记录。常见事件包括 `workflow_started`、`node_started`、`node_finished`、`workflow_finished` 和 `error`；事件载荷使用与工作流事件流相同的封装格式。"
+                },
+                "examples": {
+                  "successfulStream": {
+                    "summary": "响应示例 - 成功事件流",
+                    "value": "data: {\"event\":\"workflow_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"id\":\"run_123\",\"status\":\"running\"}}\n\ndata: {\"event\":\"node_started\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"node_type\":\"datasource\",\"title\":\"数据源\"}}\n\ndata: {\"event\":\"node_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"node_id\":\"datasource_node_1\",\"status\":\"succeeded\",\"outputs\":{}}}\n\ndata: {\"event\":\"workflow_finished\",\"workflow_run_id\":\"run_123\",\"data\":{\"status\":\"succeeded\",\"outputs\":{}}}\n\n"
+                  }
+                }
               }
-            }
+            },
+            "description": "流水线执行结果。已发布运行以 JSON 返回排队批次元数据；草稿运行在 `streaming` 模式下返回 Server-Sent Events，在 `blocking` 模式下以 JSON 返回工作流结果。"
           },
           "400": {
-            "description": "`invalid_param` : 该知识库未配置处理流水线，或请求体校验失败。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10959,15 +10798,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`invalid_param`：该知识库未配置处理流水线，或请求体校验失败。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -10976,10 +10832,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           },
           "404": {
-            "description": "`not_found` : 未找到与 `dataset_id` 匹配的知识库。",
             "content": {
               "application/json": {
                 "examples": {
@@ -10993,10 +10849,10 @@
                   }
                 }
               }
-            }
+            },
+            "description": "- `not_found`：未找到与 `dataset_id` 匹配的知识库。"
           },
           "500": {
-            "description": "`pipeline_run_error` : 流水线执行失败。",
             "content": {
               "application/json": {
                 "examples": {
@@ -11010,9 +10866,14 @@
                   }
                 }
               }
-            }
+            },
+            "description": "`pipeline_run_error`：流水线执行失败。"
           }
         },
+        "summary": "运行流水线",
+        "tags": [
+          "知识流水线"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/knowledge-pipeline/run-pipeline",
           "metadata": {
@@ -11263,54 +11124,27 @@
     },
     "/datasets/{dataset_id}/tags": {
       "get": {
-        "tags": [
-          "标签"
-        ],
-        "summary": "获取知识库绑定的标签",
         "description": "返回绑定到知识库的标签。",
         "operationId": "queryDatasetTags",
         "parameters": [
           {
-            "name": "dataset_id",
+            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。",
             "in": "path",
+            "name": "dataset_id",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "知识库 ID。从 [获取知识库列表](/zh/api-reference/knowledge-bases/list-knowledge-bases) 获取。"
+              "description": "知识库 ID。",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "绑定到知识库的标签。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "description": "标签标识符。"
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "标签显示名称。"
-                          }
-                        }
-                      },
-                      "description": "绑定到此知识库的标签列表。"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "绑定到该知识库的标签总数。"
-                    }
-                  }
+                  "$ref": "#/components/schemas/DatasetBoundTagListResponse"
                 },
                 "examples": {
                   "success": {
@@ -11319,7 +11153,7 @@
                       "data": [
                         {
                           "id": "f4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
-                          "name": "Product Docs"
+                          "name": "产品文档"
                         }
                       ],
                       "total": 1
@@ -11327,15 +11161,32 @@
                   }
                 }
               }
-            }
+            },
+            "description": "绑定到知识库的标签。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           },
           "403": {
-            "description": "`forbidden` : 该知识库未启用 API 访问。",
             "content": {
               "application/json": {
                 "examples": {
                   "forbidden": {
-                    "summary": "forbidden (api access)",
+                    "summary": "forbidden（API 访问）",
                     "value": {
                       "status": 403,
                       "code": "forbidden",
@@ -11344,26 +11195,14 @@
                   }
                 }
               }
-            }
-          },
-          "404": {
-            "description": "`not_found` : 未找到知识库。",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "not_found": {
-                    "summary": "not_found",
-                    "value": {
-                      "status": 404,
-                      "code": "not_found",
-                      "message": "Dataset not found."
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "- `forbidden`：该知识库未启用 API 访问。"
           }
         },
+        "summary": "获取知识库绑定的标签",
+        "tags": [
+          "标签"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/tags/get-knowledge-base-tags",
           "metadata": {
@@ -14465,164 +14304,34 @@
     },
     "/workspaces/current/models/model-types/{model_type}": {
       "get": {
-        "tags": [
-          "模型"
-        ],
-        "summary": "获取可用模型",
         "description": "返回指定类型的可用模型。用它查找可配置到知识库的 `text-embedding` 和 `rerank` 模型。",
-        "operationId": "getAvailableModelsZh",
+        "operationId": "getAvailableModels",
         "parameters": [
           {
-            "name": "model_type",
+            "description": "要获取的模型类型。",
             "in": "path",
+            "name": "model_type",
             "required": true,
             "schema": {
-              "type": "string",
+              "description": "要获取的模型类型。",
               "enum": [
-                "text-embedding",
-                "rerank",
                 "llm",
-                "tts",
+                "moderation",
+                "rerank",
                 "speech2text",
-                "moderation"
-              ]
-            },
-            "description": "要获取的模型类型。对于知识库配置，使用 `text-embedding` 获取嵌入模型，使用 `rerank` 获取重排序模型。"
+                "text-embedding",
+                "tts"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "指定类型的可用模型。",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "模型供应商及其可用模型的列表。",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "provider": {
-                            "type": "string",
-                            "description": "模型供应商标识符，格式为 `organization/plugin_name/provider_name`（例如 `langgenius/openai/openai`）。旧版供应商可能返回简写形式（例如 `openai`）。"
-                          },
-                          "label": {
-                            "type": "object",
-                            "description": "供应商的本地化显示名称。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "英文显示名称。"
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "中文显示名称。"
-                              }
-                            }
-                          },
-                          "icon_small": {
-                            "type": "object",
-                            "description": "供应商小图标的 URL。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string",
-                                "description": "小图标 URL。"
-                              },
-                              "zh_Hans": {
-                                "type": "string",
-                                "description": "中文图标 URL。"
-                              }
-                            }
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "供应商状态。凭证已配置且有效时为 `active`。"
-                          },
-                          "models": {
-                            "type": "array",
-                            "description": "该供应商的可用模型列表。",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "model": {
-                                  "type": "string",
-                                  "description": "模型标识符。创建或更新知识库时，将此值作为 `embedding_model` 参数使用。"
-                                },
-                                "label": {
-                                  "type": "object",
-                                  "description": "模型的本地化显示名称。",
-                                  "properties": {
-                                    "en_US": {
-                                      "type": "string",
-                                      "description": "英文模型名称。"
-                                    },
-                                    "zh_Hans": {
-                                      "type": "string",
-                                      "description": "中文模型名称。"
-                                    }
-                                  }
-                                },
-                                "model_type": {
-                                  "type": "string",
-                                  "description": "模型类型，与 `model_type` 路径参数匹配。"
-                                },
-                                "features": {
-                                  "type": "array",
-                                  "nullable": true,
-                                  "description": "模型支持的功能，无功能时为 `null`。",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "fetch_from": {
-                                  "type": "string",
-                                  "description": "模型定义的来源。`predefined-model` 表示内置模型，`customizable-model` 表示用户自配置的模型。"
-                                },
-                                "model_properties": {
-                                  "type": "object",
-                                  "description": "模型特定的属性，例如 `context_size`。"
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "description": "模型可用状态。就绪时为 `active`。"
-                                },
-                                "deprecated": {
-                                  "type": "boolean",
-                                  "description": "模型是否已弃用。"
-                                },
-                                "load_balancing_enabled": {
-                                  "type": "boolean",
-                                  "description": "模型是否启用负载均衡。"
-                                },
-                                "has_invalid_load_balancing_configs": {
-                                  "type": "boolean",
-                                  "description": "模型是否存在无效的负载均衡配置。"
-                                }
-                              }
-                            }
-                          },
-                          "tenant_id": {
-                            "type": "string",
-                            "description": "该供应商配置所属的工作空间 ID。"
-                          },
-                          "icon_small_dark": {
-                            "type": "object",
-                            "description": "深色模式图标 URL；供应商没有时为 `null`。",
-                            "properties": {
-                              "en_US": {
-                                "type": "string"
-                              },
-                              "zh_Hans": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/ProviderWithModelsListResponse"
                 },
                 "examples": {
                   "success": {
@@ -14667,9 +14376,31 @@
                   }
                 }
               }
-            }
+            },
+            "description": "指定类型的可用模型。"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "unauthorized": {
+                    "summary": "unauthorized",
+                    "value": {
+                      "status": 401,
+                      "code": "unauthorized",
+                      "message": "Authorization header must be provided and start with 'Bearer'"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "- `unauthorized`：`Authorization` 请求头缺失、格式错误或包含无效的 API 密钥。"
           }
         },
+        "summary": "获取可用模型",
+        "tags": [
+          "模型"
+        ],
         "x-mint": {
           "href": "/zh/api-reference/models/get-available-models",
           "metadata": {


### PR DESCRIPTION
## Summary

- generate metadata, tag, model, and knowledge-pipeline operations in all three Service API references
- complete the generated knowledge-operation set while preserving localized presentation
- keep legacy-only definitions for a dedicated cleanup layer

## Validation

- three-locale structural parity — 0 issues