### PR TITLE
fix: remove x-codeSamples so playground examples update live

### DIFF
--- a/.claude/skills/dify-docs-api-reference/references/spec-conventions.md
+++ b/.claude/skills/dify-docs-api-reference/references/spec-conventions.md
@@ -163,7 +163,7 @@ Same concept, same words, across all operations.
 
 ## x-codeSamples
 
-Mintlify's playground auto-generates request samples from the schema; do not duplicate it. Add a hand-written `x-codeSamples` entry only where autogen fails: `multipart/form-data`, binary bodies, and SSE consumption. House format: `{"lang": "bash", "label": "cURL", "source": "curl --request …"}` with `{api_base_url}`, `{api_key}`, `{user}` placeholders. Code samples are identical across languages.
+Do not add `x-codeSamples`; `lint_specs` flags any occurrence. A hand-written sample replaces Mintlify's generated snippets for the whole operation: the playground stops reflecting typed values, and readers lose every language tab but the one provided. Autogen handles all body types — `multipart/form-data` renders as `--form`, typed values appear live, and the pristine snippet draws from schema `default`s and the request-body example. A query parameter without a `default` is absent until typed; accept that gap rather than invent a `default` the API does not have. SSE consumption mechanics (curl's `--no-buffer`) live in the [SSE Streaming guide](/en/api-reference/guides/streaming).
 
 ## Tag Naming
 

