### PR TITLE
docs: add the legacy agent glossary row and resync the termbase

### DIFF
--- a/en/self-host/deploy/configuration/environments.mdx
+++ b/en/self-host/deploy/configuration/environments.mdx
@@ -1399,7 +1399,7 @@ A publicly known development token ships as the default, so the stack starts out
 
 Default: `true`
 
-Shows the new Agent in the web UI: the **Agents** item in the main navigation and the New Agent node in the workflow node picker. 
+Shows the new Agent in the web UI: the **Agents** item in the main navigation and the new Agent node in the workflow node picker. 
 
 Set to `false` to hide it and fall back to the classic Agent node. Replaces `ENABLE_AGENT_V2`, which still works as a fallback.
 

--- a/tools/translate/termbase_i18n.md
+++ b/tools/translate/termbase_i18n.md
@@ -13,6 +13,7 @@
 | workflow | 工作流 | ワークフロー |
 | Agent | Agent | Agent |
 | Agent app | Agent 应用 | Agent アプリ |
+| Legacy Agent | 旧版 Agent | レガシー Agent |
 | Text Generator | 文本生成应用 | テキストジェネレーター |
 | knowledge base | 知识库 | ナレッジベース |
 | plugin | 插件 | プラグイン |
@@ -129,6 +130,9 @@
 | English | Chinese | Japanese |
 |:--------|:--------|:---------|
 | Max Iterations | 最大迭代次数 | 最大反復回数 |
+| build chat | 构建对话 | ビルドチャット |
+| build note | 构建笔记 | ビルドノート |
+| artifact | 产物 | 成果物 |
 
 ### Skills
 
@@ -417,11 +421,25 @@
 |:--------|:--------|:---------|
 | Agentic Strategy | Agent 策略 | エージェンティック戦略 |
 | Agent task | Agent 任务 | Agent タスク |
-| Edit in Agent Console | 在 Agent Console 中编辑 | Agent Console で編集 |
+| Edit in Agents | 在 Agents 中编辑 | Agents で編集 |
 | Make a copy | 创建副本 | コピーを作成 |
 | New output | 新建输出 | 新しい出力 |
 | Query Variable | 查询变量 | 検索変数 |
 | Metadata Filtering | 元数据过滤 | メタデータフィルタ |
+
+### New Agent Configure
+
+| English | Chinese | Japanese |
+|:--------|:--------|:---------|
+| Build mode | 构建模式 | ビルドモード |
+| Build draft | Build 草稿 | ビルドドラフト |
+| File system | 文件系统 | ファイルシステム |
+| Persistent | 长期 | 永続ファイル |
+| Temporary | 临时 | 一時ファイル |
+| Legacy Agent | 旧版 Agent | レガシー Agent |
+| Start fresh | 开启新对话 | 新しく始める |
+| Web App URL | Web 应用 URL | Web アプリ URL |
+| Backend Service API | 后端服务 API | バックエンドサービス API |
 
 ### Question Classifier Node Config
 

--- a/tools/translate/termbase_i18n.md
+++ b/tools/translate/termbase_i18n.md
@@ -72,6 +72,8 @@
 | Doc Extractor | 文档提取器 | テキスト抽出 |
 | List Operator | 列表操作 | リスト処理 |
 | Agent | Agent | Agent |
+| Classic Agent | 经典 Agent | クラシック Agent |
+| New Agent | 新 Agent | 新しい Agent |
 | Human Input | 人工介入 | 人間の入力 |
 | Trigger | 触发器 | トリガー |
 | Schedule Trigger | 定时触发器 | スケジュールトリガー |

--- a/writing-guides/glossary.md
+++ b/writing-guides/glossary.md
@@ -78,6 +78,8 @@ Terms appear in body text exactly as written in this table. Capitalize them furt
 | Doc Extractor | 文档提取器 | テキスト抽出 | Extracts text content from document files |
 | List Operator | 列表操作 | リスト処理 | Filters, sorts, and limits list data |
 | Agent | Agent | Agent | Workflow node (distinct from Agent app type above) |
+| Classic Agent | 经典 Agent | クラシック Agent | Docs name for the original Agent node's tab on the two-tab nodes page; Chatflow's default and fully supported, not legacy. In prose, lowercase adjective: the classic Agent node |
+| New Agent | 新 Agent | 新しい Agent | Docs name for the new-generation Agent node's tab; the product labels the node plain Agent with a BETA chip. In prose, lowercase adjective: the new Agent node |
 | Human Input | 人工介入 | 人間の入力 | Pauses workflow execution to request human review or decisions |
 | Trigger | 触发器 | トリガー | Umbrella term for entry nodes that start a workflow automatically. Concrete types: Schedule Trigger, Webhook Trigger, Integration Trigger. |
 | Schedule Trigger | 定时触发器 | スケジュールトリガー | Triggers workflow execution on a cron schedule |

--- a/writing-guides/glossary.md
+++ b/writing-guides/glossary.md
@@ -19,6 +19,7 @@ Terms appear in body text exactly as written in this table. Capitalize them furt
 | workflow | 工作流 | ワークフロー | Always lowercase in English. Collective/engine sense: workflow-backed runs, workflow nodes, the workflow engine, and endpoints shared across app types. Localizes in zh/ja; the Workflow app type stays English. |
 | Agent | Agent | Agent | Dify App type (alongside Workflow, Chatflow, etc.) that autonomously uses tools |
 | Agent app | Agent 应用 | Agent アプリ | Explicit form of the Agent app type; use when context could confuse it with the Agent workflow node |
+| Legacy Agent | 旧版 Agent | レガシー Agent | The classic app type's UI deprecation badge, and its docs name wherever the new Agent supersedes it (nav, API guides, spec app-type labels). The node level stays Classic Agent / New Agent: the classic node is Chatflow's default, not legacy. |
 | Text Generator | 文本生成应用 | テキストジェネレーター | |
 | knowledge base | 知识库 | ナレッジベース | Always lowercase unless at sentence start |
 | plugin | 插件 | プラグイン | Still valid in developer contexts (building plugins). In user-facing docs, prefer "integration" when referring to the Integrations hub; use "plugin" only for tool plugins or the develop-plugin tree. |


### PR DESCRIPTION
## What

- Adds the **Legacy Agent** row to the glossary's Core Concepts (旧版 Agent / レガシー Agent), with the naming rule in its Notes: it names the classic app type wherever the new Agent supersedes it, while the node level keeps Classic Agent / New Agent because the classic node is Chatflow's default, not legacy.
- Regenerates `termbase_i18n.md`. Beyond the new row, the regen carries catch-up entries (the New Agent terms, the Agents rename, the New Agent Configure labels) — earlier glossary updates shipped without the regen, so the termbase had drifted. `derive-termbase.py --check` now passes.

## Why

"Legacy Agent" became a load-bearing docs term across nav, API guides, and the specs in #1005; translators and future writers need its fixed zh/ja renderings and the rule for when it applies.