### PR TITLE
docs: align the api pipeline labels and glossary heading with the agent naming

### DIFF
--- a/tools/api-pipeline/memberships.json
+++ b/tools/api-pipeline/memberships.json
@@ -92,19 +92,19 @@
     "agent": {
       "page": "api-reference/guides/agent",
       "labels": {
-        "en": "New Agent (Beta)",
-        "zh": "新 Agent（Beta）",
-        "ja": "新しい Agent（Beta）"
+        "en": "Agent",
+        "zh": "Agent",
+        "ja": "Agent"
       },
       "availability_labels": {
         "en": [
-          "New Agent"
+          "Agent"
         ],
         "zh": [
-          "新 Agent"
+          "Agent"
         ],
         "ja": [
-          "新しい Agent"
+          "Agent"
         ]
       },
       "ops": [
@@ -189,22 +189,22 @@
     "chat": {
       "page": "api-reference/guides/chat",
       "labels": {
-        "en": "Chatbot and Agent",
-        "zh": "Chatbot 和 Agent",
-        "ja": "ChatbotとAgent"
+        "en": "Chatbot and Legacy Agent",
+        "zh": "Chatbot 和旧版 Agent",
+        "ja": "Chatbotとレガシー Agent"
       },
       "availability_labels": {
         "en": [
           "Chatbot",
-          "Agent"
+          "Legacy Agent"
         ],
         "zh": [
           "聊天助手",
-          "Agent"
+          "旧版 Agent"
         ],
         "ja": [
           "チャットボット",
-          "Agent"
+          "レガシー Agent"
         ]
       },
       "ops": [

--- a/tools/translate/termbase_i18n.md
+++ b/tools/translate/termbase_i18n.md
@@ -429,7 +429,7 @@
 | Query Variable | 查询变量 | 検索変数 |
 | Metadata Filtering | 元数据过滤 | メタデータフィルタ |
 
-### New Agent Configure
+### Agent Configure
 
 | English | Chinese | Japanese |
 |:--------|:--------|:---------|

--- a/writing-guides/glossary.md
+++ b/writing-guides/glossary.md
@@ -439,7 +439,7 @@ For a label not yet in this table, resolve its exact i18n key before writing any
 | Query Variable | 查询变量 | 検索変数 | workflow.nodes.knowledgeRetrieval.queryVariable | Knowledge retrieval node config |
 | Metadata Filtering | 元数据过滤 | メタデータフィルタ | workflow.nodes.knowledgeRetrieval.metadata.title | Knowledge retrieval node config |
 
-### New Agent Configure
+### Agent Configure
 
 | English (UI) | Chinese (UI) | Japanese (UI) | i18n Key | Notes |
 |:-------------|:-------------|:--------------|:---------|:------|


### PR DESCRIPTION
Follow-up to #1005/#1008, caught by review on the 1.17.0 backport (#1009): two reference surfaces still carried the old naming.

- `tools/api-pipeline/memberships.json`: the agent entry's page and availability labels become "Agent" and the chat entry becomes "Chatbot and Legacy Agent" with availability ["Chatbot", "Legacy Agent"], in all three languages. These fields aren't consumed by the current scripts (check-coverage reads only page + ops), but they're the reference writers copy availability lines from, so they must match the spec's labels.
- The glossary's "### New Agent Configure" UI-labels section becomes "### Agent Configure", with the termbase regenerated from source — the same fix reaches release/1.17.0 via #1009.