--- a/en/api-reference/guides/streaming.mdx
+++ b/en/api-reference/guides/streaming.mdx
@@ -53,6 +53,10 @@ data: {"event": "workflow_started", "task_id": "c3800678-…", "workflow_run_id"
 data: {"event": "node_finished", "task_id": "c3800678-…", "workflow_run_id": "fb47b2e6-…", "data": {…}}
 ```
 
+<Tip>
+When testing with curl, pass `-N` (`--no-buffer`) so events print as they arrive instead of after the run completes.
+</Tip>
+
 ## Dispatch by Event Type
 
 Which events arrive depends on the app type. See the event tables on [Send Chat Message](/en/api-reference/chat-messages/send-chat-message), [Run Workflow](/en/api-reference/workflow-runs/run-workflow), and [Send Completion Message](/en/api-reference/completion-messages/send-completion-message) for the contract.

--- a/en/api-reference/openapi_service.json
+++ b/en/api-reference/openapi_service.json
@@ -421,14 +421,7 @@
             "title": "Send Chat Message",
             "sidebarTitle": "Send Chat Message"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/chat-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"query\": \"What are the specs of the iPhone 13 Pro Max?\", \"inputs\": {}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/chat-messages/{task_id}/stop": {
@@ -629,13 +622,6 @@
             }
           }
         },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages/{message_id}/suggested?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
         "x-mint": {
           "href": "/en/api-reference/chat-messages/get-next-suggested-questions",
           "metadata": {
@@ -793,14 +779,7 @@
             "title": "Upload File",
             "sidebarTitle": "Upload File"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/files/upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@product-photo.png' \\\n  --form 'user={user}'"
-          }
-        ]
+        }
       }
     },
     "/files/{file_id}/preview": {
@@ -1423,13 +1402,6 @@
             }
           }
         },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages?conversation_id={conversation_id}&user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
         "x-mint": {
           "href": "/en/api-reference/conversations/list-conversation-messages",
           "metadata": {
@@ -2069,14 +2041,7 @@
             "title": "Convert Audio to Text",
             "sidebarTitle": "Convert Audio to Text"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/audio-to-text' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@meeting-question.mp3' \\\n  --form 'user={user}'"
-          }
-        ]
+        }
       }
     },
     "/text-to-audio": {
@@ -3683,7 +3648,7 @@
           "Workflow Runs"
         ],
         "summary": "Stream Workflow Events",
-        "description": "**Available for**: Chatflow, Workflow apps.\n\nResume the Server-Sent Events stream for a workflow run after a pause or a dropped SSE connection. For runs that have already finished, the stream emits a single `workflow_finished` event and closes.\n\nTo check an in-progress run's node-level status and progress, call it with `include_state_snapshot=true`: the stream replays each already-executed node's status before streaming new events.",
+        "description": "**Available for**: Chatflow, Workflow apps.\n\nResume the [Server-Sent Events stream](/en/api-reference/guides/streaming) for a workflow run after a pause or a dropped SSE connection. For runs that have already finished, the stream emits a single `workflow_finished` event and closes.\n\nTo check an in-progress run's node-level status and progress, call it with `include_state_snapshot=true`: the stream replays each already-executed node's status before streaming new events.",
         "operationId": "streamWorkflowEvents",
         "parameters": [
           {
@@ -3783,18 +3748,6 @@
             }
           }
         },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "Resume stream",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          },
-          {
-            "lang": "bash",
-            "label": "With state snapshot",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}&include_state_snapshot=true' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
         "x-mint": {
           "href": "/en/api-reference/workflow-runs/stream-workflow-events",
           "metadata": {
@@ -4021,14 +3974,7 @@
             "title": "Run Workflow",
             "sidebarTitle": "Run Workflow"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl -N --request POST \\\n  --url 'https://{api_base_url}/workflows/run' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"inputs\": {\"query\": \"Summarize this text: The quick brown fox jumps over the lazy dog.\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/workflows/{workflow_id}/run": {
@@ -4559,14 +4505,7 @@
             "title": "Send Completion Message",
             "sidebarTitle": "Send Completion Message"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/completion-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"inputs\": {\"city\": \"San Francisco\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/completion-messages/{task_id}/stop": {
@@ -6083,14 +6022,7 @@
             "title": "Create Document by File",
             "sidebarTitle": "Create Document by File"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
-          }
-        ]
+        }
       }
     },
     "/datasets/{dataset_id}/documents": {
@@ -7036,14 +6968,7 @@
             "title": "Update Document",
             "sidebarTitle": "Update Document"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request PATCH \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/documents/{document_id}' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
-          }
-        ]
+        }
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/download": {
@@ -12499,14 +12424,7 @@
             "title": "Upload Pipeline File",
             "sidebarTitle": "Upload Pipeline File"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
-          }
-        ]
+        }
       }
     },
     "/datasets/{dataset_id}/pipeline/datasource-plugins": {

--- a/ja/api-reference/guides/streaming.mdx
+++ b/ja/api-reference/guides/streaming.mdx
@@ -55,6 +55,10 @@ data: {"event": "workflow_started", "task_id": "c3800678-…", "workflow_run_id"
 data: {"event": "node_finished", "task_id": "c3800678-…", "workflow_run_id": "fb47b2e6-…", "data": {…}}
 ```
 
+<Tip>
+curl でテストする場合は、`-N`（`--no-buffer`）を付けます。イベントが実行完了後にまとめてではなく、到着するたびに表示されます。
+</Tip>
+
 ## イベントタイプごとの振り分け
 
 届くイベントはアプリタイプによって異なります。イベントの一覧は [チャットメッセージを送信](/ja/api-reference/chat-messages/send-chat-message)、[ワークフローを実行](/ja/api-reference/workflow-runs/run-workflow)、[完了メッセージを送信](/ja/api-reference/completion-messages/send-completion-message) の各イベント表を参照してください。

--- a/ja/api-reference/openapi_service.json
+++ b/ja/api-reference/openapi_service.json
@@ -421,14 +421,7 @@
             "title": "チャットメッセージを送信",
             "sidebarTitle": "チャットメッセージを送信"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/chat-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"query\": \"What are the specs of the iPhone 13 Pro Max?\", \"inputs\": {}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/chat-messages/{task_id}/stop": {
@@ -629,13 +622,6 @@
             }
           }
         },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages/{message_id}/suggested?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
         "x-mint": {
           "href": "/ja/api-reference/chat-messages/get-next-suggested-questions",
           "metadata": {
@@ -793,14 +779,7 @@
             "title": "ファイルをアップロード",
             "sidebarTitle": "ファイルをアップロード"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/files/upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@product-photo.png' \\\n  --form 'user={user}'"
-          }
-        ]
+        }
       }
     },
     "/files/{file_id}/preview": {
@@ -1423,13 +1402,6 @@
             }
           }
         },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages?conversation_id={conversation_id}&user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
         "x-mint": {
           "href": "/ja/api-reference/conversations/list-conversation-messages",
           "metadata": {
@@ -2069,14 +2041,7 @@
             "title": "音声をテキストに変換",
             "sidebarTitle": "音声をテキストに変換"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/audio-to-text' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@meeting-question.mp3' \\\n  --form 'user={user}'"
-          }
-        ]
+        }
       }
     },
     "/text-to-audio": {
@@ -3683,7 +3648,7 @@
           "ワークフロー実行"
         ],
         "summary": "ワークフローイベントをストリーム",
