### PR TITLE
docs: document the weaviate host port variables

### DIFF
--- a/en/self-host/deploy/configuration/environments.mdx
+++ b/en/self-host/deploy/configuration/environments.mdx
@@ -1731,6 +1731,8 @@ These configure the vector database containers themselves (not the Dify client c
 | `WEAVIATE_ENABLE_TOKENIZER_GSE` | `false` | Enable GSE tokenizer (Chinese). |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_JA` | `false` | Enable Kagome tokenizer (Japanese). |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_KR` | `false` | Enable Kagome tokenizer (Korean). |
+| `EXPOSE_WEAVIATE_PORT` | `8080` | Host port for Weaviate's REST API in the middleware stack used by [source-code deployments](/en/self-host/deploy/advanced-deployments/local-source-code). A Dify instance run from source reaches Weaviate at `http://localhost:8080`. <br/><br/>Change it in that stack's `middleware.env` when 8080 is already taken on the host, and point [`WEAVIATE_ENDPOINT`](#vector-database-configuration) at the new port.<br/><br/>Middleware stack only: the full Compose stack keeps Weaviate on an internal network. |
+| `EXPOSE_WEAVIATE_GRPC_PORT` | `50051` | Host port for Weaviate's gRPC API in the same stack, reached at `grpc://localhost:50051`. <br/><br/>If you change it, point [`WEAVIATE_GRPC_ENDPOINT`](#vector-database-configuration) at the new port. |
 
 </Accordion>
 

--- a/ja/self-host/deploy/configuration/environments.mdx
+++ b/ja/self-host/deploy/configuration/environments.mdx
@@ -1721,6 +1721,8 @@ API と Celery ワーカー間の Redis ベースのイベント転送です。
 | `WEAVIATE_ENABLE_TOKENIZER_GSE` | `false` | GSE トークナイザーを有効化（中国語）。 |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_JA` | `false` | Kagome トークナイザーを有効化（日本語）。 |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_KR` | `false` | Kagome トークナイザーを有効化（韓国語）。 |
+| `EXPOSE_WEAVIATE_PORT` | `8080` | [ソースコードからのデプロイ](/ja/self-host/deploy/advanced-deployments/local-source-code) で使うミドルウェアスタックにおける Weaviate REST API のホスト側ポート。ソースから起動した Dify は `http://localhost:8080` で Weaviate に到達できる。<br/><br/>ホスト側で 8080 が使用中の場合は、そのスタックの `middleware.env` で別のポートに変更し、[`WEAVIATE_ENDPOINT`](#ベクトルデータベース設定) を新しいポートに合わせる。<br/><br/>ミドルウェアスタック専用。フル構成の Compose スタックでは、Weaviate は内部ネットワークに留まる。 |
+| `EXPOSE_WEAVIATE_GRPC_PORT` | `50051` | 同じスタックにおける Weaviate gRPC のホスト側ポート。`grpc://localhost:50051` で到達できる。<br/><br/>変更した場合は、[`WEAVIATE_GRPC_ENDPOINT`](#ベクトルデータベース設定) を新しいポートに合わせる。 |
 
 </Accordion>
 

--- a/zh/self-host/deploy/configuration/environments.mdx
+++ b/zh/self-host/deploy/configuration/environments.mdx
@@ -1725,6 +1725,8 @@ API 和 Celery 工作进程之间基于 Redis 的事件传输。
 | `WEAVIATE_ENABLE_TOKENIZER_GSE` | `false` | 启用 GSE 分词器（中文）。 |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_JA` | `false` | 启用 Kagome 分词器（日文）。 |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_KR` | `false` | 启用 Kagome 分词器（韩文）。 |
+| `EXPOSE_WEAVIATE_PORT` | `8080` | [源码部署](/zh/self-host/deploy/advanced-deployments/local-source-code) 所用中间件栈中 Weaviate REST API 的宿主机端口。从源码运行的 Dify 通过 `http://localhost:8080` 访问 Weaviate。<br/><br/>若宿主机上 8080 已被占用，在该栈的 `middleware.env` 中改用其他端口，并将 [`WEAVIATE_ENDPOINT`](#向量数据库配置) 指向新端口。<br/><br/>仅适用于中间件栈。完整的 Compose 栈将 Weaviate 保留在内部网络中。 |
+| `EXPOSE_WEAVIATE_GRPC_PORT` | `50051` | 同一栈中 Weaviate gRPC 接口的宿主机端口，访问地址为 `grpc://localhost:50051`。<br/><br/>改动后需将 [`WEAVIATE_GRPC_ENDPOINT`](#向量数据库配置) 指向新端口。 |
 
 </Accordion>
 


### PR DESCRIPTION
Two rows in the Weaviate Service accordion of the environment reference, en/zh/ja.

## Why now

`EXPOSE_WEAVIATE_GRPC_PORT` surfaced in the pass-6 release-sync scan. It is not a new variable — `docker-compose.middleware.yaml` has consumed it since 2025-10-13 — but langgenius/dify#38214 gave it its first `.env.example` entry in the current staging build, which is what made it visible to the env verifier at all. `EXPOSE_WEAVIATE_PORT` is its twin on the same service and was equally undocumented, so both land together rather than leaving the pair half-covered.

Both are middleware-stack only; the full Compose stack keeps Weaviate on an internal network. Each row links to the client-side endpoint variable it must be kept in sync with, which sits ~1100 lines away in the Vector Database Configuration section.

## Verification

Env verifier against the pass-6 staging build (`44dac4a90d`): 19 → 17 issues, removing exactly these two entries and nothing else. `check-format-en` 0, `check-links --internal` 0 broken links and 0 broken anchors.

CJK format check reports 4 violations, matching the pre-change baseline. Note that on this branch it reports 8 — the extra four are false positives from the inline-code-link bug fixed in langgenius/dify-docs#1026 and not yet on this branch (DC-287).

## Not in scope

The same audit found 8 more undocumented variables in `middleware.env.example`, in two coherent families (`EXPOSE_*_PORT` for Postgres, MySQL, Redis, Sandbox, SSRF proxy; `*_HOST_VOLUME` for PGDATA, Redis, Weaviate). All pre-existing, some since 2024-06-30. Left for a dedicated task rather than folded into a release-eve PR.

Tracking: DC-277.