### PR TITLE
feat: update service api validation and navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -379,6 +379,7 @@
                             "group": "Applications",
                             "openapi": "en/api-reference/openapi_service.json",
                             "pages": [
+                              "GET /",
                               "GET /info",
                               "GET /parameters",
                               "GET /meta",
@@ -450,7 +451,6 @@
                               "GET /datasets/{dataset_id}/documents/{document_id}/download",
                               "GET /datasets/{dataset_id}/documents/{batch}/indexing-status",
                               "POST /datasets/{dataset_id}/documents/{document_id}/update-by-text",
-                              "POST /datasets/{dataset_id}/documents/{document_id}/update-by-file",
                               "POST /datasets/{dataset_id}/documents/download-zip",
                               "PATCH /datasets/{dataset_id}/documents/status/{action}"
                             ]
@@ -1101,6 +1101,7 @@
                             "group": "Applications",
                             "openapi": "en/api-reference/openapi_service.json",
                             "pages": [
+                              "GET /",
                               "GET /info",
                               "GET /parameters",
                               "GET /meta",
@@ -1172,7 +1173,6 @@
                               "GET /datasets/{dataset_id}/documents/{document_id}/download",
                               "GET /datasets/{dataset_id}/documents/{batch}/indexing-status",
                               "POST /datasets/{dataset_id}/documents/{document_id}/update-by-text",
-                              "POST /datasets/{dataset_id}/documents/{document_id}/update-by-file",
                               "POST /datasets/{dataset_id}/documents/download-zip",
                               "PATCH /datasets/{dataset_id}/documents/status/{action}"
                             ]
@@ -1772,6 +1772,7 @@
                             "group": "应用配置",
                             "openapi": "zh/api-reference/openapi_service.json",
                             "pages": [
+                              "GET /",
                               "GET /info",
                               "GET /parameters",
                               "GET /meta",
@@ -1843,7 +1844,6 @@
                               "GET /datasets/{dataset_id}/documents/{document_id}/download",
                               "GET /datasets/{dataset_id}/documents/{batch}/indexing-status",
                               "POST /datasets/{dataset_id}/documents/{document_id}/update-by-text",
-                              "POST /datasets/{dataset_id}/documents/{document_id}/update-by-file",
                               "POST /datasets/{dataset_id}/documents/download-zip",
                               "PATCH /datasets/{dataset_id}/documents/status/{action}"
                             ]
@@ -2494,6 +2494,7 @@
                             "group": "应用配置",
                             "openapi": "zh/api-reference/openapi_service.json",
                             "pages": [
+                              "GET /",
                               "GET /info",
                               "GET /parameters",
                               "GET /meta",
@@ -2565,7 +2566,6 @@
                               "GET /datasets/{dataset_id}/documents/{document_id}/download",
                               "GET /datasets/{dataset_id}/documents/{batch}/indexing-status",
                               "POST /datasets/{dataset_id}/documents/{document_id}/update-by-text",
-                              "POST /datasets/{dataset_id}/documents/{document_id}/update-by-file",
                               "POST /datasets/{dataset_id}/documents/download-zip",
                               "PATCH /datasets/{dataset_id}/documents/status/{action}"
                             ]
@@ -3165,6 +3165,7 @@
                             "group": "アプリケーション設定",
                             "openapi": "ja/api-reference/openapi_service.json",
                             "pages": [
+                              "GET /",
                               "GET /info",
                               "GET /parameters",
                               "GET /meta",
@@ -3236,7 +3237,6 @@
                               "GET /datasets/{dataset_id}/documents/{document_id}/download",
                               "GET /datasets/{dataset_id}/documents/{batch}/indexing-status",
                               "POST /datasets/{dataset_id}/documents/{document_id}/update-by-text",
-                              "POST /datasets/{dataset_id}/documents/{document_id}/update-by-file",
                               "POST /datasets/{dataset_id}/documents/download-zip",
                               "PATCH /datasets/{dataset_id}/documents/status/{action}"
                             ]
