### PR TITLE
fix: clarify the screenshot clause wording

### DIFF
--- a/.claude/skills/dify-docs-terminology-check/SKILL.md
+++ b/.claude/skills/dify-docs-terminology-check/SKILL.md
@@ -2,7 +2,7 @@
 name: dify-docs-terminology-check
 description: >
   Audit terminology consistency across documentation against the codebase UI
-  labels and the glossary — in prose and in the UI strings screenshots display.
+  labels and the glossary — in prose and in the UI strings shown in screenshots.
   Covers full files, not just diffs; excludes env var docs. Use after
   finalizing a draft, or when the user says "check terminology", "check
   terms", "verify glossary", or "terminology audit".

--- a/writing-guides/index.md
+++ b/writing-guides/index.md
@@ -16,7 +16,7 @@ After completing a writing task, run these checks in order and apply the fixes b
 | Step | Skill | Purpose |
 |:-----|:------|:--------|
 | 1 | dify-docs-format-check | Enforce formatting rules on changed files, routed by path: `formatting-guide.md` for `en/`, general + Chinese/Japanese-specific rules for `zh/` and `ja/`. |
-| 2 | dify-docs-terminology-check | Verify terminology consistency against the glossary and codebase UI labels, in prose and in the UI strings screenshots display. |
+| 2 | dify-docs-terminology-check | Verify terminology consistency against the glossary and codebase UI labels, in prose and in the UI strings shown in screenshots. |
 | 3 | dify-docs-reader-test | Read each page from a first-time reader's perspective and flag comprehension gaps. |
 
 Steps 1 and 2 cover all three languages and audit the whole document, not just the diff. Step 3 is always the last step because it depends on the others passing.


### PR DESCRIPTION
Follow-up to #993: two Copilot comments landed after the merge. "The UI strings screenshots display" reads as a garden-path clause — now "the UI strings shown in screenshots" in the skill's frontmatter description and the check-chain digest in writing-guides/index.md.