### PR TITLE
feat: add a stale-screenshot sweep to the terminology check

### DIFF
--- a/.claude/skills/dify-docs-terminology-check/SKILL.md
+++ b/.claude/skills/dify-docs-terminology-check/SKILL.md
@@ -55,7 +55,7 @@ Every bolded term and every heading is a candidate. Step 5 decides deterministic
 Screenshots are candidates too:
 
 ```bash
-grep -anoE '\(/images/[^)]+' <file>  # local images, prints line:(/images/path
+grep -anoE '/images/[^) "]+' <file>  # local images, prints line:/images/path
 ```
 
 View each listed image and read every UI string it displays; strings that are labels verify under Step 5 like bolded terms. An image showing a superseded string is a finding for re-capture — the fix is a new screenshot at the same path, never a prose edit. The pattern deliberately matches only local `/images/` paths; legacy CDN images (`assets-docs.dify.ai`) stay out of scope.

--- a/.claude/skills/dify-docs-terminology-check/SKILL.md
+++ b/.claude/skills/dify-docs-terminology-check/SKILL.md
@@ -2,9 +2,10 @@
 name: dify-docs-terminology-check
 description: >
   Audit terminology consistency across documentation against the codebase UI
-  labels and the glossary. Covers full files, not just diffs; excludes env var
-  docs. Use after finalizing a draft, or when the user says "check
-  terminology", "check terms", "verify glossary", or "terminology audit".
+  labels and the glossary — in prose and in the UI strings screenshots display.
+  Covers full files, not just diffs; excludes env var docs. Use after
+  finalizing a draft, or when the user says "check terminology", "check
+  terms", "verify glossary", or "terminology audit".
 ---
 
 # Terminology Consistency Check
@@ -50,6 +51,14 @@ grep -anE '^#{2,3} ' <file>          # section headings, prints line:## Heading
 The `-a` flag is required: some legacy zh/ja pages contain stray NUL bytes, and without it grep prints only `Binary file … matches` and silently drops the term inventory.
 
 Every bolded term and every heading is a candidate. Step 5 decides deterministically which are UI labels; do not pre-filter by intuition.
+
+Screenshots are candidates too:
+
+```bash
+grep -anoE '\(/images/[^)]+' <file>  # local images, prints line:(/images/path
+```
+
+View each listed image and read every UI string it displays; strings that are labels verify under Step 5 like bolded terms. An image showing a superseded string is a finding for re-capture — the fix is a new screenshot at the same path, never a prose edit. The pattern deliberately matches only local `/images/` paths; legacy CDN images (`assets-docs.dify.ai`) stay out of scope.
 
 ## Step 5 — Classify and verify UI labels against codebase i18n
 
@@ -107,6 +116,11 @@ Checked against Dify codebase `origin/<branch>` at `<short REF>`.
 - ✅ All UI labels (bolded terms and feature section headings) match codebase
   OR
 - ⚠️ Line {n}: **{label}** — codebase says "{expected}" (web/i18n/<locale>/<file>.json, key "<key>")
+
+**Stale Screenshots**
+- ✅ No local image shows a superseded UI string
+  OR
+- ⚠️ {image path} (line {n}): shows "{old string}"; the current label is "{new label}" (key "<key>") — re-capture needed
 
 **Glossary Gaps**
 - Terms used in docs but missing from glossary: {list}

--- a/writing-guides/index.md
+++ b/writing-guides/index.md
@@ -16,7 +16,7 @@ After completing a writing task, run these checks in order and apply the fixes b
 | Step | Skill | Purpose |
 |:-----|:------|:--------|
 | 1 | dify-docs-format-check | Enforce formatting rules on changed files, routed by path: `formatting-guide.md` for `en/`, general + Chinese/Japanese-specific rules for `zh/` and `ja/`. |
-| 2 | dify-docs-terminology-check | Verify terminology consistency against the glossary and codebase UI labels. |
+| 2 | dify-docs-terminology-check | Verify terminology consistency against the glossary and codebase UI labels, in prose and in the UI strings screenshots display. |
 | 3 | dify-docs-reader-test | Read each page from a first-time reader's perspective and flag comprehension gaps. |
 
 Steps 1 and 2 cover all three languages and audit the whole document, not just the diff. Step 3 is always the last step because it depends on the others passing.


### PR DESCRIPTION
## What

- The terminology check now treats screenshots as candidates: Step 4 lists each page's local images (`grep -anoE '\(/images/[^)]+'`), the auditor views them, and every UI string they display verifies against the codebase i18n under the same Step 5 rules as bolded terms.
- A stale screenshot is reported for re-capture in a new **Stale Screenshots** report section — the fix is a new image at the same path, never a prose edit. CDN-hosted legacy images stay out of scope by construction (the pattern matches only local `/images/` paths).
- The skill's frontmatter description and the check-chain digest in `writing-guides/index.md` now state the wider scope.