### PR TITLE
docs(self-host): document Community 1.17 env, CSRF, and plugin runtime failures

### DIFF
--- a/en/self-host/deploy/troubleshooting/common-issues.mdx
+++ b/en/self-host/deploy/troubleshooting/common-issues.mdx
@@ -146,9 +146,13 @@ FATAL: no pg_hba.conf entry for host "172.19.0.7", user "postgres", database "di
 
 Allow connections from the error's network segment:
 
+<Warning>
+`trust` disables database authentication. Do not copy this into production.
+</Warning>
+
 ```bash
 docker exec -it docker-db-1 sh -c "echo 'host all all 172.19.0.0/16 trust' >> /var/lib/postgresql/data/pgdata/pg_hba.conf"
-docker-compose restart
+docker compose restart
 ```
 
 ### File not found error for encryption keys

--- a/en/self-host/deploy/troubleshooting/common-issues.mdx
+++ b/en/self-host/deploy/troubleshooting/common-issues.mdx
@@ -1,5 +1,6 @@
 ---
 title: Common Issues
+description: Fix login, CSRF, timeouts, uploads, and other Community Edition self-host failures
 ---
 
 ## Authentication & Access
@@ -30,25 +31,65 @@ This typically happens after changing domains. Update these environment variable
 
 Restart after updating configuration.
 