-        "description": "**対象アプリ**：Chatflow、Workflow。\n\n一時停止後または元の SSE 接続が切断された後にワークフロー実行の Server-Sent Events ストリームを再開します。すでに完了している実行に対しては、`workflow_finished` イベントを 1 つ送信してストリームを閉じます。\n\n進行中の実行のノードレベルのステータスと進捗を確認するには、`include_state_snapshot=true` を指定して呼び出します。ストリームは新しいイベントの送信前に、実行済み各ノードのステータスを再送します。",
+        "description": "**対象アプリ**：Chatflow、Workflow。\n\n一時停止後または元の SSE 接続が切断された後にワークフロー実行の [Server-Sent Events ストリーム](/ja/api-reference/guides/streaming) を再開します。すでに完了している実行に対しては、`workflow_finished` イベントを 1 つ送信してストリームを閉じます。\n\n進行中の実行のノードレベルのステータスと進捗を確認するには、`include_state_snapshot=true` を指定して呼び出します。ストリームは新しいイベントの送信前に、実行済み各ノードのステータスを再送します。",
         "operationId": "streamWorkflowEvents",
         "parameters": [
           {
@@ -3783,18 +3748,6 @@
             }
           }
         },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "Resume stream",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          },
-          {
-            "lang": "bash",
-            "label": "With state snapshot",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}&include_state_snapshot=true' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
         "x-mint": {
           "href": "/ja/api-reference/workflow-runs/stream-workflow-events",
           "metadata": {
@@ -4021,14 +3974,7 @@
             "title": "ワークフローを実行",
             "sidebarTitle": "ワークフローを実行"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl -N --request POST \\\n  --url 'https://{api_base_url}/workflows/run' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"inputs\": {\"query\": \"Summarize this text: The quick brown fox jumps over the lazy dog.\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/workflows/{workflow_id}/run": {
@@ -4559,14 +4505,7 @@
             "title": "完了メッセージを送信",
             "sidebarTitle": "完了メッセージを送信"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/completion-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"inputs\": {\"city\": \"San Francisco\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/completion-messages/{task_id}/stop": {
@@ -6083,14 +6022,7 @@
             "title": "ファイルからドキュメントを作成",
             "sidebarTitle": "ファイルからドキュメントを作成"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
-          }
-        ]
+        }
       }
     },
     "/datasets/{dataset_id}/documents": {
@@ -7036,14 +6968,7 @@
             "title": "ドキュメントを更新",
             "sidebarTitle": "ドキュメントを更新"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request PATCH \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/documents/{document_id}' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
-          }
-        ]
+        }
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/download": {
@@ -12499,14 +12424,7 @@
             "title": "パイプラインファイルをアップロード",
             "sidebarTitle": "パイプラインファイルをアップロード"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