@@ -3887,6 +3887,7 @@
                             "group": "アプリケーション設定",
                             "openapi": "ja/api-reference/openapi_service.json",
                             "pages": [
+                              "GET /",
                               "GET /info",
                               "GET /parameters",
                               "GET /meta",
@@ -3958,7 +3959,6 @@
                               "GET /datasets/{dataset_id}/documents/{document_id}/download",
                               "GET /datasets/{dataset_id}/documents/{batch}/indexing-status",
                               "POST /datasets/{dataset_id}/documents/{document_id}/update-by-text",
-                              "POST /datasets/{dataset_id}/documents/{document_id}/update-by-file",
                               "POST /datasets/{dataset_id}/documents/download-zip",
                               "PATCH /datasets/{dataset_id}/documents/status/{action}"
                             ]
@@ -5358,22 +5358,6 @@
       "destination": "/en/api-reference/guides/get-started"
     },
     {
-      "source": "/api-reference/knowledge-bases/list-knowledge-bases",
-      "destination": "/en/api-reference/guides/knowledge"
-    },
-    {
-      "source": "/api-reference/知识库/获取知识库列表",
-      "destination": "/zh/api-reference/guides/knowledge"
-    },
-    {
-      "source": "/api-reference/データセット/ナレッジベースリストを取得",
-      "destination": "/ja/api-reference/guides/knowledge"
-    },
-    {
-      "source": "/api-reference/:slug*",
-      "destination": "/en/api-reference/guides/get-started"
-    },
-    {
       "source": "/home",
       "destination": "/en/home"
     },
