### PR TITLE
feat: close the env reference audit and its verifier gaps

### DIFF
--- a/.claude/skills/dify-docs-env-vars/SKILL.md
+++ b/.claude/skills/dify-docs-env-vars/SKILL.md
@@ -63,14 +63,19 @@ The canonical command scans BOTH env sources — never pass only one:
 python3 .claude/skills/dify-docs-env-vars/verify-env-docs.py \
   --env-example <path-to-dify-repo>/docker/.env.example \
   --env-example <path-to-dify-repo>/docker/envs \
+  --compose <path-to-dify-repo>/docker \
   --docs en/self-host/deploy/configuration/environments.mdx
 ```
 
-`--env-example` is repeatable; a directory argument is globbed `**/*.env.example` recursively. The script first prints the list of files it parsed — confirm it shows `docker/.env.example` plus the files under `docker/envs/`. A single-source run under-scans and produces false "extra in docs" results.
+`--compose` reads the `${VAR}` references in `docker/docker-compose*.y*ml`. A variable a compose file consumes with no `.env.example` entry is invisible to every other check — `EXPOSE_WEAVIATE_GRPC_PORT` went undocumented for eleven months that way — so the script lists them under `=== IN COMPOSE BUT NOT IN ANY .env.example (<n>) ===` and treats them as source variables from then on. `--compare-rev` reads the compose files at both refs on its own. `docker-compose.pytest.ports.yaml` is skipped in both modes and the skip is printed: it publishes vector-store ports for the integration tests, and nothing a deployment reads.
+
+`--env-example` is repeatable; a directory argument is globbed `**/*.env.example` recursively. The script first prints the list of files it parsed — confirm it shows `docker/.env.example` plus the files under `docker/envs/`, then the compose file count. A single-source run under-scans and produces false "extra in docs" results.
 
 Output contract: on a fully clean doc the last line is `ALL CHECKS PASSED — documentation matches .env.example` and the script exits 0; otherwise it prints `TOTAL ISSUES: <n>` with per-category counts and exits 1.
 
-Pass bar for every task: **Extra in docs: 0** and **Default mismatches: 0**. **Missing from docs** is standing backlog and may stay nonzero, but no variable you touched may appear in it, and every triage var from the release diff must be resolved.
+**Cadence.** The full command above is the baseline audit, and the baseline was cleared at dify tag `1.17.1`. A release pass runs `--compare-rev` — it diffs both the `.env.example` files and the compose references between two refs, so a clean baseline stays clean incrementally. Re-run the full command whenever this script, the ignore list's location, or the `.env.example` layout changes, and after any pass that touched more than a handful of variables; it must end on `ALL CHECKS PASSED` or every remaining line must be accounted for in the ignore list. Run it against the `zh` and `ja` pages too — the parser understands `默认值：`, `デフォルト値：` and `（空）`, so their counts are as meaningful as English's.
+
+Pass bar for every task: the full command ends on `ALL CHECKS PASSED`, or every remaining line is accounted for in the ignore list with a reason. **Missing from docs** stopped being standing backlog when the baseline was cleared at tag `1.17.1`: a nonzero count now means a variable arrived since, and it is documented or ignored before the task ends. If the script prints `WARNING: ignore list not found`, the run is invalid — fix the path before reading any count.
 
 ### Update the ignore list if needed
 

--- a/.claude/skills/dify-docs-env-vars/SKILL.md
+++ b/.claude/skills/dify-docs-env-vars/SKILL.md
@@ -75,7 +75,7 @@ Output contract: on a fully clean doc the last line is `ALL CHECKS PASSED — do
 
 **Cadence.** The full command above is the baseline audit, and the baseline was cleared at dify tag `1.17.1`. A release pass runs `--compare-rev` — it diffs both the `.env.example` files and the compose references between two refs, so a clean baseline stays clean incrementally. Re-run the full command whenever this script, the ignore list's location, or the `.env.example` layout changes, and after any pass that touched more than a handful of variables; it must end on `ALL CHECKS PASSED` or every remaining line must be accounted for in the ignore list. Run it against the `zh` and `ja` pages too — the parser understands `默认值：`, `デフォルト値：` and `（空）`, so their counts are as meaningful as English's.
 
-Pass bar for every task: the full command ends on `ALL CHECKS PASSED`, or every remaining line is accounted for in the ignore list with a reason. **Missing from docs** stopped being standing backlog when the baseline was cleared at tag `1.17.1`: a nonzero count now means a variable arrived since, and it is documented or ignored before the task ends. If the script prints `WARNING: ignore list not found`, the run is invalid — fix the path before reading any count.
+Pass bar for every task: the full command ends on `ALL CHECKS PASSED`, or every remaining line is accounted for in the ignore list with a reason. **Missing from docs** stopped being standing backlog when the baseline was cleared at tag `1.17.1`: a nonzero count now means a variable arrived since, and it is documented or ignored before the task ends. If the script prints `WARNING: ignore list not found`, it stops with exit status 2 and prints no counts: fix the path and re-run.
 
 ### Update the ignore list if needed
 

--- a/.claude/skills/dify-docs-env-vars/verify-env-docs.py
+++ b/.claude/skills/dify-docs-env-vars/verify-env-docs.py
@@ -152,6 +152,10 @@ def _read_ignored_text(path: str) -> str:
                 print(f"(ignore list not in the working tree; read origin/main:{rel})")
                 return result.stdout
             break
+    msg = (f"WARNING: ignore list not found at {path} and no committed copy could be read; "
+           "every ignorable variable will be reported. Set DIFY_DOCS_REGISTRY or pass --ignored.")
+    print(msg)
+    print(msg, file=sys.stderr)
     return ""
 
 
@@ -183,8 +187,9 @@ def parse_mdx_docs(path: str) -> dict[str, str]:
             backtick_match = re.match(r"^`(.*)`$", default_cell)
             if backtick_match:
                 variables[name] = backtick_match.group(1)
-            elif default_cell.startswith("("):
+            elif default_cell.startswith(("(", "（")):
                 # (empty), (empty; falls back to...), (auto-generated), etc.
+                # zh/ja pages write these with full-width parentheses: （空）
                 variables[name] = ""
             else:
                 variables[name] = default_cell
@@ -202,14 +207,15 @@ def parse_mdx_docs(path: str) -> dict[str, str]:
                 next_line = lines[i + j].strip()
                 if not next_line:
                     continue
-                default_match = re.match(r"^Default:\s*(.+)", next_line)
+                # en "Default:", zh "默认值：", ja "デフォルト値："
+                default_match = re.match(r"^(?:Default|默认值|デフォルト値)\s*[:：]\s*(.+)", next_line)
                 if default_match:
                     raw = default_match.group(1).strip()
                     # Extract from backticks
                     bt = re.match(r"^`(.*)`", raw)
                     if bt:
                         variables[name] = bt.group(1)
-                    elif raw.startswith("("):
+                    elif raw.startswith(("(", "（")):
                         variables[name] = ""
                     else:
                         variables[name] = raw