-          }
-        ]
+        }
       }
     },
     "/datasets/{dataset_id}/pipeline/datasource-plugins": {

--- a/tools/api-pipeline/lint_specs.py
+++ b/tools/api-pipeline/lint_specs.py
@@ -133,16 +133,15 @@ for f in SPEC_FILES:
                         check_example(ex, schema, spec, f"{where} resp{code}[{name}]", rel)
                         collect_enum_usage(ex, all_example_values, spec)
 
-            # param examples + collect enums; x-codeSamples guard
-            req_query = []
+            # param examples + collect enums
             for prm in op.get("parameters", []) or []:
                 sch = resolve(prm.get("schema", {}), spec)
                 if isinstance(sch, dict) and "enum" in sch:
                     all_enums.append((f"{where} param `{prm['name']}`", sch["enum"]))
-                if prm.get("in") == "query" and prm.get("required"):
-                    req_query.append(prm["name"])
-            if req_query and m.lower() == "get" and not op.get("x-codeSamples"):
-                issues[rel].append(f"{where}: required query {req_query} but no x-codeSamples override")
+
+            # x-codeSamples guard: a static sample freezes the playground snippet
+            if "x-codeSamples" in op:
+                issues[rel].append(f"{where}: x-codeSamples present; remove it and let the playground autogenerate")
 
             # link targets in descriptions
             desc = op.get("description", "") or ""

--- a/zh/api-reference/guides/streaming.mdx
+++ b/zh/api-reference/guides/streaming.mdx
@@ -55,6 +55,10 @@ data: {"event": "workflow_started", "task_id": "c3800678-…", "workflow_run_id"
 data: {"event": "node_finished", "task_id": "c3800678-…", "workflow_run_id": "fb47b2e6-…", "data": {…}}
 ```
 
+<Tip>
+使用 curl 测试时，加上 `-N`（`--no-buffer`）参数，事件即可实时逐条打印，而不是等运行结束后一次性输出。
+</Tip>
+
 ## 按事件类型分发
 
 会收到哪些事件取决于应用类型。事件契约详见 [发送对话消息](/zh/api-reference/chat-messages/send-chat-message)、[执行工作流](/zh/api-reference/workflow-runs/run-workflow) 和 [发送消息](/zh/api-reference/completion-messages/send-completion-message) 页面中的事件表。

--- a/zh/api-reference/openapi_service.json
+++ b/zh/api-reference/openapi_service.json
@@ -421,14 +421,7 @@
             "title": "发送对话消息",
             "sidebarTitle": "发送对话消息"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/chat-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"query\": \"What are the specs of the iPhone 13 Pro Max?\", \"inputs\": {}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/chat-messages/{task_id}/stop": {
@@ -629,13 +622,6 @@
             }
           }
         },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages/{message_id}/suggested?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
         "x-mint": {
           "href": "/zh/api-reference/chat-messages/get-next-suggested-questions",
           "metadata": {
@@ -793,14 +779,7 @@
             "title": "上传文件",
             "sidebarTitle": "上传文件"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/files/upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@product-photo.png' \\\n  --form 'user={user}'"
-          }
-        ]
+        }
       }
     },
     "/files/{file_id}/preview": {
@@ -1423,13 +1402,6 @@
             }
           }
         },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request GET \\\n  --url 'https://{api_base_url}/messages?conversation_id={conversation_id}&user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
         "x-mint": {
           "href": "/zh/api-reference/conversations/list-conversation-messages",
           "metadata": {
@@ -2069,14 +2041,7 @@
             "title": "语音转文字",
             "sidebarTitle": "语音转文字"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/audio-to-text' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@meeting-question.mp3' \\\n  --form 'user={user}'"
-          }
-        ]
+        }
       }
     },
     "/text-to-audio": {
@@ -3683,7 +3648,7 @@
           "工作流运行"
         ],
         "summary": "流式获取工作流事件",
-        "description": "**适用于**：Chatflow、Workflow。\n\n在工作流运行暂停或原始 SSE 连接断开后恢复 Server-Sent Events 流。对于已结束的运行，流仅发送单个 `workflow_finished` 事件后关闭。\n\n如需查看进行中运行的节点级状态与进度，可在调用时附带 `include_state_snapshot=true`：流会先重放各已执行节点的状态，再流式发送新事件。",
+        "description": "**适用于**：Chatflow、Workflow。\n\n在工作流运行暂停或原始 SSE 连接断开后恢复 [Server-Sent Events 流](/zh/api-reference/guides/streaming)。对于已结束的运行，流仅发送单个 `workflow_finished` 事件后关闭。\n\n如需查看进行中运行的节点级状态与进度，可在调用时附带 `include_state_snapshot=true`：流会先重放各已执行节点的状态，再流式发送新事件。",
         "operationId": "streamWorkflowEvents",
         "parameters": [
           {
@@ -3783,18 +3748,6 @@
             }
           }
         },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "恢复事件流",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}' \\\n  --header 'Authorization: Bearer {api_key}'"
-          },
-          {
-            "lang": "bash",
-            "label": "附带状态快照",
-            "source": "curl -N --request GET \\\n  --url 'https://{api_base_url}/workflow/{workflow_run_id}/events?user={user}&include_state_snapshot=true' \\\n  --header 'Authorization: Bearer {api_key}'"
-          }
-        ],
         "x-mint": {
           "href": "/zh/api-reference/workflow-runs/stream-workflow-events",
           "metadata": {
@@ -4021,14 +3974,7 @@
             "title": "执行工作流",
             "sidebarTitle": "执行工作流"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl -N --request POST \\\n  --url 'https://{api_base_url}/workflows/run' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"inputs\": {\"query\": \"Summarize this text: The quick brown fox jumps over the lazy dog.\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/workflows/{workflow_id}/run": {
@@ -4559,14 +4505,7 @@
             "title": "发送消息",
             "sidebarTitle": "发送消息"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/completion-messages' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --header 'Content-Type: application/json' \\\n  --no-buffer \\\n  --data '{\"inputs\": {\"city\": \"San Francisco\"}, \"response_mode\": \"streaming\", \"user\": \"{user}\"}'"
-          }
-        ]
+        }
       }
     },
     "/completion-messages/{task_id}/stop": {
@@ -6083,14 +6022,7 @@
             "title": "从文件创建文档",
             "sidebarTitle": "从文件创建文档"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/document/create-by-file' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"indexing_technique\":\"high_quality\",\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
-          }
-        ]
+        }
       }
     },
     "/datasets/{dataset_id}/documents": {
@@ -7036,14 +6968,7 @@
             "title": "更新文档",
             "sidebarTitle": "更新文档"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request PATCH \\\n  --url 'https://{api_base_url}/datasets/{dataset_id}/documents/{document_id}' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf' \\\n  --form 'data={\"process_rule\":{\"mode\":\"automatic\"}};type=application/json'"
-          }
-        ]
+        }
       }
     },
     "/datasets/{dataset_id}/documents/{document_id}/download": {
@@ -12499,14 +12424,7 @@
             "title": "上传流水线文件",
             "sidebarTitle": "上传流水线文件"
           }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "bash",
-            "label": "cURL",
-            "source": "curl --request POST \\\n  --url 'https://{api_base_url}/datasets/pipeline/file-upload' \\\n  --header 'Authorization: Bearer {api_key}' \\\n  --form 'file=@quarterly-report.pdf'"
-          }
-        ]
+        }
       }
     },
     "/datasets/{dataset_id}/pipeline/datasource-plugins": {


### PR DESCRIPTION
## Why

On the 11 endpoints carrying hand-written `x-codeSamples` (Send Chat Message, Run Workflow, the upload endpoints, …), the API playground's request example never reflected typed values, and readers got no language tab other than cURL: a static sample replaces Mintlify's auto-generated snippets for the whole operation. The samples date from when autogen couldn't express multipart bodies or SSE flags. Headless-browser tests against the live site and the local preview show autogen now covers all of it: proper `--form` samples for multipart, typed values appearing live, and the full set of language tabs.

## Changes

- `{en,zh,ja}/api-reference/openapi_service.json`: remove all 11 `x-codeSamples` blocks per language, and link the SSE Streaming guide inline from the Stream Workflow Events description (its removed sample was that page's only route to the curl streaming flag).
- `{en,zh,ja}/api-reference/guides/streaming.mdx`: add a Tip — pass `-N` (`--no-buffer`) when testing with curl — the one piece of content the removed SSE samples uniquely carried.
- `tools/api-pipeline/lint_specs.py`: invert the guard; it used to require `x-codeSamples` on GETs with required query params, it now flags any occurrence so the freeze can't be reintroduced.
- `.claude/skills/dify-docs-api-reference/references/spec-conventions.md`: rewrite the `x-codeSamples` rule to match.

## Verification

- `lint_specs.py` → `TOTAL ISSUES: 0` (54 links validated); `parity_check.py` → `TOTAL PARITY ISSUES: 0`; coverage check clean.
- Headless-browser checks on the local preview: multipart (Upload File), SSE (Send Chat Message), and required-query GET (Stream Workflow Events) all regenerate their snippets live as values are typed; the streaming Tip renders in all three languages.
- Accepted trade-off: a pristine snippet omits query parameters that have no schema `default` (they appear once typed); the parameter panel's Required badges and the parameter descriptions carry required-ness.

## Notes

- Touches the same three spec files as #989; whichever merges second needs a rebase.

Closes DC-271