@@ -5396,6 +5380,22 @@
     {
       "source": "/develop-plugin/:slug*",
       "destination": "/en/develop-plugin/:slug*"
+    },
+    {
+      "source": "/api-reference/knowledge-bases/list-knowledge-bases",
+      "destination": "/en/api-reference/guides/knowledge"
+    },
+    {
+      "source": "/api-reference/知识库/获取知识库列表",
+      "destination": "/zh/api-reference/guides/knowledge"
+    },
+    {
+      "source": "/api-reference/データセット/ナレッジベースリストを取得",
+      "destination": "/ja/api-reference/guides/knowledge"
+    },
+    {
+      "source": "/api-reference/:slug*",
+      "destination": "/en/api-reference/guides/get-started"
     }
   ],
   "integrations": {

--- a/tools/api-pipeline/lint_specs.py
+++ b/tools/api-pipeline/lint_specs.py
@@ -1,4 +1,4 @@
-"""Mechanical lint for Dify OpenAPI specs: examples vs schemas, enum coverage, links, x-codeSamples guard."""
+"""Mechanical lint for Dify OpenAPI specs: examples, schemas, links, and samples."""
 
 import json
 import os
@@ -28,6 +28,21 @@ def resolve(schema, spec, depth=0):
 
 
 CHECKS = {"examples": 0, "links": 0}
+MARKDOWN_LINK_RE = re.compile(r"\]\((/[^)\s]+)\)")
+
+
+def iter_markdown_links(node, path="$"):
+    """Yield internal Markdown links from every string in an OpenAPI document."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from iter_markdown_links(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from iter_markdown_links(value, f"{path}[{index}]")
+    elif isinstance(node, str):
+        for link in MARKDOWN_LINK_RE.findall(node):
+            yield path, link
+
 
 def check_example(example, schema, spec, where, f, path=""):
     if not path:
@@ -109,6 +124,33 @@ for f in SPEC_FILES:
                 if href:
                     valid_pages.add(href.split("#")[0])
 
+    for json_path, link in iter_markdown_links(spec):
+        CHECKS["links"] += 1
+        base = link.split("#")[0]
+        api_match = re.match(r"^/(en|zh|ja)/api-reference/", link)
+        if link.startswith("/api-reference/"):
+            issues[rel].append(f"{json_path}: API link missing language prefix: {link}")
+        elif api_match:
+            if api_match.group(1) != lang:
+                issues[rel].append(
+                    f"{json_path}: API link uses the wrong language prefix: {link}"
+                )
+            if base not in valid_pages:
+                # MDX guide pages live under api-reference/ too
+                target = f"{DOCS}{base}"
+                if not (
+                    os.path.exists(target + ".mdx") or os.path.exists(target + ".md")
+                ):
+                    issues[rel].append(f"{json_path}: broken link target {link}")
+        elif not re.match(r"^/(en|zh|ja)/", link):
+            issues[rel].append(
+                f"{json_path}: non-API link without language prefix: {link}"
+            )
+        else:
+            target = f"{DOCS}{base}"
+            if not (os.path.exists(target + ".mdx") or os.path.exists(target + ".md")):
+                issues[rel].append(f"{json_path}: broken doc link {link}")
+
     all_example_values = set()
     all_enums = []  # (where, enum values)
 
@@ -129,7 +171,15 @@ for f in SPEC_FILES:
             for code, resp in (op.get("responses", {}) or {}).items():
                 for ctype, media in (resp.get("content", {}) or {}).items():
                     schema = media.get("schema", {})
-                    for name, ex in iter_examples(media):
+                    examples = list(iter_examples(media))
+                    if ctype == "application/json" and (
+                        str(code) in {"200", "201"}
+                        or str(code).startswith(("4", "5"))
+                    ) and not examples:
+                        issues[rel].append(
+                            f"{where} resp{code}: application/json response has no example"
+                        )
+                    for name, ex in examples:
                         check_example(ex, schema, spec, f"{where} resp{code}[{name}]", rel)
                         collect_enum_usage(ex, all_example_values, spec)
 
@@ -143,25 +193,6 @@ for f in SPEC_FILES:
                     req_query.append(prm["name"])
             if req_query and m.lower() == "get" and not op.get("x-codeSamples"):
                 issues[rel].append(f"{where}: required query {req_query} but no x-codeSamples override")
-
-            # link targets in descriptions
-            desc = op.get("description", "") or ""
-            for link in re.findall(r"\]\((/[^)\s]+)\)", desc):
-                CHECKS["links"] += 1
-                if link.startswith("/api-reference/") or re.match(r"^/(en|zh|ja)/api-reference/", link):
-                    base = link.split("#")[0]
-                    if base not in valid_pages:
-                        # MDX guide pages live under api-reference/ too
-                        target = f"{DOCS}{base}"
-                        if not (os.path.exists(target + ".mdx") or os.path.exists(target + ".md")):
-                            issues[rel].append(f"{where}: broken link target {link}")
-                else:
-                    if not re.match(r"^/(en|zh|ja)/", link):
-                        issues[rel].append(f"{where}: non-API link without language prefix: {link}")
-                    else:
-                        target = f"{DOCS}{link.split('#')[0]}"
-                        if not (os.path.exists(target + ".mdx") or os.path.exists(target + ".md")):
-                            issues[rel].append(f"{where}: broken doc link {link}")
 
     # enum coverage: every enum value in schemas seen in at least one example (warning-level)
     def walk_schemas(node, ctx, depth=0):
@@ -194,3 +225,4 @@ for f in sorted(issues):
         seen.add(msg)
         print("  -", msg)
     print()
+sys.exit(1 if total else 0)

--- a/tools/api-pipeline/merge_specs.py
+++ b/tools/api-pipeline/merge_specs.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 """Service API docs.json wiring and coverage checks.
 
-Since Phase 1 shipped, {lang}/api-reference/openapi_service.json is the
-hand-maintained spec of record for each language: edit it directly. The
-Phase-1 merge machinery (build/relink, resolutions.json, overrides/) that
-produced it from the five per-app-type source specs is retired; recover it
-from git history when Phase 2 rebuilds the spec from R&D's generated spec
-plus docs-owned overlays.
+The rendered {lang}/api-reference/openapi_service.json files are composed from
+Dify's generated Service API contract plus reviewed locale overlays. This
+module owns only navigation wiring and app-type coverage over those outputs;
+compose_service_api.py owns contract composition.
 
 Modes:
   wire            Regenerate the docs.json API menus (all languages ×
@@ -23,6 +21,8 @@ Usage:
 Env:
   DOCS  docs repo root (default: two levels above this file)
 """
+
+from __future__ import annotations
 
 import argparse
 import copy
@@ -59,7 +59,9 @@ def load_nav_labels() -> dict:
         return json.load(f)
 
 
-def nav_groups_for(lang: str, labels: dict) -> list:
+def nav_groups_for(
+    lang: str, labels: dict, existing_order: list[str] | None = None
+) -> list:
     """The API menu's three groups: Guides, App APIs, Knowledge API.
 
     Guides lists the hand-maintained overview pages (guides_order). The two
@@ -85,11 +87,18 @@ def nav_groups_for(lang: str, labels: dict) -> list:
         if (path, method) != (en_path, en_method):
             mismatches.append(((path, method), (en_path, en_method)))
             continue
+        if en_op.get("deprecated") is True:
+            continue
         ops_by_en_tag.setdefault(en_op["tags"][0], []).append(f"{method.upper()} {path}")
     if mismatches:
         raise ValueError(
             f"nav_groups_for({lang}): merged spec operation order diverges from en: {mismatches}"
         )
+    existing_order = existing_order or []
+    for tag, operations in ops_by_en_tag.items():
+        ops_by_en_tag[tag] = [op for op in existing_order if op in operations] + [
+            op for op in operations if op not in existing_order
+        ]
     for tag, order in labels.get("op_order", {}).items():
         if tag in ops_by_en_tag:
             ops_by_en_tag[tag] = [o for o in order if o in ops_by_en_tag[tag]] + \
@@ -121,8 +130,32 @@ def wire(langs):
         docs = json.load(f)
 
     for lang in langs:
-        groups = nav_groups_for(lang, labels)
         lang_nav = next(l for l in docs["navigation"]["languages"] if l["language"] == lang)
+        existing_order: list[str] = []
+
+        def collect_operation_pages(value):
+            if isinstance(value, str) and re.match(
+                r"^(?:DELETE|GET|HEAD|OPTIONS|PATCH|POST|PUT|TRACE) /", value
+            ):
+                existing_order.append(value)
+            elif isinstance(value, dict):
+                collect_operation_pages(value.get("pages", []))
+            elif isinstance(value, list):
+                for item in value:
+                    collect_operation_pages(item)
+
+        for product in lang_nav.get("products", []):
+            for tab in product.get("tabs", []):
+                for item in tab.get("menu", []):
+                    if item.get("item") == "API":
+                        collect_operation_pages(item.get("groups", []))
+                        break
+                if existing_order:
+                    break
+            if existing_order:
+                break
+
+        groups = nav_groups_for(lang, labels, existing_order)
         replaced = 0
         for prod in lang_nav.get("products", []):
             for tab in prod.get("tabs", []):

--- a/tools/api-pipeline/parity_check.py
+++ b/tools/api-pipeline/parity_check.py
@@ -1,4 +1,4 @@
-import json, os, sys
+import json, os, re, sys
 DOCS = os.environ['DOCS']
 
 def op_shape(op):
@@ -10,6 +10,25 @@ def op_shape(op):
     body_types = sorted(((op.get('requestBody') or {}).get('content') or {}).keys())
     n_samples = len(op.get('x-codeSamples', []))
     return {'params': params, 'responses': responses, 'body': body_types, 'samples': n_samples}
+
+
+def localized_prose(node, path='$', result=None):
+    """Collect reader-facing prose while excluding example labels and values."""
+    result = {} if result is None else result
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child_path = f'{path}.{key}'
+            if (
+                key in {'description', 'summary'}
+                and isinstance(value, str)
+                and '.examples.' not in child_path
+            ):
+                result[child_path] = value
+            localized_prose(value, child_path, result)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            localized_prose(value, f'{path}[{index}]', result)
+    return result
 
 total = 0
 en_file = f'{DOCS}/en/api-reference/openapi_service.json'
@@ -25,6 +44,16 @@ for en_file in [en_file]:
             print(f'MISSING FILE: {lang}/api-reference/{name}'); total += 1; continue
         with open(other_file, encoding='utf-8') as _fh:
             other = json.load(_fh)
+        en_prose = localized_prose(en)
+        other_prose = localized_prose(other)
+        for path, english in en_prose.items():
+            if (
+                other_prose.get(path) == english
+                and re.search(r'\b[A-Za-z]{3,}\b', english)
+                and re.search(r'\s', english)
+            ):
+                print(f'{lang}/{name}: untranslated prose at {path}: {english!r}')
+                total += 1
         en_ops = {(p, m) for p, ms in en['paths'].items() for m in ms if isinstance(ms[m], dict)}
         ot_ops = {(p, m) for p, ms in other['paths'].items() for m in ms if isinstance(ms[m], dict)}
         for p, m in sorted(en_ops - ot_ops):

--- a/tools/api-pipeline/test_merge_specs.py
+++ b/tools/api-pipeline/test_merge_specs.py
@@ -1,0 +1,100 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import merge_specs
+
+
+class NavigationGenerationTest(unittest.TestCase):
+    def test_existing_navigation_order_is_preserved_for_shared_operations(self) -> None:
+        spec = {
+            "tags": [{"name": "Documents"}],
+            "paths": {
+                "/a": {"get": {"tags": ["Documents"]}},
+                "/b": {"get": {"tags": ["Documents"]}},
+                "/new": {"get": {"tags": ["Documents"]}},
+            },
+        }
+        labels = {
+            "guides_layout": [],
+            "guides_group": {"en": "Guides"},
+            "op_order": {},
+            "reference": {
+                "app_apis": {
+                    "labels": {"en": "App APIs"},
+                    "tag_order_en": ["Documents"],
+                },
+                "knowledge_api": {
+                    "labels": {"en": "Knowledge API"},
+                    "tag_order_en": [],
+                },
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            spec_path = repo / "en" / "api-reference" / "openapi_service.json"
+            spec_path.parent.mkdir(parents=True)
+            spec_path.write_text(json.dumps(spec), encoding="utf-8")
+
+            with (
+                patch.object(merge_specs, "REPO", repo),
+                patch.object(merge_specs, "load_memberships", return_value={"pages": {}}),
+            ):
+                groups = merge_specs.nav_groups_for(
+                    "en", labels, ["GET /b", "GET /a"]
+                )
+
+        self.assertEqual(
+            groups[1]["pages"][0]["pages"],
+            ["GET /b", "GET /a", "GET /new"],
+        )
+
+    def test_deprecated_compatibility_operations_are_not_added_to_navigation(self) -> None:
+        spec = {
+            "tags": [{"name": "Documents"}],
+            "paths": {
+                "/documents": {
+                    "post": {"tags": ["Documents"]},
+                },
+                "/documents_legacy": {
+                    "post": {"deprecated": True, "tags": ["Documents"]},
+                },
+            },
+        }
+        labels = {
+            "guides_layout": [],
+            "guides_group": {"en": "Guides"},
+            "op_order": {},
+            "reference": {
+                "app_apis": {
+                    "labels": {"en": "App APIs"},
+                    "tag_order_en": ["Documents"],
+                },
+                "knowledge_api": {
+                    "labels": {"en": "Knowledge API"},
+                    "tag_order_en": [],
+                },
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            spec_path = repo / "en" / "api-reference" / "openapi_service.json"
+            spec_path.parent.mkdir(parents=True)
+            spec_path.write_text(json.dumps(spec), encoding="utf-8")
+
+            with (
+                patch.object(merge_specs, "REPO", repo),
+                patch.object(merge_specs, "load_memberships", return_value={"pages": {}}),
+            ):
+                groups = merge_specs.nav_groups_for("en", labels)
+
+        pages = groups[1]["pages"][0]["pages"]
+        self.assertEqual(pages, ["POST /documents"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- update spec linting, locale parity checks, API navigation wiring, and their tests
- preserve stable sidebar order while omitting deprecated operations
- regenerate `docs.json` from the completed three-locale references

## Validation

- 62 unit tests passed
- coverage check — 0 failures
- spec lint — 1,857 examples and 644 links checked, 0 issues
- parity check — 0 issues
- `merge_specs.py wire` — `docs.json` unchanged