+### 401 Invalid Encrypted Data on Login {#401-invalid-encrypted-data-on-login}
+
+The console Base64-encodes the password before `POST /console/api/login`. Sending plaintext (or a frontend/API image pair that disagrees on that encoding) returns **401** with `Invalid encrypted data`.
+
+Sign in through the official console. If you built a custom login client, Base64-encode the password the same way the console does.
+
+### 401 CSRF Token Is Missing or Invalid {#401-csrf-token-is-missing-or-invalid}
+
+Console sessions use an `access_token` cookie plus an `X-CSRF-Token` header that must match the `csrf_token` cookie. Authenticated Console calls without that pair return **401** `CSRF token is missing or invalid.`
+
+The official console sends both. Scripts and proxies that forward the cookie but drop the header fail this check.
+
+### Session Drops After About One Hour {#session-drops-after-about-one-hour}
+
+`access_token` and `csrf_token` cookies last `ACCESS_TOKEN_EXPIRE_MINUTES` (default `60`). The console refreshes them with the `refresh_token` cookie (`REFRESH_TOKEN_EXPIRE_DAYS`, default `30`) as long as that refresh cookie is still valid.
+
+Clients that store only the access cookie, or that block the refresh request, look logged out after about an hour. See [Environment Variables](/en/self-host/deploy/configuration/environments) for `ACCESS_TOKEN_EXPIRE_MINUTES` and `REFRESH_TOKEN_EXPIRE_DAYS`.
+
+### Install Page After Setup Completes {#install-page-after-setup-completes}
+
+`/install` is first-time bootstrap only. Once the admin account exists, that page is done. Submitting setup again is rejected.
+
+Open the sign-in page (`/`) instead of `/install`.
+
+### SECRET_KEY Changed After First Boot {#secret_key-changed-after-first-boot}
+
+`SECRET_KEY` signs session cookies, JWTs, file URLs, and OAuth credentials. Changing it after the stack has run logs everyone out, invalidates signed file URLs, and makes OAuth plugin credentials unrecoverable.
+
+Leave the generated or chosen value in place. Details and the generation command are in [SECRET_KEY](/en/self-host/deploy/configuration/environments#secret_key).
+
+### Browser Calls the Docker Hostname {#browser-calls-the-docker-hostname}
+
+For the default single-domain Compose stack behind nginx, leave `CONSOLE_API_URL` empty. The web container then exposes a relative `/console/api` prefix, and the browser stays on your public origin.
+
+Setting `CONSOLE_API_URL=http://api:5001` makes the *browser* call the Compose DNS name `api`, which does not resolve on the operator's machine. Use `SERVER_CONSOLE_API_URL` (default `http://api:5001`) for server-side calls from the web container. See [CONSOLE_API_URL](/en/self-host/deploy/configuration/environments#console_api_url).
+
 ## Configuration
 
 ### Change default port
 
 Modify `.env` configuration:
 
-```
+```text
 EXPOSE_NGINX_PORT=80
 EXPOSE_NGINX_SSL_PORT=443
 ```
 
 For API service port changes, update the nginx configuration in `docker-compose.yaml`.
 
-### Increase file upload limits
+### Increase file upload limits {#increase-file-upload-limits}
 
 Update in `.env`:
 
-- `UPLOAD_FILE_SIZE_LIMIT` - Maximum file size
-- `NGINX_CLIENT_MAX_BODY_SIZE` - Must match to avoid issues
+- `UPLOAD_FILE_SIZE_LIMIT` - Maximum document upload size in MB
+- `NGINX_CLIENT_MAX_BODY_SIZE` - Proxy body limit (default `100M`)
+
+Raise both. If only the API limit is higher, nginx returns **413** before the API sees the file. Image, video, and audio uploads have their own `UPLOAD_*_FILE_SIZE_LIMIT` variables; keep those at or below the nginx limit too.
+
+Plugin packages use `PLUGIN_MAX_PACKAGE_SIZE` (default 50 MB) with the same nginx ceiling. See [Environment Variables](/en/self-host/deploy/configuration/environments#multi-modal-configuration).
 
 ### Workflow complexity limits
 
@@ -58,7 +99,22 @@ Note: Excessive depth impacts performance.
 
 ### Node execution timeout
 
-Set `TEXT_GENERATION_TIMEOUT_MS` in `.env` to control runtime per node.
+Set `TEXT_GENERATION_TIMEOUT_MS` in `.env` to control the frontend streaming stall timeout. See [TEXT_GENERATION_TIMEOUT_MS](/en/self-host/deploy/configuration/environments#web-frontend-service).
+
+### Long Workflows Stop Around Six Minutes {#long-workflows-stop-around-six-minutes}
+
+`GUNICORN_TIMEOUT` defaults to `360` seconds (6 minutes) in `docker/.env.example`. Nginx `NGINX_PROXY_READ_TIMEOUT` defaults to `3600s`. A long workflow can die at Gunicorn while nginx would still wait.
+
+Check which layer cut the request: nginx **504** vs the API worker restarting at the Gunicorn timeout. Raise `GUNICORN_TIMEOUT` in `docker/.env` when the API is the one that stopped; raise the nginx proxy timeouts when nginx returned **504**. Then, from the `docker` directory:
+
+```bash
+docker compose up -d --force-recreate api
+docker compose up -d --force-recreate nginx
+```
+
+If you also changed `API_WEBSOCKET_GUNICORN_TIMEOUT`, recreate `api_websocket` the same way.
+
+`TEXT_GENERATION_TIMEOUT_MS` is a separate frontend stall timer. Do not treat it as the worker deadline; see [Node execution timeout](#node-execution-timeout).
 
 ## Email Configuration
 
@@ -83,7 +139,8 @@ In local deployments without email configured, the invitation page displays a li
 ### Connection errors with pg_hba.conf
 
 If you see:
-```
+
+```text
 FATAL: no pg_hba.conf entry for host "172.19.0.7", user "postgres", database "dify", no encryption
 ```
 
@@ -98,7 +155,7 @@ docker-compose restart
 
 This error occurs after changing deployment methods or deleting `api/storage/privkeys`:
 
-```
+```text
 FileNotFoundError: File not found
 File "/www/wwwroot/dify/dify/api/libs/rsa.py", line 45, in decrypt
 ```
@@ -106,11 +163,13 @@ File "/www/wwwroot/dify/dify/api/libs/rsa.py", line 45, in decrypt
 Reset encryption key pairs:
 
 Docker Compose:
+
 ```bash
 docker exec -it docker-api-1 flask reset-encrypt-key-pair
 ```
 
 Source code (from `api` directory):
+
 ```bash
 flask reset-encrypt-key-pair
 ```
@@ -128,3 +187,7 @@ Modify the `tenants` table in the database directly.
 ### Change application access domain
 
 Update `APP_WEB_URL` in `docker-compose.yaml`.
+
+## Further Reading
+
+Community operators who want executable checklists for Community Edition 1.17 can use [dify-skills](https://github.com/kabishou11/dify-skills) (unofficial, not maintained by LangGenius).

--- a/en/self-host/deploy/troubleshooting/docker-issues.mdx
+++ b/en/self-host/deploy/troubleshooting/docker-issues.mdx
@@ -1,28 +1,29 @@
 ---
 title: Docker Issues
+description: Fix nginx 502s, environment injection, WebSocket hangs, and plugin runtime failures on Docker Compose
 ---
 
 ## Network & Connectivity
 
-### 502 Bad Gateway
+### 502 Bad Gateway {#502-bad-gateway}
 
-Nginx is forwarding to wrong container IPs. Get current container IPs:
+The bundled nginx templates proxy to Compose DNS names (`api:5001`, `web:3000`, and `api_websocket:5001` for `/socket.io/`). They resolve those names through Docker's embedded DNS (`resolver 127.0.0.11 valid=30s`). Do not replace the service names with container IP addresses. Those IPs change on recreate and the next restart 502s again.
+
+Run the commands in this page from the `docker` directory of your Dify clone.
+
+After you recreate `api` or `web`, nginx can keep a stale upstream for up to 30 seconds. Reload nginx so it resolves again:
 
 ```bash
-docker ps -q | xargs -n 1 docker inspect --format '{{ .Name }}: {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
+docker compose exec nginx nginx -s reload
 ```
 
-Find these lines:
-```
-/docker-web-1: 172.19.0.5
-/docker-api-1: 172.19.0.7
+`NGINX_*` values are substituted into the templates at container start (`envsubst` in the nginx entrypoint). `nginx -s reload` does not re-run that substitution. After changing `NGINX_*` in `docker/.env`, recreate nginx:
+
+```bash
+docker compose up -d --force-recreate nginx
 ```
 
-Update `dify/docker/nginx/conf.d`:
-- Replace `http://api:5001` with `http://172.19.0.7:5001`
-- Replace `http://web:3000` with `http://172.19.0.5:3000`
-
-Restart nginx or reload configuration. Note: IPs change on container restart.
+If `/socket.io/` returns **502** with `host not found` for `api_websocket`, that service is not running. See [Canvas Hang or WebSocket 502](#canvas-hang-or-websocket-502).
 
 ### Cannot access localhost services
 
@@ -32,7 +33,7 @@ Example: For OpenLLM running on host, configure Dify with `http://192.168.1.100:
 
 ### Page loads forever with CORS errors
 
-Domain/URL changes cause cross-origin issues. Update in `docker-compose.yml`:
+Domain/URL changes cause cross-origin issues. Update in `docker/.env`:
 
 - `CONSOLE_API_URL` - Backend URL for console API
 - `CONSOLE_WEB_URL` - Frontend URL for console web
@@ -40,12 +41,63 @@ Domain/URL changes cause cross-origin issues. Update in `docker-compose.yml`:
 - `APP_API_URL` - Web app API backend URL
 - `APP_WEB_URL` - Web app URL
 
+Leave `CONSOLE_API_URL` empty for the default nginx single-domain setup. Pointing it at `http://api:5001` makes the browser call a hostname only Compose can resolve. See [Browser Calls the Docker Hostname](/en/self-host/deploy/troubleshooting/common-issues#browser-calls-the-docker-hostname).
+
+## Environment Files {#environment-files}
+
+Essential startup values live in `docker/.env` (copied from `docker/.env.example`). Optional templates live under `docker/envs/`. Copy a template next to itself and drop the `.example` suffix, for example `cp envs/core-services/shared.env.example envs/core-services/shared.env`. Compose `env_file` entries are `required: false`, so a missing file is skipped and those knobs never appear in the container.
+
+`docker/.env` is listed last on services that load `env_file`, so it wins over `docker/envs/*.env`.
+
+`api`, `api_websocket`, `worker`, `web`, `plugin_daemon`, and `sandbox` load `env_file`. `nginx`, `ssrf_proxy`, `weaviate`, `redis`, and the database services do **not**: they only receive the keys listed under `environment:` (or interpolated into `command`) from Compose, which reads `docker/.env`. Copying `docker/envs/infrastructure/nginx.env.example` to `nginx.env` does not configure the nginx container.
+
+Confirm what a container actually has:
+
+```bash
+docker compose exec api printenv GUNICORN_TIMEOUT
+docker compose exec nginx printenv NGINX_CLIENT_MAX_BODY_SIZE
+docker compose exec worker printenv CELERY_WORKER_AMOUNT
+```
+
+### Recreate vs Reload {#recreate-vs-reload}
+
+| Change | What to do |
+|:-------|:-----------|
+| `NGINX_*` in `docker/.env` | Recreate nginx. `envsubst` runs at entrypoint; reload does not. |
+| Stale **502** after recreating `api` or `web` | `docker compose exec nginx nginx -s reload` (or wait out the 30s DNS cache). |
+| `CELERY_*` | Recreate `worker`. |
+| Empty `CELERY_WORKER_AMOUNT` | The worker entrypoint uses `-c ${CELERY_WORKER_AMOUNT:-1}`, so concurrency becomes `1`. Set an explicit integer (Compose example: `4`). |
+| Other `env_file` / `.env` keys on `api`, `web`, or `plugin_daemon` | Recreate that service so it reloads the file. |
+
+## Canvas Hang or WebSocket 502 {#canvas-hang-or-websocket-502}
+
+Realtime workflow-editor collaboration goes to nginx `location /socket.io/`, which proxies to `NGINX_SOCKET_IO_UPSTREAM` (default `api_websocket:5001`). The `api_websocket` container is started by the `collaboration` profile in `COMPOSE_PROFILES` (set in `docker/.env`; the example value includes `collaboration`).
+
+If `api_websocket` is down, nginx logs `host not found` for that upstream and the editor hangs or 502s. Keep `collaboration` in `COMPOSE_PROFILES` when `ENABLE_COLLABORATION_MODE` is `true`, and confirm the container is up:
+
+```bash
+docker compose ps api_websocket
+```
+
+Browsers must reach a WebSocket URL they can resolve. Off `localhost`, set `NEXT_PUBLIC_SOCKET_URL` to `ws(s)://` plus your public host. See [ENABLE_COLLABORATION_MODE](/en/self-host/deploy/configuration/environments#enable_collaboration_mode).
+
+## Plugins {#plugins}
+
+A Marketplace click or a package upload starts an install *task*. The plugin is usable only after `plugin_daemon` finishes the local runtime (dependency install and process start). The console plugin list is served from the daemon. Trust that list and `docker compose logs plugin_daemon`, not the task banner alone.
+
+Marketplace install downloads the `.difypkg` *from the `api` container* (`MARKETPLACE_API_URL`, default `https://marketplace.dify.ai`). If `api` has no egress to the Marketplace, that download fails. Do not open host firewalls as a workaround. Download the `.difypkg` on a machine that can reach the Marketplace, then in the console use **Install from Local Package File**.
+
+Failed tasks stay red until you clear them. After a failed install, the console shows **Failed to Install Integrations**. Open it and use **Clear all**, then retry.
+
+Uploading a package larger than nginx or the daemon allows returns **413**. Raise `PLUGIN_MAX_PACKAGE_SIZE` (bytes, default `52428800`) and `NGINX_CLIENT_MAX_BODY_SIZE` together, then recreate `api`, `plugin_daemon`, and `nginx`. File uploads have the same two-layer rule; see [Increase file upload limits](/en/self-host/deploy/troubleshooting/common-issues#increase-file-upload-limits).
+
 ## Mounting & Volumes
 
 ### Nginx configuration mount failure
 
 Error:
-```
+
+```text
 Error mounting "/run/desktop/mnt/host/d/Documents/docker/nginx/nginx.conf" to rootfs at "/etc/nginx/nginx.conf": not a directory
 ```
 
@@ -62,12 +114,14 @@ docker compose up -d
 Port 80 already in use? Either:
 
 1. Stop the conflicting service (usually Apache/Nginx):
+
    ```bash
    sudo service nginx stop
    sudo service apache2 stop
    ```
 
 2. Or change port mapping in `docker-compose.yaml`:
+
    ```yaml
    ports:
      - "8080:80"  # Map to different port
@@ -78,11 +132,13 @@ Port 80 already in use? Either:
 ### View background shell outputs
 
 List running shells:
+
 ```bash
 docker exec -it docker-api-1 ls /tmp/shells/
 ```
 
 Check shell output:
+
 ```bash
 docker exec -it docker-api-1 cat /tmp/shells/[shell-id]/output.log
 ```
@@ -106,7 +162,7 @@ The `ssrf_proxy` container prevents Server-Side Request Forgery attacks.
 
 Edit `docker/volumes/ssrf_proxy/squid.conf` to add ACL rules:
 
-```
+```text
 # Block access to sensitive internal IP
 acl restricted_ip dst 192.168.101.19
 acl localnet src 192.168.101.0/24
@@ -121,3 +177,7 @@ Restart the proxy container after changes.
 ### Why is SSRF_PROXY needed? {#why-is-ssrf-proxy-needed}
 
 Prevents services from making unauthorized requests to internal network resources. The proxy intercepts and filters all outbound requests from sandboxed services.
+
+## Further Reading
+
+Community operators who want executable checklists for Community Edition 1.17 can use [dify-skills](https://github.com/kabishou11/dify-skills) (unofficial, not maintained by LangGenius).

--- a/ja/self-host/deploy/troubleshooting/common-issues.mdx
+++ b/ja/self-host/deploy/troubleshooting/common-issues.mdx
@@ -91,7 +91,7 @@ API サービスポートを変更する場合は、`docker-compose.yaml` の ng
 
 両方を上げてください。API 側だけを上げると、nginx が API より先に **413** を返します。画像、動画、音声にはそれぞれ `UPLOAD_*_FILE_SIZE_LIMIT` があり、nginx 上限以下に保ってください。
 
-プラグインパッケージは `PLUGIN_MAX_PACKAGE_SIZE`（デフォルト 50 MB）を使い、同じ nginx 上限の対象です。詳細は [環境変数](/ja/self-host/deploy/configuration/environments#multi-modal-configuration) を参照してください。
+プラグインパッケージは `PLUGIN_MAX_PACKAGE_SIZE`（デフォルト 50 MB）を使い、同じ nginx 上限の対象です。詳細は [環境変数](/ja/self-host/deploy/configuration/environments#マルチモーダル設定) を参照してください。
 
 ### ワークフローの複雑さ制限
 
@@ -101,7 +101,7 @@ API サービスポートを変更する場合は、`docker-compose.yaml` の ng
 
 ### ノード実行タイムアウト
 
-ノードごとのフロントエンドストリーミング停滞タイムアウトを制御するには、`.env` で `TEXT_GENERATION_TIMEOUT_MS` を設定してください。詳細は [TEXT_GENERATION_TIMEOUT_MS](/ja/self-host/deploy/configuration/environments#web-frontend-service) を参照してください。
+ノードごとのフロントエンドストリーミング停滞タイムアウトを制御するには、`.env` で `TEXT_GENERATION_TIMEOUT_MS` を設定してください。詳細は [TEXT_GENERATION_TIMEOUT_MS](/ja/self-host/deploy/configuration/environments#web-フロントエンドサービス) を参照してください。
 
 ### 長時間ワークフローの約 6 分での停止 {#long-workflows-stop-around-six-minutes}
 
@@ -148,9 +148,13 @@ FATAL: no pg_hba.conf entry for host "172.19.0.7", user "postgres", database "di
 
 エラーに示されたネットワークセグメントからの接続を許可してください：
 
+<Warning>
+`trust` はデータベース認証を無効にします。本番環境にコピーしないでください。
+</Warning>
+
 ```bash
 docker exec -it docker-db-1 sh -c "echo 'host all all 172.19.0.0/16 trust' >> /var/lib/postgresql/data/pgdata/pg_hba.conf"
-docker-compose restart
+docker compose restart
 ```
 
 ### 暗号化キーのファイルが見つからないエラー

--- a/ja/self-host/deploy/troubleshooting/common-issues.mdx
+++ b/ja/self-host/deploy/troubleshooting/common-issues.mdx
@@ -1,5 +1,6 @@
 ---
 title: よくある問題
+description: Community Edition セルフホストにおけるログイン、CSRF、タイムアウト、アップロードなどの障害を修正する
 ---
 
 > このドキュメントは AI によって自動翻訳されています。不正確な部分がある場合は、[英語版](/en/self-host/deploy/troubleshooting/common-issues) を参照してください。
@@ -8,7 +9,7 @@ title: よくある問題
 
 ### 管理者パスワードのリセット
 
-Docker Composeデプロイメントの場合：
+Docker Compose デプロイメントの場合：
 
 ```bash
 docker exec -it docker-api-1 flask reset-password
@@ -16,57 +17,112 @@ docker exec -it docker-api-1 flask reset-password
 
 プロンプトが表示されたら、アカウントのメールアドレスと新しいパスワードを入力してください。
 
-ソースコードデプロイメントの場合は、`api`ディレクトリから同じコマンドを実行してください。
+ソースコードデプロイメントの場合は、`api` ディレクトリから同じコマンドを実行してください。
 
-### ログイン後の401エラー
+### ログイン後の 401 エラー
 
 これは通常、ドメインを変更した後に発生します。以下の環境変数を更新してください：
 
-- `CONSOLE_CORS_ALLOW_ORIGINS` - コンソールCORSポリシー
+- `CONSOLE_CORS_ALLOW_ORIGINS` - コンソール CORS ポリシー
 - `WEB_API_CORS_ALLOW_ORIGINS` - Web アプリ CORS ポリシー
-- `CONSOLE_API_URL` - コンソールAPIのバックエンドURL
-- `CONSOLE_WEB_URL` - コンソールWebのフロントエンドURL
-- `SERVICE_API_URL` - サービスAPI URL
+- `CONSOLE_API_URL` - コンソール API のバックエンド URL
+- `CONSOLE_WEB_URL` - コンソール Web のフロントエンド URL
+- `SERVICE_API_URL` - サービス API URL
 - `APP_API_URL` - Web アプリ API バックエンド URL
 - `APP_WEB_URL` - Web アプリ URL
 
 設定を更新した後、再起動してください。
 
+### ログイン時の Invalid encrypted data {#401-invalid-encrypted-data-on-login}
+
+コンソールは `POST /console/api/login` の前にパスワードを Base64 エンコードします。平文を送る（またはフロントエンドと API イメージでそのエンコードが一致しない）と、本文 `Invalid encrypted data` の **401** が返ります。
+
+公式コンソールからサインインしてください。独自のログインクライアントを使う場合は、コンソールと同じ方法でパスワードを Base64 エンコードしてください。
+
+### CSRF トークン欠落による 401 {#401-csrf-token-is-missing-or-invalid}
+
+コンソールセッションは `access_token` Cookie と、`csrf_token` Cookie と一致する `X-CSRF-Token` ヘッダーを使います。この組がない認証済みコンソール呼び出しは **401** `CSRF token is missing or invalid.` になります。
+
+公式コンソールは両方を送ります。Cookie だけを転送してヘッダーを落とすスクリプトやプロキシはこの検査に失敗します。
+
+### 約 1 時間後のセッション切断 {#session-drops-after-about-one-hour}
+
+`access_token` と `csrf_token` Cookie の有効期間は `ACCESS_TOKEN_EXPIRE_MINUTES`（デフォルト `60`）です。`refresh_token` Cookie（`REFRESH_TOKEN_EXPIRE_DAYS`、デフォルト `30`）が有効な限り、コンソールはそれで前者を更新します。
+
+access Cookie だけを保存する、または更新リクエストを遮断するクライアントは、約 1 時間後にログアウトしたように見えます。`ACCESS_TOKEN_EXPIRE_MINUTES` と `REFRESH_TOKEN_EXPIRE_DAYS` は [環境変数](/ja/self-host/deploy/configuration/environments) を参照してください。
+
+### セットアップ完了後のインストールページ {#install-page-after-setup-completes}
+
+`/install` は初回ブートストラップ専用です。管理者アカウントを作成したら、そのページは終わりです。セットアップの再送信は拒否されます。
+
+`/install` ではなくサインインページ（`/`）を開いてください。
+
+### 初回起動後の SECRET_KEY 変更 {#secret_key-changed-after-first-boot}
+
+`SECRET_KEY` はセッション Cookie、JWT、ファイル URL、OAuth 資格情報の署名に使います。スタック起動後に変更すると、全員がログアウトし、署名付きファイル URL が無効になり、OAuth プラグイン資格情報は復元できなくなります。
+
+生成済みまたは選択済みの値を維持してください。詳細と生成コマンドは [SECRET_KEY](/ja/self-host/deploy/configuration/environments#secret_key) を参照してください。
+
+### ブラウザが Docker ホスト名を呼び出す {#browser-calls-the-docker-hostname}
+
+nginx 配下のデフォルト単一ドメイン Compose では、`CONSOLE_API_URL` を空のままにしてください。web コンテナは相対パス `/console/api` を公開し、ブラウザは公開オリジンに留まります。
+
+`CONSOLE_API_URL=http://api:5001` にすると、ブラウザが Compose DNS 名 `api` を呼び出します。運用者のマシンでは解決できません。web コンテナからのサーバーサイド呼び出しには `SERVER_CONSOLE_API_URL`（デフォルト `http://api:5001`）を使います。詳細は [CONSOLE_API_URL](/ja/self-host/deploy/configuration/environments#console_api_url) を参照してください。
+
 ## 設定
 
 ### デフォルトポートの変更
 
-`.env`設定を変更してください：
+`.env` 設定を変更してください：
 
-```
+```text
 EXPOSE_NGINX_PORT=80
 EXPOSE_NGINX_SSL_PORT=443
 ```
 
-APIサービスポートを変更する場合は、`docker-compose.yaml`のnginx設定を更新してください。
+API サービスポートを変更する場合は、`docker-compose.yaml` の nginx 設定を更新してください。
 
-### ファイルアップロード制限の増加
+### ファイルアップロード制限の増加 {#increase-file-upload-limits}
 
-`.env`で以下を更新してください：
+`.env` で以下を更新してください：
 
-- `UPLOAD_FILE_SIZE_LIMIT` - 最大ファイルサイズ
-- `NGINX_CLIENT_MAX_BODY_SIZE` - 問題を避けるために一致させる必要があります
+- `UPLOAD_FILE_SIZE_LIMIT` - ドキュメントアップロードの最大サイズ（MB）
+- `NGINX_CLIENT_MAX_BODY_SIZE` - プロキシのボディ上限（デフォルト `100M`）
+
+両方を上げてください。API 側だけを上げると、nginx が API より先に **413** を返します。画像、動画、音声にはそれぞれ `UPLOAD_*_FILE_SIZE_LIMIT` があり、nginx 上限以下に保ってください。
+
+プラグインパッケージは `PLUGIN_MAX_PACKAGE_SIZE`（デフォルト 50 MB）を使い、同じ nginx 上限の対象です。詳細は [環境変数](/ja/self-host/deploy/configuration/environments#multi-modal-configuration) を参照してください。
 
 ### ワークフローの複雑さ制限
 
-`web/app/components/workflow/constants.ts`の`MAX_TREE_DEPTH`を調整してください（デフォルト：50）。
+`web/app/components/workflow/constants.ts` の `MAX_TREE_DEPTH` を調整してください（デフォルト：50）。
 
 注意：過度な深度はパフォーマンスに影響します。
 
 ### ノード実行タイムアウト
 
-ノードごとの実行時間を制御するために、`.env`で`TEXT_GENERATION_TIMEOUT_MS`を設定してください。
+ノードごとのフロントエンドストリーミング停滞タイムアウトを制御するには、`.env` で `TEXT_GENERATION_TIMEOUT_MS` を設定してください。詳細は [TEXT_GENERATION_TIMEOUT_MS](/ja/self-host/deploy/configuration/environments#web-frontend-service) を参照してください。
+
+### 長時間ワークフローの約 6 分での停止 {#long-workflows-stop-around-six-minutes}
+
+`docker/.env.example` の `GUNICORN_TIMEOUT` のデフォルトは `360` 秒（6 分）です。Nginx の `NGINX_PROXY_READ_TIMEOUT` のデフォルトは `3600s` です。長いワークフローは nginx が待つ間に Gunicorn 側で終了することがあります。
+
+どの層が切ったかを確認してください。nginx の **504** か、Gunicorn タイムアウトでの API worker 再起動です。API が先に止まった場合は `docker/.env` の `GUNICORN_TIMEOUT` を上げ、nginx が **504** を返した場合は nginx のプロキシタイムアウトを上げます。その後、`docker` ディレクトリで実行します：
+
+```bash
+docker compose up -d --force-recreate api
+docker compose up -d --force-recreate nginx
+```
+
+`API_WEBSOCKET_GUNICORN_TIMEOUT` も変えた場合は、同じ方法で `api_websocket` を再作成します。
+
+`TEXT_GENERATION_TIMEOUT_MS` は別のフロントエンド停滞タイマーです。worker の期限として扱わないでください。[ノード実行タイムアウト](#ノード実行タイムアウト) を参照してください。
 
 ## メール設定
 
-パスワードリセットメールが届きませんか？`.env`でメール設定を構成してください：
+パスワードリセットメールが届きませんか？`.env` でメール設定を構成してください：
 
-1. メールパラメータを設定（SMTP設定）
+1. メールパラメータを設定（SMTP 設定）
 2. サービスを再起動：
 
 ```bash
@@ -82,22 +138,26 @@ docker compose up -d
 
 ## データベースの問題
 
-### pg_hba.confでの接続エラー
+### pg_hba.conf での接続エラー
 
 以下のエラーが表示される場合：
-```
+
+```text
 FATAL: no pg_hba.conf entry for host "172.19.0.7", user "postgres", database "dify", no encryption
 ```
 
-エラーのネットワークセグメントit docker-db-1 sh -c "echo 'host all all 172.19.0.0/16 trust' >> /var/lib/postgresql/data/pgdata/pg_hba.conf"
+エラーに示されたネットワークセグメントからの接続を許可してください：
+
+```bash
+docker exec -it docker-db-1 sh -c "echo 'host all all 172.19.0.0/16 trust' >> /var/lib/postgresql/data/pgdata/pg_hba.conf"
 docker-compose restart
 ```
 
 ### 暗号化キーのファイルが見つからないエラー
 
-このエラーは、デプロイメント方法を変更した後、または`api/storage/privkeys`を削除した後に発生します：
+このエラーは、デプロイメント方法を変更した後、または `api/storage/privkeys` を削除した後に発生します：
 
-```
+```text
 FileNotFoundError: File not found
 File "/www/wwwroot/dify/dify/api/libs/rsa.py", line 45, in decrypt
 ```
@@ -105,11 +165,13 @@ File "/www/wwwroot/dify/dify/api/libs/rsa.py", line 45, in decrypt
 暗号化キーペアをリセットしてください：
 
 Docker Compose：
+
 ```bash
 docker exec -it docker-api-1 flask reset-encrypt-key-pair
 ```
 
-ソースコード（`api`ディレクトリから）：
+ソースコード（`api` ディレクトリから）：
+
 ```bash
 flask reset-encrypt-key-pair
 ```
@@ -122,8 +184,12 @@ flask reset-encrypt-key-pair
 
 ### ワークスペース名の変更
 
-データベース内の`tenants`テーブルを直接変更してください。
+データベース内の `tenants` テーブルを直接変更してください。
 
 ### アプリケーションアクセスドメインの変更
 
-`docker-compose.yaml`で`APP_WEB_URL`を更新してください。
+`docker-compose.yaml` で `APP_WEB_URL` を更新してください。
+
+## 関連情報
+
+Community Edition 1.17 向けの実行可能なチェックリストが必要な場合は、[dify-skills](https://github.com/kabishou11/dify-skills) を利用できます。コミュニティ非公式であり、LangGenius による保守ではありません。

--- a/ja/self-host/deploy/troubleshooting/docker-issues.mdx
+++ b/ja/self-host/deploy/troubleshooting/docker-issues.mdx
@@ -1,57 +1,109 @@
 ---
-title: Dockerの問題
+title: Docker の問題
+description: Docker Compose の nginx 502、環境注入、WebSocket、プラグイン障害を修正する
 ---
 
 > このドキュメントは AI によって自動翻訳されています。不正確な部分がある場合は、[英語版](/en/self-host/deploy/troubleshooting/docker-issues) を参照してください。
 
 ## ネットワークと接続
 
-### 502 Bad Gateway
+### 502 Bad Gateway {#502-bad-gateway}
 
-Nginxが間違ったコンテナIPに転送しています。現在のコンテナIPを取得してください：
+同梱の nginx テンプレートは Compose DNS 名（`api:5001`、`web:3000`、`/socket.io/` 向けの `api_websocket:5001`）へプロキシします。名前解決は Docker 内蔵 DNS（`resolver 127.0.0.11 valid=30s`）です。サービス名をコンテナ IP に置き換えないでください。IP は再作成のたびに変わり、次の再起動で再び 502 になります。
+
+このページのコマンドは、Dify クローンの `docker` ディレクトリで実行してください。
+
+`api` または `web` を再作成したあと、nginx は最大 30 秒間古いアップストリームを使い続けることがあります。再解決させるには nginx をリロードしてください：
 
 ```bash
-docker ps -q | xargs -n 1 docker inspect --format '{{ .Name }}: {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
+docker compose exec nginx nginx -s reload
 ```
 
-以下の行を見つけてください：
+`NGINX_*` はコンテナ起動時に nginx エントリポイントの `envsubst` でテンプレートへ展開されます。`nginx -s reload` では再展開されません。`docker/.env` で `NGINX_*` を変えたあとは nginx を再作成してください：
+
+```bash
+docker compose up -d --force-recreate nginx
 ```
-/docker-web-1: 172.19.0.5
-/docker-api-1: 172.19.0.7
-```
 
-`dify/docker/nginx/conf.d`を更新してください：
-- `http://api:5001`を`http://172.19.0.7:5001`に置き換える
-- `http://web:3000`を`http://172.19.0.5:3000`に置き換える
+`/socket.io/` が **502** で、`api_websocket` に対する `host not found` が出る場合、そのサービスは起動していません。[キャンバスハングまたは WebSocket 502](#canvas-hang-or-websocket-502) を参照してください。
 
-nginxを再起動するか、設定を再読み込みしてください。注意：IPはコンテナ再起動時に変更されます。
+### localhost サービスにアクセスできない
 
-### localhostサービスにアクセスできない
+Docker コンテナは `127.0.0.1` 経由でホストサービスにアクセスできません。代わりにマシンのローカルネットワーク IP を使用してください。
 
-Dockerコンテナは`127.0.0.1`経由でホストサービスにアクセスできません。代わりにマシンのローカルネットワークIPを使用してください。
+例：ホストで動作している OpenLLM の場合、Dify を `http://192.168.1.100:port`（実際のローカル IP）で設定してください。
 
-例：ホストで動作しているOpenLLMの場合、Difyを`http://192.168.1.100:port`（実際のローカルIP）で設定してください。
+### ページが永続的に読み込み中で CORS エラーが発生
 
-### ページが永続的に読み込み中でCORSエラーが発生
+ドメイン/URL の変更がクロスオリジンの問題を引き起こします。`docker/.env` で更新してください：
 
-ドメイン/URLの変更がクロスオリジンの問題を引き起こします。`docker-compose.yml`で更新してください：
-
-- `CONSOLE_API_URL` - コンソールAPIのバックエンドURL
-- `CONSOLE_WEB_URL` - コンソールWebのフロントエンドURL
-- `SERVICE_API_URL` - サービスAPIのURL
+- `CONSOLE_API_URL` - コンソール API のバックエンド URL
+- `CONSOLE_WEB_URL` - コンソール Web のフロントエンド URL
+- `SERVICE_API_URL` - サービス API の URL
 - `APP_API_URL` - Web アプリの API バックエンド URL
 - `APP_WEB_URL` - Web アプリの URL
 
+nginx 配下のデフォルト単一ドメインでは `CONSOLE_API_URL` を空のままにしてください。`http://api:5001` を指定すると、ブラウザが Compose だけが解決できるホスト名を呼び出します。[ブラウザが Docker ホスト名を呼び出す](/ja/self-host/deploy/troubleshooting/common-issues#browser-calls-the-docker-hostname) を参照してください。
+
+## 環境ファイル {#environment-files}
+
+起動に必須の値は `docker/.env`（`docker/.env.example` からコピー）にあります。任意テンプレートは `docker/envs/` にあります。テンプレートを同じ場所へコピーし、`.example` サフィックスを外してください。例：`cp envs/core-services/shared.env.example envs/core-services/shared.env`。Compose の `env_file` は `required: false` のため、ファイルが無いと黙ってスキップされ、その設定項目はコンテナに入りません。
+
+`env_file` を読むサービスでは `docker/.env` が最後に並ぶため、`docker/envs/*.env` より優先されます。
+
+`api`、`api_websocket`、`worker`、`web`、`plugin_daemon`、`sandbox` は `env_file` を読みます。`nginx`、`ssrf_proxy`、`weaviate`、`redis`、データベースサービスは読みません。受け取れるのは `environment:`（または `command` への補間）に列挙されたキーだけで、Compose はそれらを `docker/.env` から読みます。`docker/envs/infrastructure/nginx.env.example` を `nginx.env` にコピーしても nginx コンテナは設定されません。
+
+コンテナ内の実際の値を確認してください：
+
+```bash
+docker compose exec api printenv GUNICORN_TIMEOUT
+docker compose exec nginx printenv NGINX_CLIENT_MAX_BODY_SIZE
+docker compose exec worker printenv CELERY_WORKER_AMOUNT
+```
+
+### 再作成とリロード {#recreate-vs-reload}
+
+| 変更 | 手順 |
+|:-----|:-----|
+| `docker/.env` の `NGINX_*` | nginx を再作成します。`envsubst` はエントリポイントで実行され、リロードでは実行されません。 |
+| `api` または `web` 再作成後の古い **502** | `docker compose exec nginx nginx -s reload`（または 30 秒の DNS キャッシュ待ち）。 |
+| `CELERY_*` | `worker` を再作成します。 |
+| 空の `CELERY_WORKER_AMOUNT` | worker エントリポイントは `-c ${CELERY_WORKER_AMOUNT:-1}` を使うため、並行数は `1` になります。明示的な整数を設定してください（Compose の例は `4`）。 |
+| `api`、`web`、`plugin_daemon` のその他の `env_file` / `.env` キー | 対象サービスを再作成してファイルを読み直します。 |
+
+## キャンバスハングまたは WebSocket 502 {#canvas-hang-or-websocket-502}
+
+ワークフローエディタのリアルタイム共同編集は nginx の `location /socket.io/` を通り、`NGINX_SOCKET_IO_UPSTREAM`（デフォルト `api_websocket:5001`）へプロキシされます。`api_websocket` コンテナは `docker/.env` の `COMPOSE_PROFILES` にある `collaboration` プロファイルで起動します（サンプル値には `collaboration` が含まれます）。
+
+`api_websocket` が停止していると、nginx はそのアップストリームに対して `host not found` を記録し、エディタがハングまたは 502 になります。`ENABLE_COLLABORATION_MODE` が `true` のときは `COMPOSE_PROFILES` に `collaboration` を残し、コンテナが起動していることを確認してください：
+
+```bash
+docker compose ps api_websocket
+```
+
+ブラウザは解決できる WebSocket URL に届く必要があります。`localhost` 以外から使う場合は、`NEXT_PUBLIC_SOCKET_URL` を `ws(s)://` と公開ホストに設定してください。詳細は [ENABLE_COLLABORATION_MODE](/ja/self-host/deploy/configuration/environments#enable_collaboration_mode) を参照してください。
+
+## プラグイン {#plugins}
+
+Marketplace のクリックやパッケージアップロードはインストールタスクを開始するだけです。プラグインが使えるのは、`plugin_daemon` がローカルランタイム（依存関係のインストールとプロセス起動）を終えたあとです。コンソールのプラグイン一覧は daemon から提供されます。タスクバナーではなく、その一覧と `docker compose logs plugin_daemon` を信頼してください。
+
+Marketplace インストールは `api` コンテナが `.difypkg` をダウンロードします（`MARKETPLACE_API_URL`、デフォルト `https://marketplace.dify.ai`）。`api` から Marketplace へ出られない場合、そのダウンロードは失敗します。回避策としてホストのファイアウォールを開けないでください。Marketplace に届くマシンで `.difypkg` を入手し、コンソールの **ローカルパッケージファイルからインストール** を使ってください。
+
+失敗したタスクは削除するまで赤のままです。インストール失敗後、コンソールに **インストールに失敗したプラグイン** が表示されます。それを開き、**すべてクリア** してから再試行してください。
+
+nginx または daemon の上限を超えるパッケージをアップロードすると **413** になります。`PLUGIN_MAX_PACKAGE_SIZE`（バイト、デフォルト `52428800`）と `NGINX_CLIENT_MAX_BODY_SIZE` を一緒に上げ、`api`、`plugin_daemon`、`nginx` を再作成してください。ファイルアップロードも同じ二層ルールです。[ファイルアップロード制限の増加](/ja/self-host/deploy/troubleshooting/common-issues#increase-file-upload-limits) を参照してください。
+
 ## マウントとボリューム
 
-### Nginx設定のマウント失敗
+### Nginx 設定のマウント失敗
 
 エラー：
-```
+
+```text
 Error mounting "/run/desktop/mnt/host/d/Documents/docker/nginx/nginx.conf" to rootfs at "/etc/nginx/nginx.conf": not a directory
 ```
 
-完全なプロジェクトをクローンしてdockerディレクトリから実行してください：
+完全なプロジェクトをクローンして docker ディレクトリから実行してください：
 
 ```bash
 git clone https://github.com/langgenius/dify.git
@@ -61,15 +113,17 @@ docker compose up -d
 
 ### ポート競合
 
-ポート80が既に使用中ですか？以下のいずれかを選択してください：
+ポート 80 が既に使用中ですか？以下のいずれかを選択してください：
 
-1. 競合するサービス（通常Apache/Nginx）を停止する：
+1. 競合するサービス（通常 Apache/Nginx）を停止する：
+
    ```bash
    sudo service nginx stop
    sudo service apache2 stop
    ```
 
-2. または`docker-compose.yaml`でポートマッピングを変更する：
+2. または `docker-compose.yaml` でポートマッピングを変更する：
+
    ```yaml
    ports:
      - "8080:80"  # 異なるポートにマッピング
@@ -80,11 +134,13 @@ docker compose up -d
 ### バックグラウンドシェルの出力を表示
 
 実行中のシェルをリスト表示：
+
 ```bash
 docker exec -it docker-api-1 ls /tmp/shells/
 ```
 
 シェル出力を確認：
+
 ```bash
 docker exec -it docker-api-1 cat /tmp/shells/[shell-id]/output.log
 ```
@@ -100,25 +156,30 @@ docker compose up -d
 
 アクセスする前に、すべてのサービスが正常になるまで待機してください。
 
-## SSRFプロキシ
+## SSRF プロキシ
 
-`ssrf_proxy`コンテナはServer-Side Request Forgery攻撃を防止します。
+`ssrf_proxy` コンテナは Server-Side Request Forgery 攻撃を防止します。
 
 ### プロキシルールのカスタマイズ
 
-`docker/volumes/ssrf_proxy/squid.conf`を編集してACLルールを追加してください：
+`docker/volumes/ssrf_proxy/squid.conf` を編集して ACL ルールを追加してください：
 
-```
-# 機密な内部IPへのアクセスをブロック
+```text
+# 機密な内部 IP へのアクセスをブロック
 acl restricted_ip dst 192.168.101.19
 acl localnet src 192.168.101.0/24
 
-http_access deny restrictenet
+http_access deny restricted_ip
+http_access allow localnet
 http_access deny all
 ```
 
 変更後はプロキシコンテナを再起動してください。
 
-### なぜSSRF_PROXYが必要なのか？ {#why-is-ssrf-proxy-needed}
+### なぜ SSRF_PROXY が必要なのか？ {#why-is-ssrf-proxy-needed}
 
-サービスが内部ネットワークリソースに対して不正なリクエストを行うことを防ぎます。プロキシはサンドボックス化されたサービスからのすべてのアウトバウンドリクエストを傍受してフィルタリングします。
+サービスが内部ネットワークリソースに対して不正なリクエストを行うことを防ぎます。プロキシはサンドボックス化されたサービスからのアウトバウンドリクエストを傍受してフィルタリングします。
+
+## 関連情報
+
+Community Edition 1.17 向けの実行可能なチェックリストが必要な場合は、[dify-skills](https://github.com/kabishou11/dify-skills) を利用できます。コミュニティ非公式であり、LangGenius による保守ではありません。

--- a/zh/self-host/deploy/troubleshooting/common-issues.mdx
+++ b/zh/self-host/deploy/troubleshooting/common-issues.mdx
@@ -91,7 +91,7 @@ EXPOSE_NGINX_SSL_PORT=443
 
 两处都要提高。若只提高 API 限制，nginx 会在 API 看到文件之前返回 **413**。图片、视频、音频上传各自有 `UPLOAD_*_FILE_SIZE_LIMIT`，同样须不超过 nginx 上限。
 
-插件包使用 `PLUGIN_MAX_PACKAGE_SIZE`（默认 50 MB），并受同一 nginx 上限约束。详见 [环境变量](/zh/self-host/deploy/configuration/environments#multi-modal-configuration)。
+插件包使用 `PLUGIN_MAX_PACKAGE_SIZE`（默认 50 MB），并受同一 nginx 上限约束。详见 [环境变量](/zh/self-host/deploy/configuration/environments#多模态配置)。
 
 ### 工作流复杂度限制
 
@@ -101,7 +101,7 @@ EXPOSE_NGINX_SSL_PORT=443
 
 ### 节点执行超时
 
-在 `.env` 中设置 `TEXT_GENERATION_TIMEOUT_MS`，控制前端流式输出的停滞超时。详见 [TEXT_GENERATION_TIMEOUT_MS](/zh/self-host/deploy/configuration/environments#web-frontend-service)。
+在 `.env` 中设置 `TEXT_GENERATION_TIMEOUT_MS`，控制前端流式输出的停滞超时。详见 [TEXT_GENERATION_TIMEOUT_MS](/zh/self-host/deploy/configuration/environments#web-前端服务)。
 
 ### 长工作流在约 6 分钟时停止 {#long-workflows-stop-around-six-minutes}
 
@@ -148,9 +148,13 @@ FATAL: no pg_hba.conf entry for host "172.19.0.7", user "postgres", database "di
 
 允许来自错误中网络段的连接：
 
+<Warning>
+`trust` 会禁用数据库认证，请勿照抄到生产环境。
+</Warning>
+
 ```bash
 docker exec -it docker-db-1 sh -c "echo 'host all all 172.19.0.0/16 trust' >> /var/lib/postgresql/data/pgdata/pg_hba.conf"
-docker-compose restart
+docker compose restart
 ```
 
 ### 加密密钥文件未找到错误

--- a/zh/self-host/deploy/troubleshooting/common-issues.mdx
+++ b/zh/self-host/deploy/troubleshooting/common-issues.mdx
@@ -1,5 +1,6 @@
 ---
 title: 常见问题
+description: 排查 Community Edition 自部署中的登录、CSRF、超时、上传及其他故障
 ---
 
 > 本文档由 AI 自动翻译。如有任何不准确之处，请参考 [英文原版](/en/self-host/deploy/troubleshooting/common-issues)。
@@ -32,25 +33,65 @@ docker exec -it docker-api-1 flask reset-password
 
 更新配置后重启服务。
 
+### 登录返回 401 Invalid encrypted data {#401-invalid-encrypted-data-on-login}
+
+控制台在 `POST /console/api/login` 之前会将密码做 Base64 编码。发送明文（或前端与 API 镜像对该编码不一致）会返回 **401**，正文为 `Invalid encrypted data`。
+
+请通过官方控制台登录。若使用自定义登录客户端，须按控制台同样方式对密码做 Base64 编码。
+
+### CSRF 令牌缺失或无效导致 401 {#401-csrf-token-is-missing-or-invalid}
+
+控制台会话使用 `access_token` Cookie，以及必须与 `csrf_token` Cookie 一致的 `X-CSRF-Token` 请求头。已认证的控制台调用缺少这一对会返回 **401** `CSRF token is missing or invalid.`
+
+官方控制台会同时发送二者。只转发 Cookie、丢掉请求头的脚本或代理会触发该检查。
+
+### 约 1 小时后会话中断 {#session-drops-after-about-one-hour}
+
+`access_token` 和 `csrf_token` Cookie 的有效期为 `ACCESS_TOKEN_EXPIRE_MINUTES`（默认 `60`）。只要 `refresh_token` Cookie 仍有效（`REFRESH_TOKEN_EXPIRE_DAYS`，默认 `30`），控制台就会用它刷新前两者。
+
+只保存了 access Cookie，或拦截了刷新请求的客户端，会在约 1 小时后看起来像已退出。详见 [环境变量](/zh/self-host/deploy/configuration/environments) 中的 `ACCESS_TOKEN_EXPIRE_MINUTES` 和 `REFRESH_TOKEN_EXPIRE_DAYS`。
+
+### 完成初始化后仍打开安装页 {#install-page-after-setup-completes}
+
+`/install` 仅用于首次引导。管理员账户创建完成后，该页面即结束。再次提交会被拒绝。
+
+请打开登录页（`/`），不要再访问 `/install`。
+
+### 首次启动后更改 SECRET_KEY {#secret_key-changed-after-first-boot}
+
+`SECRET_KEY` 用于签署会话 Cookie、JWT、文件 URL 和 OAuth 凭据。堆栈已运行后再更改，会让所有人退出、使已签名文件 URL 失效，并使 OAuth 插件凭据无法恢复。
+
+保留已生成或已选定的值。说明与生成命令见 [SECRET_KEY](/zh/self-host/deploy/configuration/environments#secret_key)。
+
+### 浏览器请求 Docker 主机名 {#browser-calls-the-docker-hostname}
+
+默认单域名、经 nginx 的 Compose 部署应保持 `CONSOLE_API_URL` 为空。此时 web 容器对外使用相对路径 `/console/api`，浏览器留在你的公网源上。
+
+将 `CONSOLE_API_URL=http://api:5001` 会使 **浏览器** 去解析 Compose DNS 名 `api`，运营者本机无法解析该名称。web 容器的服务端请求应使用 `SERVER_CONSOLE_API_URL`（默认 `http://api:5001`）。详见 [CONSOLE_API_URL](/zh/self-host/deploy/configuration/environments#console_api_url)。
+
 ## 配置
 
 ### 更改默认端口
 
 修改 `.env` 配置：
 
-```
+```text
 EXPOSE_NGINX_PORT=80
 EXPOSE_NGINX_SSL_PORT=443
 ```
 
 如需更改 API 服务端口，请更新 `docker-compose.yaml` 中的 nginx 配置。
 
-### 增加文件上传限制
+### 增加文件上传限制 {#increase-file-upload-limits}
 
 在 `.env` 中更新：
 
-- `UPLOAD_FILE_SIZE_LIMIT` - 最大文件大小
-- `NGINX_CLIENT_MAX_BODY_SIZE` - 必须匹配以避免问题
+- `UPLOAD_FILE_SIZE_LIMIT` - 文档上传的最大大小（MB）
+- `NGINX_CLIENT_MAX_BODY_SIZE` - 代理请求体上限（默认 `100M`）
+
+两处都要提高。若只提高 API 限制，nginx 会在 API 看到文件之前返回 **413**。图片、视频、音频上传各自有 `UPLOAD_*_FILE_SIZE_LIMIT`，同样须不超过 nginx 上限。
+
+插件包使用 `PLUGIN_MAX_PACKAGE_SIZE`（默认 50 MB），并受同一 nginx 上限约束。详见 [环境变量](/zh/self-host/deploy/configuration/environments#multi-modal-configuration)。
 
 ### 工作流复杂度限制
 
@@ -60,7 +101,22 @@ EXPOSE_NGINX_SSL_PORT=443
 
 ### 节点执行超时
 
-在 `.env` 中设置 `TEXT_GENERATION_TIMEOUT_MS` 以控制每个节点的运行时间。
+在 `.env` 中设置 `TEXT_GENERATION_TIMEOUT_MS`，控制前端流式输出的停滞超时。详见 [TEXT_GENERATION_TIMEOUT_MS](/zh/self-host/deploy/configuration/environments#web-frontend-service)。
+
+### 长工作流在约 6 分钟时停止 {#long-workflows-stop-around-six-minutes}
+
+`docker/.env.example` 中 `GUNICORN_TIMEOUT` 默认为 `360` 秒（6 分钟）。Nginx 的 `NGINX_PROXY_READ_TIMEOUT` 默认为 `3600s`。长工作流可能在 Gunicorn 处被杀掉，而 nginx 仍会继续等待。
+
+确认是哪一层切断了请求：nginx **504**，还是 API worker 在 Gunicorn 超时后重启。API 先停则在 `docker/.env` 中提高 `GUNICORN_TIMEOUT`；nginx 返回 **504** 则提高 nginx 代理超时。然后在 `docker` 目录执行：
+
+```bash
+docker compose up -d --force-recreate api
+docker compose up -d --force-recreate nginx
+```
+
+若同时改了 `API_WEBSOCKET_GUNICORN_TIMEOUT`，用同样方式重建 `api_websocket`。
+
+`TEXT_GENERATION_TIMEOUT_MS` 是另一套前端停滞计时，不要当成 worker 截止时间。见 [节点执行超时](#节点执行超时)。
 
 ## 邮件配置
 
@@ -85,7 +141,8 @@ docker compose up -d
 ### pg_hba.conf 连接错误
 
 如果你看到：
-```
+
+```text
 FATAL: no pg_hba.conf entry for host "172.19.0.7", user "postgres", database "dify", no encryption
 ```
 
@@ -100,7 +157,7 @@ docker-compose restart
 
 此错误发生在更改部署方法或删除 `api/storage/privkeys` 之后：
 
-```
+```text
 FileNotFoundError: File not found
 File "/www/wwwroot/dify/dify/api/libs/rsa.py", line 45, in decrypt
 ```
@@ -108,11 +165,13 @@ File "/www/wwwroot/dify/dify/api/libs/rsa.py", line 45, in decrypt
 重置加密密钥对：
 
 Docker Compose：
+
 ```bash
 docker exec -it docker-api-1 flask reset-encrypt-key-pair
 ```
 
 源代码（在 `api` 目录下）：
+
 ```bash
 flask reset-encrypt-key-pair
 ```
@@ -130,3 +189,7 @@ flask reset-encrypt-key-pair
 ### 更改应用访问域名
 
 在 `docker-compose.yaml` 中更新 `APP_WEB_URL`。
+
+## 延伸阅读
+
+需要 Community Edition 1.17 可执行检查清单的运营者，可使用 [dify-skills](https://github.com/kabishou11/dify-skills)（社区非官方，非 LangGenius 维护）。

--- a/zh/self-host/deploy/troubleshooting/docker-issues.mdx
+++ b/zh/self-host/deploy/troubleshooting/docker-issues.mdx
@@ -1,30 +1,31 @@
 ---
 title: Docker 问题
+description: 排查 Docker Compose 上的 nginx 502、环境变量注入、WebSocket 卡住以及插件运行时故障
 ---
 
 > 本文档由 AI 自动翻译。如有任何不准确之处，请参考 [英文原版](/en/self-host/deploy/troubleshooting/docker-issues)。
 
 ## 网络与连接
 
-### 502 Bad Gateway
+### 502 Bad Gateway {#502-bad-gateway}
 
-Nginx 正在转发到错误的容器 IP。获取当前容器 IP：
+自带的 nginx 模板将流量代理到 Compose DNS 名称（`api:5001`、`web:3000`，以及 `/socket.io/` 对应的 `api_websocket:5001`）。它们通过 Docker 内嵌 DNS 解析这些名称（`resolver 127.0.0.11 valid=30s`）。不要把服务名换成容器 IP。IP 会在重建后变化，下一次重启又会 502。
+
+本页命令在 Dify 克隆的 `docker` 目录下执行。
+
+重建 `api` 或 `web` 后，nginx 最长可能 30 秒仍使用过期上游。重新加载 nginx 以再次解析：
 
 ```bash
-docker ps -q | xargs -n 1 docker inspect --format '{{ .Name }}: {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
+docker compose exec nginx nginx -s reload
 ```
 
-找到这些行：
-```
-/docker-web-1: 172.19.0.5
-/docker-api-1: 172.19.0.7
+`NGINX_*` 在容器启动时由 nginx 入口脚本用 `envsubst` 写入模板。`nginx -s reload` 不会再次执行替换。在 `docker/.env` 中更改 `NGINX_*` 后，请重建 nginx：
+
+```bash
+docker compose up -d --force-recreate nginx
 ```
 
-更新 `dify/docker/nginx/conf.d`：
-- 将 `http://api:5001` 替换为 `http://172.19.0.7:5001`
-- 将 `http://web:3000` 替换为 `http://172.19.0.5:3000`
-
-重启 nginx 或重新加载配置。注意：IP 在容器重启时会发生变化。
+若 `/socket.io/` 返回 **502**，且日志为 `api_websocket` 的 `host not found`，说明该服务未运行。见 [画布卡住或 WebSocket 502](#canvas-hang-or-websocket-502)。
 
 ### 无法访问 localhost 服务
 
@@ -34,7 +35,7 @@ Docker 容器无法通过 `127.0.0.1` 访问主机服务。请使用你机器的
 
 ### 页面一直加载并出现 CORS 错误
 
-域名/URL 更改会导致跨源问题。在 `docker-compose.yml` 中更新：
+域名/URL 更改会导致跨源问题。在 `docker/.env` 中更新：
 
 - `CONSOLE_API_URL` - 控制台 API 的后端 URL
 - `CONSOLE_WEB_URL` - 控制台 Web 的前端 URL
@@ -42,12 +43,63 @@ Docker 容器无法通过 `127.0.0.1` 访问主机服务。请使用你机器的
 - `APP_API_URL` - Web 应用 API 后端 URL
 - `APP_WEB_URL` - Web 应用 URL
 
+默认经 nginx 的单域名部署请保持 `CONSOLE_API_URL` 为空。将其指向 `http://api:5001` 会让浏览器请求只有 Compose 能解析的主机名。见 [浏览器请求 Docker 主机名](/zh/self-host/deploy/troubleshooting/common-issues#browser-calls-the-docker-hostname)。
+
+## 环境文件 {#environment-files}
+
+启动必需项在 `docker/.env`（从 `docker/.env.example` 复制）。可选模板在 `docker/envs/`。将模板复制到同目录并去掉 `.example` 后缀，例如 `cp envs/core-services/shared.env.example envs/core-services/shared.env`。Compose 的 `env_file` 为 `required: false`，缺失文件会被跳过，这些参数也就不会进入容器。
+
+在加载 `env_file` 的服务上，`docker/.env` 列在最后，因此优先于 `docker/envs/*.env`。
+
+`api`、`api_websocket`、`worker`、`web`、`plugin_daemon` 和 `sandbox` 会加载 `env_file`。`nginx`、`ssrf_proxy`、`weaviate`、`redis` 和数据库服务不会：它们只接收 `docker-compose.yaml` 里 `environment:`（或写入 `command` 的插值）所列出的键，而 Compose 从 `docker/.env` 读取这些值。把 `docker/envs/infrastructure/nginx.env.example` 复制为 `nginx.env` 并不会配置 nginx 容器。
+
+确认容器内实际值：
+
+```bash
+docker compose exec api printenv GUNICORN_TIMEOUT
+docker compose exec nginx printenv NGINX_CLIENT_MAX_BODY_SIZE
+docker compose exec worker printenv CELERY_WORKER_AMOUNT
+```
+
+### 重建与重载 {#recreate-vs-reload}
+
+| 变更 | 做法 |
+|:-----|:-----|
+| `docker/.env` 中的 `NGINX_*` | 重建 nginx。`envsubst` 在入口执行；重载不会。 |
+| 重建 `api` 或 `web` 后出现过期 **502** | `docker compose exec nginx nginx -s reload`（或等待 30 秒 DNS 缓存过期）。 |
+| `CELERY_*` | 重建 `worker`。 |
+| 空的 `CELERY_WORKER_AMOUNT` | worker 入口使用 `-c ${CELERY_WORKER_AMOUNT:-1}`，并发变为 `1`。请设置明确整数（Compose 示例为 `4`）。 |
+| `api`、`web` 或 `plugin_daemon` 上其他 `env_file` / `.env` 键 | 重建该服务以重新加载文件。 |
+
+## 画布卡住或 WebSocket 502 {#canvas-hang-or-websocket-502}
+
+工作流编辑器的实时协作走 nginx 的 `location /socket.io/`，再代理到 `NGINX_SOCKET_IO_UPSTREAM`（默认 `api_websocket:5001`）。`api_websocket` 容器由 `docker/.env` 中 `COMPOSE_PROFILES` 的 `collaboration` profile 启动（示例值已包含 `collaboration`）。
+
+若 `api_websocket` 未运行，nginx 会对该上游记录 `host not found`，编辑器卡住或 502。在 `ENABLE_COLLABORATION_MODE` 为 `true` 时保留 `COMPOSE_PROFILES` 中的 `collaboration`，并确认容器已启动：
+
+```bash
+docker compose ps api_websocket
+```
+
+浏览器必须能解析到 WebSocket URL。不在 `localhost` 上访问时，将 `NEXT_PUBLIC_SOCKET_URL` 设为 `ws(s)://` 加上你的公网主机。详见 [ENABLE_COLLABORATION_MODE](/zh/self-host/deploy/configuration/environments#enable_collaboration_mode)。
+
+## 插件 {#plugins}
+
+在 Marketplace 点击安装或上传包会启动安装任务。只有 `plugin_daemon` 完成本地运行时（依赖安装与进程启动）后，插件才可用。控制台的插件列表由 daemon 提供。以该列表和 `docker compose logs plugin_daemon` 为准，不要只看任务横幅。
+
+Marketplace 安装由 `api` 容器下载 `.difypkg`（`MARKETPLACE_API_URL`，默认 `https://marketplace.dify.ai`）。若 `api` 无法访问 Marketplace，下载会失败。不要靠放开主机防火墙来绕过。在能访问 Marketplace 的机器上下载 `.difypkg`，然后在控制台使用 **本地集成包** 安装。
+
+失败任务会一直显示为红色，直到清除。安装失败后，控制台会显示 **安装失败的集成**。打开它，使用 **清除所有**，然后重试。
+
+上传超过 nginx 或 daemon 上限的包会返回 **413**。同时提高 `PLUGIN_MAX_PACKAGE_SIZE`（字节，默认 `52428800`）和 `NGINX_CLIENT_MAX_BODY_SIZE`，然后重建 `api`、`plugin_daemon` 和 `nginx`。普通文件上传同样是两层限制，见 [增加文件上传限制](/zh/self-host/deploy/troubleshooting/common-issues#increase-file-upload-limits)。
+
 ## 挂载与卷
 
 ### Nginx 配置挂载失败
 
 错误信息：
-```
+
+```text
 Error mounting "/run/desktop/mnt/host/d/Documents/docker/nginx/nginx.conf" to rootfs at "/etc/nginx/nginx.conf": not a directory
 ```
 
@@ -64,12 +116,14 @@ docker compose up -d
 端口 80 已被使用？可选择：
 
 1. 停止冲突的服务（通常是 Apache/Nginx）：
+
    ```bash
    sudo service nginx stop
    sudo service apache2 stop
    ```
 
 2. 或在 `docker-compose.yaml` 中更改端口映射：
+
    ```yaml
    ports:
      - "8080:80"  # 映射到不同端口
@@ -80,11 +134,13 @@ docker compose up -d
 ### 查看后台 shell 输出
 
 列出运行中的 shell：
+
 ```bash
 docker exec -it docker-api-1 ls /tmp/shells/
 ```
 
 检查 shell 输出：
+
 ```bash
 docker exec -it docker-api-1 cat /tmp/shells/[shell-id]/output.log
 ```
@@ -108,7 +164,7 @@ docker compose up -d
 
 编辑 `docker/volumes/ssrf_proxy/squid.conf` 添加 ACL 规则：
 
-```
+```text
 # 阻止访问敏感内部 IP
 acl restricted_ip dst 192.168.101.19
 acl localnet src 192.168.101.0/24
@@ -123,3 +179,7 @@ http_access deny all
 ### 为什么需要 SSRF_PROXY？ {#why-is-ssrf-proxy-needed}
 
 防止服务向内网资源发出未授权请求。代理会拦截并过滤来自沙盒服务的所有出站请求。
+
+## 延伸阅读
+
+需要 Community Edition 1.17 可执行检查清单的运营者，可使用 [dify-skills](https://github.com/kabishou11/dify-skills)（社区非官方，非 LangGenius 维护）。


### PR DESCRIPTION
## Summary

Community Edition 1.17 operators hit failures that the current self-host troubleshooting pages do not cover, and one documented 502 recipe is harmful on current Compose.

This update extends the existing troubleshooting pages (en / zh / ja) against Dify `1.17.0` (`docker-compose.yaml`, `docker/.env.example`, `docker/envs/**`, nginx templates, API/web entrypoints). No new nav page.

### What was missing

- Login: password must be Base64 (`Invalid encrypted data` on plaintext); Console sessions need the `access_token` cookie plus `X-CSRF-Token`; access cookies last `ACCESS_TOKEN_EXPIRE_MINUTES` (default 60); `/install` is first-time only; changing `SECRET_KEY` after boot logs everyone out and breaks signed file URLs / OAuth credentials.
- Env injection: `docker/.env` vs `docker/envs/*.env.example` (`required: false`); `api` / `worker` / `web` / `plugin_daemon` / `sandbox` load `env_file`, while nginx / ssrf / weaviate / redis / db only see listed `environment:` interpolation. Recreate vs reload: `NGINX_*` needs nginx recreate because `envsubst` runs at entrypoint; empty `CELERY_WORKER_AMOUNT` becomes concurrency 1.
- Timeouts: `GUNICORN_TIMEOUT` default 360 can kill long workflows while nginx proxy timeout is 3600s. Cross-link `TEXT_GENERATION_TIMEOUT_MS` instead of repeating it.
- Plugins: Marketplace download happens from the `api` container; no-egress `api` cannot install from Marketplace — upload a `.difypkg` via **Install from Local Package File**. Installed in the UI is not the same as `plugin_daemon` local runtime ready. Failed tasks stay red until **Clear all**. `PLUGIN_MAX_PACKAGE_SIZE` and `NGINX_CLIENT_MAX_BODY_SIZE` must move together (413).
- WebSocket: `/socket.io/` → `api_websocket:5001`; 502 `host not found` if that service is down.
- `CONSOLE_API_URL`: leaving it empty so the browser uses relative nginx is correct; `http://api:5001` is a browser footgun.
- Uploads: nginx body size and `UPLOAD_FILE_*` must both match.

### Nginx 502 correction

The old recipe (replace `http://api:5001` / `http://web:3000` with container IPs in `nginx/conf.d`) is stale. 1.17 templates still use Compose DNS names and `resolver 127.0.0.11 valid=30s`. After recreating `api` / `web`, reload nginx. After changing `NGINX_*`, recreate nginx so the entrypoint re-runs `envsubst`; reload does not.

Verified against langgenius/dify tag `1.17.0`. `DEPLOYMENT_EDITION` stays `COMMUNITY`.

Further reading on the pages points once to unofficial Community 1.17 checklists at https://github.com/kabishou11/dify-skills (not LangGenius).

## Test plan

- [ ] Read en / zh / ja `common-issues` and `docker-issues` in the docs preview
- [ ] Confirm the 502 section no longer tells operators to hardcode container IPs
- [ ] Confirm env var names against `docker/.env.example` and `docker-compose.yaml` on the 1.17.0 tag