@@ -326,6 +332,93 @@ def _env_example_paths_at_ref(repo: str, ref: str) -> list[str]:
     return sorted(files, key=precedence)
 
 
+_COMPOSE_REF_RE = re.compile(r"(?<!\$)\$\{([A-Z][A-Z0-9_]*)(?::-((?:[^{}]|\$\{[^{}]*\})*))?\}")
+
+
+def parse_compose_text(text: str) -> dict[str, str]:
+    """Collect ${VAR} and ${VAR:-fallback} references from a compose file.
+
+    A compose file can consume a variable that has no .env.example entry at all;
+    such a variable is invisible to every .env.example-based check (EXPOSE_WEAVIATE_GRPC_PORT
+    went unseen for eleven months this way). The value recorded is the innermost literal
+    fallback — what compose substitutes when nothing is set. `$${...}` is compose's escape
+    for a literal `$` (a shell variable inside a command) and is skipped.
+    """
+    found: dict[str, str] = {}
+    def visit(chunk: str) -> None:
+        for m in _COMPOSE_REF_RE.finditer(chunk):
+            name, fallback = m.group(1), (m.group(2) or "")
+            value = resolve_expansion(fallback) if fallback else ""
+            if name not in found or (not found[name] and value):
+                found[name] = value
+            if "${" in fallback:
+                visit(fallback)
+    visit(text)
+    return found
+
+
+def collect_compose_files(sources: list[str]) -> list[Path]:
+    files: list[Path] = []
+    for source in sources:
+        p = Path(source)
+        if not p.exists():
+            print(f"ERROR: compose source not found: {source}", file=sys.stderr)
+            sys.exit(1)
+        if p.is_dir():
+            for pattern in ("docker-compose*.yaml", "docker-compose*.yml"):
+                for f in sorted(p.glob(pattern)):
+                    if "pytest" in f.name:
+                        # docker/docker-compose.pytest.ports.yaml publishes vector-store ports
+                        # for the integration tests; nothing a deployment reads.
+                        print(f"(skipped {f.name}: test harness, not a deployment file)")
+                        continue
+                    files.append(f)
+        else:
+            files.append(p)
+    return files
+
+
+def parse_compose(sources: list[str]) -> tuple[dict[str, str], list[Path]]:
+    files = collect_compose_files(sources)
+    merged: dict[str, str] = {}
+    for f in files:
+        for name, value in parse_compose_text(f.read_text(encoding="utf-8")).items():
+            if name not in merged or (not merged[name] and value):
+                merged[name] = value
+    return merged, files
+
+
+def compose_vars_at_ref(repo: str, ref: str) -> dict[str, str]:
+    """${VAR} references in docker/docker-compose*.y*ml at a git ref."""
+    out = subprocess.run(
+        ["git", "-C", repo, "ls-tree", "-r", "--name-only", ref, "--", "docker/"],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    merged: dict[str, str] = {}
+    for path in out:
+        name = Path(path).name
+        if not (name.startswith("docker-compose") and name.endswith((".yaml", ".yml"))):
+            continue
+        if "pytest" in name:
+            continue  # test harness; see collect_compose_files
+        text = subprocess.run(
+            ["git", "-C", repo, "show", f"{ref}:{path}"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        for var, value in parse_compose_text(text).items():
+            if var not in merged or (not merged[var] and value):
+                merged[var] = value
+    return merged
+
+
+def merge_compose_only(env_vars: dict[str, str], compose_vars: dict[str, str]) -> list[str]:
+    """Add compose-only variables to the source map at lowest precedence; return their names."""
+    only = sorted(n for n in compose_vars if n not in env_vars)
+    for n in only:
+        env_vars[n] = compose_vars[n]
+    return only
+
+
 def env_vars_at_ref(repo: str, ref: str) -> dict[str, str]:
     """Return the merged {VAR: default} from all docker/ *.env.example files at a git ref."""
     merged: dict[str, str] = {}
@@ -348,6 +441,8 @@ def run_compare_rev(repo: str, old_ref: str, new_ref: str, docs_path, ignored_pa
     try:
         old_vars = env_vars_at_ref(repo, old_ref)
         new_vars = env_vars_at_ref(repo, new_ref)
+        merge_compose_only(old_vars, compose_vars_at_ref(repo, old_ref))
+        new_compose_only = merge_compose_only(new_vars, compose_vars_at_ref(repo, new_ref))
     except subprocess.CalledProcessError as e:
         print(f"ERROR: git failed: {e.stderr.strip() or e}", file=sys.stderr)
         return 2
@@ -362,10 +457,11 @@ def run_compare_rev(repo: str, old_ref: str, new_ref: str, docs_path, ignored_pa
         if normalize(old_vars[n]) != normalize(new_vars[n])
     )
 
-    print(f"=== ENV VAR DIFF {old_ref}..{new_ref} (uncommented .env.example vars) ===")
+    print(f"=== ENV VAR DIFF {old_ref}..{new_ref} (uncommented .env.example vars + compose ${{VAR}} refs) ===")
     print(f"NEW ({len(added)}):")
     for n in added:
-        print(f"  + {n}={new_vars[n]}")
+        tag = "  (compose-only)" if n in new_compose_only else ""
+        print(f"  + {n}={new_vars[n]}{tag}")
     print(f"REMOVED ({len(removed)}):")
     for n in removed:
         print(f"  - {n} (was {old_vars[n]!r})")
@@ -400,6 +496,15 @@ def main():
             "May be repeated. When given a directory, the verifier globs "
             "**/*.env.example recursively. Pass both `docker/.env.example` and "
             "`docker/envs/` to capture the post-PR-#31586 layout."
+        ),
+    )
+    parser.add_argument(
+        "--compose",
+        action="append",
+        help=(
+            "Path to a docker-compose*.y*ml file or a directory holding them (pass "
+            "`<repo>/docker`). May be repeated. Variables a compose file consumes with "
+            "no .env.example entry are otherwise invisible to this check."
         ),
     )
     parser.add_argument(
@@ -450,6 +555,18 @@ def main():
     print(f"Parsed {len(doc_vars)} variables from documentation")
     print(f"Loaded {len(ignored)} ignored variables from {args.ignored}")
     print()
+
+    compose_only: list[str] = []
+    if args.compose:
+        compose_vars, compose_files = parse_compose(args.compose)
+        print(f"Parsed {len(compose_vars)} ${{VAR}} references from {len(compose_files)} compose file(s)")
+        compose_only = merge_compose_only(env_vars, compose_vars)
+        if compose_only:
+            print(f"=== IN COMPOSE BUT NOT IN ANY .env.example ({len(compose_only)}) ===")
+            for name in compose_only:
+                print(f"  {name} (compose fallback: {env_vars[name]!r})")
+            print("(Only --compose sees these. Document each, or add it to env-ignored-vars.md with a reason.)")
+            print()
 
     # --- Check 1: Variables in .env.example but missing from docs ---
     missing_from_docs = sorted(

--- a/.claude/skills/dify-docs-env-vars/verify-env-docs.py
+++ b/.claude/skills/dify-docs-env-vars/verify-env-docs.py
@@ -357,6 +357,13 @@ def parse_compose_text(text: str) -> dict[str, str]:
     return found
 
 
+def is_test_compose(name: str) -> bool:
+    """docker/docker-compose.pytest.ports.yaml publishes vector-store ports for the
+    integration tests; nothing a deployment reads. Skipped whether it arrives via a
+    directory glob, an explicit path, or a git ref."""
+    return "pytest" in name
+
+
 def collect_compose_files(sources: list[str]) -> list[Path]:
     files: list[Path] = []
     for source in sources:
@@ -364,17 +371,16 @@ def collect_compose_files(sources: list[str]) -> list[Path]:
         if not p.exists():
             print(f"ERROR: compose source not found: {source}", file=sys.stderr)
             sys.exit(1)
+        candidates = [p]
         if p.is_dir():
+            candidates = []
             for pattern in ("docker-compose*.yaml", "docker-compose*.yml"):
-                for f in sorted(p.glob(pattern)):
-                    if "pytest" in f.name:
-                        # docker/docker-compose.pytest.ports.yaml publishes vector-store ports
-                        # for the integration tests; nothing a deployment reads.
-                        print(f"(skipped {f.name}: test harness, not a deployment file)")
-                        continue
-                    files.append(f)
-        else:
-            files.append(p)
+                candidates.extend(sorted(p.glob(pattern)))
+        for f in candidates:
+            if is_test_compose(f.name):
+                print(f"(skipped {f.name}: test harness, not a deployment file)")
+                continue
+            files.append(f)
     return files
 
 
@@ -399,8 +405,8 @@ def compose_vars_at_ref(repo: str, ref: str) -> dict[str, str]:
         name = Path(path).name
         if not (name.startswith("docker-compose") and name.endswith((".yaml", ".yml"))):
             continue
-        if "pytest" in name:
-            continue  # test harness; see collect_compose_files
+        if is_test_compose(name):
+            continue
         text = subprocess.run(
             ["git", "-C", repo, "show", f"{ref}:{path}"],
             capture_output=True, text=True, check=True,

--- a/.claude/skills/dify-docs-env-vars/verify-env-docs.py
+++ b/.claude/skills/dify-docs-env-vars/verify-env-docs.py
@@ -152,11 +152,13 @@ def _read_ignored_text(path: str) -> str:
                 print(f"(ignore list not in the working tree; read origin/main:{rel})")
                 return result.stdout
             break
+    # An empty ignore set would let a run end on ALL CHECKS PASSED by accident, so the
+    # run is invalid rather than noisy: stop here instead of reporting against nothing.
     msg = (f"WARNING: ignore list not found at {path} and no committed copy could be read; "
-           "every ignorable variable will be reported. Set DIFY_DOCS_REGISTRY or pass --ignored.")
+           "the run is invalid. Set DIFY_DOCS_REGISTRY or pass --ignored.")
     print(msg)
     print(msg, file=sys.stderr)
-    return ""
+    sys.exit(2)
 
 
 def parse_mdx_docs(path: str) -> dict[str, str]:
@@ -406,6 +408,7 @@ def compose_vars_at_ref(repo: str, ref: str) -> dict[str, str]:
         if not (name.startswith("docker-compose") and name.endswith((".yaml", ".yml"))):
             continue
         if is_test_compose(name):
+            print(f"(skipped {name} at {ref}: test harness, not a deployment file)")
             continue
         text = subprocess.run(
             ["git", "-C", repo, "show", f"{ref}:{path}"],

--- a/en/self-host/deploy/configuration/environments.mdx
+++ b/en/self-host/deploy/configuration/environments.mdx
@@ -1471,17 +1471,23 @@ The `e2b` backend reads its own group of variables, and the `docker/docker-compo
 |---|---|---|
 | `DIFY_AGENT_E2B_API_KEY` | (empty; falls back to `E2B_API_KEY`/`E2B_API_TOKEN`) | E2B account key; required for the `e2b` backend. |
 | `DIFY_AGENT_E2B_TEMPLATE` | `difys-default-team/dify-agent-local-sandbox` | E2B sandbox template agents run in. |
+| `EXPOSE_AGENT_BACKEND_PORT` | `15050` | Host port at which the `docker-compose.e2b.yaml` overlay publishes the agent backend (container port `5050`). Change it when 15050 is already taken on the host. |
 | `DIFY_AGENT_E2B_ACTIVE_TIMEOUT_SECONDS` | `3600` | How long one E2B sandbox stays active, spanning a complete agent run. 3600 is also the hard ceiling: higher values are rejected. <br/><br/>Keep it at or above `DIFY_AGENT_RUN_TIMEOUT_SECONDS`. If the sandbox's active time is shorter than the run's allowed time, runs lose their sandbox while still within their limit. |
 | `DIFY_AGENT_E2B_SHELLCTL_PORT` | `5004` | Port the sandbox control service listens on inside the E2B VM. |
 
 ## Database Service
 
-These configure the database containers directly in Docker Compose.
+These configure the database and Redis containers directly in Docker Compose. Rows marked *middleware stack* apply only to the stack that [source-code deployments](/en/self-host/deploy/advanced-deployments/local-source-code) start, and are set in its `middleware.env`; the full Compose stack keeps those services on an internal network.
 
 | Variable | Default | Description |
 |---|---|---|
 | `PGDATA` | `/var/lib/postgresql/data/pgdata` | PostgreSQL data directory inside the container. |
 | `MYSQL_HOST_VOLUME` | `./volumes/mysql/data` | Host path mounted as MySQL data volume. |
+| `PGDATA_HOST_VOLUME` | `./volumes/db/data` | Host path mounted as the PostgreSQL data volume. Middleware stack; the full Compose stack mounts `./volumes/db/data` directly. |
+| `REDIS_HOST_VOLUME` | `./volumes/redis/data` | Host path mounted as the Redis data volume. Middleware stack. |
+| `EXPOSE_POSTGRES_PORT` | `5432` | Host port at which the middleware stack publishes PostgreSQL. |
+| `EXPOSE_MYSQL_PORT` | `3306` | Host port at which the middleware stack publishes MySQL. |
+| `EXPOSE_REDIS_PORT` | `6379` | Host port at which the middleware stack publishes Redis. |
 
 ## Sandbox Service
 
@@ -1535,6 +1541,8 @@ These configure the Squid-based SSRF proxy container that blocks requests to int
 | Variable | Default | Description |
 |---|---|---|
 | `SSRF_HTTP_PORT` | `3128` | Proxy listening port. |
+| `EXPOSE_SSRF_PROXY_PORT` | `3128` | Host port at which the middleware stack ([source-code deployments](/en/self-host/deploy/advanced-deployments/local-source-code)) publishes the proxy's `SSRF_HTTP_PORT`. Set it in that stack's `middleware.env`; the full Compose stack keeps the proxy on an internal network. |
+| `EXPOSE_SANDBOX_PORT` | `8194` | Host port at which the middleware stack publishes the proxy's sandbox port (`SSRF_SANDBOX_PROXY_PORT`), so code run from source reaches the sandbox through the proxy. |
 | `SSRF_COREDUMP_DIR` | `/var/spool/squid` | Core dump directory. |
 | `SSRF_SANDBOX_PROXY_PORT` | `8194` | Port the SSRF proxy listens on to reverse-proxy egress to the sandbox service. |
 | `SSRF_SANDBOX_PROXY_HOST` | `sandbox` | Hostname of the sandbox service the SSRF proxy forwards to. |
@@ -1577,6 +1585,7 @@ The plugin daemon is a separate service that manages plugin lifecycle (installat
 | `PLUGIN_DAEMON_URL` | `http://plugin_daemon:5002` | Plugin daemon service URL. |
 | `PLUGIN_DAEMON_KEY` | (auto-generated) | Authentication key for the plugin daemon. |
 | `PLUGIN_DAEMON_PORT` | `5002` | Plugin daemon listening port. |
+| `DB_SSL_MODE` | `disable` | PostgreSQL `sslmode` for the plugin daemon's database connection. Set `require` when the database enforces TLS. There is no `.env.example` entry; set it in `docker/.env`. |
 | `PLUGIN_DAEMON_TIMEOUT` | `600.0` | Timeout in seconds for all plugin daemon requests (installation, execution, listing). |
 | `PLUGIN_MAX_PACKAGE_SIZE` | `52428800` | Maximum plugin package size in bytes (50 MB). Validated during marketplace downloads. |
 | `PLUGIN_MAX_FILE_SIZE` | `52428800` | Maximum size in bytes (50 MB) for a single file a plugin returns to Dify, such as a tool plugin outputting a generated image or document. A larger file fails the invocation with a "file is too large" error. |
@@ -1635,6 +1644,7 @@ OpenTelemetry provides distributed tracing and metrics collection. When enabled,
 | Variable | Default | Description |
 |---|---|---|
 | `CSP_WHITELIST` | (empty) | Additional domains to allow in Content Security Policy headers. |
+| `NEXT_TELEMETRY_DISABLED` | `0` | Set to `1` to turn off Next.js's anonymous telemetry, which the Compose stack otherwise leaves on. |
 | `ALLOW_EMBED` | `false` | Allow Dify pages to be embedded in iframes. When `false`, sets `X-Frame-Options: DENY` to prevent clickjacking. |
 | `SWAGGER_UI_ENABLED` | `false` | Expose Swagger UI at `SWAGGER_UI_PATH` for browsing API documentation. Swagger endpoints bypass authentication. |
 | `SWAGGER_UI_PATH` | `/swagger-ui.html` | URL path for Swagger UI. |
@@ -1731,8 +1741,9 @@ These configure the vector database containers themselves (not the Dify client c
 | `WEAVIATE_ENABLE_TOKENIZER_GSE` | `false` | Enable GSE tokenizer (Chinese). |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_JA` | `false` | Enable Kagome tokenizer (Japanese). |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_KR` | `false` | Enable Kagome tokenizer (Korean). |
-| `EXPOSE_WEAVIATE_PORT` | `8080` | Host port for Weaviate's REST API in the middleware stack used by [source-code deployments](/en/self-host/deploy/advanced-deployments/local-source-code). A Dify instance run from source reaches Weaviate at `http://localhost:8080`. <br/><br/>Change it in that stack's `middleware.env` when 8080 is already taken on the host, and point [`WEAVIATE_ENDPOINT`](#vector-database-configuration) at the new port.<br/><br/>Middleware stack only: the full Compose stack keeps Weaviate on an internal network. |
-| `EXPOSE_WEAVIATE_GRPC_PORT` | `50051` | Host port for Weaviate's gRPC API in the same stack, reached at `grpc://localhost:50051`. <br/><br/>If you change it, point [`WEAVIATE_GRPC_ENDPOINT`](#vector-database-configuration) at the new port. |
+| `WEAVIATE_HOST_VOLUME` | `./volumes/weaviate` | Host path mounted as the Weaviate data volume. Middleware stack ([source-code deployments](/en/self-host/deploy/advanced-deployments/local-source-code)), set in its `middleware.env`; the full Compose stack mounts `./volumes/weaviate` directly. |
+| `EXPOSE_WEAVIATE_PORT` | `8080` | Host port at which the middleware stack ([source-code deployments](/en/self-host/deploy/advanced-deployments/local-source-code)) publishes Weaviate's REST API, so Dify run from source reaches it at `http://localhost:8080`.<br/><br/>Change it when 8080 is already taken on the host, and point [`WEAVIATE_ENDPOINT`](#vector-database-configuration) at the new port. Middleware stack only; the full Compose stack keeps Weaviate on an internal network. |
+| `EXPOSE_WEAVIATE_GRPC_PORT` | `50051` | Host port at which the middleware stack publishes Weaviate's gRPC API, reached at `grpc://localhost:50051`.<br/><br/>If you change it, point [`WEAVIATE_GRPC_ENDPOINT`](#vector-database-configuration) at the new port. |
 
 </Accordion>
 

--- a/en/self-host/deploy/configuration/environments.mdx
+++ b/en/self-host/deploy/configuration/environments.mdx
@@ -1585,7 +1585,7 @@ The plugin daemon is a separate service that manages plugin lifecycle (installat
 | `PLUGIN_DAEMON_URL` | `http://plugin_daemon:5002` | Plugin daemon service URL. |
 | `PLUGIN_DAEMON_KEY` | (auto-generated) | Authentication key for the plugin daemon. |
 | `PLUGIN_DAEMON_PORT` | `5002` | Plugin daemon listening port. |
-| `DB_SSL_MODE` | `disable` | PostgreSQL `sslmode` for the plugin daemon's database connection. Set `require` when the database enforces TLS. There is no `.env.example` entry; set it in `docker/.env`. |
+| `DB_SSL_MODE` | `disable` | PostgreSQL `sslmode` for the plugin daemon's database connection. Set `require` when the database enforces TLS. There is no `.env.example` entry: set it in `docker/.env` for the full Compose stack, or in `middleware.env` for the middleware stack. |
 | `PLUGIN_DAEMON_TIMEOUT` | `600.0` | Timeout in seconds for all plugin daemon requests (installation, execution, listing). |
 | `PLUGIN_MAX_PACKAGE_SIZE` | `52428800` | Maximum plugin package size in bytes (50 MB). Validated during marketplace downloads. |
 | `PLUGIN_MAX_FILE_SIZE` | `52428800` | Maximum size in bytes (50 MB) for a single file a plugin returns to Dify, such as a tool plugin outputting a generated image or document. A larger file fails the invocation with a "file is too large" error. |
@@ -1742,7 +1742,7 @@ These configure the vector database containers themselves (not the Dify client c
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_JA` | `false` | Enable Kagome tokenizer (Japanese). |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_KR` | `false` | Enable Kagome tokenizer (Korean). |
 | `WEAVIATE_HOST_VOLUME` | `./volumes/weaviate` | Host path mounted as the Weaviate data volume. Middleware stack ([source-code deployments](/en/self-host/deploy/advanced-deployments/local-source-code)), set in its `middleware.env`; the full Compose stack mounts `./volumes/weaviate` directly. |
-| `EXPOSE_WEAVIATE_PORT` | `8080` | Host port at which the middleware stack ([source-code deployments](/en/self-host/deploy/advanced-deployments/local-source-code)) publishes Weaviate's REST API, so Dify run from source reaches it at `http://localhost:8080`.<br/><br/>Change it when 8080 is already taken on the host, and point [`WEAVIATE_ENDPOINT`](#vector-database-configuration) at the new port. Middleware stack only; the full Compose stack keeps Weaviate on an internal network. |
+| `EXPOSE_WEAVIATE_PORT` | `8080` | Host port at which the middleware stack ([source-code deployments](/en/self-host/deploy/advanced-deployments/local-source-code)) publishes Weaviate's REST API, so Dify running from source reaches it at `http://localhost:8080`.<br/><br/>Change it when 8080 is already taken on the host, and point [`WEAVIATE_ENDPOINT`](#vector-database-configuration) at the new port. Middleware stack only; the full Compose stack keeps Weaviate on an internal network. |
 | `EXPOSE_WEAVIATE_GRPC_PORT` | `50051` | Host port at which the middleware stack publishes Weaviate's gRPC API, reached at `grpc://localhost:50051`.<br/><br/>If you change it, point [`WEAVIATE_GRPC_ENDPOINT`](#vector-database-configuration) at the new port. |
 
 </Accordion>

--- a/ja/self-host/deploy/configuration/environments.mdx
+++ b/ja/self-host/deploy/configuration/environments.mdx
@@ -1575,7 +1575,7 @@ HTTPS を有効化した後、 [共通変数](#共通変数) の URL 変数（�
 | `PLUGIN_DAEMON_URL` | `http://plugin_daemon:5002` | プラグインデーモンサービス URL。 |
 | `PLUGIN_DAEMON_KEY` | （自動生成） | プラグインデーモンの認証キー。 |
 | `PLUGIN_DAEMON_PORT` | `5002` | プラグインデーモンのリッスンポート。 |
-| `DB_SSL_MODE` | `disable` | プラグインデーモンが PostgreSQL に接続する際の `sslmode`。データベースが TLS を必須とする場合は `require` にする。`.env.example` には項目がないため、`docker/.env` で設定する。 |
+| `DB_SSL_MODE` | `disable` | プラグインデーモンが PostgreSQL に接続する際の `sslmode`。データベースが TLS を必須とする場合は `require` にする。`.env.example` には項目がない。フル構成の Compose スタックでは `docker/.env`、ミドルウェアスタックでは `middleware.env` で設定する。 |
 | `PLUGIN_DAEMON_TIMEOUT` | `600.0` | すべてのプラグインデーモンリクエスト（インストール、実行、リスト表示）のタイムアウト（秒）。 |
 | `PLUGIN_MAX_PACKAGE_SIZE` | `52428800` | プラグインパッケージの最大サイズ（バイト、50 MB）。マーケットプレイスダウンロード時に検証されます。 |
 | `PLUGIN_MAX_FILE_SIZE` | `52428800` | プラグインが Dify に返す単一ファイルの最大サイズ（バイト、50 MB）。ツールプラグインが生成した画像やドキュメントの出力などが対象です。上限を超えるファイルは「file is too large」エラーで呼び出しが失敗します。 |

--- a/ja/self-host/deploy/configuration/environments.mdx
+++ b/ja/self-host/deploy/configuration/environments.mdx
@@ -1463,17 +1463,23 @@ Agent のサンドボックスをどこで実行するかを選択します。�
 |---|---|---|
 | `DIFY_AGENT_E2B_API_KEY` | （空；`E2B_API_KEY`/`E2B_API_TOKEN` にフォールバック） | E2B アカウントキー。`e2b` バックエンドでは必須。 |
 | `DIFY_AGENT_E2B_TEMPLATE` | `difys-default-team/dify-agent-local-sandbox` | Agent が実行される E2B サンドボックステンプレート。 |
+| `EXPOSE_AGENT_BACKEND_PORT` | `15050` | `docker-compose.e2b.yaml` オーバーレイが Agent バックエンド（コンテナポート `5050`）を公開するホスト側のポート。ホスト側で 15050 が使用中の場合は別のポートに変更する。 |
 | `DIFY_AGENT_E2B_ACTIVE_TIMEOUT_SECONDS` | `3600` | 1 つの E2B サンドボックスがアクティブでいられる時間。Agent の 1 回の実行全体に及ぶ。3600 が上限で、それより大きい値は拒否される。<br/><br/>`DIFY_AGENT_RUN_TIMEOUT_SECONDS` 以上に設定すること。サンドボックスのアクティブ時間が実行の許容時間より短いと、実行は制限内であってもサンドボックスを失う。 |
 | `DIFY_AGENT_E2B_SHELLCTL_PORT` | `5004` | E2B VM 内でサンドボックス制御サービスが待ち受けるポート。 |
 
 ## データベースサービス
 
-Docker Compose でデータベースコンテナを直接設定します。
+Docker Compose でデータベースと Redis のコンテナを直接設定します。「ミドルウェアスタック」と記した行は、[ソースコードからのデプロイ](/ja/self-host/deploy/advanced-deployments/local-source-code) で起動するスタックにのみ適用され、そのスタックの `middleware.env` で設定します。フル構成の Compose スタックでは、これらのサービスは内部ネットワークに留まります。
 
 | 変数 | デフォルト値 | 説明 |
 |---|---|---|
 | `PGDATA` | `/var/lib/postgresql/data/pgdata` | コンテナ内の PostgreSQL データディレクトリ。 |
 | `MYSQL_HOST_VOLUME` | `./volumes/mysql/data` | MySQL データボリュームとしてマウントされるホストパス。 |
+| `PGDATA_HOST_VOLUME` | `./volumes/db/data` | PostgreSQL データボリュームとしてマウントされるホストパス。ミドルウェアスタック。フル構成の Compose スタックは `./volumes/db/data` を直接マウントする。 |
+| `REDIS_HOST_VOLUME` | `./volumes/redis/data` | Redis データボリュームとしてマウントされるホストパス。ミドルウェアスタック。 |
+| `EXPOSE_POSTGRES_PORT` | `5432` | ミドルウェアスタックが PostgreSQL を公開するホスト側のポート。 |
+| `EXPOSE_MYSQL_PORT` | `3306` | ミドルウェアスタックが MySQL を公開するホスト側のポート。 |
+| `EXPOSE_REDIS_PORT` | `6379` | ミドルウェアスタックが Redis を公開するホスト側のポート。 |
 
 ## サンドボックスサービス
 
@@ -1527,6 +1533,8 @@ HTTPS を有効化した後、 [共通変数](#共通変数) の URL 変数（�
 | 変数 | デフォルト値 | 説明 |
 |---|---|---|
 | `SSRF_HTTP_PORT` | `3128` | プロキシのリッスンポート。 |
+| `EXPOSE_SSRF_PROXY_PORT` | `3128` | [ソースコードからのデプロイ](/ja/self-host/deploy/advanced-deployments/local-source-code) で使うミドルウェアスタックがプロキシの `SSRF_HTTP_PORT` を公開するホスト側のポート。そのスタックの `middleware.env` で設定する。フル構成の Compose スタックではプロキシは内部ネットワークに留まる。 |
+| `EXPOSE_SANDBOX_PORT` | `8194` | ミドルウェアスタックがプロキシのサンドボックス用ポート（`SSRF_SANDBOX_PROXY_PORT`）を公開するホスト側のポート。ソースから起動したコードはプロキシ経由でサンドボックスに到達する。 |
 | `SSRF_COREDUMP_DIR` | `/var/spool/squid` | コアダンプディレクトリ。 |
 | `SSRF_SANDBOX_PROXY_PORT` | `8194` | SSRF プロキシがサンドボックスサービスへの送信トラフィックをリバースプロキシするためにリッスンするポート。 |
 | `SSRF_SANDBOX_PROXY_HOST` | `sandbox` | SSRF プロキシの転送先となるサンドボックスサービスのホスト名。 |
@@ -1567,6 +1575,7 @@ HTTPS を有効化した後、 [共通変数](#共通変数) の URL 変数（�
 | `PLUGIN_DAEMON_URL` | `http://plugin_daemon:5002` | プラグインデーモンサービス URL。 |
 | `PLUGIN_DAEMON_KEY` | （自動生成） | プラグインデーモンの認証キー。 |
 | `PLUGIN_DAEMON_PORT` | `5002` | プラグインデーモンのリッスンポート。 |
+| `DB_SSL_MODE` | `disable` | プラグインデーモンが PostgreSQL に接続する際の `sslmode`。データベースが TLS を必須とする場合は `require` にする。`.env.example` には項目がないため、`docker/.env` で設定する。 |
 | `PLUGIN_DAEMON_TIMEOUT` | `600.0` | すべてのプラグインデーモンリクエスト（インストール、実行、リスト表示）のタイムアウト（秒）。 |
 | `PLUGIN_MAX_PACKAGE_SIZE` | `52428800` | プラグインパッケージの最大サイズ（バイト、50 MB）。マーケットプレイスダウンロード時に検証されます。 |
 | `PLUGIN_MAX_FILE_SIZE` | `52428800` | プラグインが Dify に返す単一ファイルの最大サイズ（バイト、50 MB）。ツールプラグインが生成した画像やドキュメントの出力などが対象です。上限を超えるファイルは「file is too large」エラーで呼び出しが失敗します。 |
@@ -1625,6 +1634,7 @@ OpenTelemetry は分散トレーシングとメトリクス収集を提供しま
 | 変数 | デフォルト値 | 説明 |
 |---|---|---|
 | `CSP_WHITELIST` | （空） | Content Security Policy ヘッダーで許可する追加ドメイン。 |
+| `NEXT_TELEMETRY_DISABLED` | `0` | `1` にすると Next.js の匿名テレメトリを無効にする。Compose スタックではデフォルトで有効のまま。 |
 | `ALLOW_EMBED` | `false` | Dify ページの iframe 埋め込みを許可。`false`の場合、クリックジャッキングを防止するため `X-Frame-Options: DENY` を設定します。 |
 | `SWAGGER_UI_ENABLED` | `false` | `SWAGGER_UI_PATH` で Swagger UI を公開し、API ドキュメントをブラウジングできるようにします。Swagger エンドポイントは認証をバイパスします。 |
 | `SWAGGER_UI_PATH` | `/swagger-ui.html` | Swagger UI の URL パス。 |
@@ -1721,8 +1731,9 @@ API と Celery ワーカー間の Redis ベースのイベント転送です。
 | `WEAVIATE_ENABLE_TOKENIZER_GSE` | `false` | GSE トークナイザーを有効化（中国語）。 |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_JA` | `false` | Kagome トークナイザーを有効化（日本語）。 |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_KR` | `false` | Kagome トークナイザーを有効化（韓国語）。 |
-| `EXPOSE_WEAVIATE_PORT` | `8080` | [ソースコードからのデプロイ](/ja/self-host/deploy/advanced-deployments/local-source-code) で使うミドルウェアスタックにおける Weaviate REST API のホスト側ポート。ソースから起動した Dify は `http://localhost:8080` で Weaviate に到達できる。<br/><br/>ホスト側で 8080 が使用中の場合は、そのスタックの `middleware.env` で別のポートに変更し、[`WEAVIATE_ENDPOINT`](#ベクトルデータベース設定) を新しいポートに合わせる。<br/><br/>ミドルウェアスタック専用。フル構成の Compose スタックでは、Weaviate は内部ネットワークに留まる。 |
-| `EXPOSE_WEAVIATE_GRPC_PORT` | `50051` | 同じスタックにおける Weaviate gRPC のホスト側ポート。`grpc://localhost:50051` で到達できる。<br/><br/>変更した場合は、[`WEAVIATE_GRPC_ENDPOINT`](#ベクトルデータベース設定) を新しいポートに合わせる。 |
+| `WEAVIATE_HOST_VOLUME` | `./volumes/weaviate` | Weaviate データボリュームとしてマウントされるホストパス。ミドルウェアスタック（[ソースコードからのデプロイ](/ja/self-host/deploy/advanced-deployments/local-source-code)）。そのスタックの `middleware.env` で設定する。フル構成の Compose スタックは `./volumes/weaviate` を直接マウントする。 |
+| `EXPOSE_WEAVIATE_PORT` | `8080` | [ソースコードからのデプロイ](/ja/self-host/deploy/advanced-deployments/local-source-code) で使うミドルウェアスタックが Weaviate REST API を公開するホスト側のポート。ソースから起動した Dify は `http://localhost:8080` で到達できる。<br/><br/>ホスト側で 8080 が使用中の場合は別のポートに変更し、[`WEAVIATE_ENDPOINT`](#ベクトルデータベース設定) を新しいポートに合わせる。ミドルウェアスタック専用。フル構成の Compose スタックでは Weaviate は内部ネットワークに留まる。 |
+| `EXPOSE_WEAVIATE_GRPC_PORT` | `50051` | ミドルウェアスタックが Weaviate gRPC を公開するホスト側のポート。`grpc://localhost:50051` で到達できる。<br/><br/>変更した場合は [`WEAVIATE_GRPC_ENDPOINT`](#ベクトルデータベース設定) を新しいポートに合わせる。 |
 
 </Accordion>
 

--- a/zh/self-host/deploy/configuration/environments.mdx
+++ b/zh/self-host/deploy/configuration/environments.mdx
@@ -1467,17 +1467,23 @@ API 访问 Agent 后端所用的地址。在 Docker Compose 中保持默认值�
 |---|---|---|
 | `DIFY_AGENT_E2B_API_KEY` | （空；回退到 `E2B_API_KEY`/`E2B_API_TOKEN`） | E2B 账户密钥；`e2b` 后端必填。 |
 | `DIFY_AGENT_E2B_TEMPLATE` | `difys-default-team/dify-agent-local-sandbox` | Agent 运行所用的 E2B 沙箱模板。 |
+| `EXPOSE_AGENT_BACKEND_PORT` | `15050` | `docker-compose.e2b.yaml` 叠加文件将 Agent 后端（容器端口 `5050`）发布到宿主机的端口。宿主机上 15050 已被占用时改用其他端口。 |
 | `DIFY_AGENT_E2B_ACTIVE_TIMEOUT_SECONDS` | `3600` | 单个 E2B 沙箱保持活跃的时长，覆盖一次完整的 Agent 运行。3600 同时是硬上限，更高的值会被拒绝。<br/><br/>应不低于 `DIFY_AGENT_RUN_TIMEOUT_SECONDS`。若沙箱的活跃时长短于运行的允许时长，运行会在未超时的情况下失去沙箱。 |
 | `DIFY_AGENT_E2B_SHELLCTL_PORT` | `5004` | 沙箱控制服务在 E2B 虚拟机内监听的端口。 |
 
 ## 数据库服务
 
-这些变量直接在 Docker Compose 中配置数据库容器。
+这些变量直接在 Docker Compose 中配置数据库与 Redis 容器。标注「中间件栈」的行只适用于 [源码部署](/zh/self-host/deploy/advanced-deployments/local-source-code) 所启动的那套栈，在其 `middleware.env` 中设置；完整的 Compose 栈将这些服务保留在内部网络中。
 
 | 变量 | 默认值 | 说明 |
 |---|---|---|
 | `PGDATA` | `/var/lib/postgresql/data/pgdata` | 容器内 PostgreSQL 数据目录。 |
 | `MYSQL_HOST_VOLUME` | `./volumes/mysql/data` | 挂载为 MySQL 数据卷的宿主机路径。 |
+| `PGDATA_HOST_VOLUME` | `./volumes/db/data` | 挂载为 PostgreSQL 数据卷的宿主机路径。中间件栈；完整的 Compose 栈直接挂载 `./volumes/db/data`。 |
+| `REDIS_HOST_VOLUME` | `./volumes/redis/data` | 挂载为 Redis 数据卷的宿主机路径。中间件栈。 |
+| `EXPOSE_POSTGRES_PORT` | `5432` | 中间件栈将 PostgreSQL 发布到宿主机的端口。 |
+| `EXPOSE_MYSQL_PORT` | `3306` | 中间件栈将 MySQL 发布到宿主机的端口。 |
+| `EXPOSE_REDIS_PORT` | `6379` | 中间件栈将 Redis 发布到宿主机的端口。 |
 
 ## 沙箱服务
 
@@ -1531,6 +1537,8 @@ API 访问 Agent 后端所用的地址。在 Docker Compose 中保持默认值�
 | 变量 | 默认值 | 说明 |
 |---|---|---|
 | `SSRF_HTTP_PORT` | `3128` | 代理监听端口。 |
+| `EXPOSE_SSRF_PROXY_PORT` | `3128` | [源码部署](/zh/self-host/deploy/advanced-deployments/local-source-code) 所用的中间件栈将代理的 `SSRF_HTTP_PORT` 发布到宿主机的端口。在该栈的 `middleware.env` 中设置；完整的 Compose 栈将代理保留在内部网络中。 |
+| `EXPOSE_SANDBOX_PORT` | `8194` | 中间件栈将代理的沙箱端口（`SSRF_SANDBOX_PROXY_PORT`）发布到宿主机的端口，从源码运行的代码经代理访问沙箱。 |
 | `SSRF_COREDUMP_DIR` | `/var/spool/squid` | 核心转储目录。 |
 | `SSRF_SANDBOX_PROXY_PORT` | `8194` | SSRF 代理用于将出站流量反向代理转发到沙箱服务的监听端口。 |
 | `SSRF_SANDBOX_PROXY_HOST` | `sandbox` | SSRF 代理转发到的沙箱服务主机名。 |
@@ -1571,6 +1579,7 @@ API 访问 Agent 后端所用的地址。在 Docker Compose 中保持默认值�
 | `PLUGIN_DAEMON_URL` | `http://plugin_daemon:5002` | 插件守护进程服务 URL。 |
 | `PLUGIN_DAEMON_KEY` | （自动生成） | 插件守护进程的认证密钥。 |
 | `PLUGIN_DAEMON_PORT` | `5002` | 插件守护进程监听端口。 |
+| `DB_SSL_MODE` | `disable` | 插件守护进程连接 PostgreSQL 时使用的 `sslmode`。数据库强制 TLS 时设为 `require`。`.env.example` 中没有这一项，在 `docker/.env` 中设置。 |
 | `PLUGIN_DAEMON_TIMEOUT` | `600.0` | 所有插件守护进程请求（安装、执行、列表）的超时时间（秒）。 |
 | `PLUGIN_MAX_PACKAGE_SIZE` | `52428800` | 最大插件包大小（字节，50 MB）。在市场下载时验证。 |
 | `PLUGIN_MAX_FILE_SIZE` | `52428800` | 插件返回给 Dify 的单个文件的最大大小（字节，50 MB），例如工具插件输出的生成图片或文档。超过限制的文件会使本次调用失败，并报「file is too large」错误。 |
@@ -1629,6 +1638,7 @@ OpenTelemetry 提供分布式追踪和指标收集。启用后，Dify 对 Flask 
 | 变量 | 默认值 | 说明 |
 |---|---|---|
 | `CSP_WHITELIST` | （空） | 在 Content Security Policy 头中允许的额外域名。 |
+| `NEXT_TELEMETRY_DISABLED` | `0` | 设为 `1` 可关闭 Next.js 的匿名遥测，Compose 栈默认保持开启。 |
 | `ALLOW_EMBED` | `false` | 允许 Dify 页面在 iframe 中嵌入。为 `false` 时设置 `X-Frame-Options: DENY` 以防止点击劫持。 |
 | `SWAGGER_UI_ENABLED` | `false` | 在 `SWAGGER_UI_PATH` 暴露 Swagger UI 以浏览 API 文档。Swagger 端点绕过认证。 |
 | `SWAGGER_UI_PATH` | `/swagger-ui.html` | Swagger UI 的 URL 路径。 |
@@ -1725,8 +1735,9 @@ API 和 Celery 工作进程之间基于 Redis 的事件传输。
 | `WEAVIATE_ENABLE_TOKENIZER_GSE` | `false` | 启用 GSE 分词器（中文）。 |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_JA` | `false` | 启用 Kagome 分词器（日文）。 |
 | `WEAVIATE_ENABLE_TOKENIZER_KAGOME_KR` | `false` | 启用 Kagome 分词器（韩文）。 |
-| `EXPOSE_WEAVIATE_PORT` | `8080` | [源码部署](/zh/self-host/deploy/advanced-deployments/local-source-code) 所用中间件栈中 Weaviate REST API 的宿主机端口。从源码运行的 Dify 通过 `http://localhost:8080` 访问 Weaviate。<br/><br/>若宿主机上 8080 已被占用，在该栈的 `middleware.env` 中改用其他端口，并将 [`WEAVIATE_ENDPOINT`](#向量数据库配置) 指向新端口。<br/><br/>仅适用于中间件栈。完整的 Compose 栈将 Weaviate 保留在内部网络中。 |
-| `EXPOSE_WEAVIATE_GRPC_PORT` | `50051` | 同一栈中 Weaviate gRPC 接口的宿主机端口，访问地址为 `grpc://localhost:50051`。<br/><br/>改动后需将 [`WEAVIATE_GRPC_ENDPOINT`](#向量数据库配置) 指向新端口。 |
+| `WEAVIATE_HOST_VOLUME` | `./volumes/weaviate` | 挂载为 Weaviate 数据卷的宿主机路径。中间件栈（[源码部署](/zh/self-host/deploy/advanced-deployments/local-source-code)），在其 `middleware.env` 中设置；完整的 Compose 栈直接挂载 `./volumes/weaviate`。 |
+| `EXPOSE_WEAVIATE_PORT` | `8080` | [源码部署](/zh/self-host/deploy/advanced-deployments/local-source-code) 所用的中间件栈将 Weaviate REST API 发布到宿主机的端口，从源码运行的 Dify 通过 `http://localhost:8080` 访问。<br/><br/>若宿主机上 8080 已被占用，改用其他端口，并将 [`WEAVIATE_ENDPOINT`](#向量数据库配置) 指向新端口。仅适用于中间件栈；完整的 Compose 栈将 Weaviate 保留在内部网络中。 |
+| `EXPOSE_WEAVIATE_GRPC_PORT` | `50051` | 中间件栈将 Weaviate gRPC 接口发布到宿主机的端口，访问地址为 `grpc://localhost:50051`。<br/><br/>改动后需将 [`WEAVIATE_GRPC_ENDPOINT`](#向量数据库配置) 指向新端口。 |
 
 </Accordion>
 

--- a/zh/self-host/deploy/configuration/environments.mdx
+++ b/zh/self-host/deploy/configuration/environments.mdx
@@ -1579,7 +1579,7 @@ API 访问 Agent 后端所用的地址。在 Docker Compose 中保持默认值�
 | `PLUGIN_DAEMON_URL` | `http://plugin_daemon:5002` | 插件守护进程服务 URL。 |
 | `PLUGIN_DAEMON_KEY` | （自动生成） | 插件守护进程的认证密钥。 |
 | `PLUGIN_DAEMON_PORT` | `5002` | 插件守护进程监听端口。 |
-| `DB_SSL_MODE` | `disable` | 插件守护进程连接 PostgreSQL 时使用的 `sslmode`。数据库强制 TLS 时设为 `require`。`.env.example` 中没有这一项，在 `docker/.env` 中设置。 |
+| `DB_SSL_MODE` | `disable` | 插件守护进程连接 PostgreSQL 时使用的 `sslmode`。数据库强制 TLS 时设为 `require`。`.env.example` 中没有这一项：完整的 Compose 栈在 `docker/.env` 中设置，中间件栈在 `middleware.env` 中设置。 |
 | `PLUGIN_DAEMON_TIMEOUT` | `600.0` | 所有插件守护进程请求（安装、执行、列表）的超时时间（秒）。 |
 | `PLUGIN_MAX_PACKAGE_SIZE` | `52428800` | 最大插件包大小（字节，50 MB）。在市场下载时验证。 |
 | `PLUGIN_MAX_FILE_SIZE` | `52428800` | 插件返回给 Dify 的单个文件的最大大小（字节，50 MB），例如工具插件输出的生成图片或文档。超过限制的文件会使本次调用失败，并报「file is too large」错误。 |


### PR DESCRIPTION
## Why an audit

CE 1.17.1's sixth release-sync pass found `EXPOSE_WEAVIATE_GRPC_PORT` undocumented. Following it back showed the check had never truly run: `middleware.env.example` held eight variables the reference never carried, the oldest from 2024-06-30.

## Three defects in `verify-env-docs.py` (`9d3d98ec`)

1. **It only parsed English.** Full-width parentheses in default cells (`（空）`) and the labels `默认值：` / `デフォルト値：` weren't recognised, so the Chinese page reported 183 phantom mismatches and 20 phantom missing variables — including `SECRET_KEY`, which appears fifteen times on it. Three lines. zh and ja now parse to exactly the 816 variables en does.
2. **It never read the compose files.** A variable a compose file consumes with no `.env.example` entry was invisible in both modes; `EXPOSE_WEAVIATE_GRPC_PORT` stayed hidden eleven months that way. `--compose` scans `docker/docker-compose*.y*ml` (the pytest ports overlay is a test harness and is skipped, loudly), and `--compare-rev` reads them at both refs. At tag 1.17.1 this widened the blind spot from the 5 I'd counted to 14.
3. **A missing ignore list was treated as an empty one, silently.** It bit me mid-audit with 43 phantom results. It now warns on stdout and stderr, and the skill says that makes the run invalid.

The skill gains the cadence rule the owner set: one full audit, cleared at tag 1.17.1, then `--compare-rev` per release, with the full run owed again only when the script, the ignore list's home, or the example-file layout changes.

## Eleven rows in three languages (`deee8f03`)

- From `middleware.env.example`: `EXPOSE_POSTGRES_PORT`, `EXPOSE_MYSQL_PORT`, `EXPOSE_REDIS_PORT`, `EXPOSE_SSRF_PROXY_PORT`, `EXPOSE_SANDBOX_PORT`, `PGDATA_HOST_VOLUME`, `REDIS_HOST_VOLUME`, `WEAVIATE_HOST_VOLUME`. The Database Service intro defines the middleware/full-stack split once so rows don't each repeat it.
- Compose-only, no `.env.example` entry: `DB_SSL_MODE` (plugin daemon — verified as `DBSslMode` in langgenius/dify-plugin-daemon), `NEXT_TELEMETRY_DISABLED` (web), `EXPOSE_AGENT_BACKEND_PORT` (e2b overlay).
- The two Weaviate port rows from #1033 rewritten to stand alone; a reader arriving by search no longer meets "the same stack".

Four compose-only names are fallback aliases already described under their replacements (`DIFY_AGENT_SHELLCTL_*`, `E2B_API_KEY`/`E2B_API_TOKEN`) and went to the registry ignore list (langgenius/dify-docs-registry#274, #275). Seven `EXPOSE_*_PORT` exist only in the pytest overlay.

## Verification

At tag 1.17.1, both example sources plus `--compose`, 46 ignored variables: **`ALL CHECKS PASSED` on en, zh and ja.** `--compare-rev 1.17.0 1.17.1`: 8 new, 1 default changed, triage 0. Editor test on the rows: ship with light edits, applied. `check-format-en` 0; `check-format-cjk` 4, the pre-existing baseline; `check-links --internal` 0 broken links and 0 broken anchors.

Corrections to the issue as first filed: the "5 extra in docs" and "3 default mismatches" it listed were artifacts of scanning `docker/envs/` alone, which the skill already warned against.

Closes DC-295.