### PR TITLE
fix: correct the pnpm version and unify the rate limit wording

### DIFF
--- a/en/api-reference/openapi_service.json
+++ b/en/api-reference/openapi_service.json
@@ -7432,7 +7432,7 @@
                 }
               }
             },
-            "description": "- `too_many_requests` : Too many concurrent requests for this app.\n- `rate_limit_error` : The workspace's Dify Cloud quota for workflow executions has been exhausted."
+            "description": "- `too_many_requests` : Too many concurrent requests for this app.\n- `rate_limit_error` : The Dify Cloud workflow execution quota for this workspace has been reached."
           },
           "500": {
             "content": {

--- a/en/self-host/deploy/advanced-deployments/local-source-code.mdx
+++ b/en/self-host/deploy/advanced-deployments/local-source-code.mdx
@@ -208,7 +208,7 @@ Start the web service is built for frontend pages .
 
 ### Environment Preparation
 
-To start the web frontend service, [Node.js v24 (LTS)](https://nodejs.org/en) and [PNPM v11](https://pnpm.io/) are required.
+To start the web frontend service, [Node.js v24 (LTS)](https://nodejs.org/en) and [PNPM v12](https://pnpm.io/) are required.
 
 - Install NodeJS
 
@@ -218,7 +218,7 @@ To start the web frontend service, [Node.js v24 (LTS)](https://nodejs.org/en) an
 
   Follow the [the installation guidance](https://pnpm.io/installation) to install PNPM. Or just run this command to install `pnpm` with `npm`.
     ```
-    npm i -g pnpm
+    npm i -g pnpm@12
     ```
 
 ### Start Web Service

--- a/ja/api-reference/openapi_service.json
+++ b/ja/api-reference/openapi_service.json
@@ -7432,7 +7432,7 @@
                 }
               }
             },
-            "description": "- `too_many_requests` : このアプリケーションへの同時リクエストが多すぎます。\n- `rate_limit_error` : ワークスペースの Dify Cloud のワークフロー実行クォータを使い切りました。"
+            "description": "- `too_many_requests` : このアプリケーションへの同時リクエストが多すぎます。\n- `rate_limit_error` : このワークスペースの Dify Cloud のワークフロー実行クォータに達しました。"
           },
           "500": {
             "content": {

--- a/ja/self-host/deploy/advanced-deployments/local-source-code.mdx
+++ b/ja/self-host/deploy/advanced-deployments/local-source-code.mdx
@@ -211,7 +211,7 @@ uv run celery -A app.celery beat
 
 ### 環境の準備
 
-Web フロントエンドサービスを起動するには、[Node.js v24 (LTS)](https://nodejs.org/en) と [PNPM v11](https://pnpm.io/) が必要です。
+Web フロントエンドサービスを起動するには、[Node.js v24 (LTS)](https://nodejs.org/en) と [PNPM v12](https://pnpm.io/) が必要です。
 
 - NodeJS のインストール
 
@@ -221,7 +221,7 @@ Web フロントエンドサービスを起動するには、[Node.js v24 (LTS)]
 
   [インストールガイド](https://pnpm.io/installation) に従って PNPM をインストールします。または、以下のコマンドで `npm` を使用して `pnpm` をインストールできます。
     ```
-    npm i -g pnpm
+    npm i -g pnpm@12
     ```
 
 ### Web サービスの起動

--- a/zh/api-reference/openapi_service.json
+++ b/zh/api-reference/openapi_service.json
@@ -7432,7 +7432,7 @@
                 }
               }
             },
-            "description": "- `too_many_requests` : 该应用的并发请求过多。\n- `rate_limit_error` : 工作空间在 Dify Cloud 的工作流执行配额已用尽。"
+            "description": "- `too_many_requests` : 该应用的并发请求过多。\n- `rate_limit_error` : 此工作空间在 Dify Cloud 的工作流执行配额已达上限。"
           },
           "500": {
             "content": {

--- a/zh/self-host/deploy/advanced-deployments/local-source-code.mdx
+++ b/zh/self-host/deploy/advanced-deployments/local-source-code.mdx
@@ -212,7 +212,7 @@ uv run celery -A app.celery beat
 
 ### 环境准备
 
-要启动 web 前端服务，需要 [Node.js v24 (LTS)](https://nodejs.org/en) 和 [PNPM v11](https://pnpm.io/)。
+要启动 web 前端服务，需要 [Node.js v24 (LTS)](https://nodejs.org/en) 和 [PNPM v12](https://pnpm.io/)。
 
 - 安装 NodeJS
 
@@ -222,7 +222,7 @@ uv run celery -A app.celery beat
 
   按照 [安装指南](https://pnpm.io/installation) 安装 PNPM。或者直接使用 `npm` 运行以下命令安装 `pnpm`。
     ```
-    npm i -g pnpm
+    npm i -g pnpm@12
     ```
 
 ### 启动 Web 服务


### PR DESCRIPTION
## PNPM v11 → v12

langgenius/dify#42005 moved `packageManager` to `pnpm@12.3.4`, and the re-cut pulled it into the 1.17.1 build. `local-source-code.mdx` shipped v11 in langgenius/dify-docs#1025, which is now wrong for this release. Node.js stays v24 — `web/Dockerfile` pins `NODE_VERSION=24.20.0`.

At the previous pass this was filed as a next-version watch item because it sat outside the build. The re-cut changed that.

## `rate_limit_error` wording

The spec carried two descriptions for the same error: `/workflows/run` and `/workflows/{workflow_id}/run` on one, `/chat-messages` on another. langgenius/dify#41975 unified the code across `workflow.py` and `completion.py`, and is now in the build — a sorted-unique grep across `api/controllers/service_api/` at the staging ref returns a single line. `/chat-messages` is moved onto that wording in all three languages.

Both wordings predate the 1.17.1 work, so this is existing debt that the build change pulled into scope.

## Verification

`coverage failures: 0`, `TOTAL ISSUES: 0`, `TOTAL PARITY ISSUES: 0`, `check-links --internal` 0 broken links and 0 broken anchors. The three specs still round-trip byte-identically through `json.dumps(obj, indent=2, ensure_ascii=False, sort_keys=True)`, so the key ordering from #1028/#1029 is undisturbed.

The pre-existing format violations on `local-source-code.mdx` (28 en, 66 zh+ja) are unchanged from the `release/1.17.1` baseline and out of scope here.

Tracking: DC-277.